### PR TITLE
fix: url for lesson and resource directory

### DIFF
--- a/percy.snapshot.list.js
+++ b/percy.snapshot.list.js
@@ -24,7 +24,7 @@ const snapshotRelativeUrls = [
   "/blog/evolution-of-oak",
   "/blog/join-the-childrens-mental-health-week-assembly-2022",
   "/legal/accessibility-statement",
-  "/lp/download-our-lesson-and-resource-directory",
+  "/lp/lesson-and-resource-directory",
 ];
 
 const urls = snapshotRelativeUrls.map((relUrl) => {


### PR DESCRIPTION
## Description

- Corrects URL in percy snap shot list

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
