### PR TITLE
feat(videos): use webp thumbnails

### DIFF
--- a/src/__tests__/pages/webinars/[webinarSlug].test.tsx
+++ b/src/__tests__/pages/webinars/[webinarSlug].test.tsx
@@ -138,7 +138,7 @@ describe("pages/webinar/[webinarSlug].tsx", () => {
           ogDescription: "NEXT_PUBLIC_SEO_APP_DESCRIPTION",
           ogUrl: "NEXT_PUBLIC_SEO_APP_URL",
           ogImage:
-            "https://image.mux.com/5678/thumbnail.png?width=1600&height=900&fit_mode=smartcrop&time=1",
+            "https://image.mux.com/5678/thumbnail.webp?width=1600&height=900&fit_mode=smartcrop&time=1",
           ogImageAlt: undefined,
           ogImageHeight: undefined,
           ogImageWidth: undefined,

--- a/src/components/VideoPlayer/getVideoThumbnail.ts
+++ b/src/components/VideoPlayer/getVideoThumbnail.ts
@@ -11,5 +11,5 @@ export const getVideoThumbnail = ({
   height = 200,
 }: GetVideoThumbnailProps) => {
   const { playbackId, thumbTime = 200 } = video;
-  return `https://image.mux.com/${playbackId}/thumbnail.png?width=${width}&height=${height}&fit_mode=smartcrop&time=${thumbTime}`;
+  return `https://image.mux.com/${playbackId}/thumbnail.webp?width=${width}&height=${height}&fit_mode=smartcrop&time=${thumbTime}`;
 };


### PR DESCRIPTION
Mux have [started supporting the webp image format for video thumnails](https://docs.mux.com/guides/video/get-images-from-a-video#get-an-image-from-a-video), it's a better image format for the web, we should use it.

To test: videos should have thumnail images, and they should be in webp format.

## Update

Looks like we would have to explicitly set the poster image in order to make it use webp over jpeg, and then we need to make sure we are requesting an image with the correct aspect ratio https://docs.mux.com/guides/video/mux-player-customize-look-and-feel#customize-the-poster-image .

Moving this to draft because it needs a bit of work, so we should schedule it properly.