### PR TITLE
Fix/storybook intro

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -23,7 +23,7 @@ module.exports = {
     NEXT_PUBLIC_GLEAP_API_URL: "NEXT_PUBLIC_GLEAP_API_URL",
     NEXT_PUBLIC_GLEAP_FRAME_URL: "NEXT_PUBLIC_GLEAP_FRAME_URL",
   }),
-  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/components/Intro.stories.mdx","../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -23,7 +23,10 @@ module.exports = {
     NEXT_PUBLIC_GLEAP_API_URL: "NEXT_PUBLIC_GLEAP_API_URL",
     NEXT_PUBLIC_GLEAP_FRAME_URL: "NEXT_PUBLIC_GLEAP_FRAME_URL",
   }),
-  stories: ["../src/components/Intro.stories.mdx","../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: [
+    "../src/components/Intro.stories.mdx",
+    "../src/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",


### PR DESCRIPTION
## Description

- fix introduction page from not building

## Issue(s)

Fixes #

## How to test

1. Go to storybook introduction page
3. You should seea short intro paragraph no errors

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
