### PR TITLE
chore(footer): add Status link to Oak footer and tidy up links

### DIFF
--- a/src/browser-lib/fixtures/footerSections.ts
+++ b/src/browser-lib/fixtures/footerSections.ts
@@ -21,12 +21,19 @@ const footerSections: FooterSections = {
       { text: "About us", href: "/about-us/who-we-are" },
       {
         text: "Careers",
-        href: "https://app.beapplied.com/org/1574/oak-national-academy",
+        href: "https://jobs.thenational.academy",
       },
       { text: "Contact us", href: "/contact-us" },
-      { text: "Help", href: "https://support.thenational.academy" },
+      {
+        text: "Help",
+        href: "https://support.thenational.academy",
+      },
       { text: "Blog", href: "/blog" },
       { text: "Webinars", href: "/webinars" },
+      {
+        text: "Status",
+        href: "https://status.thenational.academy",
+      },
     ],
   },
 

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -3,6 +3,7 @@ import renderWithTheme from "../../__tests__/__helpers__/renderWithTheme";
 import Pagination from "./Pagination";
 
 export const mockPaginationProps = {
+  totalResults: 1,
   totalPages: 25,
   currentPage: 1,
   pageSize: 20,


### PR DESCRIPTION
Adding status link and use first party domain for careers to direct to jobs page.

## Description

- Added Status to bottom of Oak section in footer that links to https://status.thenational.academy
- Edited Careers link to direct to https://jobs.thenational.academy instead of direct link

## How to test

1. Go to homepage
2. Scroll to footer
3. You should see Status at the bottom of the Oak section (middle column on desktop)
4. Click link and it should take you to https://status.thenational.academy
5. You should see Careers third in the list of the Oak section (middle column on desktop)
6. Click link and it should take you to https://jobs.thenational.academy and redirect to BeApplied

## Screenshots

How it used to look:
<img width="1773" alt="Screenshot 2023-05-17 at 10 52 06" src="https://github.com/oaknational/Oak-Web-Application/assets/4476971/e3d18b91-7dd9-49eb-ba6a-bf6ae80ef8de">

How it should now look:
<img width="1773" alt="Screenshot 2023-05-17 at 10 49 21" src="https://github.com/oaknational/Oak-Web-Application/assets/4476971/6b5645ab-2ce8-4f07-9cb3-df74f15dbfee">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
