### PR TITLE
fix: twitterbot treats logo image as unique URL

### DIFF
--- a/src/browser-lib/seo/Seo.tsx
+++ b/src/browser-lib/seo/Seo.tsx
@@ -25,7 +25,7 @@ export type SeoProps = {
 const Seo: FC<SeoProps> = ({
   title,
   description,
-  imageUrl = `${config.get("appUrl")}${config.get("appSocialSharingImg")}`,
+  imageUrl = `${config.get("appUrl")}${config.get("appSocialSharingImg")}?2022`,
   noIndex = false,
   noFollow = false,
   canonicalURL,


### PR DESCRIPTION
## Description

Twitter using old cached image

- add ?2022 to end of URL to force twitter bot to recognise app logo as new image

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
