### PR TITLE
Add VSCode debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
         "uriFormat": "%s",
         "action": "debugWithChrome"
       }
-    }
+    },
     {
       "name": "OWA: debug client-side",
       "type": "chrome",
@@ -23,6 +23,6 @@
       "type": "node-terminal",
       "request": "launch",
       "command": "npm run dev"
-    },
+    }
   ]
 }


### PR DESCRIPTION
Add VSCode debug config to enable starting debuggers easily from inside Code's UI

https://nextjs.org/docs/advanced-features/debugging

We should still have a session on using the debugger, but this will make it easier to get started.
