### PR TITLE
fix: z index box border index bug

### DIFF
--- a/src/components/BlogList/BlogListItem/BlogListItem.tsx
+++ b/src/components/BlogList/BlogListItem/BlogListItem.tsx
@@ -68,7 +68,7 @@ const BlogListItem: FC<BlogListItemProps> = (props) => {
     >
       {withImage && mainImage && (
         <Box $position={"relative"} $minWidth={240} $mr={[0, 32]} $mb={[32, 0]}>
-          <BoxBorders gapPosition="bottomRight" />
+          <BoxBorders zIndex={"inFront"} gapPosition="bottomRight" />
           <Box $ma={1}>
             <AspectRatio ratio={"3:2"}>
               <CMSImage

--- a/src/components/SpriteSheet/BrushSvgs/BoxBorders/BoxBorders.tsx
+++ b/src/components/SpriteSheet/BrushSvgs/BoxBorders/BoxBorders.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 
+import { ZIndex } from "../../../../styles/utils/zIndex";
 import Box from "../../../Box";
 import Svg from "../../../Svg";
 
@@ -12,6 +13,7 @@ export type GapPosition = keyof typeof gapPositionMap;
 
 export type BoxBordersProps = {
   gapPosition?: GapPosition;
+  zIndex?: ZIndex;
 };
 
 const Top: FC = (props) => {
@@ -110,7 +112,7 @@ const BoxBorders: FC<BoxBordersProps> = (props) => {
   return (
     <Box
       $cover
-      $zIndex="inFront"
+      $zIndex={props.zIndex ?? "neutral"}
       aria-hidden="true"
       data-testid="brush-borders"
     >


### PR DESCRIPTION
## Description

- Adds optional z index prop or default to neutral 

## Issue(s)

Fixes #793 #794 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
