### PR TITLE
fix(dependencies): lock puppeteer version to limit chromium downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "samara",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14117,9 +14117,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.969999",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.969999.tgz",
-      "integrity": "sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==",
+      "version": "0.0.981744",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+      "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
       "dev": true
     },
     "dezalgo": {
@@ -25280,14 +25280,14 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.5.2.tgz",
-      "integrity": "sha512-DJAyXODBikZ3xPs8C35CtExEw78LZR9RyelGDAs0tX1dERv3OfW7qpQ9VPBgsfz+hG2HiMTO/Tyf7BuMVWsrxg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.6.0.tgz",
+      "integrity": "sha512-EJXhTyY5bXNPLFXPGcY9JaF6EKJIX8ll8cGG3WUK+553Jx96oDf1cB+lkFOro9p0X16tY+9xx7zYWl+vnWgW2g==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.969999",
+        "devtools-protocol": "0.0.981744",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "pkg-dir": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "node-mocks-http": "^1.11.0",
     "octokit": "^1.7.1",
     "pa11y-ci": "^3.0.1",
-    "puppeteer": "^13.5.2",
+    "puppeteer": "^13.6.0",
     "start-server-and-test": "^1.14.0",
     "storybook-addon-themes": "^6.1.0",
     "storybook-css-modules-preset": "^1.1.1",
@@ -109,6 +109,9 @@
     "stylelint-config-standard": "^25.0.0",
     "typescript": "^4.6.3",
     "typescript-plugin-css-modules": "^3.4.0"
+  },
+  "overrides": {
+    "puppeteer": "$puppeteer"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
the `overrides` keyword only work in npm >= 8, so we can't fix this yet. Will look at other options.