### PR TITLE
test: add about us pages to Pa11y

### DIFF
--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -8,9 +8,23 @@ const config = {
   defaults: {
     runners: ["axe"],
     hideElements:
-      "#mtm-root-container, #mtm-frame-container, #avo-debugger, #homepage-blog-list",
+      "#mtm-root-container, #mtm-frame-container, #avo-debugger, #homepage-blog-list, .pa11y-ignore",
+    ignore: [
+      // Pa11y using Axe is looking for videos with track elements of type=captions, but the
+      // Mux player is rendering type=subtitles, so Pa11y is complaining, not sure who is wrong
+      // hiding for now
+      "video-caption",
+      // This is something to do with the video controls in the Shadow DOM, they appear white on black,
+      // but Pa11y isn't picking that up.
+      "color-contrast",
+    ],
   },
   urls: [],
+  // log: {
+  //   debug: console.log,
+  //   error: console.error,
+  //   info: console.info,
+  // },
 };
 
 const baseUrl = process.env.BASE_URL || "http://localhost:3000";
@@ -19,23 +33,7 @@ const baseUrl = process.env.BASE_URL || "http://localhost:3000";
 // e.g. `/unit` to `/unit/index.html` during tests.
 const relativeUrls = [
   "/",
-  {
-    url: "/lesson-planning",
-    ignore: [
-      // Pa11y using Axe is looking for videos with track elements of type=captions, but the
-      // Mux player is rendering type=subtitles, so Pa11y is complaining, not sure who is wrong
-      // hiding for now.
-      "video-caption",
-      // This is something to do with the video controls in the Shadow DOM, they appear white on black,
-      // but Pa11y isn't picking that up.
-      "color-contrast",
-    ],
-    // log: {
-    //   debug: console.log,
-    //   error: console.error,
-    //   info: console.info,
-    // },
-  },
+  "/lesson-planning",
   "/develop-your-curriculum",
   "/about-us/who-we-are",
   "/about-us/board",

--- a/src/components/OutlineHeading/OutlineHeading.tsx
+++ b/src/components/OutlineHeading/OutlineHeading.tsx
@@ -4,7 +4,11 @@ import color from "../../styles/utils/color";
 import responsive, { ResponsiveValues } from "../../styles/utils/responsive";
 import { margin } from "../../styles/utils/spacing";
 import typography from "../../styles/utils/typography";
-import { headingDefaults, HeadingProps , HeadingTagComponent } from "../Typography/Heading";
+import {
+  headingDefaults,
+  HeadingProps,
+  HeadingTagComponent,
+} from "../Typography/Heading";
 
 const shadow =
   "-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000";
@@ -25,9 +29,11 @@ const fontSize = css<{ $fontSize?: OutlineSizeResponsive }>`
   ${responsive("font-size", (props) => props.$fontSize, parse)}
 `;
 
-const OutlineHeading = styled(HeadingTagComponent)<
-  OutlineHeadingProps & { $fontSize: OutlineSizeResponsive }
->`
+// Pa11y complains about the "color" being white on white
+// Todo: use the theme to ensure the shadow color is the contrast color
+const OutlineHeading = styled(HeadingTagComponent).attrs({
+  className: "pa11y-ignore",
+})<OutlineHeadingProps & { $fontSize: OutlineSizeResponsive }>`
   color: white;
   text-shadow: ${shadow};
   ${fontSize}


### PR DESCRIPTION
## Description

- Adds about us pages to Pa11y testing 

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
