### PR TITLE
chore(lint): adds self closing tag rule and fixes faults

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020,
   },
-  plugins: ["@next/next", "react-hooks"],
+  plugins: ["@next/next", "react", "react-hooks"],
   extends: [
     "eslint:recommended",
     "plugin:@next/next/core-web-vitals",
@@ -31,6 +31,7 @@ module.exports = {
     ...importRules,
     "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
     "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
+    "react/self-closing-comp": ["error", { component: true, html: true }],
   },
 
   // Put the Typescript config in an override, so we can still lint js files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^2.7.1",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.5.0",
         "eslint-plugin-storybook": "^0.5.7",
         "googleapis": "^100.0.0",
@@ -21697,9 +21698,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
-      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.5",
@@ -57989,9 +57990,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
-      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.5.0",
     "eslint-plugin-storybook": "^0.5.7",
     "googleapis": "^100.0.0",

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -51,7 +51,7 @@ export const CardIconButton: ComponentStory<typeof Component> = (args) => (
         label={"Lable"}
         fullWidth
         href={"/"}
-      ></ButtonAsLink>
+       />
     </Component>
   </div>
 );
@@ -74,7 +74,7 @@ export const CardImageButton: ComponentStory<typeof Component> = (args) => (
           label={"Label"}
           fullWidth
           href={"/"}
-        ></ButtonAsLink>
+         />
       </Flex>
     </Component>
   </div>
@@ -106,7 +106,7 @@ export const CardLargeIconCentered: ComponentStory<typeof Component> = (
         label={"Label"}
         fullWidth
         href={"/"}
-      ></ButtonAsLink>
+       />
     </Component>
   </div>
 );

--- a/src/components/DropdownSelect/Select.tsx
+++ b/src/components/DropdownSelect/Select.tsx
@@ -166,7 +166,7 @@ export function Select<T extends object>(
             isPlaceholder={!state.selectedItem}
           >
             <Flex $alignItems={"center"}>
-              {props.icon && <Icon $mr={8} name={props.icon}></Icon>}
+              {props.icon && <Icon $mr={8} name={props.icon} />}
               <span data-testid={"select-span"} {...valueProps}>
                 {state.selectedItem
                   ? state.selectedItem.rendered

--- a/src/components/LessonElementLinks/LessonElementLinks.tsx
+++ b/src/components/LessonElementLinks/LessonElementLinks.tsx
@@ -60,7 +60,7 @@ const GraphicCircle: FC<GraphicCircleProps> = ({
   $background = "teachersPastelYellow",
 }) => (
   <Circle size={72} $background={$background} $dropShadow="grey20">
-    <Icon $pa={0} size={48} name={icon}></Icon>
+    <Icon $pa={0} size={48} name={icon} />
   </Circle>
 );
 

--- a/src/pages/beta/teacher.tsx
+++ b/src/pages/beta/teacher.tsx
@@ -53,9 +53,9 @@ const TeacherHome: FC = () => {
               placeholder="Search for subjects, lessons, quizes, lessons plans and much much more..."
               value={value}
               id={""}
-            ></Input>
+             />
             <Flex $mt={32} $justifyContent={"center"}>
-              <KeyStagesNav keyStages={keyStagesNavData}></KeyStagesNav>
+              <KeyStagesNav keyStages={keyStagesNavData} />
             </Flex>
           </GridArea>
         </Grid>

--- a/src/pages/develop-your-curriculum.tsx
+++ b/src/pages/develop-your-curriculum.tsx
@@ -91,9 +91,7 @@ const Curriculum: NextPage<CurriculumPageProps> = ({
               {pageData.gettingStarted.title}
             </Heading>
             <Typography>
-              <PortableText
-                value={pageData.gettingStarted.bodyPortableText}
-              ></PortableText>
+              <PortableText value={pageData.gettingStarted.bodyPortableText} />
             </Typography>
           </RotatedCard>
         </Flex>
@@ -171,9 +169,7 @@ const Curriculum: NextPage<CurriculumPageProps> = ({
               {pageData.ourApproach.title}
             </Heading>
             <Typography $mb={16} $lineHeight={["28px", "32px"]} fontSize={18}>
-              <PortableText
-                value={pageData.ourApproach.bodyPortableText}
-              ></PortableText>
+              <PortableText value={pageData.ourApproach.bodyPortableText} />
             </Typography>
             {pageData.ourApproach.cta && (
               <Flex $justifyContent={["center", "flex-start"]}>
@@ -181,7 +177,7 @@ const Curriculum: NextPage<CurriculumPageProps> = ({
                   icon={"ArrowRight"}
                   label={pageData.ourApproach.cta?.label}
                   href={"https://teachers.thenational.academy/oaks-curricula"}
-                ></ButtonAsLink>
+                />
               </Flex>
             )}
           </Flex>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -118,7 +118,7 @@ const Home: FC = () => {
                         alt={"classroom illustration"}
                         imageSrc={"/images/illustrations/classroom.svg"}
                         position={"left center"}
-                      ></CardImage>
+                      />
                     </Flex>
                   </Box>
                   <Heading
@@ -151,7 +151,7 @@ const Home: FC = () => {
                     <CardImage
                       alt="teacher hub illustration"
                       imageSrc={"/images/illustrations/teacher.svg"}
-                    ></CardImage>
+                    />
                   </Box>
                   <Heading
                     $mr={[0, 56]}


### PR DESCRIPTION
## Description

- adds lint rule so that empty tags must be self closing. i.e.
```tsx
<MyComponent {...props} /> // is valid
<MyComponent {...props}></MyComponent> // is not valid
```

Just makes it clearer when reading the close, what has contents and what doesn't
