### PR TITLE
chore(precommit): check-types on all present files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,5 @@
 
 npm run format
 npx lint-staged
+npm run check-types
 npm run test:ci

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,34 +5,6 @@ const buildEslintCommand = (filenames) =>
     .map((f) => path.relative(process.cwd(), f))
     .join(" --file ")}`;
 
-// https://github.com/okonet/lint-staged/issues/968#issuecomment-1011403980
-const checkTypes = [
-  `sh -c "
-    git merge HEAD &> /dev/null
-    result=$?
-    if [ $result -ne 0 ]
-    then
-        # merging, do nothing
-        exit 1
-    else
-        git stash push --message pre-tsc --keep-index --include-untracked
-    fi"`,
-  `sh -c "
-    git merge HEAD &> /dev/null
-    result=$?
-    if [ $result -ne 0 ]
-    then
-        # merging, do nothing
-        exit 1
-    else
-        npx tsc --pretty; STATUS=$?; git stash pop --quiet; exit $STATUS
-    fi"`,
-];
-
 module.exports = {
-  "*.{js,jsx,ts,tsx}": [
-    buildEslintCommand,
-    "npm run lint:styles",
-    ...checkTypes,
-  ],
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand, "npm run lint:styles"],
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "cc": "commit",
     "cca": "git add . && commit",
+    "check-types": "tsc --noEmit",
     "dev": "next dev",
     "format": "prettier */**/*.t{s,sx} --write",
     "lint": "next lint",
@@ -14,8 +15,7 @@
     "prepare": "husky install",
     "start": "next start",
     "test": "jest --watch --collectCoverage=false",
-    "test:ci": "jest",
-    "check-types": "tsc --noEmit"
+    "test:ci": "jest"
   },
   "dependencies": {
     "clsx": "^1.1.1",


### PR DESCRIPTION
## Description

- removes the code snippet found at https://github.com/okonet/lint-staged/issues/968#issuecomment-1011403980 since it didn't work for merge commits
- instead we run `npm run tsc -noEmit` on the whole codebase 
  - however, this can include unstaged changes so is not wholly reliable
  - but we run tsc as part of ci, so it's not the end of the world


## Issue(s)

Fixes #

## How to test

The improvement:
1. When you make a merge commit, it should check types and not fail 
The flaw
2. Make a change in a .tsx file which typescript complains about, save it, but don't stage it
3. Run `git commit --m "chore: empty" --allow-empty`  
4. Precommit should fail, because it checked types on the unstaged file

