### PR TITLE
fix: turn off lintstaged if in a merge

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,8 +7,26 @@ const buildEslintCommand = (filenames) =>
 
 // https://github.com/okonet/lint-staged/issues/968#issuecomment-1011403980
 const checkTypes = [
-  "sh -c 'git stash push --message pre-tsc --keep-index --include-untracked'",
-  "sh -c 'npx tsc --pretty; STATUS=$?; git stash pop --quiet; exit $STATUS'",
+  `sh -c "
+    git merge HEAD &> /dev/null
+    result=$?
+    if [ $result -ne 0 ]
+    then
+        # merging, do nothing
+        exit 1
+    else
+        git stash push --message pre-tsc --keep-index --include-untracked
+    fi"`,
+  `sh -c "
+    git merge HEAD &> /dev/null
+    result=$?
+    if [ $result -ne 0 ]
+    then
+        # merging, do nothing
+        exit 1
+    else
+        npx tsc --pretty; STATUS=$?; git stash pop --quiet; exit $STATUS
+    fi"`,
 ];
 
 module.exports = {


### PR DESCRIPTION
Disable the lintstaged type checks if we are in a merge, because they break us out of the merge state before the commit is created (blowing everything up)

So far this works under normal circumstances, will test in a merge once `main` has new commits.