### PR TITLE
chore(gql-queries): update gql queries to filter sceince lessons from…

### DIFF
--- a/src/node-lib/curriculum-api/generated/sdk.ts
+++ b/src/node-lib/curriculum-api/generated/sdk.ts
@@ -13681,26 +13681,36 @@ export type Mutation_Root = {
   delete_mv_learning_themes?: Maybe<Mv_Learning_Themes_Mutation_Response>;
   /** delete data from the table: "mv_learning_themes0000001" */
   delete_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
+  /** delete data from the table: "mv_learning_themes_2" */
+  delete_mv_learning_themes_2?: Maybe<Mv_Learning_Themes_2_Mutation_Response>;
   /** delete data from the table: "mv_lessons" */
   delete_mv_lessons?: Maybe<Mv_Lessons_Mutation_Response>;
   /** delete data from the table: "mv_lessons0000001" */
   delete_mv_lessons0000001?: Maybe<Mv_Lessons0000001_Mutation_Response>;
   /** delete data from the table: "mv_lessons0000002" */
   delete_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
+  /** delete data from the table: "mv_lessons_3" */
+  delete_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
   /** delete data from the table: "mv_programmes" */
   delete_mv_programmes?: Maybe<Mv_Programmes_Mutation_Response>;
   /** delete data from the table: "mv_programmes_1" */
   delete_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
+  /** delete data from the table: "mv_programmes_2" */
+  delete_mv_programmes_2?: Maybe<Mv_Programmes_2_Mutation_Response>;
   /** delete data from the table: "mv_questions" */
   delete_mv_questions?: Maybe<Mv_Questions_Mutation_Response>;
   /** delete data from the table: "mv_questions0000001" */
   delete_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
+  /** delete data from the table: "mv_questions_2" */
+  delete_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
   /** delete data from the table: "mv_quizzes" */
   delete_mv_quizzes?: Maybe<Mv_Quizzes_Mutation_Response>;
   /** delete data from the table: "mv_subjects" */
   delete_mv_subjects?: Maybe<Mv_Subjects_Mutation_Response>;
   /** delete data from the table: "mv_subjects0000001" */
   delete_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
+  /** delete data from the table: "mv_subjects_2" */
+  delete_mv_subjects_2?: Maybe<Mv_Subjects_2_Mutation_Response>;
   /** delete data from the table: "mv_tiers" */
   delete_mv_tiers?: Maybe<Mv_Tiers_Mutation_Response>;
   /** delete data from the table: "mv_units" */
@@ -13969,6 +13979,10 @@ export type Mutation_Root = {
   insert_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
   /** insert a single row into the table: "mv_learning_themes0000001" */
   insert_mv_learning_themes0000001_one?: Maybe<Mv_Learning_Themes0000001>;
+  /** insert data into the table: "mv_learning_themes_2" */
+  insert_mv_learning_themes_2?: Maybe<Mv_Learning_Themes_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_learning_themes_2" */
+  insert_mv_learning_themes_2_one?: Maybe<Mv_Learning_Themes_2>;
   /** insert a single row into the table: "mv_learning_themes" */
   insert_mv_learning_themes_one?: Maybe<Mv_Learning_Themes>;
   /** insert data into the table: "mv_lessons" */
@@ -13981,6 +13995,10 @@ export type Mutation_Root = {
   insert_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
   /** insert a single row into the table: "mv_lessons0000002" */
   insert_mv_lessons0000002_one?: Maybe<Mv_Lessons0000002>;
+  /** insert data into the table: "mv_lessons_3" */
+  insert_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
+  /** insert a single row into the table: "mv_lessons_3" */
+  insert_mv_lessons_3_one?: Maybe<Mv_Lessons_3>;
   /** insert a single row into the table: "mv_lessons" */
   insert_mv_lessons_one?: Maybe<Mv_Lessons>;
   /** insert data into the table: "mv_programmes" */
@@ -13989,6 +14007,10 @@ export type Mutation_Root = {
   insert_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
   /** insert a single row into the table: "mv_programmes_1" */
   insert_mv_programmes_1_one?: Maybe<Mv_Programmes_1>;
+  /** insert data into the table: "mv_programmes_2" */
+  insert_mv_programmes_2?: Maybe<Mv_Programmes_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_programmes_2" */
+  insert_mv_programmes_2_one?: Maybe<Mv_Programmes_2>;
   /** insert a single row into the table: "mv_programmes" */
   insert_mv_programmes_one?: Maybe<Mv_Programmes>;
   /** insert data into the table: "mv_questions" */
@@ -13997,6 +14019,10 @@ export type Mutation_Root = {
   insert_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
   /** insert a single row into the table: "mv_questions0000001" */
   insert_mv_questions0000001_one?: Maybe<Mv_Questions0000001>;
+  /** insert data into the table: "mv_questions_2" */
+  insert_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_questions_2" */
+  insert_mv_questions_2_one?: Maybe<Mv_Questions_2>;
   /** insert a single row into the table: "mv_questions" */
   insert_mv_questions_one?: Maybe<Mv_Questions>;
   /** insert data into the table: "mv_quizzes" */
@@ -14009,6 +14035,10 @@ export type Mutation_Root = {
   insert_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
   /** insert a single row into the table: "mv_subjects0000001" */
   insert_mv_subjects0000001_one?: Maybe<Mv_Subjects0000001>;
+  /** insert data into the table: "mv_subjects_2" */
+  insert_mv_subjects_2?: Maybe<Mv_Subjects_2_Mutation_Response>;
+  /** insert a single row into the table: "mv_subjects_2" */
+  insert_mv_subjects_2_one?: Maybe<Mv_Subjects_2>;
   /** insert a single row into the table: "mv_subjects" */
   insert_mv_subjects_one?: Maybe<Mv_Subjects>;
   /** insert data into the table: "mv_tiers" */
@@ -14281,26 +14311,36 @@ export type Mutation_Root = {
   update_mv_learning_themes?: Maybe<Mv_Learning_Themes_Mutation_Response>;
   /** update data of the table: "mv_learning_themes0000001" */
   update_mv_learning_themes0000001?: Maybe<Mv_Learning_Themes0000001_Mutation_Response>;
+  /** update data of the table: "mv_learning_themes_2" */
+  update_mv_learning_themes_2?: Maybe<Mv_Learning_Themes_2_Mutation_Response>;
   /** update data of the table: "mv_lessons" */
   update_mv_lessons?: Maybe<Mv_Lessons_Mutation_Response>;
   /** update data of the table: "mv_lessons0000001" */
   update_mv_lessons0000001?: Maybe<Mv_Lessons0000001_Mutation_Response>;
   /** update data of the table: "mv_lessons0000002" */
   update_mv_lessons0000002?: Maybe<Mv_Lessons0000002_Mutation_Response>;
+  /** update data of the table: "mv_lessons_3" */
+  update_mv_lessons_3?: Maybe<Mv_Lessons_3_Mutation_Response>;
   /** update data of the table: "mv_programmes" */
   update_mv_programmes?: Maybe<Mv_Programmes_Mutation_Response>;
   /** update data of the table: "mv_programmes_1" */
   update_mv_programmes_1?: Maybe<Mv_Programmes_1_Mutation_Response>;
+  /** update data of the table: "mv_programmes_2" */
+  update_mv_programmes_2?: Maybe<Mv_Programmes_2_Mutation_Response>;
   /** update data of the table: "mv_questions" */
   update_mv_questions?: Maybe<Mv_Questions_Mutation_Response>;
   /** update data of the table: "mv_questions0000001" */
   update_mv_questions0000001?: Maybe<Mv_Questions0000001_Mutation_Response>;
+  /** update data of the table: "mv_questions_2" */
+  update_mv_questions_2?: Maybe<Mv_Questions_2_Mutation_Response>;
   /** update data of the table: "mv_quizzes" */
   update_mv_quizzes?: Maybe<Mv_Quizzes_Mutation_Response>;
   /** update data of the table: "mv_subjects" */
   update_mv_subjects?: Maybe<Mv_Subjects_Mutation_Response>;
   /** update data of the table: "mv_subjects0000001" */
   update_mv_subjects0000001?: Maybe<Mv_Subjects0000001_Mutation_Response>;
+  /** update data of the table: "mv_subjects_2" */
+  update_mv_subjects_2?: Maybe<Mv_Subjects_2_Mutation_Response>;
   /** update data of the table: "mv_tiers" */
   update_mv_tiers?: Maybe<Mv_Tiers_Mutation_Response>;
   /** update data of the table: "mv_units" */
@@ -14841,6 +14881,12 @@ export type Mutation_RootDelete_Mv_Learning_Themes0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Learning_Themes_2Args = {
+  where: Mv_Learning_Themes_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_LessonsArgs = {
   where: Mv_Lessons_Bool_Exp;
 };
@@ -14859,6 +14905,12 @@ export type Mutation_RootDelete_Mv_Lessons0000002Args = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Lessons_3Args = {
+  where: Mv_Lessons_3_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_ProgrammesArgs = {
   where: Mv_Programmes_Bool_Exp;
 };
@@ -14871,6 +14923,12 @@ export type Mutation_RootDelete_Mv_Programmes_1Args = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Mv_Programmes_2Args = {
+  where: Mv_Programmes_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_Mv_QuestionsArgs = {
   where: Mv_Questions_Bool_Exp;
 };
@@ -14879,6 +14937,12 @@ export type Mutation_RootDelete_Mv_QuestionsArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Mv_Questions0000001Args = {
   where: Mv_Questions0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Questions_2Args = {
+  where: Mv_Questions_2_Bool_Exp;
 };
 
 
@@ -14897,6 +14961,12 @@ export type Mutation_RootDelete_Mv_SubjectsArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Mv_Subjects0000001Args = {
   where: Mv_Subjects0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Mv_Subjects_2Args = {
+  where: Mv_Subjects_2_Bool_Exp;
 };
 
 
@@ -15768,6 +15838,18 @@ export type Mutation_RootInsert_Mv_Learning_Themes0000001_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Learning_Themes_2Args = {
+  objects: Array<Mv_Learning_Themes_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Learning_Themes_2_OneArgs = {
+  object: Mv_Learning_Themes_2_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Learning_Themes_OneArgs = {
   object: Mv_Learning_Themes_Insert_Input;
 };
@@ -15804,6 +15886,18 @@ export type Mutation_RootInsert_Mv_Lessons0000002_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Lessons_3Args = {
+  objects: Array<Mv_Lessons_3_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Lessons_3_OneArgs = {
+  object: Mv_Lessons_3_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Lessons_OneArgs = {
   object: Mv_Lessons_Insert_Input;
 };
@@ -15828,6 +15922,18 @@ export type Mutation_RootInsert_Mv_Programmes_1_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Mv_Programmes_2Args = {
+  objects: Array<Mv_Programmes_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Programmes_2_OneArgs = {
+  object: Mv_Programmes_2_Insert_Input;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_Mv_Programmes_OneArgs = {
   object: Mv_Programmes_Insert_Input;
 };
@@ -15848,6 +15954,18 @@ export type Mutation_RootInsert_Mv_Questions0000001Args = {
 /** mutation root */
 export type Mutation_RootInsert_Mv_Questions0000001_OneArgs = {
   object: Mv_Questions0000001_Insert_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Questions_2Args = {
+  objects: Array<Mv_Questions_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Questions_2_OneArgs = {
+  object: Mv_Questions_2_Insert_Input;
 };
 
 
@@ -15884,6 +16002,18 @@ export type Mutation_RootInsert_Mv_Subjects0000001Args = {
 /** mutation root */
 export type Mutation_RootInsert_Mv_Subjects0000001_OneArgs = {
   object: Mv_Subjects0000001_Insert_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Subjects_2Args = {
+  objects: Array<Mv_Subjects_2_Insert_Input>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Mv_Subjects_2_OneArgs = {
+  object: Mv_Subjects_2_Insert_Input;
 };
 
 
@@ -16895,6 +17025,14 @@ export type Mutation_RootUpdate_Mv_Learning_Themes0000001Args = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Learning_Themes_2Args = {
+  _inc?: InputMaybe<Mv_Learning_Themes_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Learning_Themes_2_Set_Input>;
+  where: Mv_Learning_Themes_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_LessonsArgs = {
   _inc?: InputMaybe<Mv_Lessons_Inc_Input>;
   _set?: InputMaybe<Mv_Lessons_Set_Input>;
@@ -16919,6 +17057,14 @@ export type Mutation_RootUpdate_Mv_Lessons0000002Args = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Lessons_3Args = {
+  _inc?: InputMaybe<Mv_Lessons_3_Inc_Input>;
+  _set?: InputMaybe<Mv_Lessons_3_Set_Input>;
+  where: Mv_Lessons_3_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_ProgrammesArgs = {
   _inc?: InputMaybe<Mv_Programmes_Inc_Input>;
   _set?: InputMaybe<Mv_Programmes_Set_Input>;
@@ -16935,6 +17081,14 @@ export type Mutation_RootUpdate_Mv_Programmes_1Args = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Mv_Programmes_2Args = {
+  _inc?: InputMaybe<Mv_Programmes_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Programmes_2_Set_Input>;
+  where: Mv_Programmes_2_Bool_Exp;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_Mv_QuestionsArgs = {
   _inc?: InputMaybe<Mv_Questions_Inc_Input>;
   _set?: InputMaybe<Mv_Questions_Set_Input>;
@@ -16947,6 +17101,14 @@ export type Mutation_RootUpdate_Mv_Questions0000001Args = {
   _inc?: InputMaybe<Mv_Questions0000001_Inc_Input>;
   _set?: InputMaybe<Mv_Questions0000001_Set_Input>;
   where: Mv_Questions0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Questions_2Args = {
+  _inc?: InputMaybe<Mv_Questions_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Questions_2_Set_Input>;
+  where: Mv_Questions_2_Bool_Exp;
 };
 
 
@@ -16971,6 +17133,14 @@ export type Mutation_RootUpdate_Mv_Subjects0000001Args = {
   _inc?: InputMaybe<Mv_Subjects0000001_Inc_Input>;
   _set?: InputMaybe<Mv_Subjects0000001_Set_Input>;
   where: Mv_Subjects0000001_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Mv_Subjects_2Args = {
+  _inc?: InputMaybe<Mv_Subjects_2_Inc_Input>;
+  _set?: InputMaybe<Mv_Subjects_2_Set_Input>;
+  where: Mv_Subjects_2_Bool_Exp;
 };
 
 
@@ -18228,6 +18398,308 @@ export type Mv_Learning_Themes0000001_Variance_Fields = {
 
 /** order by variance() on columns of table "mv_learning_themes0000001" */
 export type Mv_Learning_Themes0000001_Variance_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2 = {
+  __typename?: 'mv_learning_themes_2';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Aggregate = {
+  __typename?: 'mv_learning_themes_2_aggregate';
+  aggregate?: Maybe<Mv_Learning_Themes_2_Aggregate_Fields>;
+  nodes: Array<Mv_Learning_Themes_2>;
+};
+
+/** aggregate fields of "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Aggregate_Fields = {
+  __typename?: 'mv_learning_themes_2_aggregate_fields';
+  avg?: Maybe<Mv_Learning_Themes_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Learning_Themes_2_Max_Fields>;
+  min?: Maybe<Mv_Learning_Themes_2_Min_Fields>;
+  stddev?: Maybe<Mv_Learning_Themes_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Learning_Themes_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Learning_Themes_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Learning_Themes_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Learning_Themes_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Learning_Themes_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Learning_Themes_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Learning_Themes_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Learning_Themes_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Learning_Themes_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Learning_Themes_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Learning_Themes_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Learning_Themes_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Learning_Themes_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Learning_Themes_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Learning_Themes_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Learning_Themes_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Learning_Themes_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Learning_Themes_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Learning_Themes_2_Avg_Fields = {
+  __typename?: 'mv_learning_themes_2_avg_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Avg_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_learning_themes_2". All fields are combined with a logical 'AND'. */
+export type Mv_Learning_Themes_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Learning_Themes_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Learning_Themes_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Learning_Themes_2_Bool_Exp>>>;
+  id?: InputMaybe<Int_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  tier_name?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Inc_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Insert_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Learning_Themes_2_Max_Fields = {
+  __typename?: 'mv_learning_themes_2_max_fields';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Max_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Learning_Themes_2_Min_Fields = {
+  __typename?: 'mv_learning_themes_2_min_fields';
+  id?: Maybe<Scalars['Int']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_name?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Min_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Mutation_Response = {
+  __typename?: 'mv_learning_themes_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Learning_Themes_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Obj_Rel_Insert_Input = {
+  data: Mv_Learning_Themes_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Order_By = {
+  id?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_name?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_learning_themes_2" */
+export enum Mv_Learning_Themes_2_Select_Column {
+  /** column name */
+  Id = 'id',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  TierName = 'tier_name',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title'
+}
+
+/** input type for updating data in table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Set_Input = {
+  id?: InputMaybe<Scalars['Int']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_name?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Learning_Themes_2_Stddev_Fields = {
+  __typename?: 'mv_learning_themes_2_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Stddev_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Learning_Themes_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_learning_themes_2_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Stddev_Pop_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Learning_Themes_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_learning_themes_2_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Stddev_Samp_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Learning_Themes_2_Sum_Fields = {
+  __typename?: 'mv_learning_themes_2_sum_fields';
+  id?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Sum_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Learning_Themes_2_Var_Pop_Fields = {
+  __typename?: 'mv_learning_themes_2_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Var_Pop_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Learning_Themes_2_Var_Samp_Fields = {
+  __typename?: 'mv_learning_themes_2_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Var_Samp_Order_By = {
+  id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Learning_Themes_2_Variance_Fields = {
+  __typename?: 'mv_learning_themes_2_variance_fields';
+  id?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_learning_themes_2" */
+export type Mv_Learning_Themes_2_Variance_Order_By = {
   id?: InputMaybe<Order_By>;
 };
 
@@ -19689,6 +20161,582 @@ export type Mv_Lessons0000002_Variance_Order_By = {
   worksheet_count?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "mv_lessons_3" */
+export type Mv_Lessons_3 = {
+  __typename?: 'mv_lessons_3';
+  content_guidance?: Maybe<Scalars['String']>;
+  core_content?: Maybe<Scalars['json']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  expired?: Maybe<Scalars['Boolean']>;
+  has_copyright_material?: Maybe<Scalars['Boolean']>;
+  has_downloadable_resources?: Maybe<Scalars['Boolean']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  transcript_sentences?: Maybe<Scalars['_text']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_lessons_3" */
+export type Mv_Lessons_3Core_ContentArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate = {
+  __typename?: 'mv_lessons_3_aggregate';
+  aggregate?: Maybe<Mv_Lessons_3_Aggregate_Fields>;
+  nodes: Array<Mv_Lessons_3>;
+};
+
+/** aggregate fields of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_Fields = {
+  __typename?: 'mv_lessons_3_aggregate_fields';
+  avg?: Maybe<Mv_Lessons_3_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Lessons_3_Max_Fields>;
+  min?: Maybe<Mv_Lessons_3_Min_Fields>;
+  stddev?: Maybe<Mv_Lessons_3_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Lessons_3_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Lessons_3_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Lessons_3_Sum_Fields>;
+  var_pop?: Maybe<Mv_Lessons_3_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Lessons_3_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Lessons_3_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_lessons_3" */
+export type Mv_Lessons_3_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Lessons_3_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Lessons_3_Max_Order_By>;
+  min?: InputMaybe<Mv_Lessons_3_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Lessons_3_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Lessons_3_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Lessons_3_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Lessons_3_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Lessons_3_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Lessons_3_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Lessons_3_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_lessons_3" */
+export type Mv_Lessons_3_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Lessons_3_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Lessons_3_Avg_Fields = {
+  __typename?: 'mv_lessons_3_avg_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Avg_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_lessons_3". All fields are combined with a logical 'AND'. */
+export type Mv_Lessons_3_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Lessons_3_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Lessons_3_Bool_Exp>>>;
+  content_guidance?: InputMaybe<String_Comparison_Exp>;
+  core_content?: InputMaybe<Json_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  equipment_required?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  has_copyright_material?: InputMaybe<Boolean_Comparison_Exp>;
+  has_downloadable_resources?: InputMaybe<Boolean_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  position_in_unit?: InputMaybe<Int_Comparison_Exp>;
+  presentation_count?: InputMaybe<Bigint_Comparison_Exp>;
+  presentation_url?: InputMaybe<String_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  quiz_count?: InputMaybe<Bigint_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  supervision_level?: InputMaybe<String_Comparison_Exp>;
+  theme_slug?: InputMaybe<String_Comparison_Exp>;
+  theme_title?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  transcript_sentences?: InputMaybe<_Text_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_title?: InputMaybe<String_Comparison_Exp>;
+  video_count?: InputMaybe<Int_Comparison_Exp>;
+  video_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
+  worksheet_count?: InputMaybe<Bigint_Comparison_Exp>;
+  worksheet_url?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_lessons_3" */
+export type Mv_Lessons_3_Inc_Input = {
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_lessons_3" */
+export type Mv_Lessons_3_Insert_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Lessons_3_Max_Fields = {
+  __typename?: 'mv_lessons_3_max_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Max_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Lessons_3_Min_Fields = {
+  __typename?: 'mv_lessons_3_min_fields';
+  content_guidance?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  equipment_required?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  presentation_url?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  supervision_level?: Maybe<Scalars['String']>;
+  theme_slug?: Maybe<Scalars['String']>;
+  theme_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+  video_count?: Maybe<Scalars['Int']>;
+  video_mux_playback_id?: Maybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+  worksheet_url?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Min_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_lessons_3" */
+export type Mv_Lessons_3_Mutation_Response = {
+  __typename?: 'mv_lessons_3_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Lessons_3>;
+};
+
+/** input type for inserting object relation for remote table "mv_lessons_3" */
+export type Mv_Lessons_3_Obj_Rel_Insert_Input = {
+  data: Mv_Lessons_3_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_lessons_3" */
+export type Mv_Lessons_3_Order_By = {
+  content_guidance?: InputMaybe<Order_By>;
+  core_content?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  equipment_required?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  has_copyright_material?: InputMaybe<Order_By>;
+  has_downloadable_resources?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  presentation_url?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  supervision_level?: InputMaybe<Order_By>;
+  theme_slug?: InputMaybe<Order_By>;
+  theme_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  transcript_sentences?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  video_mux_playback_id?: InputMaybe<Order_By>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+  worksheet_url?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_lessons_3" */
+export enum Mv_Lessons_3_Select_Column {
+  /** column name */
+  ContentGuidance = 'content_guidance',
+  /** column name */
+  CoreContent = 'core_content',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  EquipmentRequired = 'equipment_required',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasCopyrightMaterial = 'has_copyright_material',
+  /** column name */
+  HasDownloadableResources = 'has_downloadable_resources',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  PositionInUnit = 'position_in_unit',
+  /** column name */
+  PresentationCount = 'presentation_count',
+  /** column name */
+  PresentationUrl = 'presentation_url',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  QuizCount = 'quiz_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  SupervisionLevel = 'supervision_level',
+  /** column name */
+  ThemeSlug = 'theme_slug',
+  /** column name */
+  ThemeTitle = 'theme_title',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  TranscriptSentences = 'transcript_sentences',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitTitle = 'unit_title',
+  /** column name */
+  VideoCount = 'video_count',
+  /** column name */
+  VideoMuxPlaybackId = 'video_mux_playback_id',
+  /** column name */
+  VideoWithSignLanguageMuxPlaybackId = 'video_with_sign_language_mux_playback_id',
+  /** column name */
+  WorksheetCount = 'worksheet_count',
+  /** column name */
+  WorksheetUrl = 'worksheet_url'
+}
+
+/** input type for updating data in table "mv_lessons_3" */
+export type Mv_Lessons_3_Set_Input = {
+  content_guidance?: InputMaybe<Scalars['String']>;
+  core_content?: InputMaybe<Scalars['json']>;
+  description?: InputMaybe<Scalars['String']>;
+  equipment_required?: InputMaybe<Scalars['String']>;
+  expired?: InputMaybe<Scalars['Boolean']>;
+  has_copyright_material?: InputMaybe<Scalars['Boolean']>;
+  has_downloadable_resources?: InputMaybe<Scalars['Boolean']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  position_in_unit?: InputMaybe<Scalars['Int']>;
+  presentation_count?: InputMaybe<Scalars['bigint']>;
+  presentation_url?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  quiz_count?: InputMaybe<Scalars['bigint']>;
+  slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  supervision_level?: InputMaybe<Scalars['String']>;
+  theme_slug?: InputMaybe<Scalars['String']>;
+  theme_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  transcript_sentences?: InputMaybe<Scalars['_text']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+  video_count?: InputMaybe<Scalars['Int']>;
+  video_mux_playback_id?: InputMaybe<Scalars['String']>;
+  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']>;
+  worksheet_count?: InputMaybe<Scalars['bigint']>;
+  worksheet_url?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Lessons_3_Stddev_Fields = {
+  __typename?: 'mv_lessons_3_stddev_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Lessons_3_Stddev_Pop_Fields = {
+  __typename?: 'mv_lessons_3_stddev_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Lessons_3_Stddev_Samp_Fields = {
+  __typename?: 'mv_lessons_3_stddev_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Stddev_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Lessons_3_Sum_Fields = {
+  __typename?: 'mv_lessons_3_sum_fields';
+  position_in_unit?: Maybe<Scalars['Int']>;
+  presentation_count?: Maybe<Scalars['bigint']>;
+  quiz_count?: Maybe<Scalars['bigint']>;
+  video_count?: Maybe<Scalars['Int']>;
+  worksheet_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Sum_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Lessons_3_Var_Pop_Fields = {
+  __typename?: 'mv_lessons_3_var_pop_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Var_Pop_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Lessons_3_Var_Samp_Fields = {
+  __typename?: 'mv_lessons_3_var_samp_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Var_Samp_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Lessons_3_Variance_Fields = {
+  __typename?: 'mv_lessons_3_variance_fields';
+  position_in_unit?: Maybe<Scalars['Float']>;
+  presentation_count?: Maybe<Scalars['Float']>;
+  quiz_count?: Maybe<Scalars['Float']>;
+  video_count?: Maybe<Scalars['Float']>;
+  worksheet_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_lessons_3" */
+export type Mv_Lessons_3_Variance_Order_By = {
+  position_in_unit?: InputMaybe<Order_By>;
+  presentation_count?: InputMaybe<Order_By>;
+  quiz_count?: InputMaybe<Order_By>;
+  video_count?: InputMaybe<Order_By>;
+  worksheet_count?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_lessons" */
 export type Mv_Lessons_Aggregate = {
   __typename?: 'mv_lessons_aggregate';
@@ -20505,6 +21553,325 @@ export type Mv_Programmes_1_Variance_Order_By = {
   unit_count?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "mv_programmes_2" */
+export type Mv_Programmes_2 = {
+  __typename?: 'mv_programmes_2';
+  active_lesson_count?: Maybe<Scalars['numeric']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  tier_title?: Maybe<Scalars['String']>;
+  total_unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** aggregated selection of "mv_programmes_2" */
+export type Mv_Programmes_2_Aggregate = {
+  __typename?: 'mv_programmes_2_aggregate';
+  aggregate?: Maybe<Mv_Programmes_2_Aggregate_Fields>;
+  nodes: Array<Mv_Programmes_2>;
+};
+
+/** aggregate fields of "mv_programmes_2" */
+export type Mv_Programmes_2_Aggregate_Fields = {
+  __typename?: 'mv_programmes_2_aggregate_fields';
+  avg?: Maybe<Mv_Programmes_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Programmes_2_Max_Fields>;
+  min?: Maybe<Mv_Programmes_2_Min_Fields>;
+  stddev?: Maybe<Mv_Programmes_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Programmes_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Programmes_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Programmes_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Programmes_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Programmes_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Programmes_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_programmes_2" */
+export type Mv_Programmes_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Programmes_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_programmes_2" */
+export type Mv_Programmes_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Programmes_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Programmes_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Programmes_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Programmes_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Programmes_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Programmes_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Programmes_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Programmes_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Programmes_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Programmes_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_programmes_2" */
+export type Mv_Programmes_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Programmes_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Programmes_2_Avg_Fields = {
+  __typename?: 'mv_programmes_2_avg_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Avg_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_programmes_2". All fields are combined with a logical 'AND'. */
+export type Mv_Programmes_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Programmes_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Programmes_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Programmes_2_Bool_Exp>>>;
+  active_lesson_count?: InputMaybe<Numeric_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  tier_title?: InputMaybe<String_Comparison_Exp>;
+  total_unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_programmes_2" */
+export type Mv_Programmes_2_Inc_Input = {
+  active_lesson_count?: InputMaybe<Scalars['numeric']>;
+  total_unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_programmes_2" */
+export type Mv_Programmes_2_Insert_Input = {
+  active_lesson_count?: InputMaybe<Scalars['numeric']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  tier_title?: InputMaybe<Scalars['String']>;
+  total_unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Programmes_2_Max_Fields = {
+  __typename?: 'mv_programmes_2_max_fields';
+  active_lesson_count?: Maybe<Scalars['numeric']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  tier_title?: Maybe<Scalars['String']>;
+  total_unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by max() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Max_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  tier_title?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Programmes_2_Min_Fields = {
+  __typename?: 'mv_programmes_2_min_fields';
+  active_lesson_count?: Maybe<Scalars['numeric']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  programme_slug?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  tier_slug?: Maybe<Scalars['String']>;
+  tier_title?: Maybe<Scalars['String']>;
+  total_unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by min() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Min_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  tier_title?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_programmes_2" */
+export type Mv_Programmes_2_Mutation_Response = {
+  __typename?: 'mv_programmes_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Programmes_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_programmes_2" */
+export type Mv_Programmes_2_Obj_Rel_Insert_Input = {
+  data: Mv_Programmes_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_programmes_2" */
+export type Mv_Programmes_2_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  tier_title?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_programmes_2" */
+export enum Mv_Programmes_2_Select_Column {
+  /** column name */
+  ActiveLessonCount = 'active_lesson_count',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  TierTitle = 'tier_title',
+  /** column name */
+  TotalUnitCount = 'total_unit_count'
+}
+
+/** input type for updating data in table "mv_programmes_2" */
+export type Mv_Programmes_2_Set_Input = {
+  active_lesson_count?: InputMaybe<Scalars['numeric']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  programme_slug?: InputMaybe<Scalars['String']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  tier_slug?: InputMaybe<Scalars['String']>;
+  tier_title?: InputMaybe<Scalars['String']>;
+  total_unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Programmes_2_Stddev_Fields = {
+  __typename?: 'mv_programmes_2_stddev_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Stddev_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Programmes_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_programmes_2_stddev_pop_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Stddev_Pop_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Programmes_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_programmes_2_stddev_samp_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Stddev_Samp_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Programmes_2_Sum_Fields = {
+  __typename?: 'mv_programmes_2_sum_fields';
+  active_lesson_count?: Maybe<Scalars['numeric']>;
+  total_unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Sum_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Programmes_2_Var_Pop_Fields = {
+  __typename?: 'mv_programmes_2_var_pop_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Var_Pop_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Programmes_2_Var_Samp_Fields = {
+  __typename?: 'mv_programmes_2_var_samp_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Var_Samp_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Programmes_2_Variance_Fields = {
+  __typename?: 'mv_programmes_2_variance_fields';
+  active_lesson_count?: Maybe<Scalars['Float']>;
+  total_unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_programmes_2" */
+export type Mv_Programmes_2_Variance_Order_By = {
+  active_lesson_count?: InputMaybe<Order_By>;
+  total_unit_count?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_programmes" */
 export type Mv_Programmes_Aggregate = {
   __typename?: 'mv_programmes_aggregate';
@@ -20782,6 +22149,7 @@ export type Mv_Questions = {
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
   question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   required?: Maybe<Scalars['Boolean']>;
   subject_slug?: Maybe<Scalars['String']>;
@@ -21341,6 +22709,531 @@ export type Mv_Questions0000001_Variance_Order_By = {
   quiz_id?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2 = {
+  __typename?: 'mv_questions_2';
+  active?: Maybe<Scalars['Boolean']>;
+  answer?: Maybe<Scalars['json']>;
+  choice_images?: Maybe<Scalars['json']>;
+  choices?: Maybe<Scalars['json']>;
+  choices_combined?: Maybe<Scalars['_jsonb']>;
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  images?: Maybe<Scalars['json']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  required?: Maybe<Scalars['Boolean']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2AnswerArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2Choice_ImagesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2ChoicesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** columns and relationships of "mv_questions_2" */
+export type Mv_Questions_2ImagesArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregated selection of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate = {
+  __typename?: 'mv_questions_2_aggregate';
+  aggregate?: Maybe<Mv_Questions_2_Aggregate_Fields>;
+  nodes: Array<Mv_Questions_2>;
+};
+
+/** aggregate fields of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_Fields = {
+  __typename?: 'mv_questions_2_aggregate_fields';
+  avg?: Maybe<Mv_Questions_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Questions_2_Max_Fields>;
+  min?: Maybe<Mv_Questions_2_Min_Fields>;
+  stddev?: Maybe<Mv_Questions_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Questions_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Questions_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Questions_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Questions_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Questions_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Questions_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_questions_2" */
+export type Mv_Questions_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Questions_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Questions_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Questions_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Questions_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Questions_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Questions_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Questions_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Questions_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Questions_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Questions_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_questions_2" */
+export type Mv_Questions_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Questions_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Questions_2_Avg_Fields = {
+  __typename?: 'mv_questions_2_avg_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Avg_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_questions_2". All fields are combined with a logical 'AND'. */
+export type Mv_Questions_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Questions_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Questions_2_Bool_Exp>>>;
+  active?: InputMaybe<Boolean_Comparison_Exp>;
+  answer?: InputMaybe<Json_Comparison_Exp>;
+  choice_images?: InputMaybe<Json_Comparison_Exp>;
+  choices?: InputMaybe<Json_Comparison_Exp>;
+  choices_combined?: InputMaybe<_Jsonb_Comparison_Exp>;
+  display_number?: InputMaybe<String_Comparison_Exp>;
+  feedback_correct?: InputMaybe<String_Comparison_Exp>;
+  feedback_incorrect?: InputMaybe<String_Comparison_Exp>;
+  images?: InputMaybe<Json_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_slug?: InputMaybe<String_Comparison_Exp>;
+  lesson_title?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  points?: InputMaybe<Int_Comparison_Exp>;
+  question_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_type?: InputMaybe<String_Comparison_Exp>;
+  required?: InputMaybe<Boolean_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_title?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  type?: InputMaybe<String_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_questions_2" */
+export type Mv_Questions_2_Inc_Input = {
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "mv_questions_2" */
+export type Mv_Questions_2_Insert_Input = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  answer?: InputMaybe<Scalars['json']>;
+  choice_images?: InputMaybe<Scalars['json']>;
+  choices?: InputMaybe<Scalars['json']>;
+  choices_combined?: InputMaybe<Scalars['_jsonb']>;
+  display_number?: InputMaybe<Scalars['String']>;
+  feedback_correct?: InputMaybe<Scalars['String']>;
+  feedback_incorrect?: InputMaybe<Scalars['String']>;
+  images?: InputMaybe<Scalars['json']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_slug?: InputMaybe<Scalars['String']>;
+  lesson_title?: InputMaybe<Scalars['String']>;
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+  quiz_type?: InputMaybe<Scalars['String']>;
+  required?: InputMaybe<Scalars['Boolean']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Questions_2_Max_Fields = {
+  __typename?: 'mv_questions_2_max_fields';
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+/** order by max() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Max_Order_By = {
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Questions_2_Min_Fields = {
+  __typename?: 'mv_questions_2_min_fields';
+  display_number?: Maybe<Scalars['String']>;
+  feedback_correct?: Maybe<Scalars['String']>;
+  feedback_incorrect?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_slug?: Maybe<Scalars['String']>;
+  lesson_title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+  quiz_type?: Maybe<Scalars['String']>;
+  subject_slug?: Maybe<Scalars['String']>;
+  subject_title?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  unit_slug?: Maybe<Scalars['String']>;
+  unit_title?: Maybe<Scalars['String']>;
+};
+
+/** order by min() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Min_Order_By = {
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_questions_2" */
+export type Mv_Questions_2_Mutation_Response = {
+  __typename?: 'mv_questions_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Questions_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_questions_2" */
+export type Mv_Questions_2_Obj_Rel_Insert_Input = {
+  data: Mv_Questions_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_questions_2" */
+export type Mv_Questions_2_Order_By = {
+  active?: InputMaybe<Order_By>;
+  answer?: InputMaybe<Order_By>;
+  choice_images?: InputMaybe<Order_By>;
+  choices?: InputMaybe<Order_By>;
+  choices_combined?: InputMaybe<Order_By>;
+  display_number?: InputMaybe<Order_By>;
+  feedback_correct?: InputMaybe<Order_By>;
+  feedback_incorrect?: InputMaybe<Order_By>;
+  images?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  lesson_title?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+  quiz_type?: InputMaybe<Order_By>;
+  required?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subject_title?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  type?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unit_title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_questions_2" */
+export enum Mv_Questions_2_Select_Column {
+  /** column name */
+  Active = 'active',
+  /** column name */
+  Answer = 'answer',
+  /** column name */
+  ChoiceImages = 'choice_images',
+  /** column name */
+  Choices = 'choices',
+  /** column name */
+  ChoicesCombined = 'choices_combined',
+  /** column name */
+  DisplayNumber = 'display_number',
+  /** column name */
+  FeedbackCorrect = 'feedback_correct',
+  /** column name */
+  FeedbackIncorrect = 'feedback_incorrect',
+  /** column name */
+  Images = 'images',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonSlug = 'lesson_slug',
+  /** column name */
+  LessonTitle = 'lesson_title',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  Points = 'points',
+  /** column name */
+  QuestionId = 'question_id',
+  /** column name */
+  QuizId = 'quiz_id',
+  /** column name */
+  QuizType = 'quiz_type',
+  /** column name */
+  Required = 'required',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  SubjectTitle = 'subject_title',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  Type = 'type',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitTitle = 'unit_title'
+}
+
+/** input type for updating data in table "mv_questions_2" */
+export type Mv_Questions_2_Set_Input = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  answer?: InputMaybe<Scalars['json']>;
+  choice_images?: InputMaybe<Scalars['json']>;
+  choices?: InputMaybe<Scalars['json']>;
+  choices_combined?: InputMaybe<Scalars['_jsonb']>;
+  display_number?: InputMaybe<Scalars['String']>;
+  feedback_correct?: InputMaybe<Scalars['String']>;
+  feedback_incorrect?: InputMaybe<Scalars['String']>;
+  images?: InputMaybe<Scalars['json']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_slug?: InputMaybe<Scalars['String']>;
+  lesson_title?: InputMaybe<Scalars['String']>;
+  order?: InputMaybe<Scalars['Int']>;
+  points?: InputMaybe<Scalars['Int']>;
+  question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
+  quiz_type?: InputMaybe<Scalars['String']>;
+  required?: InputMaybe<Scalars['Boolean']>;
+  subject_slug?: InputMaybe<Scalars['String']>;
+  subject_title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<Scalars['String']>;
+  unit_slug?: InputMaybe<Scalars['String']>;
+  unit_title?: InputMaybe<Scalars['String']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Questions_2_Stddev_Fields = {
+  __typename?: 'mv_questions_2_stddev_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Questions_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_questions_2_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Pop_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Questions_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_questions_2_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Stddev_Samp_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Questions_2_Sum_Fields = {
+  __typename?: 'mv_questions_2_sum_fields';
+  order?: Maybe<Scalars['Int']>;
+  points?: Maybe<Scalars['Int']>;
+  question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Sum_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Questions_2_Var_Pop_Fields = {
+  __typename?: 'mv_questions_2_var_pop_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Var_Pop_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Questions_2_Var_Samp_Fields = {
+  __typename?: 'mv_questions_2_var_samp_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Var_Samp_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Questions_2_Variance_Fields = {
+  __typename?: 'mv_questions_2_variance_fields';
+  order?: Maybe<Scalars['Float']>;
+  points?: Maybe<Scalars['Float']>;
+  question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_questions_2" */
+export type Mv_Questions_2_Variance_Order_By = {
+  order?: InputMaybe<Order_By>;
+  points?: InputMaybe<Order_By>;
+  question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
+};
+
 /** aggregated selection of "mv_questions" */
 export type Mv_Questions_Aggregate = {
   __typename?: 'mv_questions_aggregate';
@@ -21397,6 +23290,7 @@ export type Mv_Questions_Avg_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "mv_questions" */
@@ -21404,6 +23298,7 @@ export type Mv_Questions_Avg_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "mv_questions". All fields are combined with a logical 'AND'. */
@@ -21427,6 +23322,7 @@ export type Mv_Questions_Bool_Exp = {
   order?: InputMaybe<Int_Comparison_Exp>;
   points?: InputMaybe<Int_Comparison_Exp>;
   question_id?: InputMaybe<Int_Comparison_Exp>;
+  quiz_id?: InputMaybe<Int_Comparison_Exp>;
   quiz_type?: InputMaybe<String_Comparison_Exp>;
   required?: InputMaybe<Boolean_Comparison_Exp>;
   subject_slug?: InputMaybe<String_Comparison_Exp>;
@@ -21442,6 +23338,7 @@ export type Mv_Questions_Inc_Input = {
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
   question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "mv_questions" */
@@ -21462,6 +23359,7 @@ export type Mv_Questions_Insert_Input = {
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
   question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
   quiz_type?: InputMaybe<Scalars['String']>;
   required?: InputMaybe<Scalars['Boolean']>;
   subject_slug?: InputMaybe<Scalars['String']>;
@@ -21485,6 +23383,7 @@ export type Mv_Questions_Max_Fields = {
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
   question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
@@ -21506,6 +23405,7 @@ export type Mv_Questions_Max_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
@@ -21528,6 +23428,7 @@ export type Mv_Questions_Min_Fields = {
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
   question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
   quiz_type?: Maybe<Scalars['String']>;
   subject_slug?: Maybe<Scalars['String']>;
   subject_title?: Maybe<Scalars['String']>;
@@ -21549,6 +23450,7 @@ export type Mv_Questions_Min_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
   subject_title?: InputMaybe<Order_By>;
@@ -21590,6 +23492,7 @@ export type Mv_Questions_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
   quiz_type?: InputMaybe<Order_By>;
   required?: InputMaybe<Order_By>;
   subject_slug?: InputMaybe<Order_By>;
@@ -21635,6 +23538,8 @@ export enum Mv_Questions_Select_Column {
   /** column name */
   QuestionId = 'question_id',
   /** column name */
+  QuizId = 'quiz_id',
+  /** column name */
   QuizType = 'quiz_type',
   /** column name */
   Required = 'required',
@@ -21670,6 +23575,7 @@ export type Mv_Questions_Set_Input = {
   order?: InputMaybe<Scalars['Int']>;
   points?: InputMaybe<Scalars['Int']>;
   question_id?: InputMaybe<Scalars['Int']>;
+  quiz_id?: InputMaybe<Scalars['Int']>;
   quiz_type?: InputMaybe<Scalars['String']>;
   required?: InputMaybe<Scalars['Boolean']>;
   subject_slug?: InputMaybe<Scalars['String']>;
@@ -21686,6 +23592,7 @@ export type Mv_Questions_Stddev_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "mv_questions" */
@@ -21693,6 +23600,7 @@ export type Mv_Questions_Stddev_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -21701,6 +23609,7 @@ export type Mv_Questions_Stddev_Pop_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "mv_questions" */
@@ -21708,6 +23617,7 @@ export type Mv_Questions_Stddev_Pop_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -21716,6 +23626,7 @@ export type Mv_Questions_Stddev_Samp_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "mv_questions" */
@@ -21723,6 +23634,7 @@ export type Mv_Questions_Stddev_Samp_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -21731,6 +23643,7 @@ export type Mv_Questions_Sum_Fields = {
   order?: Maybe<Scalars['Int']>;
   points?: Maybe<Scalars['Int']>;
   question_id?: Maybe<Scalars['Int']>;
+  quiz_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "mv_questions" */
@@ -21738,6 +23651,7 @@ export type Mv_Questions_Sum_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
@@ -21746,6 +23660,7 @@ export type Mv_Questions_Var_Pop_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "mv_questions" */
@@ -21753,6 +23668,7 @@ export type Mv_Questions_Var_Pop_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -21761,6 +23677,7 @@ export type Mv_Questions_Var_Samp_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "mv_questions" */
@@ -21768,6 +23685,7 @@ export type Mv_Questions_Var_Samp_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -21776,6 +23694,7 @@ export type Mv_Questions_Variance_Fields = {
   order?: Maybe<Scalars['Float']>;
   points?: Maybe<Scalars['Float']>;
   question_id?: Maybe<Scalars['Float']>;
+  quiz_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "mv_questions" */
@@ -21783,6 +23702,7 @@ export type Mv_Questions_Variance_Order_By = {
   order?: InputMaybe<Order_By>;
   points?: InputMaybe<Order_By>;
   question_id?: InputMaybe<Order_By>;
+  quiz_id?: InputMaybe<Order_By>;
 };
 
 /** columns and relationships of "mv_quizzes" */
@@ -22509,6 +24429,359 @@ export type Mv_Subjects0000001_Variance_Fields = {
 
 /** order by variance() on columns of table "mv_subjects0000001" */
 export type Mv_Subjects0000001_Variance_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "mv_subjects_2" */
+export type Mv_Subjects_2 = {
+  __typename?: 'mv_subjects_2';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** aggregated selection of "mv_subjects_2" */
+export type Mv_Subjects_2_Aggregate = {
+  __typename?: 'mv_subjects_2_aggregate';
+  aggregate?: Maybe<Mv_Subjects_2_Aggregate_Fields>;
+  nodes: Array<Mv_Subjects_2>;
+};
+
+/** aggregate fields of "mv_subjects_2" */
+export type Mv_Subjects_2_Aggregate_Fields = {
+  __typename?: 'mv_subjects_2_aggregate_fields';
+  avg?: Maybe<Mv_Subjects_2_Avg_Fields>;
+  count?: Maybe<Scalars['Int']>;
+  max?: Maybe<Mv_Subjects_2_Max_Fields>;
+  min?: Maybe<Mv_Subjects_2_Min_Fields>;
+  stddev?: Maybe<Mv_Subjects_2_Stddev_Fields>;
+  stddev_pop?: Maybe<Mv_Subjects_2_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Mv_Subjects_2_Stddev_Samp_Fields>;
+  sum?: Maybe<Mv_Subjects_2_Sum_Fields>;
+  var_pop?: Maybe<Mv_Subjects_2_Var_Pop_Fields>;
+  var_samp?: Maybe<Mv_Subjects_2_Var_Samp_Fields>;
+  variance?: Maybe<Mv_Subjects_2_Variance_Fields>;
+};
+
+
+/** aggregate fields of "mv_subjects_2" */
+export type Mv_Subjects_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Mv_Subjects_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "mv_subjects_2" */
+export type Mv_Subjects_2_Aggregate_Order_By = {
+  avg?: InputMaybe<Mv_Subjects_2_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Mv_Subjects_2_Max_Order_By>;
+  min?: InputMaybe<Mv_Subjects_2_Min_Order_By>;
+  stddev?: InputMaybe<Mv_Subjects_2_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Mv_Subjects_2_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Mv_Subjects_2_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Mv_Subjects_2_Sum_Order_By>;
+  var_pop?: InputMaybe<Mv_Subjects_2_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Mv_Subjects_2_Var_Samp_Order_By>;
+  variance?: InputMaybe<Mv_Subjects_2_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "mv_subjects_2" */
+export type Mv_Subjects_2_Arr_Rel_Insert_Input = {
+  data: Array<Mv_Subjects_2_Insert_Input>;
+};
+
+/** aggregate avg on columns */
+export type Mv_Subjects_2_Avg_Fields = {
+  __typename?: 'mv_subjects_2_avg_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Avg_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "mv_subjects_2". All fields are combined with a logical 'AND'. */
+export type Mv_Subjects_2_Bool_Exp = {
+  _and?: InputMaybe<Array<InputMaybe<Mv_Subjects_2_Bool_Exp>>>;
+  _not?: InputMaybe<Mv_Subjects_2_Bool_Exp>;
+  _or?: InputMaybe<Array<InputMaybe<Mv_Subjects_2_Bool_Exp>>>;
+  active_unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+  key_stage_short_code?: InputMaybe<String_Comparison_Exp>;
+  key_stage_slug?: InputMaybe<String_Comparison_Exp>;
+  key_stage_title?: InputMaybe<String_Comparison_Exp>;
+  lesson_count?: InputMaybe<Numeric_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  tier_count?: InputMaybe<Bigint_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_count?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+/** input type for incrementing integer column in table "mv_subjects_2" */
+export type Mv_Subjects_2_Inc_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** input type for inserting data into table "mv_subjects_2" */
+export type Mv_Subjects_2_Insert_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  key_stage_short_code?: InputMaybe<Scalars['String']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  slug?: InputMaybe<Scalars['String']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate max on columns */
+export type Mv_Subjects_2_Max_Fields = {
+  __typename?: 'mv_subjects_2_max_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by max() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Max_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Mv_Subjects_2_Min_Fields = {
+  __typename?: 'mv_subjects_2_min_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  key_stage_short_code?: Maybe<Scalars['String']>;
+  key_stage_slug?: Maybe<Scalars['String']>;
+  key_stage_title?: Maybe<Scalars['String']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  slug?: Maybe<Scalars['String']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  title?: Maybe<Scalars['String']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by min() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Min_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "mv_subjects_2" */
+export type Mv_Subjects_2_Mutation_Response = {
+  __typename?: 'mv_subjects_2_mutation_response';
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data of the affected rows by the mutation */
+  returning: Array<Mv_Subjects_2>;
+};
+
+/** input type for inserting object relation for remote table "mv_subjects_2" */
+export type Mv_Subjects_2_Obj_Rel_Insert_Input = {
+  data: Mv_Subjects_2_Insert_Input;
+};
+
+/** ordering options when selecting data from "mv_subjects_2" */
+export type Mv_Subjects_2_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  key_stage_short_code?: InputMaybe<Order_By>;
+  key_stage_slug?: InputMaybe<Order_By>;
+  key_stage_title?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "mv_subjects_2" */
+export enum Mv_Subjects_2_Select_Column {
+  /** column name */
+  ActiveUnitCount = 'active_unit_count',
+  /** column name */
+  KeyStageShortCode = 'key_stage_short_code',
+  /** column name */
+  KeyStageSlug = 'key_stage_slug',
+  /** column name */
+  KeyStageTitle = 'key_stage_title',
+  /** column name */
+  LessonCount = 'lesson_count',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  TierCount = 'tier_count',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitCount = 'unit_count'
+}
+
+/** input type for updating data in table "mv_subjects_2" */
+export type Mv_Subjects_2_Set_Input = {
+  active_unit_count?: InputMaybe<Scalars['bigint']>;
+  key_stage_short_code?: InputMaybe<Scalars['String']>;
+  key_stage_slug?: InputMaybe<Scalars['String']>;
+  key_stage_title?: InputMaybe<Scalars['String']>;
+  lesson_count?: InputMaybe<Scalars['numeric']>;
+  slug?: InputMaybe<Scalars['String']>;
+  tier_count?: InputMaybe<Scalars['bigint']>;
+  title?: InputMaybe<Scalars['String']>;
+  unit_count?: InputMaybe<Scalars['bigint']>;
+};
+
+/** aggregate stddev on columns */
+export type Mv_Subjects_2_Stddev_Fields = {
+  __typename?: 'mv_subjects_2_stddev_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Stddev_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Mv_Subjects_2_Stddev_Pop_Fields = {
+  __typename?: 'mv_subjects_2_stddev_pop_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Stddev_Pop_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Mv_Subjects_2_Stddev_Samp_Fields = {
+  __typename?: 'mv_subjects_2_stddev_samp_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Stddev_Samp_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Mv_Subjects_2_Sum_Fields = {
+  __typename?: 'mv_subjects_2_sum_fields';
+  active_unit_count?: Maybe<Scalars['bigint']>;
+  lesson_count?: Maybe<Scalars['numeric']>;
+  tier_count?: Maybe<Scalars['bigint']>;
+  unit_count?: Maybe<Scalars['bigint']>;
+};
+
+/** order by sum() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Sum_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Mv_Subjects_2_Var_Pop_Fields = {
+  __typename?: 'mv_subjects_2_var_pop_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Var_Pop_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Mv_Subjects_2_Var_Samp_Fields = {
+  __typename?: 'mv_subjects_2_var_samp_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Var_Samp_Order_By = {
+  active_unit_count?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  tier_count?: InputMaybe<Order_By>;
+  unit_count?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Mv_Subjects_2_Variance_Fields = {
+  __typename?: 'mv_subjects_2_variance_fields';
+  active_unit_count?: Maybe<Scalars['Float']>;
+  lesson_count?: Maybe<Scalars['Float']>;
+  tier_count?: Maybe<Scalars['Float']>;
+  unit_count?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "mv_subjects_2" */
+export type Mv_Subjects_2_Variance_Order_By = {
   active_unit_count?: InputMaybe<Order_By>;
   lesson_count?: InputMaybe<Order_By>;
   tier_count?: InputMaybe<Order_By>;
@@ -26438,6 +28711,10 @@ export type Query_Root = {
   mv_learning_themes0000001: Array<Mv_Learning_Themes0000001>;
   /** fetch aggregated fields from the table: "mv_learning_themes0000001" */
   mv_learning_themes0000001_aggregate: Mv_Learning_Themes0000001_Aggregate;
+  /** fetch data from the table: "mv_learning_themes_2" */
+  mv_learning_themes_2: Array<Mv_Learning_Themes_2>;
+  /** fetch aggregated fields from the table: "mv_learning_themes_2" */
+  mv_learning_themes_2_aggregate: Mv_Learning_Themes_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_learning_themes" */
   mv_learning_themes_aggregate: Mv_Learning_Themes_Aggregate;
   /** fetch data from the table: "mv_lessons" */
@@ -26450,6 +28727,10 @@ export type Query_Root = {
   mv_lessons0000002: Array<Mv_Lessons0000002>;
   /** fetch aggregated fields from the table: "mv_lessons0000002" */
   mv_lessons0000002_aggregate: Mv_Lessons0000002_Aggregate;
+  /** fetch data from the table: "mv_lessons_3" */
+  mv_lessons_3: Array<Mv_Lessons_3>;
+  /** fetch aggregated fields from the table: "mv_lessons_3" */
+  mv_lessons_3_aggregate: Mv_Lessons_3_Aggregate;
   /** fetch aggregated fields from the table: "mv_lessons" */
   mv_lessons_aggregate: Mv_Lessons_Aggregate;
   /** fetch data from the table: "mv_programmes" */
@@ -26458,6 +28739,10 @@ export type Query_Root = {
   mv_programmes_1: Array<Mv_Programmes_1>;
   /** fetch aggregated fields from the table: "mv_programmes_1" */
   mv_programmes_1_aggregate: Mv_Programmes_1_Aggregate;
+  /** fetch data from the table: "mv_programmes_2" */
+  mv_programmes_2: Array<Mv_Programmes_2>;
+  /** fetch aggregated fields from the table: "mv_programmes_2" */
+  mv_programmes_2_aggregate: Mv_Programmes_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_programmes" */
   mv_programmes_aggregate: Mv_Programmes_Aggregate;
   /** fetch data from the table: "mv_questions" */
@@ -26466,6 +28751,10 @@ export type Query_Root = {
   mv_questions0000001: Array<Mv_Questions0000001>;
   /** fetch aggregated fields from the table: "mv_questions0000001" */
   mv_questions0000001_aggregate: Mv_Questions0000001_Aggregate;
+  /** fetch data from the table: "mv_questions_2" */
+  mv_questions_2: Array<Mv_Questions_2>;
+  /** fetch aggregated fields from the table: "mv_questions_2" */
+  mv_questions_2_aggregate: Mv_Questions_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_questions" */
   mv_questions_aggregate: Mv_Questions_Aggregate;
   /** fetch data from the table: "mv_quizzes" */
@@ -26478,6 +28767,10 @@ export type Query_Root = {
   mv_subjects0000001: Array<Mv_Subjects0000001>;
   /** fetch aggregated fields from the table: "mv_subjects0000001" */
   mv_subjects0000001_aggregate: Mv_Subjects0000001_Aggregate;
+  /** fetch data from the table: "mv_subjects_2" */
+  mv_subjects_2: Array<Mv_Subjects_2>;
+  /** fetch aggregated fields from the table: "mv_subjects_2" */
+  mv_subjects_2_aggregate: Mv_Subjects_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_subjects" */
   mv_subjects_aggregate: Mv_Subjects_Aggregate;
   /** fetch data from the table: "mv_tiers" */
@@ -27640,6 +29933,26 @@ export type Query_RootMv_Learning_Themes0000001_AggregateArgs = {
 
 
 /** query root */
+export type Query_RootMv_Learning_Themes_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes_2_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Learning_Themes_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes_2_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes_2_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Learning_Themes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Learning_Themes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -27700,6 +30013,26 @@ export type Query_RootMv_Lessons0000002_AggregateArgs = {
 
 
 /** query root */
+export type Query_RootMv_Lessons_3Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Lessons_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Lessons_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -27740,6 +30073,26 @@ export type Query_RootMv_Programmes_1_AggregateArgs = {
 
 
 /** query root */
+export type Query_RootMv_Programmes_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_2_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Programmes_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_2_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_2_Bool_Exp>;
+};
+
+
+/** query root */
 export type Query_RootMv_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -27776,6 +30129,26 @@ export type Query_RootMv_Questions0000001_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Questions0000001_Order_By>>;
   where?: InputMaybe<Mv_Questions0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Questions_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Questions_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
 };
 
 
@@ -27836,6 +30209,26 @@ export type Query_RootMv_Subjects0000001_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
   where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Subjects_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects_2_Order_By>>;
+  where?: InputMaybe<Mv_Subjects_2_Bool_Exp>;
+};
+
+
+/** query root */
+export type Query_RootMv_Subjects_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects_2_Order_By>>;
+  where?: InputMaybe<Mv_Subjects_2_Bool_Exp>;
 };
 
 
@@ -31099,6 +33492,10 @@ export type Subscription_Root = {
   mv_learning_themes0000001: Array<Mv_Learning_Themes0000001>;
   /** fetch aggregated fields from the table: "mv_learning_themes0000001" */
   mv_learning_themes0000001_aggregate: Mv_Learning_Themes0000001_Aggregate;
+  /** fetch data from the table: "mv_learning_themes_2" */
+  mv_learning_themes_2: Array<Mv_Learning_Themes_2>;
+  /** fetch aggregated fields from the table: "mv_learning_themes_2" */
+  mv_learning_themes_2_aggregate: Mv_Learning_Themes_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_learning_themes" */
   mv_learning_themes_aggregate: Mv_Learning_Themes_Aggregate;
   /** fetch data from the table: "mv_lessons" */
@@ -31111,6 +33508,10 @@ export type Subscription_Root = {
   mv_lessons0000002: Array<Mv_Lessons0000002>;
   /** fetch aggregated fields from the table: "mv_lessons0000002" */
   mv_lessons0000002_aggregate: Mv_Lessons0000002_Aggregate;
+  /** fetch data from the table: "mv_lessons_3" */
+  mv_lessons_3: Array<Mv_Lessons_3>;
+  /** fetch aggregated fields from the table: "mv_lessons_3" */
+  mv_lessons_3_aggregate: Mv_Lessons_3_Aggregate;
   /** fetch aggregated fields from the table: "mv_lessons" */
   mv_lessons_aggregate: Mv_Lessons_Aggregate;
   /** fetch data from the table: "mv_programmes" */
@@ -31119,6 +33520,10 @@ export type Subscription_Root = {
   mv_programmes_1: Array<Mv_Programmes_1>;
   /** fetch aggregated fields from the table: "mv_programmes_1" */
   mv_programmes_1_aggregate: Mv_Programmes_1_Aggregate;
+  /** fetch data from the table: "mv_programmes_2" */
+  mv_programmes_2: Array<Mv_Programmes_2>;
+  /** fetch aggregated fields from the table: "mv_programmes_2" */
+  mv_programmes_2_aggregate: Mv_Programmes_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_programmes" */
   mv_programmes_aggregate: Mv_Programmes_Aggregate;
   /** fetch data from the table: "mv_questions" */
@@ -31127,6 +33532,10 @@ export type Subscription_Root = {
   mv_questions0000001: Array<Mv_Questions0000001>;
   /** fetch aggregated fields from the table: "mv_questions0000001" */
   mv_questions0000001_aggregate: Mv_Questions0000001_Aggregate;
+  /** fetch data from the table: "mv_questions_2" */
+  mv_questions_2: Array<Mv_Questions_2>;
+  /** fetch aggregated fields from the table: "mv_questions_2" */
+  mv_questions_2_aggregate: Mv_Questions_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_questions" */
   mv_questions_aggregate: Mv_Questions_Aggregate;
   /** fetch data from the table: "mv_quizzes" */
@@ -31139,6 +33548,10 @@ export type Subscription_Root = {
   mv_subjects0000001: Array<Mv_Subjects0000001>;
   /** fetch aggregated fields from the table: "mv_subjects0000001" */
   mv_subjects0000001_aggregate: Mv_Subjects0000001_Aggregate;
+  /** fetch data from the table: "mv_subjects_2" */
+  mv_subjects_2: Array<Mv_Subjects_2>;
+  /** fetch aggregated fields from the table: "mv_subjects_2" */
+  mv_subjects_2_aggregate: Mv_Subjects_2_Aggregate;
   /** fetch aggregated fields from the table: "mv_subjects" */
   mv_subjects_aggregate: Mv_Subjects_Aggregate;
   /** fetch data from the table: "mv_tiers" */
@@ -32301,6 +34714,26 @@ export type Subscription_RootMv_Learning_Themes0000001_AggregateArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Learning_Themes_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes_2_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Learning_Themes_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Learning_Themes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Learning_Themes_2_Order_By>>;
+  where?: InputMaybe<Mv_Learning_Themes_2_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Learning_Themes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Learning_Themes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -32361,6 +34794,26 @@ export type Subscription_RootMv_Lessons0000002_AggregateArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Lessons_3Args = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Lessons_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Lessons_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Lessons_3_Order_By>>;
+  where?: InputMaybe<Mv_Lessons_3_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Lessons_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -32401,6 +34854,26 @@ export type Subscription_RootMv_Programmes_1_AggregateArgs = {
 
 
 /** subscription root */
+export type Subscription_RootMv_Programmes_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_2_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Programmes_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Programmes_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Programmes_2_Order_By>>;
+  where?: InputMaybe<Mv_Programmes_2_Bool_Exp>;
+};
+
+
+/** subscription root */
 export type Subscription_RootMv_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Mv_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -32437,6 +34910,26 @@ export type Subscription_RootMv_Questions0000001_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Questions0000001_Order_By>>;
   where?: InputMaybe<Mv_Questions0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Questions_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Questions_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Questions_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Questions_2_Order_By>>;
+  where?: InputMaybe<Mv_Questions_2_Bool_Exp>;
 };
 
 
@@ -32497,6 +34990,26 @@ export type Subscription_RootMv_Subjects0000001_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Mv_Subjects0000001_Order_By>>;
   where?: InputMaybe<Mv_Subjects0000001_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Subjects_2Args = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects_2_Order_By>>;
+  where?: InputMaybe<Mv_Subjects_2_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type Subscription_RootMv_Subjects_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Mv_Subjects_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Mv_Subjects_2_Order_By>>;
+  where?: InputMaybe<Mv_Subjects_2_Bool_Exp>;
 };
 
 
@@ -40822,7 +43335,7 @@ export type SubjectListingQueryVariables = Exact<{
 }>;
 
 
-export type SubjectListingQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_programmes_available: Array<{ __typename?: 'mv_programmes_1', keyStageSlug?: string | null, programmeSlug?: string | null, slug?: string | null, title?: string | null, tierSlug?: string | null, unitCount?: any | null }>, mv_programmes_unavailable: Array<{ __typename?: 'mv_programmes_1', keyStageSlug?: string | null, programmeSlug?: string | null, slug?: string | null, title?: string | null, tierSlug?: string | null, unitCount?: any | null }> };
+export type SubjectListingQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_programmes_available: Array<{ __typename?: 'mv_programmes_2', keyStageSlug?: string | null, programmeSlug?: string | null, slug?: string | null, title?: string | null, tierSlug?: string | null, unitCount?: any | null }>, mv_programmes_unavailable: Array<{ __typename?: 'mv_programmes_2', keyStageSlug?: string | null, programmeSlug?: string | null, slug?: string | null, title?: string | null, tierSlug?: string | null, unitCount?: any | null }> };
 
 export type TeachersHomePageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -40835,7 +43348,7 @@ export type TeachersKeyStageSubjectTiersQueryVariables = Exact<{
 }>;
 
 
-export type TeachersKeyStageSubjectTiersQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects', slug?: string | null, title?: string | null }>, mv_tiers: Array<{ __typename?: 'mv_tiers', slug?: string | null, title?: string | null, unitCount?: any | null, lessonCount?: any | null }> };
+export type TeachersKeyStageSubjectTiersQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects_2', slug?: string | null, title?: string | null }>, mv_tiers: Array<{ __typename?: 'mv_tiers', slug?: string | null, title?: string | null, unitCount?: any | null, lessonCount?: any | null }> };
 
 export type TeachersKeyStageSubjectTiersPathsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -40849,7 +43362,7 @@ export type TeachersKeyStageSubjectUnitLessonsQueryVariables = Exact<{
 }>;
 
 
-export type TeachersKeyStageSubjectUnitLessonsQuery = { __typename?: 'query_root', mv_units: Array<{ __typename?: 'mv_units', unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null }>, mv_lessons: Array<{ __typename?: 'mv_lessons', slug?: string | null, title?: string | null, description?: string | null, expired?: boolean | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, themeTitle?: string | null, themeSlug?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, supervisionLevel?: string | null, videoCount?: number | null, presentationCount?: any | null, worksheetCount?: any | null, hasCopyrightMaterial?: boolean | null, hasDownloadableResources?: boolean | null, quizCount?: any | null }> };
+export type TeachersKeyStageSubjectUnitLessonsQuery = { __typename?: 'query_root', mv_units: Array<{ __typename?: 'mv_units_2', unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null }>, mv_lessons: Array<{ __typename?: 'mv_lessons_3', slug?: string | null, title?: string | null, description?: string | null, expired?: boolean | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, themeTitle?: string | null, themeSlug?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, supervisionLevel?: string | null, videoCount?: number | null, presentationCount?: any | null, worksheetCount?: any | null, hasCopyrightMaterial?: boolean | null, hasDownloadableResources?: boolean | null, quizCount?: any | null }> };
 
 export type TeachersKeyStageSubjectUnitsQueryVariables = Exact<{
   keyStageSlug: Scalars['String'];
@@ -40859,7 +43372,7 @@ export type TeachersKeyStageSubjectUnitsQueryVariables = Exact<{
 }>;
 
 
-export type TeachersKeyStageSubjectUnitsQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects', slug?: string | null, title?: string | null }>, mv_tiers: Array<{ __typename?: 'mv_tiers', slug?: string | null, title?: string | null, unitCount?: any | null, lessonCount?: any | null }>, mv_units: Array<{ __typename?: 'mv_units', slug?: string | null, title?: string | null, year?: string | null, expired?: boolean | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, themeSlug?: string | null, themeTitle?: string | null, lessonCount?: any | null, quizCount?: any | null, unitStudyOrder?: number | null, expiredLessonCount?: any | null }>, mv_learning_themes: Array<{ __typename?: 'mv_learning_themes', slug?: string | null, label?: string | null, tierSlug?: string | null, tierName?: string | null, subjectTitle?: string | null, subjectSlug?: string | null, keyStageTitle?: string | null, keyStageSlug?: string | null }> };
+export type TeachersKeyStageSubjectUnitsQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects_2', slug?: string | null, title?: string | null }>, mv_tiers: Array<{ __typename?: 'mv_tiers', slug?: string | null, title?: string | null, unitCount?: any | null, lessonCount?: any | null }>, mv_units: Array<{ __typename?: 'mv_units_2', slug?: string | null, title?: string | null, year?: string | null, expired?: boolean | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, themeSlug?: string | null, themeTitle?: string | null, lessonCount?: any | null, quizCount?: any | null, unitStudyOrder?: number | null, expiredLessonCount?: any | null }>, mv_learning_themes: Array<{ __typename?: 'mv_learning_themes_2', slug?: string | null, label?: string | null, tierSlug?: string | null, tierName?: string | null, subjectTitle?: string | null, subjectSlug?: string | null, keyStageTitle?: string | null, keyStageSlug?: string | null }> };
 
 export type TeachersKeyStageSubjectUnitLessonsDownloadsQueryVariables = Exact<{
   lessonSlug: Scalars['String'];
@@ -40874,14 +43387,14 @@ export type TeachersKeyStageSubjectUnitLessonsDownloadsQuery = { __typename?: 'q
 export type TeachersKeyStageSubjectUnitsPathsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TeachersKeyStageSubjectUnitsPathsQuery = { __typename?: 'query_root', mv_subjects: Array<{ __typename?: 'mv_subjects', subjectSlug?: string | null, keyStageSlug?: string | null }> };
+export type TeachersKeyStageSubjectUnitsPathsQuery = { __typename?: 'query_root', mv_subjects: Array<{ __typename?: 'mv_subjects_2', subjectSlug?: string | null, keyStageSlug?: string | null }> };
 
 export type TeachersKeyStageSubjectsQueryVariables = Exact<{
   keyStageSlug: Scalars['String'];
 }>;
 
 
-export type TeachersKeyStageSubjectsQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects', slug?: string | null, title?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonCount?: any | null, unitCount?: any | null, tierCount?: any | null, activeUnitCount?: any | null }> };
+export type TeachersKeyStageSubjectsQuery = { __typename?: 'query_root', mv_key_stages: Array<{ __typename?: 'mv_key_stages', slug?: string | null, title?: string | null }>, mv_subjects: Array<{ __typename?: 'mv_subjects_2', slug?: string | null, title?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonCount?: any | null, unitCount?: any | null, tierCount?: any | null, activeUnitCount?: any | null }> };
 
 export type TeachersLessonOverviewQueryVariables = Exact<{
   lessonSlug: Scalars['String'];
@@ -40891,12 +43404,12 @@ export type TeachersLessonOverviewQueryVariables = Exact<{
 }>;
 
 
-export type TeachersLessonOverviewQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons', slug?: string | null, title?: string | null, expired?: boolean | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, presentationUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, hasCopyrightMaterial?: boolean | null, coreContent?: any | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: any | null, hasDownloadableResources?: boolean | null }>, exitQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, exitQuiz: Array<{ __typename?: 'mv_questions', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }>, introQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, introQuiz: Array<{ __typename?: 'mv_questions', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }> };
+export type TeachersLessonOverviewQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons_3', slug?: string | null, title?: string | null, expired?: boolean | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, contentGuidance?: string | null, equipmentRequired?: string | null, presentationUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, hasCopyrightMaterial?: boolean | null, coreContent?: any | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: any | null, hasDownloadableResources?: boolean | null }>, exitQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, exitQuiz: Array<{ __typename?: 'mv_questions_2', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }>, introQuizInfo: Array<{ __typename?: 'mv_quizzes', title?: string | null, questionCount?: any | null }>, introQuiz: Array<{ __typename?: 'mv_questions_2', active?: boolean | null, answer?: any | null, images?: any | null, points?: number | null, required?: boolean | null, title?: string | null, type?: string | null, order?: number | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, choices?: any | null, feedbackCorrect?: string | null, feedbackIncorrect?: string | null, quizType?: string | null, displayNumber?: string | null }> };
 
 export type TeachersLessonOverviewPathsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TeachersLessonOverviewPathsQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons', lessonSlug?: string | null, keyStageSlug?: string | null, subjectSlug?: string | null, unitSlug?: string | null }> };
+export type TeachersLessonOverviewPathsQuery = { __typename?: 'query_root', mv_lessons: Array<{ __typename?: 'mv_lessons_3', lessonSlug?: string | null, keyStageSlug?: string | null, subjectSlug?: string | null, unitSlug?: string | null }> };
 
 export type TierListingQueryVariables = Exact<{
   keyStageSlug: Scalars['String'];
@@ -40922,25 +43435,25 @@ export const SubjectListingDocument = gql`
     slug
     title
   }
-  mv_programmes_available: mv_programmes_1(
-    where: {key_stage_slug: {_eq: $keyStageSlug}, unit_count: {_neq: 0}}
+  mv_programmes_available: mv_programmes_2(
+    where: {key_stage_slug: {_eq: $keyStageSlug}, total_unit_count: {_neq: 0}}
   ) {
     keyStageSlug: key_stage_slug
     programmeSlug: programme_slug
     slug: subject_slug
     title: subject_title
     tierSlug: tier_slug
-    unitCount: unit_count
+    unitCount: total_unit_count
   }
-  mv_programmes_unavailable: mv_programmes_1(
-    where: {key_stage_slug: {_eq: $keyStageSlug}, unit_count: {_eq: 0}}
+  mv_programmes_unavailable: mv_programmes_2(
+    where: {key_stage_slug: {_eq: $keyStageSlug}, total_unit_count: {_eq: 0}}
   ) {
     keyStageSlug: key_stage_slug
     programmeSlug: programme_slug
     slug: subject_slug
     title: subject_title
     tierSlug: tier_slug
-    unitCount: unit_count
+    unitCount: total_unit_count
   }
 }
     `;
@@ -40959,7 +43472,9 @@ export const TeachersKeyStageSubjectTiersDocument = gql`
     slug
     title
   }
-  mv_subjects(where: {slug: {_eq: $subjectSlug}}) {
+  mv_subjects: mv_subjects_2(
+    where: {key_stage_slug: {_eq: $keyStageSlug}, slug: {_eq: $subjectSlug}}
+  ) {
     slug
     title
   }
@@ -40983,7 +43498,7 @@ export const TeachersKeyStageSubjectTiersPathsDocument = gql`
     `;
 export const TeachersKeyStageSubjectUnitLessonsDocument = gql`
     query teachersKeyStageSubjectUnitLessons($keyStageSlug: String!, $subjectSlug: String!, $unitSlug: String!) {
-  mv_units(
+  mv_units: mv_units_2(
     where: {slug: {_eq: $unitSlug}, subject_slug: {_eq: $subjectSlug}, key_stage_slug: {_eq: $keyStageSlug}}
   ) {
     unitSlug: slug
@@ -40993,7 +43508,7 @@ export const TeachersKeyStageSubjectUnitLessonsDocument = gql`
     subjectSlug: subject_slug
     subjectTitle: subject_title
   }
-  mv_lessons(
+  mv_lessons: mv_lessons_3(
     order_by: {position_in_unit: asc}
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}}
   ) {
@@ -41026,7 +43541,9 @@ export const TeachersKeyStageSubjectUnitsDocument = gql`
     slug
     title
   }
-  mv_subjects(where: {slug: {_eq: $subjectSlug}}) {
+  mv_subjects: mv_subjects_2(
+    where: {key_stage_slug: {_eq: $keyStageSlug}, slug: {_eq: $subjectSlug}}
+  ) {
     slug
     title
   }
@@ -41038,7 +43555,7 @@ export const TeachersKeyStageSubjectUnitsDocument = gql`
     unitCount: unit_count
     lessonCount: lesson_count
   }
-  mv_units(
+  mv_units: mv_units_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, tier_slug: {_eq: $tierSlug}, theme_slug: {_eq: $learningThemeSlug}}
     order_by: {year: asc, unit_study_order: asc}
   ) {
@@ -41057,7 +43574,7 @@ export const TeachersKeyStageSubjectUnitsDocument = gql`
     expired
     expiredLessonCount: expired_lesson_count
   }
-  mv_learning_themes(
+  mv_learning_themes: mv_learning_themes_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, tier_slug: {_eq: $tierSlug}}
   ) {
     label: title
@@ -41092,7 +43609,7 @@ export const TeachersKeyStageSubjectUnitLessonsDownloadsDocument = gql`
     `;
 export const TeachersKeyStageSubjectUnitsPathsDocument = gql`
     query teachersKeyStageSubjectUnitsPaths {
-  mv_subjects {
+  mv_subjects: mv_subjects_2 {
     subjectSlug: slug
     keyStageSlug: key_stage_slug
   }
@@ -41104,7 +43621,7 @@ export const TeachersKeyStageSubjectsDocument = gql`
     slug
     title
   }
-  mv_subjects(
+  mv_subjects: mv_subjects_2(
     order_by: {slug: asc}
     where: {key_stage_slug: {_eq: $keyStageSlug}}
   ) {
@@ -41121,7 +43638,7 @@ export const TeachersKeyStageSubjectsDocument = gql`
     `;
 export const TeachersLessonOverviewDocument = gql`
     query teachersLessonOverview($lessonSlug: String!, $keyStageSlug: String!, $subjectSlug: String!, $unitSlug: String!) {
-  mv_lessons(
+  mv_lessons: mv_lessons_3(
     where: {slug: {_eq: $lessonSlug}, key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}}
   ) {
     slug
@@ -41151,7 +43668,7 @@ export const TeachersLessonOverviewDocument = gql`
     title
     questionCount: question_count
   }
-  exitQuiz: mv_questions(
+  exitQuiz: mv_questions_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}, quiz_type: {_eq: "exit"}, lesson_slug: {_eq: $lessonSlug}}
     order_by: {order: asc}
   ) {
@@ -41183,7 +43700,7 @@ export const TeachersLessonOverviewDocument = gql`
     title
     questionCount: question_count
   }
-  introQuiz: mv_questions(
+  introQuiz: mv_questions_2(
     where: {key_stage_slug: {_eq: $keyStageSlug}, subject_slug: {_eq: $subjectSlug}, unit_slug: {_eq: $unitSlug}, quiz_type: {_eq: "intro"}, lesson_slug: {_eq: $lessonSlug}}
     order_by: {order: asc}
   ) {
@@ -41213,7 +43730,7 @@ export const TeachersLessonOverviewDocument = gql`
     `;
 export const TeachersLessonOverviewPathsDocument = gql`
     query teachersLessonOverviewPaths {
-  mv_lessons {
+  mv_lessons: mv_lessons_3 {
     lessonSlug: slug
     keyStageSlug: key_stage_slug
     subjectSlug: subject_slug

--- a/src/node-lib/curriculum-api/queries/subjectListing.gql
+++ b/src/node-lib/curriculum-api/queries/subjectListing.gql
@@ -3,24 +3,30 @@ query subjectListing($keyStageSlug: String!) {
     slug
     title
   }
-  mv_programmes_available: mv_programmes_1(
-    where: { key_stage_slug: { _eq: $keyStageSlug }, unit_count: { _neq: 0 } }
+  mv_programmes_available: mv_programmes_2(
+    where: {
+      key_stage_slug: { _eq: $keyStageSlug }
+      total_unit_count: { _neq: 0 }
+    }
   ) {
     keyStageSlug: key_stage_slug
     programmeSlug: programme_slug
     slug: subject_slug
     title: subject_title
     tierSlug: tier_slug
-    unitCount: unit_count
+    unitCount: total_unit_count
   }
-  mv_programmes_unavailable: mv_programmes_1(
-    where: { key_stage_slug: { _eq: $keyStageSlug }, unit_count: { _eq: 0 } }
+  mv_programmes_unavailable: mv_programmes_2(
+    where: {
+      key_stage_slug: { _eq: $keyStageSlug }
+      total_unit_count: { _eq: 0 }
+    }
   ) {
     keyStageSlug: key_stage_slug
     programmeSlug: programme_slug
     slug: subject_slug
     title: subject_title
     tierSlug: tier_slug
-    unitCount: unit_count
+    unitCount: total_unit_count
   }
 }

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectTiers.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectTiers.gql
@@ -6,7 +6,12 @@ query teachersKeyStageSubjectTiers(
     slug
     title
   }
-  mv_subjects(where: { slug: { _eq: $subjectSlug } }) {
+  mv_subjects: mv_subjects_2(
+    where: {
+      key_stage_slug: { _eq: $keyStageSlug }
+      slug: { _eq: $subjectSlug }
+    }
+  ) {
     slug
     title
   }

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitLessons.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitLessons.gql
@@ -3,7 +3,7 @@ query teachersKeyStageSubjectUnitLessons(
   $subjectSlug: String!
   $unitSlug: String!
 ) {
-  mv_units(
+  mv_units: mv_units_2(
     where: {
       slug: { _eq: $unitSlug }
       subject_slug: { _eq: $subjectSlug }
@@ -17,7 +17,7 @@ query teachersKeyStageSubjectUnitLessons(
     subjectSlug: subject_slug
     subjectTitle: subject_title
   }
-  mv_lessons(
+  mv_lessons: mv_lessons_3(
     order_by: { position_in_unit: asc }
     where: {
       key_stage_slug: { _eq: $keyStageSlug }

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnits.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnits.gql
@@ -8,7 +8,12 @@ query teachersKeyStageSubjectUnits(
     slug
     title
   }
-  mv_subjects(where: { slug: { _eq: $subjectSlug } }) {
+  mv_subjects: mv_subjects_2(
+    where: {
+      key_stage_slug: { _eq: $keyStageSlug }
+      slug: { _eq: $subjectSlug }
+    }
+  ) {
     slug
     title
   }
@@ -23,7 +28,7 @@ query teachersKeyStageSubjectUnits(
     unitCount: unit_count
     lessonCount: lesson_count
   }
-  mv_units(
+  mv_units: mv_units_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }
@@ -47,7 +52,7 @@ query teachersKeyStageSubjectUnits(
     expired
     expiredLessonCount: expired_lesson_count
   }
-  mv_learning_themes(
+  mv_learning_themes: mv_learning_themes_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitsPaths.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjectUnitsPaths.gql
@@ -1,5 +1,5 @@
 query teachersKeyStageSubjectUnitsPaths {
-  mv_subjects {
+  mv_subjects: mv_subjects_2 {
     subjectSlug: slug
     keyStageSlug: key_stage_slug
   }

--- a/src/node-lib/curriculum-api/queries/teachersKeyStageSubjects.gql
+++ b/src/node-lib/curriculum-api/queries/teachersKeyStageSubjects.gql
@@ -3,7 +3,7 @@ query teachersKeyStageSubjects($keyStageSlug: String!) {
     slug
     title
   }
-  mv_subjects(
+  mv_subjects: mv_subjects_2(
     order_by: { slug: asc }
     where: { key_stage_slug: { _eq: $keyStageSlug } }
   ) {

--- a/src/node-lib/curriculum-api/queries/teachersLessonOverview.gql
+++ b/src/node-lib/curriculum-api/queries/teachersLessonOverview.gql
@@ -4,7 +4,7 @@ query teachersLessonOverview(
   $subjectSlug: String!
   $unitSlug: String!
 ) {
-  mv_lessons(
+  mv_lessons: mv_lessons_3(
     where: {
       slug: { _eq: $lessonSlug }
       key_stage_slug: { _eq: $keyStageSlug }
@@ -45,7 +45,7 @@ query teachersLessonOverview(
     title
     questionCount: question_count
   }
-  exitQuiz: mv_questions(
+  exitQuiz: mv_questions_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }
@@ -89,7 +89,7 @@ query teachersLessonOverview(
     title
     questionCount: question_count
   }
-  introQuiz: mv_questions(
+  introQuiz: mv_questions_2(
     where: {
       key_stage_slug: { _eq: $keyStageSlug }
       subject_slug: { _eq: $subjectSlug }

--- a/src/node-lib/curriculum-api/queries/teachersLessonOverviewPaths.gql
+++ b/src/node-lib/curriculum-api/queries/teachersLessonOverviewPaths.gql
@@ -1,5 +1,5 @@
 query teachersLessonOverviewPaths {
-  mv_lessons{
+  mv_lessons: mv_lessons_3 {
     lessonSlug: slug
     keyStageSlug: key_stage_slug
     subjectSlug: subject_slug


### PR DESCRIPTION
… programmesrequest

## Description

- Updates gql queries to filter out science lessons

## Issue(s)

Fixes #1460 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):

![Screenshot 2023-04-17 at 09 25 34](https://user-images.githubusercontent.com/91190841/232434647-141d1b9a-334d-47c4-bf74-32ef25298efe.png)
![Screenshot 2023-04-17 at 09 25 58](https://user-images.githubusercontent.com/91190841/232434653-c040706e-57c5-4a51-918d-fedf295077e7.png)


How it should now look:


![Screenshot 2023-04-17 at 09 24 55](https://user-images.githubusercontent.com/91190841/232434587-20f1cd56-771a-4e85-a7dc-68ab7f07d6af.png)
![Screenshot 2023-04-17 at 09 25 08](https://user-images.githubusercontent.com/91190841/232434593-f58ee43c-a60b-4ba1-b8eb-dc1c0b1aedc4.png)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
