### PR TITLE
chore: 1239 update allowed version of npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": ">=8.0.0 <=9.3.1"
+        "npm": ">=8.0.0 <10"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   },
   "engines": {
     "node": "18",
-    "npm": ">=8.0.0 <=9.3.1"
+    "npm": ">=8.0.0 <10"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
## Description

Updated allowed version of npm package to `"npm": ">=8.0.0 <10"`

## Issue(s)

Fixes #1239
