### PR TITLE
fix: explicitly set downloaded filename of board page assets

### DIFF
--- a/src/pages/about-us/board.tsx
+++ b/src/pages/about-us/board.tsx
@@ -116,7 +116,7 @@ const AboutUsBoard: NextPage<AboutPageProps> = ({
                       <IconButtonAsLink
                         icon={"Download"}
                         aria-label={`Download ${doc.title} as ${doc.file.asset.size} ${doc.file.asset.extension}`}
-                        href={`${doc.file.asset.url}?dl`}
+                        href={`${doc.file.asset.url}?dl=${doc.title}.pdf`}
                         background={"teachersHighlight"}
                       />
                     </Flex>


### PR DESCRIPTION
## Description
When downloading assets from the about board page, the file name _at the time of upload to sanity_ is being used as the downloaded file name, e.g. `20220823 ONA Framework Document.pdf`

Changing the `originalFileName` in sanity doesn't seem to have worked, so I'm explicitly setting it to be the download title, e.g. `Oak's Framework Agreement.pdf`

n.b. this includes punctuation, not sure if that's a problem? But some had punctuation already in the original filenames

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}/about-us/board
2. Click on a download icon on a file
3. You should see a nice file name in your downloads folder

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
