### PR TITLE
feat: add latest utm params to hubspot form submissions

### DIFF
--- a/src/browser-lib/hubspot/forms/getHubspotFormPayload.test.ts
+++ b/src/browser-lib/hubspot/forms/getHubspotFormPayload.test.ts
@@ -10,12 +10,22 @@ describe("getHubspotFormPayload()", () => {
           name: "full_name value",
           userRole: "Student",
           oakUserId: "oak_user_id value",
+          utm_campaign: "a campaign",
+          utm_content: "some content",
+          utm_medium: "some medium",
+          utm_source: "a source",
+          utm_term: "term",
         },
       })
     ).toEqual({
       fields: [
         { name: "email", value: "email value" },
         { name: "full_name", value: "full_name value" },
+        { name: "latest_utm_campaign", value: "a campaign" },
+        { name: "latest_utm_content", value: "some content" },
+        { name: "latest_utm_medium", value: "some medium" },
+        { name: "latest_utm_source", value: "a source" },
+        { name: "latest_utm_term", value: "term" },
         { name: "oak_user_id", value: "oak_user_id value" },
         { name: "user_type", value: "Student" },
       ],

--- a/src/browser-lib/hubspot/forms/getHubspotFormPayload.ts
+++ b/src/browser-lib/hubspot/forms/getHubspotFormPayload.ts
@@ -11,6 +11,11 @@ const getHubspotFormPayload = (props: {
     full_name: data.name,
     user_type: data.userRole,
     oak_user_id: data.oakUserId,
+    latest_utm_campaign: data.utm_campaign,
+    latest_utm_content: data.utm_content,
+    latest_utm_medium: data.utm_medium,
+    latest_utm_source: data.utm_source,
+    latest_utm_term: data.utm_term,
   };
 
   const payload = {

--- a/src/browser-lib/hubspot/forms/hubspotSubmitForm.ts
+++ b/src/browser-lib/hubspot/forms/hubspotSubmitForm.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import errorReporter from "../../../common-lib/error-reporter";
 import config from "../../../config";
 import OakError, { ErrorMeta } from "../../../errors/OakError";
+import { UtmParams } from "../../../hooks/useUtmParams";
 
 import getHubspotFormPayload from "./getHubspotFormPayload";
 import getHubspotUserToken from "./getHubspotUserToken";
@@ -73,7 +74,7 @@ export type HubspotFormData = {
    * form value. It is stripped out in getHubspotFormPayload.
    */
   userRole: UserRole | "";
-};
+} & UtmParams;
 type HubspotSubmitFormProps = {
   hubspotFormId: string;
   data: HubspotFormData;

--- a/src/components/Forms/NewsletterForm/useNewsletterForm.test.ts
+++ b/src/components/Forms/NewsletterForm/useNewsletterForm.test.ts
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks";
 
+import { HubspotFormData } from "../../../browser-lib/hubspot/forms/hubspotSubmitForm";
+
 import useNewsletterForm from "./useNewsletterForm";
 
 const identify = jest.fn();
@@ -16,10 +18,36 @@ jest.mock("../../../browser-lib/analytics/useAnonymousId", () => ({
   __esModule: true,
   default: () => testAnonymousId,
 }));
+const hubspotSubmitForm = jest.fn();
+jest.mock("../../../browser-lib/hubspot/forms/hubspotSubmitForm", () => ({
+  __esModule: true,
+  default: (...args: []) => hubspotSubmitForm(...args),
+}));
+jest.mock("../../../hooks/useUtmParams", () => ({
+  __esModule: true,
+  default: () => ({ utm_source: "les_twitz" }),
+}));
 
 describe("useNewsletterForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+  test("should call hubspotSubmitForm() and include utm params", () => {
+    const { result } = renderHook(() => useNewsletterForm());
+    const data: HubspotFormData = {
+      email: "test",
+      name: "sdfo9dfj",
+      userRole: "Teacher",
+    };
+    result.current.onSubmit(data);
+
+    expect(hubspotSubmitForm).toHaveBeenCalledWith({
+      data: {
+        ...data,
+        utm_source: "les_twitz",
+      },
+      hubspotFormId: "NEXT_PUBLIC_HUBSPOT_NEWSLETTER_FORM_ID",
+    });
   });
   test("should call analytics.identify() with email", () => {
     const { result } = renderHook(() => useNewsletterForm());

--- a/src/components/Forms/NewsletterForm/useNewsletterForm.ts
+++ b/src/components/Forms/NewsletterForm/useNewsletterForm.ts
@@ -3,6 +3,7 @@ import { HubspotFormData } from "../../../browser-lib/hubspot/forms/hubspotSubmi
 import config from "../../../config";
 import useAnalytics from "../../../context/Analytics/useAnalytics";
 import useAnonymousId from "../../../browser-lib/analytics/useAnonymousId";
+import useUtmParams from "../../../hooks/useUtmParams";
 
 const hubspotNewsletterFormId = config.get("hubspotNewsletterFormId");
 
@@ -12,6 +13,7 @@ type UseNewsletterFormProps = {
 const useNewsletterForm = (props: UseNewsletterFormProps = {}) => {
   const anonymousId = useAnonymousId();
   const { identify } = useAnalytics();
+  const utmParams = useUtmParams();
 
   const onSubmit = (data: HubspotFormData) => {
     if (props.onSubmit) {
@@ -20,7 +22,7 @@ const useNewsletterForm = (props: UseNewsletterFormProps = {}) => {
 
     const hubspotFormResponse = hubspotSubmitForm({
       hubspotFormId: hubspotNewsletterFormId,
-      data,
+      data: { ...data, ...utmParams },
     });
 
     identify(anonymousId, { email: data.email || data.emailTextOnly });

--- a/src/config/localStorageKeys.ts
+++ b/src/config/localStorageKeys.ts
@@ -4,3 +4,4 @@ export const LS_KEY_USER = "oak-user";
 export const LS_KEY_ACCESS_TOKEN = "oak-access-token";
 export const LS_KEY_BOOKMARKS = "oak-bookmarks";
 export const LS_KEY_ANONYMOUS_ID = "oak-anonymous-id";
+export const LS_KEY_UTM_PARAMS = "oak-utm-params";

--- a/src/hooks/useUtmParams.test.ts
+++ b/src/hooks/useUtmParams.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import "../__tests__/__helpers__/LocalStorageMock";
+
+import useUtmParams from "./useUtmParams";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useRouter = jest.spyOn(require("next/router"), "useRouter");
+
+describe("useUtmParams()", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  jest.mock("next/dist/client/router", () => require("next-router-mock"));
+
+  test("defaults to empty object", () => {
+    useRouter.mockReturnValue({ query: {} });
+
+    const { result } = renderHook(() => useUtmParams());
+    expect(result.current).toMatchObject({});
+  });
+  test("returns utm params", () => {
+    useRouter.mockReturnValueOnce({
+      query: { utm_source: "twitter", bar: "baz" },
+    });
+    const { result } = renderHook(() => useUtmParams());
+    expect(result.current).toMatchObject({ utm_source: "twitter" });
+  });
+  test("gets params from local storage if available", async () => {
+    window.localStorage.setItem(
+      "oak-utm-params",
+      JSON.stringify({ utm_campaign: "tests rule", utm_term: "hella yeah" })
+    );
+    const { result } = renderHook(() => useUtmParams());
+    expect(result.current).toMatchObject({
+      utm_campaign: "tests rule",
+      utm_term: "hella yeah",
+    });
+    useRouter.mockReturnValueOnce({
+      query: { utm_source: "twitter", bar: "baz" },
+    });
+  });
+  test("utm params local storage gets updated when they change in the query", () => {
+    useRouter.mockReturnValueOnce({
+      query: {
+        utm_campaign: "tests rule",
+        utm_term: "hella yeah",
+      },
+    });
+    const { result, rerender } = renderHook(() => useUtmParams());
+    expect(result.current).toMatchObject({
+      utm_campaign: "tests rule",
+      utm_term: "hella yeah",
+    });
+    useRouter.mockReturnValueOnce({
+      query: { utm_source: "twitter", bar: "baz" },
+    });
+    rerender();
+    expect(window.localStorage.getItem("oak-utm-params")).toMatch(
+      JSON.stringify({
+        utm_source: "twitter",
+      })
+    );
+  });
+});

--- a/src/hooks/useUtmParams.ts
+++ b/src/hooks/useUtmParams.ts
@@ -1,0 +1,61 @@
+import { useRouter } from "next/router";
+import { useEffect, useMemo } from "react";
+
+import { LS_KEY_UTM_PARAMS } from "../config/localStorageKeys";
+
+import useLocalStorage from "./useLocalStorage";
+
+const paramNames = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+type UtmParamName = typeof paramNames[number];
+
+export type UtmParams = Partial<Record<UtmParamName, string>>;
+/**
+ * This hook returns the last known UTM parameters.
+ * We're using local storage (as we are with anonymous-id), the downside being
+ * that if multiple users are using the same browser account, then there's a
+ * possibility that a conversion is wrongly attributed. But it's very much
+ * an edge case.
+ */
+const useUtmParams = (): UtmParams => {
+  const router = useRouter();
+
+  const [utmParams, setUtmParams] = useLocalStorage<UtmParams>(
+    LS_KEY_UTM_PARAMS,
+    {}
+  );
+
+  const utmParamsFromQuery = useMemo(
+    () =>
+      paramNames.reduce((accum: UtmParams, curr) => {
+        const param = router.query[curr];
+
+        if (Array.isArray(param) && param[0]) {
+          accum[curr] = param[0];
+        }
+        if (typeof param === "string") {
+          accum[curr] = param;
+        }
+
+        return accum;
+      }, {}),
+    [router.query]
+  );
+
+  useEffect(() => {
+    if (Object.keys(utmParamsFromQuery).length) {
+      // Only update utmParams if the query contains
+      setUtmParams(utmParamsFromQuery);
+    }
+  }, [utmParamsFromQuery, setUtmParams]);
+
+  return utmParams;
+};
+
+export default useUtmParams;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -228,7 +228,9 @@ const Home: NextPage<HomePageProps> = (props) => {
                     >
                       <Image
                         alt=""
-                        src={"/images/illustrations/teacher-carrying-stuff-165-200.png"}
+                        src={
+                          "/images/illustrations/teacher-carrying-stuff-165-200.png"
+                        }
                         layout="fill"
                         objectFit="contain"
                         priority

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -246,7 +246,9 @@ const PlanALesson: NextPage<PlanALessonProps> = ({
                     objectFit="contain"
                     objectPosition="center bottom"
                     alt=""
-                    src={"/images/illustrations/teacher-carrying-stuff-237-286.png"}
+                    src={
+                      "/images/illustrations/teacher-carrying-stuff-237-286.png"
+                    }
                   />
                 </Cover>
                 <ButtonAsLink
@@ -440,7 +442,9 @@ const PlanALesson: NextPage<PlanALessonProps> = ({
                   objectFit="contain"
                   objectPosition="center bottom"
                   alt=""
-                  src={"/images/illustrations/teacher-carrying-stuff-237-286.png"}
+                  src={
+                    "/images/illustrations/teacher-carrying-stuff-237-286.png"
+                  }
                 />
               </Cover>
 


### PR DESCRIPTION
## Description

- adds `useUtmParams` hook which stores the latest utm params found in location.search
- appends these utm params to the form submission to hubspot

## How to test

1. Go to https://oak-web-application-5fykatmh0-oak-national-academy.vercel.app/?utm_source=email-platform&utm_medium=email&utm_campaign=prtest
2. Navigate about (so that parameters are lost from the url)
3. close the browser and re-open
4. Submit the newsletter form with network tab open
5. You should see a 200 from the form submission and the utm params in the payload 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
