### PR TITLE
fix: use semi-colon between lexend font-weights, 

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -41,7 +41,7 @@ class MyDocument extends Document {
       <Html lang="en-GB">
         <Head>
           <link
-            href="https://fonts.googleapis.com/css2?family=Lexend:wght@400,600&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600&display=swap"
             rel="stylesheet"
           />
           <link


### PR DESCRIPTION
## Description

- changes comma to semi-colon in font-weight list when fetching lexend fonts

## Issue(s)

fixes #423

## How to test

1. Go to {cloud link}
2. Lexend fonts should load and display


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
