### PR TITLE
chore: tightens up import/order rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,13 @@
     "@typescript-eslint/no-explicit-any": "error",
     "import/first": "error",
     "import/no-unresolved": "error",
-    "import/order": "error"
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        "warnOnUnassignedImports": true
+      }
+    ]
   },
   "settings": {
     "import/parsers": {

--- a/src/components/Main.test.tsx
+++ b/src/components/Main.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from "@testing-library/react";
 
-import styles from "../styles/Home.module.css";
 import Main from "./Main";
 
 describe("Main", () => {
   it("renders a heading", () => {
-    render(<Main styles={styles} />);
+    render(<Main />);
 
     const heading = screen.getByRole("heading", {
       name: /welcome to next\.js!/i,

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+
 import styles from "../styles/Home.module.css";
 
 const Main: FC = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
-import "../styles/globals.css";
 import type { AppProps } from "next/app";
+
+import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
-import styles from "../styles/Home.module.css";
 
+import styles from "../styles/Home.module.css";
 import Main from "../components/Main";
 
 const Home: NextPage = () => {


### PR DESCRIPTION
Fixes #14 

**Adds rules:**
```json
      {
        "newlines-between": "always",
        "warnOnUnassignedImports": true
      }
```