### PR TITLE
fix(about-us): centering issues

### DIFF
--- a/src/pages/about-us/board.tsx
+++ b/src/pages/about-us/board.tsx
@@ -113,7 +113,13 @@ const AboutUsBoard: NextPage<AboutPageProps> = ({ pageData }) => {
             <Hr $color={"pastelTurqoise"} $mv={0} $mt={32} />
           </Typography>
         </Flex>
-        <Card $pv={0} $mv={[80, 92]} $ph={[16, 80]} $width={["100%", "70%"]}>
+        <Card
+          $mh="auto"
+          $mv={[80, 92]}
+          $ph={[16, 80]}
+          $pv={0}
+          $width={["100%", "70%"]}
+        >
           <Heading $mb={20} $font={"heading-5"} tag={"h2"}>
             Governance
           </Heading>

--- a/src/pages/about-us/partners.tsx
+++ b/src/pages/about-us/partners.tsx
@@ -79,6 +79,7 @@ const AboutUsPartners: NextPage<AboutPageProps> = ({ pageData }) => {
           iconPosition={"trailing"}
           label={"Our teachers"}
           href={"https://classroom.thenational.academy/teachers"}
+          $mh="auto"
           $mb={[80, 92]}
         />
 


### PR DESCRIPTION
## Description

- adds `$mh="auto"` to centered content

## How to test

1. Go to about/board and about/partners

## Screenshots

![image](https://user-images.githubusercontent.com/12934669/197247110-07318534-0ddf-48f6-a946-3b852da9f8c6.png)

![image](https://user-images.githubusercontent.com/12934669/197247055-5feeb687-c5c0-4ff4-aa52-b6276d5fe0f3.png)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
