### PR TITLE
fix: add outline around content of button to prevent gaps

### DIFF
--- a/src/components/Button/ButtonAsLink.tsx
+++ b/src/components/Button/ButtonAsLink.tsx
@@ -16,7 +16,6 @@ import {
 
 const StyledA = styled.a<ButtonStylesProps>`
   ${buttonStyles}
-  outline: ${(props) => `solid ${props.background} 2px`};
   ${({ disabled }) =>
     disabled === true &&
     `

--- a/src/components/SpriteSheet/BrushSvgs/ButtonBorders/ButtonBorders.tsx
+++ b/src/components/SpriteSheet/BrushSvgs/ButtonBorders/ButtonBorders.tsx
@@ -70,31 +70,31 @@ const buttonBorderTop = css`
   ${buttonBorder}
   height: ${TOP_THICKNESS}px;
   left: 0;
-  bottom: 100%;
+  bottom: calc(100% - 1px);
 `;
 
 const buttonBorderRight = css`
   ${buttonBorder}
   width: ${RIGHT_THICKNESS}px;
-  top: -${TOP_THICKNESS}px;
-  left: 100%;
-  height: calc(100% + ${TOP_THICKNESS + BOTTOM_THICKNESS}px);
+  top: -${TOP_THICKNESS - 1}px;
+  left: calc(100% - 1px);
+  height: calc(100% - 2px + ${TOP_THICKNESS + BOTTOM_THICKNESS}px);
 `;
 
 const buttonBorderBottom = css`
   ${buttonBorder}
   height: ${BOTTOM_THICKNESS}px;
   height: 6px;
-  top: 100%;
+  top: calc(100% - 1px);
   left: 0;
 `;
 
 const buttonBorderLeft = css`
   ${buttonBorder}
   width: ${LEFT_THICKNESS}px;
-  top: -${TOP_THICKNESS}px;
-  right: 100%;
-  height: calc(100% + ${TOP_THICKNESS + BOTTOM_THICKNESS}px);
+  top: -${TOP_THICKNESS - 1}px;
+  right: calc(100% - 1px);
+  height: calc(100% - 2px + ${TOP_THICKNESS + BOTTOM_THICKNESS}px);
 `;
 
 const ButtonBorderTop = styled(Svg)`


### PR DESCRIPTION
## Description

- Bring borders in by 1px on all sides to hide any pixel rounding gaps

## Issue(s)

Fixes #567 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
