### PR TITLE
fix: correct typo

### DIFF
--- a/src/components/pages/Home/HomeHelpCard.tsx
+++ b/src/components/pages/Home/HomeHelpCard.tsx
@@ -20,7 +20,7 @@ const HomeHelpCard: FC = () => {
         $mt={"auto"}
         fullWidth
         href={getHelpUrl()}
-        label="Visit help center"
+        label="Visit help centre"
         htmlAnchorProps={{ target: "_blank" }}
       />
     </Card>


### PR DESCRIPTION
## Description

- `centre` not `center`

Fixes #566 
