### PR TITLE
Trigger ci

### DIFF
--- a/src/browser-lib/hubspot/hubspot.ts
+++ b/src/browser-lib/hubspot/hubspot.ts
@@ -1,5 +1,6 @@
 /**
  * @todo use hubspot "doNotTrack" option:
+ *
  * https://developers.hubspot.com/docs/api/events/cookie-banner
  */
 


### PR DESCRIPTION
I broke the Percy run against `main` by switching it to the default domain for the site, but not updating the traffic management security rules to allow GitHub CI processes access on that domain. I have updated the access rules. This PR is purely to trigger the creation of a new release and therefore a new build, in order to establish a non-broken baseline for Percy diffs.