### PR TITLE
chore: copy change help center

### DIFF
--- a/src/components/AboutContactCard/AboutContactCard.tsx
+++ b/src/components/AboutContactCard/AboutContactCard.tsx
@@ -26,7 +26,7 @@ const cardCopy = [
   {
     heading: "Find help",
     p: "Search our FAQs and find useful information for teachers, schools, pupils and parents in our ",
-    linkText: "Help Centre",
+    linkText: "help centre",
     href: getHelpUrl(),
     linkType: "link",
   },

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -32,7 +32,7 @@ const ContactUs: NextPage = () => {
             Search our FAQs and find useful information for teachers, schools,
             pupils and parents in our{" "}
             <a href={getHelpUrl()} target="_blank">
-              Help Centre.
+              help centre.
             </a>
           </>
         ),


### PR DESCRIPTION
## Description

- On the contact us and about us page, we have written "Help Centre". This should be... "help centre"

Change below made on Sanity
- Change "or print them off as worksheets to use in class or as homework." to "or print them off to use in class or as homework." on the lesson planning page (the use of worksheet in the intro quiz section was deemed confusing.


## Issue(s)

Fixes #622

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
