### PR TITLE
fix: put padding on grid not max width

### DIFF
--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -243,7 +243,7 @@ const BlogDetailPage: NextPage<BlogPageProps> = (props) => {
       $background="white"
       isPreviewMode={props.isPreviewMode}
     >
-      <MaxWidth $ph={[12, 12, 0]} $pt={56}>
+      <MaxWidth $pt={56}>
         <Card
           $pa={0}
           $background={"teachersPastelYellow"}
@@ -303,7 +303,7 @@ const BlogDetailPage: NextPage<BlogPageProps> = (props) => {
           </Flex>
         </Card>
 
-        <Grid $mt={[48, 64]}>
+        <Grid $mt={[48, 64]} $ph={[12, 0]}>
           <GridArea $colSpan={[12, 7]}>
             <P $fontSize={14} $lineHeight={"20px"} $mt={16} $fontFamily={"ui"}>
               {blog.category.title}

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -32,7 +32,7 @@ const BlogListingPage: NextPage<BlogListingPageProps> = (props) => {
       $background="white"
       isPreviewMode={props.isPreviewMode}
     >
-      <MaxWidth $ph={[12, 12, 0]} $pt={[72, 80, 80]}>
+      <MaxWidth $pt={[72, 80, 80]}>
         <SummaryCard
           title={"Blog Listing"}
           heading={"Inspiration for inside and outside the classroom"}
@@ -43,7 +43,7 @@ const BlogListingPage: NextPage<BlogListingPageProps> = (props) => {
           background="teachersPastelYellow"
           imageProps={cardImage}
         />
-        <Grid>
+        <Grid $ph={[12, 0]}>
           <GridArea $colSpan={[12, 12, 8]} $mt={[48, 72]}>
             <BlogList
               title={"Stay up to date!"}


### PR DESCRIPTION
## Description

- Fixes padding on `/blog` and `/blog/[slug]`

## Issue(s)

Fixes #617 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
