### PR TITLE
fix(downloads query): add where clause to downloads query

### DIFF
--- a/src/node-lib/curriculum-api/generated/sdk.ts
+++ b/src/node-lib/curriculum-api/generated/sdk.ts
@@ -18501,6 +18501,7 @@ export type Mv_Questions = {
   answer?: Maybe<Scalars['json']>;
   choice_images?: Maybe<Scalars['json']>;
   choices?: Maybe<Scalars['json']>;
+  display_number?: Maybe<Scalars['String']>;
   feedback_correct?: Maybe<Scalars['String']>;
   feedback_incorrect?: Maybe<Scalars['String']>;
   images?: Maybe<Scalars['json']>;
@@ -18510,6 +18511,7 @@ export type Mv_Questions = {
   lesson_title?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   required?: Maybe<Scalars['Boolean']>;
   subject_slug?: Maybe<Scalars['String']>;
@@ -18599,12 +18601,14 @@ export type Mv_Questions_Avg_Fields = {
   __typename?: 'mv_questions_avg_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "mv_questions" */
 export type Mv_Questions_Avg_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "mv_questions". All fields are combined with a logical 'AND'. */
@@ -18616,6 +18620,7 @@ export type Mv_Questions_Bool_Exp = {
   answer?: InputMaybe<Json_Comparison_Exp>;
   choice_images?: InputMaybe<Json_Comparison_Exp>;
   choices?: InputMaybe<Json_Comparison_Exp>;
+  display_number?: InputMaybe<String_Comparison_Exp>;
   feedback_correct?: InputMaybe<String_Comparison_Exp>;
   feedback_incorrect?: InputMaybe<String_Comparison_Exp>;
   images?: InputMaybe<Json_Comparison_Exp>;
@@ -18625,6 +18630,7 @@ export type Mv_Questions_Bool_Exp = {
   lesson_title?: InputMaybe<String_Comparison_Exp>;
   order?: InputMaybe<Int_Comparison_Exp>;
   points?: InputMaybe<Int_Comparison_Exp>;
+  question_id?: InputMaybe<Int_Comparison_Exp>;
   quiz_type?: InputMaybe<String_Comparison_Exp>;
   required?: InputMaybe<Boolean_Comparison_Exp>;
   subject_slug?: InputMaybe<String_Comparison_Exp>;
@@ -18639,6 +18645,7 @@ export type Mv_Questions_Bool_Exp = {
 export type Mv_Questions_Inc_Input = {
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "mv_questions" */
@@ -18647,6 +18654,7 @@ export type Mv_Questions_Insert_Input = {
   answer?: InputMaybe<Scalars['json']>;
   choice_images?: InputMaybe<Scalars['json']>;
   choices?: InputMaybe<Scalars['json']>;
+  display_number?: InputMaybe<Scalars['String']>;
   feedback_correct?: InputMaybe<Scalars['String']>;
   feedback_incorrect?: InputMaybe<Scalars['String']>;
   images?: InputMaybe<Scalars['json']>;
@@ -18656,6 +18664,7 @@ export type Mv_Questions_Insert_Input = {
   lesson_title?: InputMaybe<Scalars['String']>;
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
   quiz_type?: InputMaybe<Scalars['String']>;
   required?: InputMaybe<Scalars['Boolean']>;
   subject_slug?: InputMaybe<Scalars['String']>;
@@ -18669,6 +18678,7 @@ export type Mv_Questions_Insert_Input = {
 /** aggregate max on columns */
 export type Mv_Questions_Max_Fields = {
   __typename?: 'mv_questions_max_fields';
+  display_number?: Maybe<Scalars['String']>;
   feedback_correct?: Maybe<Scalars['String']>;
   feedback_incorrect?: Maybe<Scalars['String']>;
   key_stage_slug?: Maybe<Scalars['String']>;
@@ -18677,6 +18687,7 @@ export type Mv_Questions_Max_Fields = {
   lesson_title?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
@@ -18688,6 +18699,7 @@ export type Mv_Questions_Max_Fields = {
 
 /** order by max() on columns of table "mv_questions" */
 export type Mv_Questions_Max_Order_By = {
+  display_number?: InputMaybe<Order_By>;
   feedback_correct?: InputMaybe<Order_By>;
   feedback_incorrect?: InputMaybe<Order_By>;
   key_stage_slug?: InputMaybe<Order_By>;
@@ -18696,6 +18708,7 @@ export type Mv_Questions_Max_Order_By = {
   lesson_title?: InputMaybe<Order_By>;
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
@@ -18708,6 +18721,7 @@ export type Mv_Questions_Max_Order_By = {
 /** aggregate min on columns */
 export type Mv_Questions_Min_Fields = {
   __typename?: 'mv_questions_min_fields';
+  display_number?: Maybe<Scalars['String']>;
   feedback_correct?: Maybe<Scalars['String']>;
   feedback_incorrect?: Maybe<Scalars['String']>;
   key_stage_slug?: Maybe<Scalars['String']>;
@@ -18716,6 +18730,7 @@ export type Mv_Questions_Min_Fields = {
   lesson_title?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
@@ -18727,6 +18742,7 @@ export type Mv_Questions_Min_Fields = {
 
 /** order by min() on columns of table "mv_questions" */
 export type Mv_Questions_Min_Order_By = {
+  display_number?: InputMaybe<Order_By>;
   feedback_correct?: InputMaybe<Order_By>;
   feedback_incorrect?: InputMaybe<Order_By>;
   key_stage_slug?: InputMaybe<Order_By>;
@@ -18735,6 +18751,7 @@ export type Mv_Questions_Min_Order_By = {
   lesson_title?: InputMaybe<Order_By>;
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
@@ -18764,6 +18781,7 @@ export type Mv_Questions_Order_By = {
   answer?: InputMaybe<Order_By>;
   choice_images?: InputMaybe<Order_By>;
   choices?: InputMaybe<Order_By>;
+  display_number?: InputMaybe<Order_By>;
   feedback_correct?: InputMaybe<Order_By>;
   feedback_incorrect?: InputMaybe<Order_By>;
   images?: InputMaybe<Order_By>;
@@ -18773,6 +18791,7 @@ export type Mv_Questions_Order_By = {
   lesson_title?: InputMaybe<Order_By>;
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   required?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
@@ -18794,6 +18813,8 @@ export enum Mv_Questions_Select_Column {
   /** column name */
   Choices = 'choices',
   /** column name */
+  DisplayNumber = 'display_number',
+  /** column name */
   FeedbackCorrect = 'feedback_correct',
   /** column name */
   FeedbackIncorrect = 'feedback_incorrect',
@@ -18811,6 +18832,8 @@ export enum Mv_Questions_Select_Column {
   Order = 'order',
   /** column name */
   Points = 'points',
+  /** column name */
+  QuestionId = 'question_id',
   /** column name */
   QuizType = 'quiz_type',
   /** column name */
@@ -18835,6 +18858,7 @@ export type Mv_Questions_Set_Input = {
   answer?: InputMaybe<Scalars['json']>;
   choice_images?: InputMaybe<Scalars['json']>;
   choices?: InputMaybe<Scalars['json']>;
+  display_number?: InputMaybe<Scalars['String']>;
   feedback_correct?: InputMaybe<Scalars['String']>;
   feedback_incorrect?: InputMaybe<Scalars['String']>;
   images?: InputMaybe<Scalars['json']>;
@@ -18844,6 +18868,7 @@ export type Mv_Questions_Set_Input = {
   lesson_title?: InputMaybe<Scalars['String']>;
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
   quiz_type?: InputMaybe<Scalars['String']>;
   required?: InputMaybe<Scalars['Boolean']>;
   subject_slug?: InputMaybe<Scalars['String']>;
@@ -18859,12 +18884,14 @@ export type Mv_Questions_Stddev_Fields = {
   __typename?: 'mv_questions_stddev_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "mv_questions" */
 export type Mv_Questions_Stddev_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -18872,12 +18899,14 @@ export type Mv_Questions_Stddev_Pop_Fields = {
   __typename?: 'mv_questions_stddev_pop_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "mv_questions" */
 export type Mv_Questions_Stddev_Pop_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -18885,12 +18914,14 @@ export type Mv_Questions_Stddev_Samp_Fields = {
   __typename?: 'mv_questions_stddev_samp_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "mv_questions" */
 export type Mv_Questions_Stddev_Samp_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -18898,12 +18929,14 @@ export type Mv_Questions_Sum_Fields = {
   __typename?: 'mv_questions_sum_fields';
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "mv_questions" */
 export type Mv_Questions_Sum_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
@@ -18911,12 +18944,14 @@ export type Mv_Questions_Var_Pop_Fields = {
   __typename?: 'mv_questions_var_pop_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "mv_questions" */
 export type Mv_Questions_Var_Pop_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -18924,12 +18959,14 @@ export type Mv_Questions_Var_Samp_Fields = {
   __typename?: 'mv_questions_var_samp_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "mv_questions" */
 export type Mv_Questions_Var_Samp_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -18937,12 +18974,14 @@ export type Mv_Questions_Variance_Fields = {
   __typename?: 'mv_questions_variance_fields';
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "mv_questions" */
 export type Mv_Questions_Variance_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
 };
 
 /** columns and relationships of "mv_quizzes" */
@@ -18954,6 +18993,7 @@ export type Mv_Quizzes = {
   lesson_slug?: Maybe<Scalars['String']>;
   lesson_title?: Maybe<Scalars['String']>;
   max_points?: Maybe<Scalars['Int']>;
+  question_count?: Maybe<Scalars['bigint']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
@@ -19016,11 +19056,13 @@ export type Mv_Quizzes_Arr_Rel_Insert_Input = {
 export type Mv_Quizzes_Avg_Fields = {
   __typename?: 'mv_quizzes_avg_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Avg_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "mv_quizzes". All fields are combined with a logical 'AND'. */
@@ -19034,6 +19076,7 @@ export type Mv_Quizzes_Bool_Exp = {
   lesson_slug?: InputMaybe<String_Comparison_Exp>;
   lesson_title?: InputMaybe<String_Comparison_Exp>;
   max_points?: InputMaybe<Int_Comparison_Exp>;
+  question_count?: InputMaybe<Bigint_Comparison_Exp>;
   subject_slug?: InputMaybe<String_Comparison_Exp>;
   subject_title?: InputMaybe<String_Comparison_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
@@ -19045,6 +19088,7 @@ export type Mv_Quizzes_Bool_Exp = {
 /** input type for incrementing integer column in table "mv_quizzes" */
 export type Mv_Quizzes_Inc_Input = {
   max_points?: InputMaybe<Scalars['Int']>;
+  question_count?: InputMaybe<Scalars['bigint']>;
 };
 
 /** input type for inserting data into table "mv_quizzes" */
@@ -19055,6 +19099,7 @@ export type Mv_Quizzes_Insert_Input = {
   lesson_slug?: InputMaybe<Scalars['String']>;
   lesson_title?: InputMaybe<Scalars['String']>;
   max_points?: InputMaybe<Scalars['Int']>;
+  question_count?: InputMaybe<Scalars['bigint']>;
   subject_slug?: InputMaybe<Scalars['String']>;
   subject_title?: InputMaybe<Scalars['String']>;
   title?: InputMaybe<Scalars['String']>;
@@ -19072,6 +19117,7 @@ export type Mv_Quizzes_Max_Fields = {
   lesson_slug?: Maybe<Scalars['String']>;
   lesson_title?: Maybe<Scalars['String']>;
   max_points?: Maybe<Scalars['Int']>;
+  question_count?: Maybe<Scalars['bigint']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
@@ -19088,6 +19134,7 @@ export type Mv_Quizzes_Max_Order_By = {
   lesson_slug?: InputMaybe<Order_By>;
   lesson_title?: InputMaybe<Order_By>;
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -19105,6 +19152,7 @@ export type Mv_Quizzes_Min_Fields = {
   lesson_slug?: Maybe<Scalars['String']>;
   lesson_title?: Maybe<Scalars['String']>;
   max_points?: Maybe<Scalars['Int']>;
+  question_count?: Maybe<Scalars['bigint']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
@@ -19121,6 +19169,7 @@ export type Mv_Quizzes_Min_Order_By = {
   lesson_slug?: InputMaybe<Order_By>;
   lesson_title?: InputMaybe<Order_By>;
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -19151,6 +19200,7 @@ export type Mv_Quizzes_Order_By = {
   lesson_slug?: InputMaybe<Order_By>;
   lesson_title?: InputMaybe<Order_By>;
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -19174,6 +19224,8 @@ export enum Mv_Quizzes_Select_Column {
   /** column name */
   MaxPoints = 'max_points',
   /** column name */
+  QuestionCount = 'question_count',
+  /** column name */
   SubjectSlug = 'subject_slug',
   /** column name */
   SubjectTitle = 'subject_title',
@@ -19195,6 +19247,7 @@ export type Mv_Quizzes_Set_Input = {
   lesson_slug?: InputMaybe<Scalars['String']>;
   lesson_title?: InputMaybe<Scalars['String']>;
   max_points?: InputMaybe<Scalars['Int']>;
+  question_count?: InputMaybe<Scalars['bigint']>;
   subject_slug?: InputMaybe<Scalars['String']>;
   subject_title?: InputMaybe<Scalars['String']>;
   title?: InputMaybe<Scalars['String']>;
@@ -19207,77 +19260,91 @@ export type Mv_Quizzes_Set_Input = {
 export type Mv_Quizzes_Stddev_Fields = {
   __typename?: 'mv_quizzes_stddev_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Stddev_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Mv_Quizzes_Stddev_Pop_Fields = {
   __typename?: 'mv_quizzes_stddev_pop_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Stddev_Pop_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Mv_Quizzes_Stddev_Samp_Fields = {
   __typename?: 'mv_quizzes_stddev_samp_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Stddev_Samp_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Mv_Quizzes_Sum_Fields = {
   __typename?: 'mv_quizzes_sum_fields';
   max_points?: Maybe<Scalars['Int']>;
+  question_count?: Maybe<Scalars['bigint']>;
 };
 
 /** order by sum() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Sum_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
 export type Mv_Quizzes_Var_Pop_Fields = {
   __typename?: 'mv_quizzes_var_pop_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Var_Pop_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Mv_Quizzes_Var_Samp_Fields = {
   __typename?: 'mv_quizzes_var_samp_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Var_Samp_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Mv_Quizzes_Variance_Fields = {
   __typename?: 'mv_quizzes_variance_fields';
   max_points?: Maybe<Scalars['Float']>;
+  question_count?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "mv_quizzes" */
 export type Mv_Quizzes_Variance_Order_By = {
   max_points?: InputMaybe<Order_By>;
+  question_count?: InputMaybe<Order_By>;
 };
 
 /** columns and relationships of "mv_subjects" */
@@ -36321,7 +36388,9 @@ export const TeachersKeyStageSubjectUnitsDocument = gql`
     `;
 export const TeachersKeyStageSubjectUnitLessonsDownloadsDocument = gql`
     query teachersKeyStageSubjectUnitLessonsDownloads($lessonSlug: String!, $keyStageSlug: String!, $subjectSlug: String!, $unitSlug: String!) {
-  mv_downloads {
+  mv_downloads(
+    where: {slug: {_eq: $lessonSlug}, key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}}
+  ) {
     downloads
     keyStageSlug: key_stage_slug
     keyStageTitle: key_stage_title

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitsLessonsDownloads.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitsLessonsDownloads.gql
@@ -4,7 +4,14 @@ query teachersKeyStageSubjectUnitLessonsDownloads(
   $subjectSlug: String!
   $unitSlug: String!
 ) {
-  mv_downloads {
+  mv_downloads(
+    where: {
+      slug: { _eq: $lessonSlug }
+      key_stage_slug: { _eq: $keyStageSlug }
+      subject_slug: { _eq: $subjectSlug }
+      unit_slug: { _eq: $unitSlug }
+    }
+  ) {
     downloads
     keyStageSlug: key_stage_slug
     keyStageTitle: key_stage_title

--- a/src/pages/beta/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/beta/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { NextPage, GetServerSideProps, GetServerSidePropsResult } from "next";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";


### PR DESCRIPTION
## Description

- List of changes
add where clause to downloads query
## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
