### PR TITLE
docs(security): communicate GitHub private vulnerability reporting option

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -11,6 +11,8 @@ Preferred-Languages: en
 Encryption: https://www.thenational.academy/.well-known/pgp-key.txt
 Encryption: https://keys.openpgp.org/vks/v1/by-fingerprint/E925058764BF1E055A95CFA7971F062051B60B7D
 
+Alternatively please follow the GitHub private vulnerability reporting steps https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability .
+
 # This security is annually reviewed
 Expires: 2023-07-31T20:59:00.000Z
 


### PR DESCRIPTION
Update the security policy to indicate the reporting via GitHub is an option (once we turn it on)