### PR TITLE
fix: use icon and not icon button inner in toast

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -75,10 +75,10 @@ const Toast: FC = () => {
           <Flex $alignItems={"center"}>
             <Icon
               name="Tick"
-              size={32}
+              size={36}
               variant={"brush"}
-              $background={"teachersHighlight"}
-              $color={"white"}
+              $background={"white"}
+              $color={"pupilsHighlight"}
             />
             <Typography $color={"black"} $font={"heading-7"} $ml={16}>
               {message}


### PR DESCRIPTION
## Description

- Fixes ugly underline over icon in toast


Fixes https://github.com/oaknational/Oak-Web-Application/issues/864


## How to test

1. Go to a blog post
2. Click on copy button
3. You should see tick in toast looks good

## Screenshots
<img width="1440" alt="Screenshot 2022-10-10 at 09 07 41" src="https://user-images.githubusercontent.com/2959739/194840366-8ffe43e2-892f-4047-810e-32adbdb36b4b.png">

<img width="1440" alt="Screenshot 2022-10-10 at 10 54 02" src="https://user-images.githubusercontent.com/2959739/194840461-7844e31b-ea6f-4027-ba60-a200f9c4a2da.png">


How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
