### PR TITLE
Move the default domain redirect to an edge function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,20 +9,6 @@
   [[context.production.plugins]]
     package = "./netlify/plugins/slack-reporting"
 
-# Force all access through a managed TLD.
-[[redirects]]
-from = 'http://oak-web-application.netlify.app/*'
-to = 'https://owa.thenational.academy/:splat'
-status = 302
-force = true
-
-# Force all access through a managed TLD.
-[[redirects]]
-from = 'https://oak-web-application.netlify.app/*'
-to = 'https://owa.thenational.academy/:splat'
-status = 302
-force = true
-
 # On preview and branch deploys, use the subdomain redirect edge function
 # to force all access through our managed TLD.
 [[context.deploy-preview.edge_functions]]
@@ -31,3 +17,9 @@ force = true
 [[context.branch-deploy.edge_functions]]
   path = '/*'
   function = 'subdomain-redirect'
+
+# Force production access to the default netlify deployment through
+# our subdomain, unless it's from our load balancer.
+[[context.production.edge_functions]]
+  path = '/*'
+  function = 'production-redirect'

--- a/netlify/edge-functions/production-redirect.ts
+++ b/netlify/edge-functions/production-redirect.ts
@@ -1,0 +1,47 @@
+// import type { Context } from "https://edge.netlify.com";
+
+/**
+ * Given a request at the Netlify edge to the default domain,
+ * check if it comes from a Cloudflare load balancer. If so,
+ * let it through, else redirect the user to a Cloudflare
+ * controlled canonical domain for the deployment.
+ *
+ * Note: this function is interpreted in a deno environment.
+ */
+async function redirectNetlifySubdomains(
+  request: Request
+  // context: Context
+): Promise<Response | undefined> {
+  const requestUrl = request?.url;
+  console.log(`Request URL: ${requestUrl}`);
+
+  const isRequestToDefaultDomain = requestUrl.startsWith(
+    "https://oak-web-application.netlify.app"
+  );
+
+  // Request isn't to the default domain, ignore it.
+  if (!isRequestToDefaultDomain) {
+    console.log("Not default domain, ignoring");
+    return;
+  }
+
+  const isFromCloudflare = false;
+  // Determine if the request is coming from the proxying Cloudflare worker.
+  // redirected = request.headers.get("x-cloudflare-redirect") || false;
+  // Hopefully there are some `cf-something` headers that indicate the
+  // request came from Cloudflare.
+  console.log("headers", new Map(request.headers));
+
+  // The request is from Cloudflare, ignore it.
+  if (isFromCloudflare) {
+    console.log("Allowing Cloudflare");
+    return;
+  }
+
+  // The request is to the default domain and is not from Cloudflare,
+  // redirect to the canonical domain.
+  console.log("redirecting");
+  return await Response.redirect("https://owa.thenational.academy");
+}
+
+export default redirectNetlifySubdomains;


### PR DESCRIPTION
We want to allow access to the Netlify default domain for OWA if the request is coming from Cloudflare (so we can use it as an origin in a load balancer).

If the traffic doesn't come from Cloudflare we want to redirect the request to a canonical domain. For now this is `owa.` , once Netlify becomes the production hosting service the canonical domain will need changing to `www.`.

Unfortunately need to merge in order to test.