### PR TITLE
fix(hubspot): don't fire an initial pageview, ti's done automatically

### DIFF
--- a/src/context/Analytics/AnalyticsProvider.tsx
+++ b/src/context/Analytics/AnalyticsProvider.tsx
@@ -7,12 +7,15 @@ import getAvoBridge from "../../browser-lib/avo/getAvoBridge";
 import { useCookieConsent } from "../../browser-lib/cookie-consent/CookieConsentProvider";
 import { ServiceType } from "../../browser-lib/cookie-consent/types";
 import useAnalyticsService from "../../browser-lib/analytics/useAnalyticsService";
-import posthogWithQueue from "../../browser-lib/posthog/posthog";
+import posthogWithQueue, {
+  PosthogConfig,
+} from "../../browser-lib/posthog/posthog";
 import hubspotWithQueue from "../../browser-lib/hubspot/hubspot";
 import config from "../../config";
 import useHasConsentedTo from "../../browser-lib/cookie-consent/useHasConsentedTo";
 import useStableCallback from "../../hooks/useStableCallback";
 import isBrowser from "../../utils/isBrowser";
+import { HubspotConfig } from "../../browser-lib/hubspot/startHubspot";
 
 let loaded = false;
 
@@ -47,6 +50,9 @@ export type AnalyticsService<ServiceConfig> = {
   optOut: () => void;
   optIn: () => void;
 };
+type AnalyticsServiceWithConfig =
+  | AnalyticsService<HubspotConfig>
+  | AnalyticsService<PosthogConfig>;
 
 type AvoOptions = Parameters<typeof initAvo>[0];
 
@@ -106,25 +112,31 @@ const AnalyticsProvider: FC<AnalyticsProviderProps> = (props) => {
   /**
    * Page view tracking
    */
-  const page = useStableCallback(() => {
-    const props = { path: getPathAndQuery() };
-    posthog.page(props);
-    hubspot.page(props);
-  });
+  const page = useStableCallback(
+    (opts: { services: AnalyticsServiceWithConfig[] }) => {
+      const { services } = opts;
+      const props = { path: getPathAndQuery() };
+      services.forEach((service) => {
+        service.page(props);
+      });
+    }
+  );
   useEffect(() => {
     if (!loaded) {
       // fire page event on first load only
-      page();
+      page({ services: [posthog] });
     }
     loaded = true;
-  }, [page]);
+  }, [page, posthog]);
   useEffect(() => {
-    router.events.on("routeChangeComplete", () => page());
+    router.events.on("routeChangeComplete", () =>
+      page({ services: [posthog, hubspot] })
+    );
 
     return () => {
       router.events.off("routeChangeComplete", page);
     };
-  }, [page]);
+  }, [page, posthog, hubspot]);
 
   /**
    * Identify


### PR DESCRIPTION
## Description

- only fire posthog page event on first load (hubspot does it automatically)



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
