### PR TITLE
chore: update project name in various files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Samara
+# Oak Web Application
 
-A really good remote education app.
+The Oak National Academy web application code base.
 
 - [Getting started](#Getting-started)
 - [Automatic Checks](#Automatic-Checks)

--- a/oak-config/oak.config.example.json
+++ b/oak-config/oak.config.example.json
@@ -30,7 +30,7 @@
   },
   "oak": {
     "appBaseUrl": "http://localhost:3000",
-    "appName": "Samara",
+    "appName": "Oak Web Application",
     "searchApiUrl": "https://example.com"
   },
   "posthog": {

--- a/oak-config/oak.config.test.json
+++ b/oak-config/oak.config.test.json
@@ -27,7 +27,7 @@
   },
   "oak": {
     "appBaseUrl": "http://localhost:3000",
-    "appName": "Samara"
+    "appName": "Oak Web Application"
   },
   "posthog": {
     "apiHost": "http://localhost:8899",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "samara",
+  "name": "oak-web-application",
   "version": "0.46.0",
   "private": true,
   "license": "MIT",
@@ -147,7 +147,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/oaknational/Samara.git"
+    "url": "https://github.com/oaknational/Oak-Web-Application.git"
   },
   "engines": {
     "node": "16",

--- a/scripts/build/fetch_secrets/helpers.test.js
+++ b/scripts/build/fetch_secrets/helpers.test.js
@@ -26,7 +26,7 @@ describe("get_secret_names_from_public_config.js", () => {
       },
       oak: {
         appBaseUrl: "http://localhost:3000",
-        appName: "Samara",
+        appName: "Oak Web Application",
       },
     });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,10 @@
+# DO not update, this was the historic name of the repo, and is still used in Sonar as the internal ID.
 sonar.projectKey=oaknational_Samara
 sonar.organization=oaknational
 
 # This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=Samara
-#sonar.projectVersion=1.0
+#sonar.projectName=
+#sonar.projectVersion=
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/src/browser-lib/cookie-consent/confirmic/metomic-react.hacked.ts
+++ b/src/browser-lib/cookie-consent/confirmic/metomic-react.hacked.ts
@@ -197,7 +197,7 @@ var m = function () {},
       O = h[1],
       j = f && (!a || v);
     return (
-      t(function () {       
+      t(function () {
         // Matthew Gregory edit - 2022 - 07 - 05 - just return children if in a test
         // environment
         if (process.env.NODE_ENV === "test") return d;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -51,7 +51,7 @@ class MyDocument extends Document {
           <meta name="release-stage" content={config.get("releaseStage")} />
           <meta name="revised" content={new Date().toUTCString()} />
           <meta name="version" content={config.get("appVersion")} />
-          {/* Remove before launch https://github.com/oaknational/Samara/issues/118 */}
+          {/* Remove before launch https://github.com/oaknational/Oak-Web-Application/issues/118 */}
           <meta name="robots" content="noindex" />
         </Head>
         <body>


### PR DESCRIPTION
Change the project name from Samara to Oak Web Application in various files.

Deliberately leaving it as the internal ID used in the Sonar project because it can't be changed, but if it bothers people we can delete that project and create a new one.