### PR TITLE
style(menu): about us arrow

### DIFF
--- a/src/components/MenuLinks/MenuLinks.tsx
+++ b/src/components/MenuLinks/MenuLinks.tsx
@@ -21,6 +21,7 @@ const isSubPath = ({
 const MenuListItem: FC<MenuListItemProps> = (props) => {
   const {
     href,
+    activeLinkSubPath,
     linkText,
     fontFamily,
     fontSize,
@@ -30,6 +31,8 @@ const MenuListItem: FC<MenuListItemProps> = (props) => {
     onClick,
     target,
   } = props;
+
+  const subPathHref = activeLinkSubPath || href;
 
   return (
     <li>
@@ -42,6 +45,7 @@ const MenuListItem: FC<MenuListItemProps> = (props) => {
           currentPath,
           href,
           arrowSize,
+          activeLinkSubPath,
           $mr: (fontSize[0] / 2) as PixelSpacing,
         })}
         <P
@@ -49,9 +53,9 @@ const MenuListItem: FC<MenuListItemProps> = (props) => {
           $fontSize={fontSize}
           $mt={0}
           $textDecoration={
-            isSubPath({ href, currentPath }) ? "underline" : "none"
+            isSubPath({ href: subPathHref, currentPath }) ? "underline" : "none"
           }
-          $opacity={isSubPath({ href, currentPath }) ? 0.6 : 1}
+          $opacity={isSubPath({ href: subPathHref, currentPath }) ? 0.6 : 1}
         >
           <Link href={href}>
             <a onClick={onClick} target={target}>
@@ -67,12 +71,16 @@ const MenuListItem: FC<MenuListItemProps> = (props) => {
 const renderLocationIcon = ({
   href,
   currentPath,
+  activeLinkSubPath,
   arrowSize,
   $mr,
-}: Pick<MenuListItemProps, "href" | "currentPath" | "arrowSize"> & {
+}: Pick<
+  MenuListItemProps,
+  "href" | "currentPath" | "arrowSize" | "activeLinkSubPath"
+> & {
   $mr: PixelSpacing;
 }) => {
-  return isSubPath({ currentPath, href }) ? (
+  return isSubPath({ currentPath, href: activeLinkSubPath || href }) ? (
     <Flex $mr={$mr}>
       <Icon
         variant="minimal"

--- a/src/components/MenuLinks/types.tsx
+++ b/src/components/MenuLinks/types.tsx
@@ -7,6 +7,7 @@ export type MenuListItemProps = {
   fontFamily: OakFontName;
   fontSize: [PixelSpacing];
   href: string;
+  activeLinkSubPath?: string;
   target?: HTMLAttributeAnchorTarget;
   onClick?: () => void;
   linkText: string;

--- a/src/components/SiteHeader/SiteHeader.tsx
+++ b/src/components/SiteHeader/SiteHeader.tsx
@@ -72,6 +72,7 @@ const SiteHeader: FC = () => {
     },
     {
       href: "/about-us/who-we-are",
+      activeLinkSubPath: "/about-us",
       linkText: "About us",
       fontSize: [16],
       fontFamily: "ui",


### PR DESCRIPTION
## Description

- changes logic so that you can pass `activeLinkSubPath` to menu links, so that the active arrow icon will go in the right place for about-us

## Issue(s)

Fixes #648 

## How to test

1. Go to {cloud link}
2. Click to open the navmenu
3. You should see the active icon next to "About us"


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
