### PR TITLE
style: added row gap to download card grid

### DIFF
--- a/src/pages/about-us/board.tsx
+++ b/src/pages/about-us/board.tsx
@@ -93,7 +93,7 @@ const AboutUsBoard: NextPage<AboutPageProps> = ({
             <Hr $mv={32} />
           </Typography>
 
-          <Grid $cg={[12, 20]}>
+          <Grid $rg={[16]} $cg={[12, 20]}>
             {pageData.board.documents.map((doc) => (
               <GridArea key={doc.title} $colSpan={[6, 3, 2]}>
                 <Card $height={220} $pa={16}>


### PR DESCRIPTION
## Description

- Adds row gap for document download cards

## Issue(s)

Fixes #641 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
