### PR TITLE
fix: pa11y on blog pages

### DIFF
--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -37,6 +37,10 @@ const relativeUrls = [
   "/develop-your-curriculum",
   "/about-us/who-we-are",
   "/about-us/board",
+  "/blog",
+  "/blog/how-to-design-a-unit-of-study",
+  "/blog/evolution-of-oak",
+  "/blog/join-the-childrens-mental-health-week-assembly-2022",
   // Ignore beta pages for now.
   // "/beta/lessons/physics-only-review-chj3cd/",
   // "/beta/sign-in",


### PR DESCRIPTION
## Description

- Add blog pages to pa11y testing

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
