### PR TITLE
fix: lesson planning links same tab

### DIFF
--- a/src/common-lib/urls/index.ts
+++ b/src/common-lib/urls/index.ts
@@ -31,7 +31,7 @@ export const isOakPage = (page: MaybeOakPageName): page is OakPageName => {
   return Object.keys(OAK_PAGES).includes(page);
 };
 export const isExternalHref = (href: MaybeOakHref) => {
-  return !href.startsWith("/");
+  return !href.startsWith("/") && !href.startsWith("#");
 };
 
 export type ResolveOakHrefProps =


### PR DESCRIPTION
## Description

- lesson planning links don't open in new tab (and any `#` links)

## How to test

Lesson planning links should stay in same tab when clikced
