### PR TITLE
fix(ISR): standardise ISR config

### DIFF
--- a/src/pages/about-us/partners.tsx
+++ b/src/pages/about-us/partners.tsx
@@ -1,8 +1,8 @@
 import { NextPage, GetStaticProps } from "next";
 import { FC } from "react";
 
-import config from "../../config/browser";
 import CMSClient from "../../node-lib/cms";
+import { decorateWithIsr } from "../../node-lib/isr";
 import { AboutPartnersPage } from "../../common-lib/cms-types";
 import Layout from "../../components/Layout";
 import MaxWidth from "../../components/MaxWidth/MaxWidth";
@@ -121,12 +121,13 @@ export const getStaticProps: GetStaticProps<AboutPageProps> = async (
     };
   }
 
-  return {
+  const results = {
     props: {
       pageData: aboutPartnersPage,
     },
-    revalidate: config.get("sanityRevalidateSeconds"),
   };
+  const resultsWithIsr = decorateWithIsr(results);
+  return resultsWithIsr;
 };
 
 export default AboutUsPartners;

--- a/src/pages/about-us/work-with-us.tsx
+++ b/src/pages/about-us/work-with-us.tsx
@@ -2,8 +2,8 @@ import { NextPage, GetStaticProps } from "next";
 import { PortableText } from "@portabletext/react";
 import { Fragment } from "react";
 
-import config from "../../config/browser";
 import CMSClient from "../../node-lib/cms";
+import { decorateWithIsr } from "../../node-lib/isr";
 import { AboutWorkWithUsPage } from "../../common-lib/cms-types";
 import Layout from "../../components/Layout";
 import MaxWidth from "../../components/MaxWidth/MaxWidth";
@@ -99,12 +99,13 @@ export const getStaticProps: GetStaticProps<AboutPageProps> = async (
     };
   }
 
-  return {
+  const results = {
     props: {
       pageData: aboutWorkWithUsPage,
     },
-    revalidate: config.get("sanityRevalidateSeconds"),
   };
+  const resultsWithIsr = decorateWithIsr(results);
+  return resultsWithIsr;
 };
 
 export default AboutUsBoard;


### PR DESCRIPTION
Have all the ISR config come from a single location.

To test: look at the build logs, none of the pages in the Nextjs build summary should be labelled as having ISR.
