### PR TITLE
fix: only optout of hubspot if is loaded

### DIFF
--- a/src/browser-lib/hubspot/useHubspot.ts
+++ b/src/browser-lib/hubspot/useHubspot.ts
@@ -19,7 +19,9 @@ const useHubspot = ({ enabled }: UseHubspotProps) => {
       });
       hubspot.optIn();
     } else {
-      hubspot.optOut();
+      if (hubspot.loaded()) {
+        hubspot.optOut();
+      }
     }
   }, [enabled]);
 


### PR DESCRIPTION
## Description

- Only call `hubspot.optOut()` if `hubspot.loaded()`

Progresses #376

## How to test

1. Go to {cloud link}
2. Open web console
3. You should not see error in console about `hubspot.optOut()`


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
