### PR TITLE
feat: 0000 update npm engine version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": "8"
+        "npm": ">=8.0.0 <=9.3.1"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   },
   "engines": {
     "node": "18",
-    "npm": "8"
+    "npm": ">=8.0.0 <=9.3.1"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
## Description

updated allowed npm version in `package.json` 

there was a node js release of version 18.14.0 yesterday that requires min npm version 9.3.1
https://nodejs.org/en/download/releases/

until now we were allowing max version 8 of npm so the builds on Netlify were failing since yesterday's release (not sure why minor upgrade od node required a major upgrade of npm)

