### PR TITLE
fix: prevent p tags from portable text being nested

### DIFF
--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -9,7 +9,7 @@ import Card, { CardProps } from "../components/Card";
 import Flex from "../components/Flex";
 import Grid, { GridArea } from "../components/Grid";
 import Layout from "../components/Layout";
-import Typography, { Heading, Span } from "../components/Typography";
+import Typography, { Heading } from "../components/Typography";
 import ButtonAsLink from "../components/Button/ButtonAsLink";
 import Icon, { IconName } from "../components/Icon";
 import LessonElementLinks from "../components/LessonElementLinks";
@@ -315,9 +315,9 @@ const PlanALesson: NextPage<PlanALessonProps> = ({
                         >
                           {title}
                         </Heading>
-                        <Span $fontSize={18} $lineHeight={"24px"}>
+                        <Typography $fontSize={18} $lineHeight={"24px"}>
                           <PortableText value={portableText} />
-                        </Span>
+                        </Typography>
                         {withSearchCTA && (
                           <Flex $justifyContent={["center", "flex-start"]}>
                             <ButtonAsLink


### PR DESCRIPTION
## Description

- Fix nested p tag problem for portable text on planning page
- Retain styling

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
