### PR TITLE
style: improve policy page spacing

### DIFF
--- a/src/pages/legal/[policyPageSlug].tsx
+++ b/src/pages/legal/[policyPageSlug].tsx
@@ -27,16 +27,20 @@ const customPolicyComponent: PortableTextComponents = {
       </Heading>
     ),
     h3: ({ children }) => (
-      <Heading $mb={[32, 24]} $mt={[32, 64]} tag={"h3"} $fontSize={[20, 24]}>
+      <Heading $mb={[24, 32]} $mt={[32, 64]} tag={"h3"} $fontSize={[20, 24]}>
         {children}
       </Heading>
     ),
     h4: ({ children }) => (
-      <Heading $mb={[32, 24]} $mt={[32, 48]} tag={"h4"} $fontSize={[16, 20]}>
+      <Heading $mb={[24, 32]} $mt={[32, 48]} tag={"h4"} $fontSize={[16, 20]}>
         {children}
       </Heading>
     ),
-    normal: ({ children }) => <P $mb={[32, 32]}>{children}</P>,
+    normal: ({ children }) => (
+      <P $fontSize={[16, 18]} $mb={[24]}>
+        {children}
+      </P>
+    ),
   },
 };
 
@@ -52,7 +56,7 @@ const Policies: NextPage<PolicyPageProps> = ({ policy, isPreviewMode }) => {
           <GridArea $colSpan={[12, 12, 12]}>
             {/* change flex justify center to textAlign when PR fix is in */}
             <Flex $alignItems={"center"}>
-              <Heading $mv={48} $fontSize={40} tag={"h1"}>
+              <Heading $mt={80} $mb={32} $fontSize={40} tag={"h1"}>
                 {policy.title}
               </Heading>
             </Flex>


### PR DESCRIPTION
## Description

- Adjusting spacing on policy slug page
- Adjusting font size on p / bullet points

## Issue(s)

When a policy page body starts with a heading there is a large margin between the page heading and the page title. This will be an issue if we continue to in-force the spacing rules around these pages. Verity is investigating changing copy and removing these headings.  

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
