### PR TITLE
feat(video): make video playing detectable outside the shadow DOM

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -99,6 +99,10 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
 
   const PLAYING_CLASSNAME = "playing";
   const onPlay = () => {
+    // This enables the detection of whether or not a video
+    // is being played without having to look in the
+    // shadow DOM, useful for simple automated test tools
+    // and site monitoring synthetics.
     mediaElRef.current?.classList.add(PLAYING_CLASSNAME);
     videoTracking.onPlay();
   };


### PR DESCRIPTION
use a class name to make it possible to detect whether or not a video is playing, outside of the shadow DOM controlled by Mux (so that simple test tools can see it happening).