### PR TITLE
chore: exclude webinar pages from sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -26,6 +26,9 @@ module.exports = {
     // Don't add beta pages to the sitemap for now.
     "/beta",
     "/beta/*",
+    // Exclude WIP webinar pages
+    "/webinars",
+    "/webinars/*",
     // Don't list the file that generates the sitemaps for the dynamic pages.
     "/server-sitemap-index.xml",
   ],

--- a/src/pages/webinars/[webinarSlug].tsx
+++ b/src/pages/webinars/[webinarSlug].tsx
@@ -14,6 +14,10 @@ export type WebinarPageProps = {
   webinar: SerializedWebinar;
 };
 
+/**
+ * @TODO: Remove /webinars/* from next-sitemap.config.js when built
+ */
+
 const WebinarDetailPage: NextPage<WebinarPageProps> = (props) => {
   return (
     <Layout seoProps={getSeoProps(props.webinar.seo)} $background="grey1">

--- a/src/pages/webinars/index.tsx
+++ b/src/pages/webinars/index.tsx
@@ -16,6 +16,10 @@ export type WebinarListingPageProps = {
   webinars: SerializedWebinarPreview[];
 };
 
+/**
+ * @TODO: Remove /webinars/* from next-sitemap.config.js when built
+ */
+
 const WebinarListingPage: NextPage<WebinarListingPageProps> = (props) => {
   const webinars = props.webinars.map(webinarToBlogListItem);
 


### PR DESCRIPTION
## Description
Add `/webinars` and `/webinars/[slug]` to the sitemap exclusions list pending the templates being completed

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
