### PR TITLE
chore(sentence-case): change hard-coded sentence case values

### DIFF
--- a/src/pages/beta/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/beta/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
@@ -279,7 +279,7 @@ const LessonDownloadsPage: NextPage<LessonDownloadsPageProps> = ({
               $flexDirection={["column", "row"]}
             >
               <Heading tag="h2" $font={"heading-5"} $mb={[16, 8]}>
-                Teacher resources
+                Lesson resources
               </Heading>
               <Box $ml={[0, 48]}>
                 <Button


### PR DESCRIPTION
## Description

- Key stage sentence case on Breadcrumbs
- Lesson resources -> Teacher resources on downloads page
- Intro Quiz -> Starter quiz downloads page
- Key stage sentence case changed on Units, Subject and Lesson listing pages


 #1192

## How to test

1. Go to https://deploy-preview-1425--oak-web-application.netlify.thenational.academy/beta/teachers/key-stages/ks4/subjects/maths/units/directed-numbers-fe66/lessons/subtract-directed-numbers-cgu3gc/downloads

3. Click around the site, key stage should be sentence case

## Screenshots

How it used to look (delete if n/a):

Some changes already active due to changes made on data tools

<img width="1310" alt="Screenshot 2023-03-17 at 12 39 11" src="https://user-images.githubusercontent.com/91190841/225906933-a066c0e4-01f5-4965-8600-30e19ae3c263.png">

How it should now look:


<img width="1337" alt="Screenshot 2023-03-17 at 12 36 44" src="https://user-images.githubusercontent.com/91190841/225906495-8cc85afa-44bb-48ee-affc-9071b42a98b6.png">
<img width="591" alt="Screenshot 2023-03-17 at 12 36 16" src="https://user-images.githubusercontent.com/91190841/225906498-bb2d7ba5-91d4-4988-9491-bb23e1375c76.png">
<img width="714" alt="Screenshot 2023-03-17 at 12 36 08" src="https://user-images.githubusercontent.com/91190841/225906501-5958c8a0-9756-4f4b-b0b1-55052c018b07.png">
<img width="629" alt="Screenshot 2023-03-17 at 12 35 57" src="https://user-images.githubusercontent.com/91190841/225906502-037e530d-2a2b-4366-8055-f68ade928f9e.png">


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
