### PR TITLE
feat(monitoring): add configurable ID for Pingdom uptime checks

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -324,6 +324,15 @@ const envVars = satisfies<Record<string, EnvVar>>()({
     availableInBrowser: true,
     default: null,
   },
+  pingdomUptimeId: {
+    value: process.env.PINGDOM_UPTIME_ID,
+    envName: "PINGDOM_UPTIME_ID",
+    required: true,
+    availableInBrowser: false,
+    // The old ID, already configured for all sites in Pingdom.
+    default:
+      "d6-7d-b6-4b-74-15-da-2e-2c-3c-00-34-3b-5f-f5-44-03-0f-fc-9f-c9-ce-16-7c-97-42-16-ab-1a-2e-82-5d",
+  },
 });
 
 for (const [

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -48,6 +48,11 @@ class MyDocument extends Document {
           <meta name="release-stage" content={config.get("releaseStage")} />
           <meta name="revised" content={new Date().toUTCString()} />
           <meta name="version" content={config.get("appVersion")} />
+
+          <meta
+            name="pingdom-uptime-check"
+            content={config.get("pingdomUptimeId")}
+          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Add the meta tag required for the WWW monitoring in Pingdom to keep working when we switch sites. Also make it configurable so we can track different deployments based on deployment specific envs.