### PR TITLE
fix: blocks not centred on landing page

### DIFF
--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -56,6 +56,7 @@ const relativeUrls = [
   "/blog/evolution-of-oak",
   "/blog/join-the-childrens-mental-health-week-assembly-2022",
   "/legal/accessibility-statement",
+  "/lp/download-our-lesson-and-resource-directory",
   // Ignore beta pages for now.
   // "/beta/lessons/physics-only-review-chj3cd/",
   // "/beta/sign-in",

--- a/percy.snapshot.list.js
+++ b/percy.snapshot.list.js
@@ -21,6 +21,7 @@ const snapshotRelativeUrls = [
   "/blog/evolution-of-oak",
   "/blog/join-the-childrens-mental-health-week-assembly-2022",
   "/legal/accessibility-statement",
+  "/lp/download-our-lesson-and-resource-directory",
 ];
 
 const urls = snapshotRelativeUrls.map((relUrl) => {

--- a/src/components/pages/LandingPages/LandingPageHero.tsx
+++ b/src/components/pages/LandingPages/LandingPageHero.tsx
@@ -15,9 +15,9 @@ export type LandingPageHeroProps = Pick<LandingPage, "hero">;
 const LandingPageHero: FC<LandingPageHeroProps> = (props) => {
   return (
     <Flex $flexDirection={["column", "row"]} $mt={[92]}>
-      <Flex $width={"100%"}>
+      <Flex $justifyContent={"center"} $width={"100%"}>
         <LandingPageTitle
-          image={props.hero.image ? true : false}
+          leftAlign={props.hero.image ? true : false}
           heading={props.hero.heading}
           title={props.hero.title}
           cta={props.hero.cta}

--- a/src/components/pages/LandingPages/LandingPageTitle.tsx
+++ b/src/components/pages/LandingPages/LandingPageTitle.tsx
@@ -10,14 +10,14 @@ export const LandingPageTitle: FC<{
   title: string;
   heading?: string | null;
   cta?: CTA | null;
-  image?: boolean;
-}> = ({ cta, heading, title, image }) => {
+  leftAlign?: boolean;
+}> = ({ cta, heading, title, leftAlign }) => {
   return (
     <Flex
       $maxWidth={840}
       $mb={[92]}
       $flexDirection={"column"}
-      $alignItems={["flex-start", image ? "flex-start" : "center"]}
+      $alignItems={["flex-start", leftAlign ? "flex-start" : "center"]}
       $ph={16}
     >
       <Heading
@@ -33,7 +33,7 @@ export const LandingPageTitle: FC<{
           $font={["heading-4", "heading-5"]}
           $mv={[0]}
           tag="h2"
-          $textAlign={["left", image ? "start" : "center"]}
+          $textAlign={["left", leftAlign ? "start" : "center"]}
         >
           {heading}
         </Heading>

--- a/src/components/pages/LandingPages/Quote.tsx
+++ b/src/components/pages/LandingPages/Quote.tsx
@@ -14,6 +14,7 @@ export const Quote: FC<QuoteSchema> = ({ text, attribution }) => {
       $mb={[56, 92]}
       $ph={[16]}
       $maxWidth={[720]}
+      $ma={"auto"}
     >
       <Blockquote $mb={[16]} $font={"heading-4"} $textAlign={"center"}>
         &ldquo;{text}&rdquo;


### PR DESCRIPTION
## Description

- Center blocks on landing page

## Issue(s)

Fixes #901

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
