### PR TITLE
fix: increase maxwidth width to 1280  and add padding to mobile view

### DIFF
--- a/src/browser-lib/seo/DefaultSeo.tsx
+++ b/src/browser-lib/seo/DefaultSeo.tsx
@@ -19,7 +19,7 @@ const DefaultSeo = () => {
         images: [
           {
             url: `${config.get("appUrl")}${config.get("appSocialSharingImg")}`,
-            width: 1200,
+            width: 1280,
             height: 630,
             alt: config.get("appName"),
           },

--- a/src/components/MaxWidth/MaxWidth.tsx
+++ b/src/components/MaxWidth/MaxWidth.tsx
@@ -12,7 +12,7 @@ import Flex from "../Flex";
 const MaxWidth = styled(Flex)``;
 
 MaxWidth.defaultProps = {
-  $maxWidth: [480, 1200],
+  $maxWidth: [480, 1280],
   $ph: [0, 12],
   $flexDirection: "column",
   $flexGrow: 1,

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -34,7 +34,7 @@ const SiteFooter: FC<SiteFooterProps> = ({
         $flexDirection={"column"}
         $pa={12}
         $pt={40}
-        $maxWidth={1200}
+        $maxWidth={1280}
         $ma={"auto"}
       >
         <Typography $fontSize={12} $color="grey8">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ const Home: FC = () => {
     <LandingPageLayout seoProps={DEFAULT_SEO_PROPS}>
       <Flex $flexDirection={"column"} $position="relative">
         <Flex $justifyContent={"center"} $background={"pupilsLightGreen"}>
-          <MaxWidth>
+          <MaxWidth $ph={12}>
             <Grid $cg={[8, 16]}>
               <GridArea $colSpan={[12, 12, 8]}>
                 <Heading

--- a/src/styles/theme/types.ts
+++ b/src/styles/theme/types.ts
@@ -35,7 +35,7 @@ export type PixelSpacing =
   | 240
   | 360
   | 480
-  | 1200;
+  | 1280;
 export type NullablePixelSpacing = PixelSpacing | null;
 export type NegativePixelSpacing = -16 | -12 | -8 | -4;
 export type PercentSpacing =


### PR DESCRIPTION
## Description

- Add padding of 12px left and right on mobile on homepage
- Increase page wrapper from 1200px to 1280px as per design

## Issue(s)

Fixes #448 

## How to test

1. Open in mobile phone or mobile view in devtools https://oak-web-application-62gymjt50-oak-national-academy.vercel.app/
2. You should see padding on sides.

1. Open on desktop view. https://oak-web-application-62gymjt50-oak-national-academy.vercel.app/
2. Page is 80px wider.

## Screenshots

<img width="431" alt="Screenshot 2022-08-15 at 22 08 53" src="https://user-images.githubusercontent.com/2959739/184719256-93348f86-863d-4348-869a-1207c2c2574f.png">

<img width="1440" alt="Screenshot 2022-08-15 at 22 11 58" src="https://user-images.githubusercontent.com/2959739/184719322-569ba429-96d7-4307-8e95-d8f94b277050.png">


## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
