### PR TITLE
chore(graph-ql query): update the mv_questions query to point at most…

### DIFF
--- a/src/node-lib/curriculum-api/generated/sdk.ts
+++ b/src/node-lib/curriculum-api/generated/sdk.ts
@@ -13679,24 +13679,40 @@ export type Mutation_Root = {
   delete_mv_key_stages?: Maybe<Mv_Key_Stages_Mutation_Response>;
   /** delete data from the table: "mv_learning_themes" */
   delete_mv_learning_themes?: Maybe<Mv_Learning_Themes_Mutation_Response>;
+  /** delete data from the table: "mv_learning_themes0000001" */
+  delete_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
   /** delete data from the table: "mv_lessons" */
   delete_mv_lessons?: Maybe<Mv_Lessons_Mutation_Response>;
   /** delete data from the table: "mv_lessons0000001" */
   delete_mv_lessons0000001?: Maybe<Mv_Lessons0000001_Mutation_Response>;
+  /** delete data from the table: "mv_lessons0000002" */
+  delete_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
+  /** delete data from the table: "mv_lessons_3" */
+  delete_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
   /** delete data from the table: "mv_programmes" */
   delete_mv_programmes?: Maybe<Mv_Programmes_Mutation_Response>;
+  /** delete data from the table: "mv_programmes_1" */
+  delete_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
   /** delete data from the table: "mv_questions" */
   delete_mv_questions?: Maybe<Mv_Questions_Mutation_Response>;
   /** delete data from the table: "mv_questions0000001" */
   delete_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
+  /** delete data from the table: "mv_questions_2" */
+  delete_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
   /** delete data from the table: "mv_quizzes" */
   delete_mv_quizzes?: Maybe<Mv_Quizzes_Mutation_Response>;
   /** delete data from the table: "mv_subjects" */
   delete_mv_subjects?: Maybe<Mv_Subjects_Mutation_Response>;
+  /** delete data from the table: "mv_subjects0000001" */
+  delete_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
   /** delete data from the table: "mv_tiers" */
   delete_mv_tiers?: Maybe<Mv_Tiers_Mutation_Response>;
   /** delete data from the table: "mv_units" */
   delete_mv_units?: Maybe<Mv_Units_Mutation_Response>;
+  /** delete data from the table: "mv_units0000001" */
+  delete_mv_units0000001?: Maybe<Mv_Units0000001_Mutation_Response>;
+  /** delete data from the table: "mv_units_2" */
+  delete_mv_units_2?: Maybe<Mv_Units_2_Mutation_Response>;
   /** delete data from the table: "paper_tiers" */
   delete_paper_tiers?: Maybe<Paper_Tiers_Mutation_Response>;
   /** delete single row from the table: "paper_tiers" */
@@ -13953,6 +13969,10 @@ export type Mutation_Root = {
   insert_mv_key_stages_one?: Maybe<Mv_Key_Stages>;
   /** insert data into the table: "mv_learning_themes" */
   insert_mv_learning_themes?: Maybe<Mv_Learning_Themes_Mutation_Response>;
+  /** insert data into the table: "mv_learning_themes0000001" */
+  insert_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
+  /** insert a single row into the table: "mv_learning_themes0000001" */
+  insert_mv_learning_themes0000001_one?: Maybe<Mv_Learning_Themes0000001>;
   /** insert a single row into the table: "mv_learning_themes" */
   insert_mv_learning_themes_one?: Maybe<Mv_Learning_Themes>;
   /** insert data into the table: "mv_lessons" */
@@ -13961,10 +13981,22 @@ export type Mutation_Root = {
   insert_mv_lessons0000001?: Maybe<Mv_Lessons0000001_Mutation_Response>;
   /** insert a single row into the table: "mv_lessons0000001" */
   insert_mv_lessons0000001_one?: Maybe<Mv_Lessons0000001>;
+  /** insert data into the table: "mv_lessons0000002" */
+  insert_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
+  /** insert a single row into the table: "mv_lessons0000002" */
+  insert_mv_lessons0000002_one?: Maybe<Mv_Lessons0000002>;
+  /** insert data into the table: "mv_lessons_3" */
+  insert_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
+  /** insert a single row into the table: "mv_lessons_3" */
+  insert_mv_lessons_3_one?: Maybe<Mv_Lessons_3>;
   /** insert a single row into the table: "mv_lessons" */
   insert_mv_lessons_one?: Maybe<Mv_Lessons>;
   /** insert data into the table: "mv_programmes" */
   insert_mv_programmes?: Maybe<Mv_Programmes_Mutation_Response>;
+  /** insert data into the table: "mv_programmes_1" */
+  insert_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
+  /** insert a single row into the table: "mv_programmes_1" */
+  insert_mv_programmes_1_one?: Maybe<Mv_Programmes_1>;
   /** insert a single row into the table: "mv_programmes" */
   insert_mv_programmes_one?: Maybe<Mv_Programmes>;
   /** insert data into the table: "mv_questions" */
@@ -13973,6 +14005,10 @@ export type Mutation_Root = {
   insert_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
   /** insert a single row into the table: "mv_questions0000001" */
   insert_mv_questions0000001_one?: Maybe<Mv_Questions0000001>;
+  /** insert data into the table: "mv_questions_2" */
+  insert_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_questions_2" */
+  insert_mv_questions_2_one?: Maybe<Mv_Questions_2>;
   /** insert a single row into the table: "mv_questions" */
   insert_mv_questions_one?: Maybe<Mv_Questions>;
   /** insert data into the table: "mv_quizzes" */
@@ -13981,6 +14017,10 @@ export type Mutation_Root = {
   insert_mv_quizzes_one?: Maybe<Mv_Quizzes>;
   /** insert data into the table: "mv_subjects" */
   insert_mv_subjects?: Maybe<Mv_Subjects_Mutation_Response>;
+  /** insert data into the table: "mv_subjects0000001" */
+  insert_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
+  /** insert a single row into the table: "mv_subjects0000001" */
+  insert_mv_subjects0000001_one?: Maybe<Mv_Subjects0000001>;
   /** insert a single row into the table: "mv_subjects" */
   insert_mv_subjects_one?: Maybe<Mv_Subjects>;
   /** insert data into the table: "mv_tiers" */
@@ -13989,6 +14029,14 @@ export type Mutation_Root = {
   insert_mv_tiers_one?: Maybe<Mv_Tiers>;
   /** insert data into the table: "mv_units" */
   insert_mv_units?: Maybe<Mv_Units_Mutation_Response>;
+  /** insert data into the table: "mv_units0000001" */
+  insert_mv_units0000001?: Maybe<Mv_Units0000001_Mutation_Response>;
+  /** insert a single row into the table: "mv_units0000001" */
+  insert_mv_units0000001_one?: Maybe<Mv_Units0000001>;
+  /** insert data into the table: "mv_units_2" */
+  insert_mv_units_2?: Maybe<Mv_Units_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_units_2" */
+  insert_mv_units_2_one?: Maybe<Mv_Units_2>;
   /** insert a single row into the table: "mv_units" */
   insert_mv_units_one?: Maybe<Mv_Units>;
   /** insert data into the table: "paper_tiers" */
@@ -14243,24 +14291,40 @@ export type Mutation_Root = {
   update_mv_key_stages?: Maybe<Mv_Key_Stages_Mutation_Response>;
   /** update data of the table: "mv_learning_themes" */
   update_mv_learning_themes?: Maybe<Mv_Learning_Themes_Mutation_Response>;
+  /** update data of the table: "mv_learning_themes0000001" */
+  update_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
   /** update data of the table: "mv_lessons" */
   update_mv_lessons?: Maybe<Mv_Lessons_Mutation_Response>;
   /** update data of the table: "mv_lessons0000001" */
   update_mv_lessons0000001?: Maybe<Mv_Lessons0000001_Mutation_Response>;
+  /** update data of the table: "mv_lessons0000002" */
+  update_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
+  /** update data of the table: "mv_lessons_3" */
+  update_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
   /** update data of the table: "mv_programmes" */
   update_mv_programmes?: Maybe<Mv_Programmes_Mutation_Response>;
+  /** update data of the table: "mv_programmes_1" */
+  update_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
   /** update data of the table: "mv_questions" */
   update_mv_questions?: Maybe<Mv_Questions_Mutation_Response>;
   /** update data of the table: "mv_questions0000001" */
   update_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
+  /** update data of the table: "mv_questions_2" */
+  update_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
   /** update data of the table: "mv_quizzes" */
   update_mv_quizzes?: Maybe<Mv_Quizzes_Mutation_Response>;
   /** update data of the table: "mv_subjects" */
   update_mv_subjects?: Maybe<Mv_Subjects_Mutation_Response>;
+  /** update data of the table: "mv_subjects0000001" */
+  update_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
   /** update data of the table: "mv_tiers" */
   update_mv_tiers?: Maybe<Mv_Tiers_Mutation_Response>;
   /** update data of the table: "mv_units" */
   update_mv_units?: Maybe<Mv_Units_Mutation_Response>;
+  /** update data of the table: "mv_units0000001" */
+  update_mv_units0000001?: Maybe<Mv_Units0000001_Mutation_Response>;
+  /** update data of the table: "mv_units_2" */
+  update_mv_units_2?: Maybe<Mv_Units_2_Mutation_Response>;
   /** update data of the table: "paper_tiers" */
   update_paper_tiers?: Maybe<Paper_Tiers_Mutation_Response>;
   /** update single row of the table: "paper_tiers" */
@@ -14787,6 +14851,12 @@ export type Mutation_RootDelete_Mv_Learning_ThemesArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Learning_Themes0000001Args = {
+  where: Mv_Learning_Themes0000001_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_LessonsArgs = {
   where: Mv_Lessons_Bool_Exp;
 };
@@ -14799,8 +14869,26 @@ export type Mutation_RootDelete_Mv_Lessons0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Lessons0000002Args = {
+  where: Mv_Lessons0000002_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Lessons_3Args = {
+  where: Mv_Lessons_3_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_ProgrammesArgs = {
   where: Mv_Programmes_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Programmes_1Args = {
+  where: Mv_Programmes_1_Bool_Exp;
 };
 
 
@@ -14817,6 +14905,12 @@ export type Mutation_RootDelete_Mv_Questions0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Questions_2Args = {
+  where: Mv_Questions_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_QuizzesArgs = {
   where: Mv_Quizzes_Bool_Exp;
 };
@@ -14829,6 +14923,12 @@ export type Mutation_RootDelete_Mv_SubjectsArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Subjects0000001Args = {
+  where: Mv_Subjects0000001_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_TiersArgs = {
   where: Mv_Tiers_Bool_Exp;
 };
@@ -14837,6 +14937,18 @@ export type Mutation_RootDelete_Mv_TiersArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Mv_UnitsArgs = {
   where: Mv_Units_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Units0000001Args = {
+  where: Mv_Units0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Units_2Args = {
+  where: Mv_Units_2_Bool_Exp;
 };
 
 
@@ -15672,6 +15784,18 @@ export type Mutation_RootInsert_Mv_Learning_ThemesArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Learning_Themes0000001Args = {
+  objects: Array<Mv_Learning_Themes0000001_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Learning_Themes0000001_OneArgs = {
+  object: Mv_Learning_Themes0000001_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Learning_Themes_OneArgs = {
   object: Mv_Learning_Themes_Insert_Input;
 };
@@ -15696,6 +15820,30 @@ export type Mutation_RootInsert_Mv_Lessons0000001_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Lessons0000002Args = {
+  objects: Array<Mv_Lessons0000002_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Lessons0000002_OneArgs = {
+  object: Mv_Lessons0000002_Insert_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Lessons_3Args = {
+  objects: Array<Mv_Lessons_3_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Lessons_3_OneArgs = {
+  object: Mv_Lessons_3_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Lessons_OneArgs = {
   object: Mv_Lessons_Insert_Input;
 };
@@ -15704,6 +15852,18 @@ export type Mutation_RootInsert_Mv_Lessons_OneArgs = {
 /** mutation root */
 export type Mutation_RootInsert_Mv_ProgrammesArgs = {
   objects: Array<Mv_Programmes_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Programmes_1Args = {
+  objects: Array<Mv_Programmes_1_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Programmes_1_OneArgs = {
+  object: Mv_Programmes_1_Insert_Input;
 };
 
 
@@ -15732,6 +15892,18 @@ export type Mutation_RootInsert_Mv_Questions0000001_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Questions_2Args = {
+  objects: Array<Mv_Questions_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Questions_2_OneArgs = {
+  object: Mv_Questions_2_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Questions_OneArgs = {
   object: Mv_Questions_Insert_Input;
 };
@@ -15756,6 +15928,18 @@ export type Mutation_RootInsert_Mv_SubjectsArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Subjects0000001Args = {
+  objects: Array<Mv_Subjects0000001_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Subjects0000001_OneArgs = {
+  object: Mv_Subjects0000001_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Subjects_OneArgs = {
   object: Mv_Subjects_Insert_Input;
 };
@@ -15776,6 +15960,30 @@ export type Mutation_RootInsert_Mv_Tiers_OneArgs = {
 /** mutation root */
 export type Mutation_RootInsert_Mv_UnitsArgs = {
   objects: Array<Mv_Units_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Units0000001Args = {
+  objects: Array<Mv_Units0000001_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Units0000001_OneArgs = {
+  object: Mv_Units0000001_Insert_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Units_2Args = {
+  objects: Array<Mv_Units_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Units_2_OneArgs = {
+  object: Mv_Units_2_Insert_Input;
 };
 
 
@@ -16731,6 +16939,14 @@ export type Mutation_RootUpdate_Mv_Learning_ThemesArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Learning_Themes0000001Args = {
+  _inc?: InputMaybe<Mv_Learning_Themes0000001_Inc_Input>;
+  _set?: InputMaybe<Mv_Learning_Themes0000001_Set_Input>;
+  where: Mv_Learning_Themes0000001_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_LessonsArgs = {
   _inc?: InputMaybe<Mv_Lessons_Inc_Input>;
   _set?: InputMaybe<Mv_Lessons_Set_Input>;
@@ -16747,10 +16963,34 @@ export type Mutation_RootUpdate_Mv_Lessons0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Lessons0000002Args = {
+  _inc?: InputMaybe<Mv_Lessons0000002_Inc_Input>;
+  _set?: InputMaybe<Mv_Lessons0000002_Set_Input>;
+  where: Mv_Lessons0000002_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Lessons_3Args = {
+  _inc?: InputMaybe<Mv_Lessons_3_Inc_Input>;
+  _set?: InputMaybe<Mv_Lessons_3_Set_Input>;
+  where: Mv_Lessons_3_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_ProgrammesArgs = {
   _inc?: InputMaybe<Mv_Programmes_Inc_Input>;
   _set?: InputMaybe<Mv_Programmes_Set_Input>;
   where: Mv_Programmes_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Programmes_1Args = {
+  _inc?: InputMaybe<Mv_Programmes_1_Inc_Input>;
+  _set?: InputMaybe<Mv_Programmes_1_Set_Input>;
+  where: Mv_Programmes_1_Bool_Exp;
 };
 
 
@@ -16771,6 +17011,14 @@ export type Mutation_RootUpdate_Mv_Questions0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Questions_2Args = {
+  _inc?: InputMaybe<Mv_Questions_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Questions_2_Set_Input>;
+  where: Mv_Questions_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_QuizzesArgs = {
   _inc?: InputMaybe<Mv_Quizzes_Inc_Input>;
   _set?: InputMaybe<Mv_Quizzes_Set_Input>;
@@ -16787,6 +17035,14 @@ export type Mutation_RootUpdate_Mv_SubjectsArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Subjects0000001Args = {
+  _inc?: InputMaybe<Mv_Subjects0000001_Inc_Input>;
+  _set?: InputMaybe<Mv_Subjects0000001_Set_Input>;
+  where: Mv_Subjects0000001_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_TiersArgs = {
   _inc?: InputMaybe<Mv_Tiers_Inc_Input>;
   _set?: InputMaybe<Mv_Tiers_Set_Input>;
@@ -16799,6 +17055,22 @@ export type Mutation_RootUpdate_Mv_UnitsArgs = {
   _inc?: InputMaybe<Mv_Units_Inc_Input>;
   _set?: InputMaybe<Mv_Units_Set_Input>;
   where: Mv_Units_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Units0000001Args = {
+  _inc?: InputMaybe<Mv_Units0000001_Inc_Input>;
+  _set?: InputMaybe<Mv_Units0000001_Set_Input>;
+  where: Mv_Units0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Units_2Args = {
+  _inc?: InputMaybe<Mv_Units_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Units_2_Set_Input>;
+  where: Mv_Units_2_Bool_Exp;
 };
 
 
@@ -17725,6 +17997,308 @@ export type Mv_Learning_Themes = {
   title?: Maybe<Scalars['String']>;
 };
 
+/** columns and relationships of "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001 = {
+  __typename?: 'mv_learning_themes0000001';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Aggregate = {
+  __typename?: 'mv_learning_themes0000001_aggregate';
+  aggregate?: Maybe<Mv_Learning_Themes0000001_Aggregate_Fields>;
+  nodes: Array<Mv_Learning_Themes0000001>;
+};
+
+/** aggregate fields of "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Aggregate_Fields = {
+  __typename?: 'mv_learning_themes0000001_aggregate_fields';
+  avg?: Maybe<Mv_Learning_Themes0000001_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Learning_Themes0000001_Max_Fields>;
+  min?: Maybe<Mv_Learning_Themes0000001_Min_Fields>;
+  stddev?: Maybe<Mv_Learning_Themes0000001_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Learning_Themes0000001_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Learning_Themes0000001_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Learning_Themes0000001_Sum_Fields>;
+  var_pop?: Maybe<Mv_Learning_Themes0000001_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Learning_Themes0000001_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Learning_Themes0000001_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Learning_Themes0000001_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Learning_Themes0000001_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Learning_Themes0000001_Max_Order_By>;
+  min?: InputMaybe<Mv_Learning_Themes0000001_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Learning_Themes0000001_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Learning_Themes0000001_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Learning_Themes0000001_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Learning_Themes0000001_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Learning_Themes0000001_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Learning_Themes0000001_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Learning_Themes0000001_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Learning_Themes0000001_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Learning_Themes0000001_Avg_Fields = {
+  __typename?: 'mv_learning_themes0000001_avg_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Avg_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_learning_themes0000001". All fields are combined with a logical 'AND'. */
+export type Mv_Learning_Themes0000001_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>>>;
+  id?: InputMaybe<Int_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  tier_name?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Inc_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Insert_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Learning_Themes0000001_Max_Fields = {
+  __typename?: 'mv_learning_themes0000001_max_fields';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Max_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Learning_Themes0000001_Min_Fields = {
+  __typename?: 'mv_learning_themes0000001_min_fields';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Min_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Mutation_Response = {
+  __typename?: 'mv_learning_themes0000001_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Learning_Themes0000001>;
+};
+
+/** input type for inserting object relation for remote table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Obj_Rel_Insert_Input = {
+  data: Mv_Learning_Themes0000001_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_learning_themes0000001" */
+export enum Mv_Learning_Themes0000001_Select_Column {
+  /** column name */
+  Id = 'id',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  TierName = 'tier_name',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title'
+}
+
+/** input type for updating data in table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Set_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Learning_Themes0000001_Stddev_Fields = {
+  __typename?: 'mv_learning_themes0000001_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Stddev_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Learning_Themes0000001_Stddev_Pop_Fields = {
+  __typename?: 'mv_learning_themes0000001_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Stddev_Pop_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Learning_Themes0000001_Stddev_Samp_Fields = {
+  __typename?: 'mv_learning_themes0000001_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Stddev_Samp_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Learning_Themes0000001_Sum_Fields = {
+  __typename?: 'mv_learning_themes0000001_sum_fields';
+  id?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Sum_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Learning_Themes0000001_Var_Pop_Fields = {
+  __typename?: 'mv_learning_themes0000001_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Var_Pop_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Learning_Themes0000001_Var_Samp_Fields = {
+  __typename?: 'mv_learning_themes0000001_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Var_Samp_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Learning_Themes0000001_Variance_Fields = {
+  __typename?: 'mv_learning_themes0000001_variance_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_learning_themes0000001" */
+export type Mv_Learning_Themes0000001_Variance_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_learning_themes" */
 export type Mv_Learning_Themes_Aggregate = {
   __typename?: 'mv_learning_themes_aggregate';
@@ -18618,6 +19192,1147 @@ export type Mv_Lessons0000001_Variance_Order_By = {
   worksheet_count?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "mv_lessons0000002" */
+export type Mv_Lessons0000002 = {
+  __typename?: 'mv_lessons0000002';
+  content_guidance?: Maybe<Scalars['String']>;
+  core_content?: Maybe<Scalars['json']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  expired?: Maybe<Scalars['Boolean']>;
+  has_copyright_material?: Maybe<Scalars['Boolean']>;
+  has_downloadable_resources?: Maybe<Scalars['Boolean']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  transcript_sentences?: Maybe<Scalars['_text']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_lessons0000002" */
+export type Mv_Lessons0000002Core_ContentArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_lessons0000002" */
+export type Mv_Lessons0000002_Aggregate = {
+  __typename?: 'mv_lessons0000002_aggregate';
+  aggregate?: Maybe<Mv_Lessons0000002_Aggregate_Fields>;
+  nodes: Array<Mv_Lessons0000002>;
+};
+
+/** aggregate fields of "mv_lessons0000002" */
+export type Mv_Lessons0000002_Aggregate_Fields = {
+  __typename?: 'mv_lessons0000002_aggregate_fields';
+  avg?: Maybe<Mv_Lessons0000002_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Lessons0000002_Max_Fields>;
+  min?: Maybe<Mv_Lessons0000002_Min_Fields>;
+  stddev?: Maybe<Mv_Lessons0000002_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Lessons0000002_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Lessons0000002_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Lessons0000002_Sum_Fields>;
+  var_pop?: Maybe<Mv_Lessons0000002_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Lessons0000002_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Lessons0000002_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_lessons0000002" */
+export type Mv_Lessons0000002_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Lessons0000002_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Lessons0000002_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Lessons0000002_Max_Order_By>;
+  min?: InputMaybe<Mv_Lessons0000002_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Lessons0000002_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Lessons0000002_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Lessons0000002_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Lessons0000002_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Lessons0000002_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Lessons0000002_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Lessons0000002_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Lessons0000002_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Lessons0000002_Avg_Fields = {
+  __typename?: 'mv_lessons0000002_avg_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Avg_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_lessons0000002". All fields are combined with a logical 'AND'. */
+export type Mv_Lessons0000002_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Lessons0000002_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Lessons0000002_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Lessons0000002_Bool_Exp>>>;
+  content_guidance?: InputMaybe<String_Comparison_Exp>;
+  core_content?: InputMaybe<Json_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  equipment_required?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  has_copyright_material?: InputMaybe<Boolean_Comparison_Exp>;
+  has_downloadable_resources?: InputMaybe<Boolean_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  position_in_unit?: InputMaybe<Int_Comparison_Exp>;
+  presentation_count?: InputMaybe<Bigint_Comparison_Exp>;
+  presentation_url?: InputMaybe<String_Comparison_Exp>;
+  quiz_count?: InputMaybe<Bigint_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  supervision_level?: InputMaybe<String_Comparison_Exp>;
+  theme_slug?: InputMaybe<String_Comparison_Exp>;
+  theme_title?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  transcript_sentences?: InputMaybe<_Text_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_title?: InputMaybe<String_Comparison_Exp>;
+  video_count?: InputMaybe<Int_Comparison_Exp>;
+  video_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  worksheet_count?: InputMaybe<Bigint_Comparison_Exp>;
+  worksheet_url?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Inc_Input = {
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Insert_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Lessons0000002_Max_Fields = {
+  __typename?: 'mv_lessons0000002_max_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Max_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Lessons0000002_Min_Fields = {
+  __typename?: 'mv_lessons0000002_min_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Min_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Mutation_Response = {
+  __typename?: 'mv_lessons0000002_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Lessons0000002>;
+};
+
+/** input type for inserting object relation for remote table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Obj_Rel_Insert_Input = {
+  data: Mv_Lessons0000002_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_lessons0000002" */
+export type Mv_Lessons0000002_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  core_content?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  has_copyright_material?: InputMaybe<Order_By>;
+  has_downloadable_resources?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  transcript_sentences?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_lessons0000002" */
+export enum Mv_Lessons0000002_Select_Column {
+  /** column name */
+  ContentGuidance = 'content_guidance',
+  /** column name */
+  CoreContent = 'core_content',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  EquipmentRequired = 'equipment_required',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasCopyrightMaterial = 'has_copyright_material',
+  /** column name */
+  HasDownloadableResources = 'has_downloadable_resources',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  PositionInUnit = 'position_in_unit',
+  /** column name */
+  PresentationCount = 'presentation_count',
+  /** column name */
+  PresentationUrl = 'presentation_url',
+  /** column name */
+  QuizCount = 'quiz_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  SupervisionLevel = 'supervision_level',
+  /** column name */
+  ThemeSlug = 'theme_slug',
+  /** column name */
+  ThemeTitle = 'theme_title',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  TranscriptSentences = 'transcript_sentences',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitTitle = 'unit_title',
+  /** column name */
+  VideoCount = 'video_count',
+  /** column name */
+  VideoMuxPlaybackId = 'video_mux_playback_id',
+  /** column name */
+  VideoWithSignLanguageMuxPlaybackId = 'video_with_sign_language_mux_playback_id',
+  /** column name */
+  WorksheetCount = 'worksheet_count',
+  /** column name */
+  WorksheetUrl = 'worksheet_url'
+}
+
+/** input type for updating data in table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Set_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Lessons0000002_Stddev_Fields = {
+  __typename?: 'mv_lessons0000002_stddev_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Stddev_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Lessons0000002_Stddev_Pop_Fields = {
+  __typename?: 'mv_lessons0000002_stddev_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Stddev_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Lessons0000002_Stddev_Samp_Fields = {
+  __typename?: 'mv_lessons0000002_stddev_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Stddev_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Lessons0000002_Sum_Fields = {
+  __typename?: 'mv_lessons0000002_sum_fields';
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  video_count?: Maybe<Scalars['Int']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Sum_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Lessons0000002_Var_Pop_Fields = {
+  __typename?: 'mv_lessons0000002_var_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Var_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Lessons0000002_Var_Samp_Fields = {
+  __typename?: 'mv_lessons0000002_var_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Var_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Lessons0000002_Variance_Fields = {
+  __typename?: 'mv_lessons0000002_variance_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_lessons0000002" */
+export type Mv_Lessons0000002_Variance_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "mv_lessons_3" */
+export type Mv_Lessons_3 = {
+  __typename?: 'mv_lessons_3';
+  content_guidance?: Maybe<Scalars['String']>;
+  core_content?: Maybe<Scalars['json']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  expired?: Maybe<Scalars['Boolean']>;
+  has_copyright_material?: Maybe<Scalars['Boolean']>;
+  has_downloadable_resources?: Maybe<Scalars['Boolean']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  transcript_sentences?: Maybe<Scalars['_text']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_lessons_3" */
+export type Mv_Lessons_3Core_ContentArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate = {
+  __typename?: 'mv_lessons_3_aggregate';
+  aggregate?: Maybe<Mv_Lessons_3_Aggregate_Fields>;
+  nodes: Array<Mv_Lessons_3>;
+};
+
+/** aggregate fields of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_Fields = {
+  __typename?: 'mv_lessons_3_aggregate_fields';
+  avg?: Maybe<Mv_Lessons_3_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Lessons_3_Max_Fields>;
+  min?: Maybe<Mv_Lessons_3_Min_Fields>;
+  stddev?: Maybe<Mv_Lessons_3_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Lessons_3_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Lessons_3_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Lessons_3_Sum_Fields>;
+  var_pop?: Maybe<Mv_Lessons_3_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Lessons_3_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Lessons_3_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Lessons_3_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Lessons_3_Max_Order_By>;
+  min?: InputMaybe<Mv_Lessons_3_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Lessons_3_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Lessons_3_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Lessons_3_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Lessons_3_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Lessons_3_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Lessons_3_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Lessons_3_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_lessons_3" */
+export type Mv_Lessons_3_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Lessons_3_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Lessons_3_Avg_Fields = {
+  __typename?: 'mv_lessons_3_avg_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Avg_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_lessons_3". All fields are combined with a logical 'AND'. */
+export type Mv_Lessons_3_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Lessons_3_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Lessons_3_Bool_Exp>>>;
+  content_guidance?: InputMaybe<String_Comparison_Exp>;
+  core_content?: InputMaybe<Json_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  equipment_required?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  has_copyright_material?: InputMaybe<Boolean_Comparison_Exp>;
+  has_downloadable_resources?: InputMaybe<Boolean_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  position_in_unit?: InputMaybe<Int_Comparison_Exp>;
+  presentation_count?: InputMaybe<Bigint_Comparison_Exp>;
+  presentation_url?: InputMaybe<String_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  quiz_count?: InputMaybe<Bigint_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  supervision_level?: InputMaybe<String_Comparison_Exp>;
+  theme_slug?: InputMaybe<String_Comparison_Exp>;
+  theme_title?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  transcript_sentences?: InputMaybe<_Text_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_title?: InputMaybe<String_Comparison_Exp>;
+  video_count?: InputMaybe<Int_Comparison_Exp>;
+  video_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  worksheet_count?: InputMaybe<Bigint_Comparison_Exp>;
+  worksheet_url?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_lessons_3" */
+export type Mv_Lessons_3_Inc_Input = {
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_lessons_3" */
+export type Mv_Lessons_3_Insert_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Lessons_3_Max_Fields = {
+  __typename?: 'mv_lessons_3_max_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Max_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Lessons_3_Min_Fields = {
+  __typename?: 'mv_lessons_3_min_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Min_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_lessons_3" */
+export type Mv_Lessons_3_Mutation_Response = {
+  __typename?: 'mv_lessons_3_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Lessons_3>;
+};
+
+/** input type for inserting object relation for remote table "mv_lessons_3" */
+export type Mv_Lessons_3_Obj_Rel_Insert_Input = {
+  data: Mv_Lessons_3_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_lessons_3" */
+export type Mv_Lessons_3_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  core_content?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  has_copyright_material?: InputMaybe<Order_By>;
+  has_downloadable_resources?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  transcript_sentences?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_lessons_3" */
+export enum Mv_Lessons_3_Select_Column {
+  /** column name */
+  ContentGuidance = 'content_guidance',
+  /** column name */
+  CoreContent = 'core_content',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  EquipmentRequired = 'equipment_required',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasCopyrightMaterial = 'has_copyright_material',
+  /** column name */
+  HasDownloadableResources = 'has_downloadable_resources',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  PositionInUnit = 'position_in_unit',
+  /** column name */
+  PresentationCount = 'presentation_count',
+  /** column name */
+  PresentationUrl = 'presentation_url',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  QuizCount = 'quiz_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  SupervisionLevel = 'supervision_level',
+  /** column name */
+  ThemeSlug = 'theme_slug',
+  /** column name */
+  ThemeTitle = 'theme_title',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  TranscriptSentences = 'transcript_sentences',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitTitle = 'unit_title',
+  /** column name */
+  VideoCount = 'video_count',
+  /** column name */
+  VideoMuxPlaybackId = 'video_mux_playback_id',
+  /** column name */
+  VideoWithSignLanguageMuxPlaybackId = 'video_with_sign_language_mux_playback_id',
+  /** column name */
+  WorksheetCount = 'worksheet_count',
+  /** column name */
+  WorksheetUrl = 'worksheet_url'
+}
+
+/** input type for updating data in table "mv_lessons_3" */
+export type Mv_Lessons_3_Set_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Lessons_3_Stddev_Fields = {
+  __typename?: 'mv_lessons_3_stddev_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Lessons_3_Stddev_Pop_Fields = {
+  __typename?: 'mv_lessons_3_stddev_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Lessons_3_Stddev_Samp_Fields = {
+  __typename?: 'mv_lessons_3_stddev_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Lessons_3_Sum_Fields = {
+  __typename?: 'mv_lessons_3_sum_fields';
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  video_count?: Maybe<Scalars['Int']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Sum_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Lessons_3_Var_Pop_Fields = {
+  __typename?: 'mv_lessons_3_var_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Var_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Lessons_3_Var_Samp_Fields = {
+  __typename?: 'mv_lessons_3_var_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Var_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Lessons_3_Variance_Fields = {
+  __typename?: 'mv_lessons_3_variance_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Variance_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_lessons" */
 export type Mv_Lessons_Aggregate = {
   __typename?: 'mv_lessons_aggregate';
@@ -19163,6 +20878,275 @@ export type Mv_Programmes = {
   subject_title?: Maybe<Scalars['String']>;
   tier_slug?: Maybe<Scalars['String']>;
   unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** columns and relationships of "mv_programmes_1" */
+export type Mv_Programmes_1 = {
+  __typename?: 'mv_programmes_1';
+  key_stage_slug?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** aggregated selection of "mv_programmes_1" */
+export type Mv_Programmes_1_Aggregate = {
+  __typename?: 'mv_programmes_1_aggregate';
+  aggregate?: Maybe<Mv_Programmes_1_Aggregate_Fields>;
+  nodes: Array<Mv_Programmes_1>;
+};
+
+/** aggregate fields of "mv_programmes_1" */
+export type Mv_Programmes_1_Aggregate_Fields = {
+  __typename?: 'mv_programmes_1_aggregate_fields';
+  avg?: Maybe<Mv_Programmes_1_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Programmes_1_Max_Fields>;
+  min?: Maybe<Mv_Programmes_1_Min_Fields>;
+  stddev?: Maybe<Mv_Programmes_1_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Programmes_1_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Programmes_1_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Programmes_1_Sum_Fields>;
+  var_pop?: Maybe<Mv_Programmes_1_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Programmes_1_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Programmes_1_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_programmes_1" */
+export type Mv_Programmes_1_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Programmes_1_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_programmes_1" */
+export type Mv_Programmes_1_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Programmes_1_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Programmes_1_Max_Order_By>;
+  min?: InputMaybe<Mv_Programmes_1_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Programmes_1_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Programmes_1_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Programmes_1_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Programmes_1_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Programmes_1_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Programmes_1_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Programmes_1_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_programmes_1" */
+export type Mv_Programmes_1_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Programmes_1_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Programmes_1_Avg_Fields = {
+  __typename?: 'mv_programmes_1_avg_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Avg_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_programmes_1". All fields are combined with a logical 'AND'. */
+export type Mv_Programmes_1_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Programmes_1_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Programmes_1_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Programmes_1_Bool_Exp>>>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_programmes_1" */
+export type Mv_Programmes_1_Inc_Input = {
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_programmes_1" */
+export type Mv_Programmes_1_Insert_Input = {
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Programmes_1_Max_Fields = {
+  __typename?: 'mv_programmes_1_max_fields';
+  key_stage_slug?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by max() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Max_Order_By = {
+  key_stage_slug?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Programmes_1_Min_Fields = {
+  __typename?: 'mv_programmes_1_min_fields';
+  key_stage_slug?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by min() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Min_Order_By = {
+  key_stage_slug?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_programmes_1" */
+export type Mv_Programmes_1_Mutation_Response = {
+  __typename?: 'mv_programmes_1_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Programmes_1>;
+};
+
+/** input type for inserting object relation for remote table "mv_programmes_1" */
+export type Mv_Programmes_1_Obj_Rel_Insert_Input = {
+  data: Mv_Programmes_1_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_programmes_1" */
+export type Mv_Programmes_1_Order_By = {
+  key_stage_slug?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_programmes_1" */
+export enum Mv_Programmes_1_Select_Column {
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  UnitCount = 'unit_count'
+}
+
+/** input type for updating data in table "mv_programmes_1" */
+export type Mv_Programmes_1_Set_Input = {
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Programmes_1_Stddev_Fields = {
+  __typename?: 'mv_programmes_1_stddev_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Stddev_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Programmes_1_Stddev_Pop_Fields = {
+  __typename?: 'mv_programmes_1_stddev_pop_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Stddev_Pop_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Programmes_1_Stddev_Samp_Fields = {
+  __typename?: 'mv_programmes_1_stddev_samp_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Stddev_Samp_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Programmes_1_Sum_Fields = {
+  __typename?: 'mv_programmes_1_sum_fields';
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Sum_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Programmes_1_Var_Pop_Fields = {
+  __typename?: 'mv_programmes_1_var_pop_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Var_Pop_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Programmes_1_Var_Samp_Fields = {
+  __typename?: 'mv_programmes_1_var_samp_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Var_Samp_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Programmes_1_Variance_Fields = {
+  __typename?: 'mv_programmes_1_variance_fields';
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_programmes_1" */
+export type Mv_Programmes_1_Variance_Order_By = {
+  unit_count?: InputMaybe<Order_By>;
 };
 
 /** aggregated selection of "mv_programmes" */
@@ -19996,6 +21980,531 @@ export type Mv_Questions0000001_Variance_Fields = {
 
 /** order by variance() on columns of table "mv_questions0000001" */
 export type Mv_Questions0000001_Variance_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2 = {
+  __typename?: 'mv_questions_2';
+  active?: Maybe<Scalars['Boolean']>;
+  answer?: Maybe<Scalars['json']>;
+  choice_images?: Maybe<Scalars['json']>;
+  choices?: Maybe<Scalars['json']>;
+  choices_combined?: Maybe<Scalars['_jsonb']>;
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  images?: Maybe<Scalars['json']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  required?: Maybe<Scalars['Boolean']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2AnswerArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2Choice_ImagesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2ChoicesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2ImagesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate = {
+  __typename?: 'mv_questions_2_aggregate';
+  aggregate?: Maybe<Mv_Questions_2_Aggregate_Fields>;
+  nodes: Array<Mv_Questions_2>;
+};
+
+/** aggregate fields of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_Fields = {
+  __typename?: 'mv_questions_2_aggregate_fields';
+  avg?: Maybe<Mv_Questions_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Questions_2_Max_Fields>;
+  min?: Maybe<Mv_Questions_2_Min_Fields>;
+  stddev?: Maybe<Mv_Questions_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Questions_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Questions_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Questions_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Questions_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Questions_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Questions_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Questions_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Questions_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Questions_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Questions_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Questions_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Questions_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Questions_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Questions_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Questions_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Questions_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_questions_2" */
+export type Mv_Questions_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Questions_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Questions_2_Avg_Fields = {
+  __typename?: 'mv_questions_2_avg_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Avg_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_questions_2". All fields are combined with a logical 'AND'. */
+export type Mv_Questions_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Questions_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Questions_2_Bool_Exp>>>;
+  active?: InputMaybe<Boolean_Comparison_Exp>;
+  answer?: InputMaybe<Json_Comparison_Exp>;
+  choice_images?: InputMaybe<Json_Comparison_Exp>;
+  choices?: InputMaybe<Json_Comparison_Exp>;
+  choices_combined?: InputMaybe<_Jsonb_Comparison_Exp>;
+  display_number?: InputMaybe<String_Comparison_Exp>;
+  feedback_correct?: InputMaybe<String_Comparison_Exp>;
+  feedback_incorrect?: InputMaybe<String_Comparison_Exp>;
+  images?: InputMaybe<Json_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_slug?: InputMaybe<String_Comparison_Exp>;
+  lesson_title?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  points?: InputMaybe<Int_Comparison_Exp>;
+  question_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_type?: InputMaybe<String_Comparison_Exp>;
+  required?: InputMaybe<Boolean_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  type?: InputMaybe<String_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_questions_2" */
+export type Mv_Questions_2_Inc_Input = {
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_questions_2" */
+export type Mv_Questions_2_Insert_Input = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  answer?: InputMaybe<Scalars['json']>;
+  choice_images?: InputMaybe<Scalars['json']>;
+  choices?: InputMaybe<Scalars['json']>;
+  choices_combined?: InputMaybe<Scalars['_jsonb']>;
+  display_number?: InputMaybe<Scalars['String']>;
+  feedback_correct?: InputMaybe<Scalars['String']>;
+  feedback_incorrect?: InputMaybe<Scalars['String']>;
+  images?: InputMaybe<Scalars['json']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_slug?: InputMaybe<Scalars['String']>;
+  lesson_title?: InputMaybe<Scalars['String']>;
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+  quiz_type?: InputMaybe<Scalars['String']>;
+  required?: InputMaybe<Scalars['Boolean']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Questions_2_Max_Fields = {
+  __typename?: 'mv_questions_2_max_fields';
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Max_Order_By = {
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Questions_2_Min_Fields = {
+  __typename?: 'mv_questions_2_min_fields';
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Min_Order_By = {
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_questions_2" */
+export type Mv_Questions_2_Mutation_Response = {
+  __typename?: 'mv_questions_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Questions_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_questions_2" */
+export type Mv_Questions_2_Obj_Rel_Insert_Input = {
+  data: Mv_Questions_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_questions_2" */
+export type Mv_Questions_2_Order_By = {
+  active?: InputMaybe<Order_By>;
+  answer?: InputMaybe<Order_By>;
+  choice_images?: InputMaybe<Order_By>;
+  choices?: InputMaybe<Order_By>;
+  choices_combined?: InputMaybe<Order_By>;
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  images?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  required?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_questions_2" */
+export enum Mv_Questions_2_Select_Column {
+  /** column name */
+  Active = 'active',
+  /** column name */
+  Answer = 'answer',
+  /** column name */
+  ChoiceImages = 'choice_images',
+  /** column name */
+  Choices = 'choices',
+  /** column name */
+  ChoicesCombined = 'choices_combined',
+  /** column name */
+  DisplayNumber = 'display_number',
+  /** column name */
+  FeedbackCorrect = 'feedback_correct',
+  /** column name */
+  FeedbackIncorrect = 'feedback_incorrect',
+  /** column name */
+  Images = 'images',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonSlug = 'lesson_slug',
+  /** column name */
+  LessonTitle = 'lesson_title',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  Points = 'points',
+  /** column name */
+  QuestionId = 'question_id',
+  /** column name */
+  QuizId = 'quiz_id',
+  /** column name */
+  QuizType = 'quiz_type',
+  /** column name */
+  Required = 'required',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  Type = 'type',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitTitle = 'unit_title'
+}
+
+/** input type for updating data in table "mv_questions_2" */
+export type Mv_Questions_2_Set_Input = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  answer?: InputMaybe<Scalars['json']>;
+  choice_images?: InputMaybe<Scalars['json']>;
+  choices?: InputMaybe<Scalars['json']>;
+  choices_combined?: InputMaybe<Scalars['_jsonb']>;
+  display_number?: InputMaybe<Scalars['String']>;
+  feedback_correct?: InputMaybe<Scalars['String']>;
+  feedback_incorrect?: InputMaybe<Scalars['String']>;
+  images?: InputMaybe<Scalars['json']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_slug?: InputMaybe<Scalars['String']>;
+  lesson_title?: InputMaybe<Scalars['String']>;
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+  quiz_type?: InputMaybe<Scalars['String']>;
+  required?: InputMaybe<Scalars['Boolean']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Questions_2_Stddev_Fields = {
+  __typename?: 'mv_questions_2_stddev_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Questions_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_questions_2_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Pop_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Questions_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_questions_2_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Samp_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Questions_2_Sum_Fields = {
+  __typename?: 'mv_questions_2_sum_fields';
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Sum_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Questions_2_Var_Pop_Fields = {
+  __typename?: 'mv_questions_2_var_pop_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Var_Pop_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Questions_2_Var_Samp_Fields = {
+  __typename?: 'mv_questions_2_var_samp_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Var_Samp_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Questions_2_Variance_Fields = {
+  __typename?: 'mv_questions_2_variance_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Variance_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
@@ -20850,6 +23359,359 @@ export type Mv_Subjects = {
   unit_count?: Maybe<Scalars['bigint']>;
 };
 
+/** columns and relationships of "mv_subjects0000001" */
+export type Mv_Subjects0000001 = {
+  __typename?: 'mv_subjects0000001';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** aggregated selection of "mv_subjects0000001" */
+export type Mv_Subjects0000001_Aggregate = {
+  __typename?: 'mv_subjects0000001_aggregate';
+  aggregate?: Maybe<Mv_Subjects0000001_Aggregate_Fields>;
+  nodes: Array<Mv_Subjects0000001>;
+};
+
+/** aggregate fields of "mv_subjects0000001" */
+export type Mv_Subjects0000001_Aggregate_Fields = {
+  __typename?: 'mv_subjects0000001_aggregate_fields';
+  avg?: Maybe<Mv_Subjects0000001_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Subjects0000001_Max_Fields>;
+  min?: Maybe<Mv_Subjects0000001_Min_Fields>;
+  stddev?: Maybe<Mv_Subjects0000001_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Subjects0000001_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Subjects0000001_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Subjects0000001_Sum_Fields>;
+  var_pop?: Maybe<Mv_Subjects0000001_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Subjects0000001_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Subjects0000001_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_subjects0000001" */
+export type Mv_Subjects0000001_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Subjects0000001_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Subjects0000001_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Subjects0000001_Max_Order_By>;
+  min?: InputMaybe<Mv_Subjects0000001_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Subjects0000001_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Subjects0000001_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Subjects0000001_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Subjects0000001_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Subjects0000001_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Subjects0000001_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Subjects0000001_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Subjects0000001_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Subjects0000001_Avg_Fields = {
+  __typename?: 'mv_subjects0000001_avg_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Avg_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_subjects0000001". All fields are combined with a logical 'AND'. */
+export type Mv_Subjects0000001_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Subjects0000001_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Subjects0000001_Bool_Exp>>>;
+  active_unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+  key_stage_short_code?: InputMaybe<String_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_count?: InputMaybe<Numeric_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  tier_count?: InputMaybe<Bigint_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Inc_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Insert_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  key_stage_short_code?: InputMaybe<Scalars['String']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  slug?: InputMaybe<Scalars['String']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Subjects0000001_Max_Fields = {
+  __typename?: 'mv_subjects0000001_max_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by max() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Max_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Subjects0000001_Min_Fields = {
+  __typename?: 'mv_subjects0000001_min_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by min() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Min_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Mutation_Response = {
+  __typename?: 'mv_subjects0000001_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Subjects0000001>;
+};
+
+/** input type for inserting object relation for remote table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Obj_Rel_Insert_Input = {
+  data: Mv_Subjects0000001_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_subjects0000001" */
+export type Mv_Subjects0000001_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_subjects0000001" */
+export enum Mv_Subjects0000001_Select_Column {
+  /** column name */
+  ActiveUnitCount = 'active_unit_count',
+  /** column name */
+  KeyStageShortCode = 'key_stage_short_code',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonCount = 'lesson_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  TierCount = 'tier_count',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitCount = 'unit_count'
+}
+
+/** input type for updating data in table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Set_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  key_stage_short_code?: InputMaybe<Scalars['String']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  slug?: InputMaybe<Scalars['String']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Subjects0000001_Stddev_Fields = {
+  __typename?: 'mv_subjects0000001_stddev_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Stddev_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Subjects0000001_Stddev_Pop_Fields = {
+  __typename?: 'mv_subjects0000001_stddev_pop_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Stddev_Pop_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Subjects0000001_Stddev_Samp_Fields = {
+  __typename?: 'mv_subjects0000001_stddev_samp_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Stddev_Samp_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Subjects0000001_Sum_Fields = {
+  __typename?: 'mv_subjects0000001_sum_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Sum_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Subjects0000001_Var_Pop_Fields = {
+  __typename?: 'mv_subjects0000001_var_pop_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Var_Pop_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Subjects0000001_Var_Samp_Fields = {
+  __typename?: 'mv_subjects0000001_var_samp_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Var_Samp_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Subjects0000001_Variance_Fields = {
+  __typename?: 'mv_subjects0000001_variance_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_subjects0000001" */
+export type Mv_Subjects0000001_Variance_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_subjects" */
 export type Mv_Subjects_Aggregate = {
   __typename?: 'mv_subjects_aggregate';
@@ -21496,6 +24358,981 @@ export type Mv_Units = {
   title?: Maybe<Scalars['String']>;
   unit_study_order?: Maybe<Scalars['Int']>;
   year?: Maybe<Scalars['String']>;
+};
+
+/** columns and relationships of "mv_units0000001" */
+export type Mv_Units0000001 = {
+  __typename?: 'mv_units0000001';
+  expired?: Maybe<Scalars['Boolean']>;
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_units0000001" */
+export type Mv_Units0000001_Aggregate = {
+  __typename?: 'mv_units0000001_aggregate';
+  aggregate?: Maybe<Mv_Units0000001_Aggregate_Fields>;
+  nodes: Array<Mv_Units0000001>;
+};
+
+/** aggregate fields of "mv_units0000001" */
+export type Mv_Units0000001_Aggregate_Fields = {
+  __typename?: 'mv_units0000001_aggregate_fields';
+  avg?: Maybe<Mv_Units0000001_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Units0000001_Max_Fields>;
+  min?: Maybe<Mv_Units0000001_Min_Fields>;
+  stddev?: Maybe<Mv_Units0000001_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Units0000001_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Units0000001_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Units0000001_Sum_Fields>;
+  var_pop?: Maybe<Mv_Units0000001_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Units0000001_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Units0000001_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_units0000001" */
+export type Mv_Units0000001_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Units0000001_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_units0000001" */
+export type Mv_Units0000001_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Units0000001_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Units0000001_Max_Order_By>;
+  min?: InputMaybe<Mv_Units0000001_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Units0000001_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Units0000001_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Units0000001_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Units0000001_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Units0000001_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Units0000001_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Units0000001_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_units0000001" */
+export type Mv_Units0000001_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Units0000001_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Units0000001_Avg_Fields = {
+  __typename?: 'mv_units0000001_avg_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Avg_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_units0000001". All fields are combined with a logical 'AND'. */
+export type Mv_Units0000001_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Units0000001_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Units0000001_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Units0000001_Bool_Exp>>>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  expired_lesson_count?: InputMaybe<Bigint_Comparison_Exp>;
+  id?: InputMaybe<Int_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_count?: InputMaybe<Bigint_Comparison_Exp>;
+  programme_of_study_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_count?: InputMaybe<Bigint_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  theme_slug?: InputMaybe<String_Comparison_Exp>;
+  theme_title?: InputMaybe<String_Comparison_Exp>;
+  tier_name?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_study_order?: InputMaybe<Int_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_units0000001" */
+export type Mv_Units0000001_Inc_Input = {
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_units0000001" */
+export type Mv_Units0000001_Insert_Input = {
+  expired?: InputMaybe<Scalars['Boolean']>;
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Units0000001_Max_Fields = {
+  __typename?: 'mv_units0000001_max_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Max_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Units0000001_Min_Fields = {
+  __typename?: 'mv_units0000001_min_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Min_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_units0000001" */
+export type Mv_Units0000001_Mutation_Response = {
+  __typename?: 'mv_units0000001_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Units0000001>;
+};
+
+/** input type for inserting object relation for remote table "mv_units0000001" */
+export type Mv_Units0000001_Obj_Rel_Insert_Input = {
+  data: Mv_Units0000001_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_units0000001" */
+export type Mv_Units0000001_Order_By = {
+  expired?: InputMaybe<Order_By>;
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_units0000001" */
+export enum Mv_Units0000001_Select_Column {
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  ExpiredLessonCount = 'expired_lesson_count',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonCount = 'lesson_count',
+  /** column name */
+  ProgrammeOfStudyId = 'programme_of_study_id',
+  /** column name */
+  QuizCount = 'quiz_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  ThemeSlug = 'theme_slug',
+  /** column name */
+  ThemeTitle = 'theme_title',
+  /** column name */
+  TierName = 'tier_name',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitStudyOrder = 'unit_study_order',
+  /** column name */
+  Year = 'year'
+}
+
+/** input type for updating data in table "mv_units0000001" */
+export type Mv_Units0000001_Set_Input = {
+  expired?: InputMaybe<Scalars['Boolean']>;
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Units0000001_Stddev_Fields = {
+  __typename?: 'mv_units0000001_stddev_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Stddev_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Units0000001_Stddev_Pop_Fields = {
+  __typename?: 'mv_units0000001_stddev_pop_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Stddev_Pop_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Units0000001_Stddev_Samp_Fields = {
+  __typename?: 'mv_units0000001_stddev_samp_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Stddev_Samp_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Units0000001_Sum_Fields = {
+  __typename?: 'mv_units0000001_sum_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Sum_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Units0000001_Var_Pop_Fields = {
+  __typename?: 'mv_units0000001_var_pop_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Var_Pop_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Units0000001_Var_Samp_Fields = {
+  __typename?: 'mv_units0000001_var_samp_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Var_Samp_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Units0000001_Variance_Fields = {
+  __typename?: 'mv_units0000001_variance_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_units0000001" */
+export type Mv_Units0000001_Variance_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "mv_units_2" */
+export type Mv_Units_2 = {
+  __typename?: 'mv_units_2';
+  expired?: Maybe<Scalars['Boolean']>;
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_units_2" */
+export type Mv_Units_2_Aggregate = {
+  __typename?: 'mv_units_2_aggregate';
+  aggregate?: Maybe<Mv_Units_2_Aggregate_Fields>;
+  nodes: Array<Mv_Units_2>;
+};
+
+/** aggregate fields of "mv_units_2" */
+export type Mv_Units_2_Aggregate_Fields = {
+  __typename?: 'mv_units_2_aggregate_fields';
+  avg?: Maybe<Mv_Units_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Units_2_Max_Fields>;
+  min?: Maybe<Mv_Units_2_Min_Fields>;
+  stddev?: Maybe<Mv_Units_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Units_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Units_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Units_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Units_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Units_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Units_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_units_2" */
+export type Mv_Units_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Units_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_units_2" */
+export type Mv_Units_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Units_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Units_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Units_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Units_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Units_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Units_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Units_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Units_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Units_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Units_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_units_2" */
+export type Mv_Units_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Units_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Units_2_Avg_Fields = {
+  __typename?: 'mv_units_2_avg_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_units_2" */
+export type Mv_Units_2_Avg_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_units_2". All fields are combined with a logical 'AND'. */
+export type Mv_Units_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Units_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Units_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Units_2_Bool_Exp>>>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  expired_lesson_count?: InputMaybe<Bigint_Comparison_Exp>;
+  id?: InputMaybe<Int_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_count?: InputMaybe<Bigint_Comparison_Exp>;
+  programme_of_study_id?: InputMaybe<Int_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  quiz_count?: InputMaybe<Bigint_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  theme_slug?: InputMaybe<String_Comparison_Exp>;
+  theme_title?: InputMaybe<String_Comparison_Exp>;
+  tier_name?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_study_order?: InputMaybe<Int_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_units_2" */
+export type Mv_Units_2_Inc_Input = {
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_units_2" */
+export type Mv_Units_2_Insert_Input = {
+  expired?: InputMaybe<Scalars['Boolean']>;
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Units_2_Max_Fields = {
+  __typename?: 'mv_units_2_max_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_units_2" */
+export type Mv_Units_2_Max_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Units_2_Min_Fields = {
+  __typename?: 'mv_units_2_min_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+  year?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_units_2" */
+export type Mv_Units_2_Min_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_units_2" */
+export type Mv_Units_2_Mutation_Response = {
+  __typename?: 'mv_units_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Units_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_units_2" */
+export type Mv_Units_2_Obj_Rel_Insert_Input = {
+  data: Mv_Units_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_units_2" */
+export type Mv_Units_2_Order_By = {
+  expired?: InputMaybe<Order_By>;
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_units_2" */
+export enum Mv_Units_2_Select_Column {
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  ExpiredLessonCount = 'expired_lesson_count',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonCount = 'lesson_count',
+  /** column name */
+  ProgrammeOfStudyId = 'programme_of_study_id',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  QuizCount = 'quiz_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  ThemeSlug = 'theme_slug',
+  /** column name */
+  ThemeTitle = 'theme_title',
+  /** column name */
+  TierName = 'tier_name',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitStudyOrder = 'unit_study_order',
+  /** column name */
+  Year = 'year'
+}
+
+/** input type for updating data in table "mv_units_2" */
+export type Mv_Units_2_Set_Input = {
+  expired?: InputMaybe<Scalars['Boolean']>;
+  expired_lesson_count?: InputMaybe<Scalars['bigint']>;
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['bigint']>;
+  programme_of_study_id?: InputMaybe<Scalars['Int']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_study_order?: InputMaybe<Scalars['Int']>;
+  year?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Units_2_Stddev_Fields = {
+  __typename?: 'mv_units_2_stddev_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_units_2" */
+export type Mv_Units_2_Stddev_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Units_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_units_2_stddev_pop_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_units_2" */
+export type Mv_Units_2_Stddev_Pop_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Units_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_units_2_stddev_samp_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_units_2" */
+export type Mv_Units_2_Stddev_Samp_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Units_2_Sum_Fields = {
+  __typename?: 'mv_units_2_sum_fields';
+  expired_lesson_count?: Maybe<Scalars['bigint']>;
+  id?: Maybe<Scalars['Int']>;
+  lesson_count?: Maybe<Scalars['bigint']>;
+  programme_of_study_id?: Maybe<Scalars['Int']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  unit_study_order?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_units_2" */
+export type Mv_Units_2_Sum_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Units_2_Var_Pop_Fields = {
+  __typename?: 'mv_units_2_var_pop_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_units_2" */
+export type Mv_Units_2_Var_Pop_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Units_2_Var_Samp_Fields = {
+  __typename?: 'mv_units_2_var_samp_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_units_2" */
+export type Mv_Units_2_Var_Samp_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Units_2_Variance_Fields = {
+  __typename?: 'mv_units_2_variance_fields';
+  expired_lesson_count?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  programme_of_study_id?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  unit_study_order?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_units_2" */
+export type Mv_Units_2_Variance_Order_By = {
+  expired_lesson_count?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  programme_of_study_id?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  unit_study_order?: InputMaybe<Order_By>;
 };
 
 /** aggregated selection of "mv_units" */
@@ -23794,6 +27631,10 @@ export type Query_Root = {
   mv_key_stages_aggregate: Mv_Key_Stages_Aggregate;
   /** fetch data from the table: "mv_learning_themes" */
   mv_learning_themes: Array<Mv_Learning_Themes>;
+  /** fetch data from the table: "mv_learning_themes0000001" */
+  mv_learning_themes0000001: Array<Mv_Learning_Themes0000001>;
+  /** fetch aggregated fields from the table: "mv_learning_themes0000001" */
+  mv_learning_themes0000001_aggregate: Mv_Learning_Themes0000001_Aggregate;
   /** fetch aggregated fields from the table: "mv_learning_themes" */
   mv_learning_themes_aggregate: Mv_Learning_Themes_Aggregate;
   /** fetch data from the table: "mv_lessons" */
@@ -23802,10 +27643,22 @@ export type Query_Root = {
   mv_lessons0000001: Array<Mv_Lessons0000001>;
   /** fetch aggregated fields from the table: "mv_lessons0000001" */
   mv_lessons0000001_aggregate: Mv_Lessons0000001_Aggregate;
+  /** fetch data from the table: "mv_lessons0000002" */
+  mv_lessons0000002: Array<Mv_Lessons0000002>;
+  /** fetch aggregated fields from the table: "mv_lessons0000002" */
+  mv_lessons0000002_aggregate: Mv_Lessons0000002_Aggregate;
+  /** fetch data from the table: "mv_lessons_3" */
+  mv_lessons_3: Array<Mv_Lessons_3>;
+  /** fetch aggregated fields from the table: "mv_lessons_3" */
+  mv_lessons_3_aggregate: Mv_Lessons_3_Aggregate;
   /** fetch aggregated fields from the table: "mv_lessons" */
   mv_lessons_aggregate: Mv_Lessons_Aggregate;
   /** fetch data from the table: "mv_programmes" */
   mv_programmes: Array<Mv_Programmes>;
+  /** fetch data from the table: "mv_programmes_1" */
+  mv_programmes_1: Array<Mv_Programmes_1>;
+  /** fetch aggregated fields from the table: "mv_programmes_1" */
+  mv_programmes_1_aggregate: Mv_Programmes_1_Aggregate;
   /** fetch aggregated fields from the table: "mv_programmes" */
   mv_programmes_aggregate: Mv_Programmes_Aggregate;
   /** fetch data from the table: "mv_questions" */
@@ -23814,6 +27667,10 @@ export type Query_Root = {
   mv_questions0000001: Array<Mv_Questions0000001>;
   /** fetch aggregated fields from the table: "mv_questions0000001" */
   mv_questions0000001_aggregate: Mv_Questions0000001_Aggregate;
+  /** fetch data from the table: "mv_questions_2" */
+  mv_questions_2: Array<Mv_Questions_2>;
+  /** fetch aggregated fields from the table: "mv_questions_2" */
+  mv_questions_2_aggregate: Mv_Questions_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_questions" */
   mv_questions_aggregate: Mv_Questions_Aggregate;
   /** fetch data from the table: "mv_quizzes" */
@@ -23822,6 +27679,10 @@ export type Query_Root = {
   mv_quizzes_aggregate: Mv_Quizzes_Aggregate;
   /** fetch data from the table: "mv_subjects" */
   mv_subjects: Array<Mv_Subjects>;
+  /** fetch data from the table: "mv_subjects0000001" */
+  mv_subjects0000001: Array<Mv_Subjects0000001>;
+  /** fetch aggregated fields from the table: "mv_subjects0000001" */
+  mv_subjects0000001_aggregate: Mv_Subjects0000001_Aggregate;
   /** fetch aggregated fields from the table: "mv_subjects" */
   mv_subjects_aggregate: Mv_Subjects_Aggregate;
   /** fetch data from the table: "mv_tiers" */
@@ -23830,6 +27691,14 @@ export type Query_Root = {
   mv_tiers_aggregate: Mv_Tiers_Aggregate;
   /** fetch data from the table: "mv_units" */
   mv_units: Array<Mv_Units>;
+  /** fetch data from the table: "mv_units0000001" */
+  mv_units0000001: Array<Mv_Units0000001>;
+  /** fetch aggregated fields from the table: "mv_units0000001" */
+  mv_units0000001_aggregate: Mv_Units0000001_Aggregate;
+  /** fetch data from the table: "mv_units_2" */
+  mv_units_2: Array<Mv_Units_2>;
+  /** fetch aggregated fields from the table: "mv_units_2" */
+  mv_units_2_aggregate: Mv_Units_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_units" */
   mv_units_aggregate: Mv_Units_Aggregate;
   /** fetch data from the table: "paper_tiers" */
@@ -24956,6 +28825,26 @@ export type Query_RootMv_Learning_ThemesArgs = {
 
 
 /** query root */
+export type Query_RootMv_Learning_Themes0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes0000001_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Learning_Themes0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes0000001_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Learning_Themes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Learning_Themes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -24996,6 +28885,46 @@ export type Query_RootMv_Lessons0000001_AggregateArgs = {
 
 
 /** query root */
+export type Query_RootMv_Lessons0000002Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons0000002_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons0000002_Order_By>>;
+  where?: InputMaybe<Mv_Lessons0000002_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Lessons0000002_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons0000002_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons0000002_Order_By>>;
+  where?: InputMaybe<Mv_Lessons0000002_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Lessons_3Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Lessons_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Lessons_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -25012,6 +28941,26 @@ export type Query_RootMv_ProgrammesArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Programmes_Order_By>>;
   where?: InputMaybe<Mv_Programmes_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Programmes_1Args = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_1_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_1_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Programmes_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_1_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_1_Bool_Exp>;
 };
 
 
@@ -25056,6 +29005,26 @@ export type Query_RootMv_Questions0000001_AggregateArgs = {
 
 
 /** query root */
+export type Query_RootMv_Questions_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Questions_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Questions_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Questions_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -25096,6 +29065,26 @@ export type Query_RootMv_SubjectsArgs = {
 
 
 /** query root */
+export type Query_RootMv_Subjects0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
+  where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Subjects0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
+  where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Subjects_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Subjects_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -25132,6 +29121,46 @@ export type Query_RootMv_UnitsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Units_Order_By>>;
   where?: InputMaybe<Mv_Units_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Units0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Units0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units0000001_Order_By>>;
+  where?: InputMaybe<Mv_Units0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Units0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Units0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units0000001_Order_By>>;
+  where?: InputMaybe<Mv_Units0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Units_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Units_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units_2_Order_By>>;
+  where?: InputMaybe<Mv_Units_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Units_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Units_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units_2_Order_By>>;
+  where?: InputMaybe<Mv_Units_2_Bool_Exp>;
 };
 
 
@@ -28311,6 +32340,10 @@ export type Subscription_Root = {
   mv_key_stages_aggregate: Mv_Key_Stages_Aggregate;
   /** fetch data from the table: "mv_learning_themes" */
   mv_learning_themes: Array<Mv_Learning_Themes>;
+  /** fetch data from the table: "mv_learning_themes0000001" */
+  mv_learning_themes0000001: Array<Mv_Learning_Themes0000001>;
+  /** fetch aggregated fields from the table: "mv_learning_themes0000001" */
+  mv_learning_themes0000001_aggregate: Mv_Learning_Themes0000001_Aggregate;
   /** fetch aggregated fields from the table: "mv_learning_themes" */
   mv_learning_themes_aggregate: Mv_Learning_Themes_Aggregate;
   /** fetch data from the table: "mv_lessons" */
@@ -28319,10 +32352,22 @@ export type Subscription_Root = {
   mv_lessons0000001: Array<Mv_Lessons0000001>;
   /** fetch aggregated fields from the table: "mv_lessons0000001" */
   mv_lessons0000001_aggregate: Mv_Lessons0000001_Aggregate;
+  /** fetch data from the table: "mv_lessons0000002" */
+  mv_lessons0000002: Array<Mv_Lessons0000002>;
+  /** fetch aggregated fields from the table: "mv_lessons0000002" */
+  mv_lessons0000002_aggregate: Mv_Lessons0000002_Aggregate;
+  /** fetch data from the table: "mv_lessons_3" */
+  mv_lessons_3: Array<Mv_Lessons_3>;
+  /** fetch aggregated fields from the table: "mv_lessons_3" */
+  mv_lessons_3_aggregate: Mv_Lessons_3_Aggregate;
   /** fetch aggregated fields from the table: "mv_lessons" */
   mv_lessons_aggregate: Mv_Lessons_Aggregate;
   /** fetch data from the table: "mv_programmes" */
   mv_programmes: Array<Mv_Programmes>;
+  /** fetch data from the table: "mv_programmes_1" */
+  mv_programmes_1: Array<Mv_Programmes_1>;
+  /** fetch aggregated fields from the table: "mv_programmes_1" */
+  mv_programmes_1_aggregate: Mv_Programmes_1_Aggregate;
   /** fetch aggregated fields from the table: "mv_programmes" */
   mv_programmes_aggregate: Mv_Programmes_Aggregate;
   /** fetch data from the table: "mv_questions" */
@@ -28331,6 +32376,10 @@ export type Subscription_Root = {
   mv_questions0000001: Array<Mv_Questions0000001>;
   /** fetch aggregated fields from the table: "mv_questions0000001" */
   mv_questions0000001_aggregate: Mv_Questions0000001_Aggregate;
+  /** fetch data from the table: "mv_questions_2" */
+  mv_questions_2: Array<Mv_Questions_2>;
+  /** fetch aggregated fields from the table: "mv_questions_2" */
+  mv_questions_2_aggregate: Mv_Questions_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_questions" */
   mv_questions_aggregate: Mv_Questions_Aggregate;
   /** fetch data from the table: "mv_quizzes" */
@@ -28339,6 +32388,10 @@ export type Subscription_Root = {
   mv_quizzes_aggregate: Mv_Quizzes_Aggregate;
   /** fetch data from the table: "mv_subjects" */
   mv_subjects: Array<Mv_Subjects>;
+  /** fetch data from the table: "mv_subjects0000001" */
+  mv_subjects0000001: Array<Mv_Subjects0000001>;
+  /** fetch aggregated fields from the table: "mv_subjects0000001" */
+  mv_subjects0000001_aggregate: Mv_Subjects0000001_Aggregate;
   /** fetch aggregated fields from the table: "mv_subjects" */
   mv_subjects_aggregate: Mv_Subjects_Aggregate;
   /** fetch data from the table: "mv_tiers" */
@@ -28347,6 +32400,14 @@ export type Subscription_Root = {
   mv_tiers_aggregate: Mv_Tiers_Aggregate;
   /** fetch data from the table: "mv_units" */
   mv_units: Array<Mv_Units>;
+  /** fetch data from the table: "mv_units0000001" */
+  mv_units0000001: Array<Mv_Units0000001>;
+  /** fetch aggregated fields from the table: "mv_units0000001" */
+  mv_units0000001_aggregate: Mv_Units0000001_Aggregate;
+  /** fetch data from the table: "mv_units_2" */
+  mv_units_2: Array<Mv_Units_2>;
+  /** fetch aggregated fields from the table: "mv_units_2" */
+  mv_units_2_aggregate: Mv_Units_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_units" */
   mv_units_aggregate: Mv_Units_Aggregate;
   /** fetch data from the table: "paper_tiers" */
@@ -29473,6 +33534,26 @@ export type Subscription_RootMv_Learning_ThemesArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Learning_Themes0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes0000001_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Learning_Themes0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes0000001_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Learning_Themes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Learning_Themes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -29513,6 +33594,46 @@ export type Subscription_RootMv_Lessons0000001_AggregateArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Lessons0000002Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons0000002_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons0000002_Order_By>>;
+  where?: InputMaybe<Mv_Lessons0000002_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Lessons0000002_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons0000002_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons0000002_Order_By>>;
+  where?: InputMaybe<Mv_Lessons0000002_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Lessons_3Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Lessons_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Lessons_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -29529,6 +33650,26 @@ export type Subscription_RootMv_ProgrammesArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Programmes_Order_By>>;
   where?: InputMaybe<Mv_Programmes_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Programmes_1Args = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_1_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_1_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Programmes_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_1_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_1_Bool_Exp>;
 };
 
 
@@ -29573,6 +33714,26 @@ export type Subscription_RootMv_Questions0000001_AggregateArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Questions_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Questions_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Questions_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Questions_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -29613,6 +33774,26 @@ export type Subscription_RootMv_SubjectsArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Subjects0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
+  where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Subjects0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
+  where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Subjects_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Subjects_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -29649,6 +33830,46 @@ export type Subscription_RootMv_UnitsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Units_Order_By>>;
   where?: InputMaybe<Mv_Units_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Units0000001Args = {
+  distinct_on?: InputMaybe<Array<Mv_Units0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units0000001_Order_By>>;
+  where?: InputMaybe<Mv_Units0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Units0000001_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Units0000001_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units0000001_Order_By>>;
+  where?: InputMaybe<Mv_Units0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Units_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Units_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units_2_Order_By>>;
+  where?: InputMaybe<Mv_Units_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Units_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Units_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Units_2_Order_By>>;
+  where?: InputMaybe<Mv_Units_2_Bool_Exp>;
 };
 
 
@@ -37951,7 +42172,7 @@ export type TeachersLessonOverviewQueryVariables = Exact<{
 }>;
 
 
-export type TeachersLessonOverviewQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons', slug?: string | null, title?: string | null, expired?: boolean | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, presentationUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, hasCopyrightMaterial?: boolean | null, coreContent?: any | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: any | null, hasDownloadableResources?: boolean | null }>, exitQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, exitQuiz: Array<{ __typename?: 'mv_questions0000001', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }>, introQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, introQuiz: Array<{ __typename?: 'mv_questions0000001', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }> };
+export type TeachersLessonOverviewQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons', slug?: string | null, title?: string | null, expired?: boolean | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, presentationUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, hasCopyrightMaterial?: boolean | null, coreContent?: any | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: any | null, hasDownloadableResources?: boolean | null }>, exitQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, exitQuiz: Array<{ __typename?: 'mv_questions_2', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }>, introQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, introQuiz: Array<{ __typename?: 'mv_questions_2', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }> };
 
 export type TeachersLessonOverviewPathsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -38166,7 +42387,7 @@ export const TeachersLessonOverviewDocument = gql`
     title
     questionCount: question_count
   }
-  exitQuiz: mv_questions0000001(
+  exitQuiz: mv_questions_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}, quiz_type: {_eq: "exit"}, lesson_slug: {_eq: $lessonSlug}}
     order_by: {order: asc}
   ) {
@@ -38198,7 +42419,7 @@ export const TeachersLessonOverviewDocument = gql`
     title
     questionCount: question_count
   }
-  introQuiz: mv_questions0000001(
+  introQuiz: mv_questions_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}, quiz_type: {_eq: "intro"}, lesson_slug: {_eq: $lessonSlug}}
     order_by: {order: asc}
   ) {

--- a/src/node-lib/curriculum-api/queries/teachersLessonOverview.gql
+++ b/src/node-lib/curriculum-api/queries/teachersLessonOverview.gql
@@ -45,7 +45,7 @@ query teachersLessonOverview(
     title
     questionCount: question_count
   }
-  exitQuiz: mv_questions0000001(
+  exitQuiz: mv_questions_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }
@@ -89,7 +89,7 @@ query teachersLessonOverview(
     title
     questionCount: question_count
   }
-  introQuiz: mv_questions0000001(
+  introQuiz: mv_questions_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }


### PR DESCRIPTION
… recent version of mv_questions

## Description

- updates the query to point at the correct version of mv_questions 

## Issue(s)

Fixes #1420 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):

![Screenshot 2023-04-05 at 14 17 00](https://user-images.githubusercontent.com/91190841/230092149-d6bfe8eb-5038-4b7e-80c4-0d1c152a0afd.png)



How it should now look:
![Screenshot 2023-04-05 at 14 12 52](https://user-images.githubusercontent.com/91190841/230091956-8153856b-b777-4e80-b317-7a30f3985c61.png)

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
