### PR TITLE
chore: silence avo in test AnalyticsProvider

### DIFF
--- a/src/__tests__/__helpers__/renderWithProviders.tsx
+++ b/src/__tests__/__helpers__/renderWithProviders.tsx
@@ -28,6 +28,14 @@ type ProviderProps = {
   authProviderProps?: MockedAuthProviderProps;
 };
 
+const noopAvoLogger = {
+  logDebug: () => true,
+  logWarn: () => true,
+  // returning false will make avo use console errors, which
+  // we may prefer for actual errors
+  logError: () => false,
+};
+
 export const AllTheProviders: FC<ProviderProps> = ({
   children,
   authProviderProps,
@@ -36,7 +44,7 @@ export const AllTheProviders: FC<ProviderProps> = ({
     <CookieConsentProvider>
       <ThemeProvider theme={theme}>
         <ErrorBoundary>
-          <AnalyticsProvider>
+          <AnalyticsProvider avoOptions={{ avoLogger: noopAvoLogger }}>
             <MockedAuthProvider {...authProviderProps}>
               <MockedApolloProvider>
                 <MemoryRouterProvider>

--- a/src/context/Analytics/AnalyticsProvider.tsx
+++ b/src/context/Analytics/AnalyticsProvider.tsx
@@ -46,6 +46,12 @@ export type AnalyticsService<ServiceConfig> = {
   optIn: () => void;
 };
 
+type AvoOptions = Parameters<typeof initAvo>[0];
+
+export type AnalyticsProviderProps = {
+  avoOptions?: Partial<AvoOptions>;
+};
+
 export const analyticsContext = createContext<AnalyticsContext | null>(null);
 
 const getPathAndQuery = () => {
@@ -55,8 +61,8 @@ const getPathAndQuery = () => {
   return window.location.pathname + window.location.search;
 };
 
-const AnalyticsProvider: FC = (props) => {
-  const { children } = props;
+const AnalyticsProvider: FC<AnalyticsProviderProps> = (props) => {
+  const { children, avoOptions = {} } = props;
 
   const trackingEnabled = useCookieConsent().hasConsentedToPolicy("statistics");
 
@@ -89,7 +95,11 @@ const AnalyticsProvider: FC = (props) => {
   /**
    * Avo
    */
-  initAvo({ env: getAvoEnv() }, {}, getAvoBridge({ posthog, hubspot }));
+  initAvo(
+    { env: getAvoEnv(), ...avoOptions },
+    {},
+    getAvoBridge({ posthog, hubspot })
+  );
 
   /**
    * Page view tracking


### PR DESCRIPTION
## Description
Pass an `AvoLogger` from `renderWithProviders` to silence the avo warnings in every test

![iTerm2 - 2022-09-01 at 13 04 45](https://user-images.githubusercontent.com/2717635/187937297-1d7e4649-ca2f-4136-91ad-5baea579c93f.png)

@mantagen Maybe providing `avoOptions` and not just `avoLogger` is overkill/premature? Happy to narrow it


## Checklist

- [ ] ~Added or updated tests where appropriate~
- [ ] ~Manually tested across browsers / devices~
- [ ] ~Considered impact on accessibility~
- [ ] ~Design sign-off~
- [ ] ~Approved by product owner~
