### PR TITLE
fix: replace sanity asset urls with first party proxy domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mux/mux-player-react": "^1.8.0",
         "@portabletext/react": "^1.0.6",
         "@react-aria/aria-modal-polyfill": "^3.6.0",
+        "@sanity/asset-utils": "^1.3.0",
         "@sanity/image-url": "^1.0.1",
         "@svgr/webpack": "^7.0.0",
         "@types/uuid": "^8.3.4",
@@ -9438,6 +9439,14 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
       "dev": true
+    },
+    "node_modules/@sanity/asset-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-1.3.0.tgz",
+      "integrity": "sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@sanity/client": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@mux/mux-player-react": "^1.8.0",
     "@portabletext/react": "^1.0.6",
     "@react-aria/aria-modal-polyfill": "^3.6.0",
+    "@sanity/asset-utils": "^1.3.0",
     "@sanity/image-url": "^1.0.1",
     "@svgr/webpack": "^7.0.0",
     "@types/uuid": "^8.3.4",

--- a/src/node-lib/cms/sanity-client/index.test.ts
+++ b/src/node-lib/cms/sanity-client/index.test.ts
@@ -105,6 +105,16 @@ describe("cms/sanity-client", () => {
     });
   });
 
+  describe("aboutBoardPage", () => {
+    it("document urls are proxied", async () => {
+      const result = await getSanityClient().aboutBoardPage();
+
+      expect(result?.documents[0]?.file.asset.url).toMatch(
+        /^https:\/\/NEXT_PUBLIC_SANITY_ASSET_CDN_HOST\/files/
+      );
+    });
+  });
+
   describe("landingPageBySlug", () => {
     it("fetches the specified landing page", async () => {
       await getSanityClient().landingPageBySlug("some-landing-page");

--- a/src/node-lib/cms/sanity-client/index.ts
+++ b/src/node-lib/cms/sanity-client/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { tryGetAssetPath } from "@sanity/asset-utils";
 
 import sanityGraphqlApi from "../../sanity-graphql";
 import {
@@ -23,6 +24,7 @@ import {
   blogListingPageSchema,
 } from "../../../common-lib/cms-types";
 import { webinarsListingPageSchema } from "../../../common-lib/cms-types/webinarsListingPage";
+import browserConfig from "../../../config/browser";
 
 import { getSingleton, getBySlug, getList } from "./cmsMethods";
 
@@ -102,6 +104,20 @@ const getSanityClient = () => ({
     aboutBoardPageSchema,
     (result) => {
       const boardPageData = result?.allAboutCorePageBoard?.[0];
+      if (boardPageData?.documents) {
+        boardPageData.documents.forEach((doc) => {
+          const asset = doc?.file?.asset;
+          const url = asset?.url;
+          const assetPath = url ? tryGetAssetPath(url) : null;
+          const proxiedUrl = assetPath
+            ? `https://${browserConfig.get("sanityAssetCDNHost")}/${assetPath}`
+            : null;
+
+          if (doc?.file?.asset?.url) {
+            doc.file.asset.url = proxiedUrl;
+          }
+        });
+      }
       const parentPageData = result?.aboutCorePage?.[0];
 
       return boardPageData && parentPageData

--- a/src/node-lib/sanity-graphql/index.ts
+++ b/src/node-lib/sanity-graphql/index.ts
@@ -9,6 +9,13 @@ import {
   // SdkFunctionWrapper,
 } from "./generated/sdk";
 
+export const sanityConfig = {
+  projectId: serverConfig.get("sanityProjectId"),
+  dataset: serverConfig.get("sanityDataset"),
+  datasetTag: serverConfig.get("sanityDatasetTag"),
+  useCDN: serverConfig.get("sanityUseCDN") === "true",
+};
+
 const getGraphqlEndpoint = (opts: {
   projectId: string;
   dataset: string;
@@ -20,12 +27,7 @@ const getGraphqlEndpoint = (opts: {
   return `https://${opts.projectId}.${subdomain}.sanity.io/v1/graphql/${opts.dataset}/${opts.datasetTag}`;
 };
 
-const graphqlAPIUrl = getGraphqlEndpoint({
-  projectId: serverConfig.get("sanityProjectId"),
-  dataset: serverConfig.get("sanityDataset"),
-  datasetTag: serverConfig.get("sanityDatasetTag"),
-  useCDN: serverConfig.get("sanityUseCDN") === "true",
-});
+const graphqlAPIUrl = getGraphqlEndpoint(sanityConfig);
 
 export const sanityGraphqlClient = new GraphQLClient(graphqlAPIUrl, {
   headers: {


### PR DESCRIPTION
## Description

- in cms client, overwrite board page document asset url with proxied api host
- adds test

## Issue(s)

Fixes #645

## How to test

1. Go to {cloud link}
2. Go to about/board
3. You should see that the downloadable documents come from `sanity-asset-cdn.thenational.academy` and the downloads work
