### PR TITLE
chore(footer): accessiblity-statement typo

### DIFF
--- a/src/browser-lib/fixtures/footerSections.ts
+++ b/src/browser-lib/fixtures/footerSections.ts
@@ -37,7 +37,7 @@ const footerSections: FooterSections = {
       { text: "Manage cookie settings", type: "consent-manager-toggle" },
       { text: "Copyright notice", href: "/legal/copyright-notice" },
       { text: "Terms & conditions", href: "/legal/terms-and-conditions" },
-      { text: "Accessibilty statement", href: "/legal/accessibilty-statement" },
+      { text: "Accessibilty statement", href: "/legal/accessibility-statement" },
       { text: "Safeguarding statement", href: "/legal/safeguarding-statement" },
       {
         text: "Physical activity disclaimer",


### PR DESCRIPTION
## Description

- accessiblity-statement typo

## Issue(s)

Fixes #627 

## How to test

1. Go to {cloud link}
2. Click on Accessibility Statement in footer
3. It should not 404

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
