### PR TITLE
fix: change vertical margin on hr

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -325,7 +325,9 @@ const Home: NextPage<HomePageProps> = (props) => {
                     <li key={`BlogList-BlogListItem-${i}`}>
                       {/* Blog List Item is failing Pa11y tests and is to be excluded */}
                       <BlogListItem {...item} withImage={true} />
-                      {i < posts.length - 1 && <Hr $color="black" $mv={16} />}
+                      {i < posts.length - 1 && (
+                        <Hr $color="black" $mt={[0, 16]} $mb={16} />
+                      )}
                     </li>
                   ))}
                 </Flex>


### PR DESCRIPTION
## Description

- Adjust vertical margin to 16px

## Issue(s)

Fixes #594 

## How to test

1. Go to https://oak-web-application-elnliutdb-oak-national-academy.vercel.app/
2. You should see vertical margin changed

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
