### PR TITLE
use rel URLs for names, so they match across deployments

### DIFF
--- a/percy.snapshot.list.js
+++ b/percy.snapshot.list.js
@@ -15,13 +15,13 @@ const snapshotRelativeUrls = ["/", "/lessons/made_up_slug/"];
 const urls = snapshotRelativeUrls.map((relUrl) => {
   if (typeof relUrl === "string") {
     const url = new URL(relUrl, baseUrl).href;
-    return { name: url, url };
+    return { name: relUrl, url };
   } else {
     const url = new URL(relUrl.url, baseUrl).href;
     return {
       // Pass through any fancy config.
       ...relUrl,
-      name: url,
+      name: relUrl.url,
       url,
     };
   }


### PR DESCRIPTION
we were using the full URL, so the domain was changing between the PR deploys and the production deploys, so none of the snapshots names were matching