### PR TITLE
chore(comma-separate): comma separate multiple correct short answer o…

### DIFF
--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
@@ -147,6 +147,11 @@ const choiceIsInAnswerArray = (
 
 const QuestionListItem: FC<QuestionListItemProps> = (props) => {
   const { title, images, choices, answer, type, displayNumber } = props;
+
+  const joinAnswer = type === "short-answer" && Array.isArray(answer);
+  const joinedAnswer = joinAnswer ? answer.join(", ") : "";
+  const joinedAnswerIndex = 0;
+
   return (
     <Flex $flexDirection={"column"} $mb={[32, 48]}>
       <Flex $mb={16}>
@@ -276,9 +281,17 @@ const QuestionListItem: FC<QuestionListItemProps> = (props) => {
           $width={"max-content"}
           $maxWidth={"100%"}
         >
-          {[...answer].map((ans, index) => {
-            return <CorrectAnswer choice={ans} index={index} type={type} />;
-          })}
+          {type === "short-answer" ? (
+            <CorrectAnswer
+              choice={joinedAnswer}
+              type={type}
+              index={joinedAnswerIndex}
+            />
+          ) : (
+            [...answer].map((ans, index) => {
+              return <CorrectAnswer choice={ans} index={index} type={type} />;
+            })
+          )}
         </Flex>
       )}
     </Flex>


### PR DESCRIPTION
## Description

- Comma separates multiple correct short answers 

## Issue(s)

Fixes #1447 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):

![226985053-508933ee-5d9d-40b0-a028-a82b5b4b93ad](https://github.com/oaknational/Oak-Web-Application/assets/91190841/86619d39-b5dd-48aa-ac48-ca96c94b1064)


How it should now look:

<img width="756" alt="Screenshot 2023-05-19 at 11 55 11" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/e62886f4-f2d1-4c39-8a06-2869c9b859c3">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
