### PR TITLE
chore: no floating promises eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/no-floating-promises": "error",
         ...importRules,
       },
       settings: {


### PR DESCRIPTION
## Description

- add no-floating-promises eslint rule
This rule reports when a Promise is created and not properly handled. Valid ways of handling a Promise-valued statement include:

awaiting it
returning it
Calling its .then() with two arguments
Calling its .catch() with one argument
https://typescript-eslint.io/rules/no-floating-promises/

## Issue(s)

Fixes #

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
