### PR TITLE
style: card link with icon hover styles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ src/node-lib/sanity-graphql/generated
 .next
 next-env.d.ts
 out
+storybook-static
 
 # Test coverage
 coverage

--- a/src/components/Card/CardLink.tsx
+++ b/src/components/Card/CardLink.tsx
@@ -5,21 +5,26 @@ import {
   ReactNode,
 } from "react";
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { zIndexMap } from "../../styles/utils/zIndex";
+import { DROP_SHADOW } from "../../styles/utils/dropShadow";
 
+type HoverStyles = ("underline-link-text" | "drop-shadow")[];
 /**
  * 'CardLinkProps' is the combination of AnchorElement props and Next's Link
  * props. We use the href prop from next/link so omit it from Anchor props
  */
-export type CardLinkProps = { children: ReactNode } & Omit<
+export type CardLinkProps = {
+  children: ReactNode;
+  hoverStyles?: HoverStyles;
+} & Omit<
   DetailedHTMLProps<InputHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   "href" | "ref"
 > &
   Omit<NextLinkProps, "as" | "passHref" | "children">;
 
-const CardLinkA = styled.a`
+const CardLinkA = styled.a<{ hoverStyles: HoverStyles }>`
   ::after {
     content: "";
     position: absolute;
@@ -29,14 +34,40 @@ const CardLinkA = styled.a`
     left: 0;
     z-index: ${zIndexMap.inFront};
   }
+
+  :hover {
+    ${(props) =>
+      props.hoverStyles.includes("underline-link-text") &&
+      css`
+        text-decoration: underline;
+      `}
+
+    ${(props) =>
+      props.hoverStyles.includes("drop-shadow") &&
+      css`
+        ::after {
+          box-shadow: ${DROP_SHADOW.interactiveCardHover};
+        }
+      `}
+  }
 `;
+
 /**
  * A convenience component to use in a Card component which makes the card
  * clickable as a link.
  */
 const CardLink = forwardRef<HTMLAnchorElement, CardLinkProps>(
   (
-    { href, prefetch, replace, scroll, shallow, locale, ...cardLinkProps },
+    {
+      href,
+      prefetch,
+      replace,
+      scroll,
+      shallow,
+      locale,
+      hoverStyles = [],
+      ...cardLinkProps
+    },
     ref
   ) => {
     return (
@@ -48,7 +79,7 @@ const CardLink = forwardRef<HTMLAnchorElement, CardLinkProps>(
         locale={locale}
         passHref
       >
-        <CardLinkA ref={ref} {...cardLinkProps} />
+        <CardLinkA ref={ref} hoverStyles={hoverStyles} {...cardLinkProps} />
       </NextLink>
     );
   }

--- a/src/components/Card/CardLinkIcon.tsx
+++ b/src/components/Card/CardLinkIcon.tsx
@@ -36,7 +36,11 @@ const CardLinkIcon: FC<CardLinkIconProps> = ({
     >
       <BoxBorders />
       <Heading $fontSize={[20, 24]} tag={titleTag} $color={"black"}>
-        <CardLink href={href} {...cardLinkProps}>
+        <CardLink
+          href={href}
+          hoverStyles={["underline-link-text", "drop-shadow"]}
+          {...cardLinkProps}
+        >
           {title}
         </CardLink>
       </Heading>

--- a/src/styles/utils/dropShadow.ts
+++ b/src/styles/utils/dropShadow.ts
@@ -2,20 +2,21 @@ import { css } from "styled-components";
 
 import responsive from "./responsive";
 
-type DropShadowVariant = "grey20" | "notificationCard";
+type DropShadowVariant = "grey20" | "notificationCard" | "interactiveCardHover";
 export type DropShadowProps = {
   $dropShadow?: DropShadowVariant;
 };
-const dropShadowMap: Record<DropShadowVariant, string> = {
+export const DROP_SHADOW: Record<DropShadowVariant, string> = {
   grey20: "0 8px 8px rgba(92, 92, 92, 20%)",
   notificationCard: "0px 4px 16px rgba(84, 84, 84, 0.3)",
+  interactiveCardHover: "3px 3px 8px rgba(0, 0, 0, 70%)",
 };
 const parseDropShadow = (variant?: DropShadowVariant | null) => {
   if (!variant) {
     return;
   }
 
-  return dropShadowMap[variant];
+  return DROP_SHADOW[variant];
 };
 const dropShadow = css`
   ${responsive<DropShadowProps, DropShadowVariant>(


### PR DESCRIPTION
## Description

- adds styles hover styles for the home page "card links with icons"

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Hover on the "Plan a lesson" and "Develop your curriculum" button
3. You should see hover styles as below

## Screenshots

![image](https://user-images.githubusercontent.com/12934669/189112528-ee5c2a50-1563-450c-8a98-f40cebdbb723.png)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
