### PR TITLE
fix(blog): replacce sanity cdn links with proxied urls

### DIFF
--- a/src/common-lib/urls/getProxiedSanityAssetUrl.test.ts
+++ b/src/common-lib/urls/getProxiedSanityAssetUrl.test.ts
@@ -1,0 +1,24 @@
+import getProxiedSanityAssetUrl from "./getProxiedSanityAssetUrl";
+
+describe("getProxiedSanityAssetUrl", () => {
+  test("should return url with proxied cdn host", () => {
+    expect(
+      getProxiedSanityAssetUrl(
+        "https://cdn.sanity.io/files/cuvjke51/production/becc1901c9dbacb8889f5952605672be926d5386.pdf"
+      )
+    ).toEqual(
+      "https://NEXT_PUBLIC_SANITY_ASSET_CDN_HOST/files/cuvjke51/production/becc1901c9dbacb8889f5952605672be926d5386.pdf"
+    );
+  });
+  test("should return original url if not valid sanity cdn url", () => {
+    expect(
+      getProxiedSanityAssetUrl("https://www.thenational.academy/something-else")
+    ).toEqual("https://www.thenational.academy/something-else");
+  });
+  test("should return null if null passed", () => {
+    expect(getProxiedSanityAssetUrl(null)).toEqual(null);
+  });
+  test("should return undefined if undefined passed", () => {
+    expect(getProxiedSanityAssetUrl(undefined)).toEqual(undefined);
+  });
+});

--- a/src/common-lib/urls/getProxiedSanityAssetUrl.ts
+++ b/src/common-lib/urls/getProxiedSanityAssetUrl.ts
@@ -1,0 +1,27 @@
+import { tryGetAssetPath } from "@sanity/asset-utils";
+
+import browserConfig from "../../config/browser";
+
+/**
+ *
+ * @param url
+ * @returns {string} The url with proxied cdn as host, or if url not sanity
+ * asset url, returns the url unmodified.
+ */
+function getProxiedSanityAssetUrl(url: null): null;
+function getProxiedSanityAssetUrl(url: undefined): undefined;
+function getProxiedSanityAssetUrl(url: string): string;
+function getProxiedSanityAssetUrl(
+  url: string | null | undefined
+): string | null | undefined;
+function getProxiedSanityAssetUrl(url: string | null | undefined) {
+  const assetPath = url ? tryGetAssetPath(url) : null;
+
+  if (!assetPath) {
+    return url;
+  }
+
+  return `https://${browserConfig.get("sanityAssetCDNHost")}/${assetPath}`;
+}
+
+export default getProxiedSanityAssetUrl;

--- a/src/components/PortableText/PortableText.tsx
+++ b/src/components/PortableText/PortableText.tsx
@@ -15,6 +15,7 @@ import {
 import { CTAInternalLinkEntry } from "../../common-lib/cms-types";
 import { LI, OL, P, Span } from "../Typography";
 import OakLink from "../OakLink";
+import getProxiedSanityAssetUrl from "../../common-lib/urls/getProxiedSanityAssetUrl";
 
 import { PTActionTrigger } from "./PTActionTrigger";
 
@@ -69,7 +70,7 @@ export const PTInternalLink: PortableTextMarkComponent<{
     return null;
   }
 
-  let href;
+  let href: string | undefined;
   try {
     href = resolveInternalHref(reference);
   } catch (err) {
@@ -80,6 +81,9 @@ export const PTInternalLink: PortableTextMarkComponent<{
   if (!href) {
     return null;
   }
+
+  href = getProxiedSanityAssetUrl(href);
+
   return (
     <OakLink href={href} page={null} $isInline>
       {props.children}

--- a/src/components/Posts/PostPortableText/PostPortableText.tsx
+++ b/src/components/Posts/PostPortableText/PostPortableText.tsx
@@ -48,6 +48,7 @@ type PostPortableTextProps = {
 
 const PostPortableText: FC<PostPortableTextProps> = (props) => {
   const { portableText } = props;
+
   return (
     <BasePortableTextProvider>
       <PortableText

--- a/src/node-lib/cms/sanity-client/index.ts
+++ b/src/node-lib/cms/sanity-client/index.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { tryGetAssetPath } from "@sanity/asset-utils";
 
 import sanityGraphqlApi from "../../sanity-graphql";
 import {
@@ -24,7 +23,7 @@ import {
   blogListingPageSchema,
 } from "../../../common-lib/cms-types";
 import { webinarsListingPageSchema } from "../../../common-lib/cms-types/webinarsListingPage";
-import browserConfig from "../../../config/browser";
+import getProxiedSanityAssetUrl from "../../../common-lib/urls/getProxiedSanityAssetUrl";
 
 import { getSingleton, getBySlug, getList } from "./cmsMethods";
 
@@ -108,10 +107,7 @@ const getSanityClient = () => ({
         boardPageData.documents.forEach((doc) => {
           const asset = doc?.file?.asset;
           const url = asset?.url;
-          const assetPath = url ? tryGetAssetPath(url) : null;
-          const proxiedUrl = assetPath
-            ? `https://${browserConfig.get("sanityAssetCDNHost")}/${assetPath}`
-            : null;
+          const proxiedUrl = getProxiedSanityAssetUrl(url);
 
           if (doc?.file?.asset?.url) {
             doc.file.asset.url = proxiedUrl;


### PR DESCRIPTION
## Description


- adds util `getProxiedSanityAssetUrl`
- in blog/webinar content, replace link hrefs with prixed urls

## Issue(s)

Fixes #645 

## How to test

1. Go to {cloud link}
2. Go to /blog/our-strategy-update
3. You should see the pdfs at the bottom are hosted at `https://sanity-asset-cdn.thenational.academy` (and the downloads work

