### PR TITLE
Feat/1582 add science lessons to search

### DIFF
--- a/src/context/Search/constructElasticQuery.test.ts
+++ b/src/context/Search/constructElasticQuery.test.ts
@@ -35,33 +35,6 @@ describe("Search/constructElasticQuery", () => {
             { term: { expired: false } },
             { term: { is_specialist: false } },
             { terms: { key_stage_slug: ["1", "2", "3", "4"] } },
-            {
-              bool: {
-                must_not: {
-                  bool: {
-                    must: [
-                      { term: { subject_slug: "science" } },
-                      { term: { key_stage_slug: "3" } },
-                    ],
-                  },
-                },
-              },
-            },
-            {
-              bool: {
-                must_not: [
-                  {
-                    terms: {
-                      subject_slug: [
-                        "biology",
-                        "chemistry",
-                        "combined_science",
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
           ],
           minimum_should_match: 1,
         },
@@ -108,33 +81,6 @@ describe("Search/constructElasticQuery", () => {
             { term: { expired: false } },
             { term: { is_specialist: false } },
             { terms: { key_stage_slug: ["3"] } },
-            {
-              bool: {
-                must_not: {
-                  bool: {
-                    must: [
-                      { term: { subject_slug: "science" } },
-                      { term: { key_stage_slug: "3" } },
-                    ],
-                  },
-                },
-              },
-            },
-            {
-              bool: {
-                must_not: [
-                  {
-                    terms: {
-                      subject_slug: [
-                        "biology",
-                        "chemistry",
-                        "combined_science",
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
           ],
           minimum_should_match: 1,
         },

--- a/src/context/Search/constructElasticQuery.ts
+++ b/src/context/Search/constructElasticQuery.ts
@@ -42,32 +42,6 @@ const constructElasticQuery = (query: ConstructQueryParams) => {
           },
         };
 
-  const excludeNewScienceLessonsFilter = [
-    {
-      bool: {
-        must_not: {
-          bool: {
-            must: [
-              { term: { subject_slug: "science" } },
-              { term: { key_stage_slug: "3" } },
-            ],
-          },
-        },
-      },
-    },
-    {
-      bool: {
-        must_not: [
-          {
-            terms: {
-              subject_slug: ["biology", "chemistry", "combined_science"],
-            },
-          },
-        ],
-      },
-    },
-  ];
-
   const highlight = {
     number_of_fragments: 0,
     pre_tags: ["<b>"],
@@ -125,7 +99,6 @@ const constructElasticQuery = (query: ConstructQueryParams) => {
             },
           },
           { ...keyStageFilter },
-          ...excludeNewScienceLessonsFilter,
         ],
         /* if this is not set in a "should" any filtered content will appear
           not just those in the multi-matches above */


### PR DESCRIPTION
## Description

- Deletes filter to add science lessons back into the search

## Issue(s)

Fixes #1582 

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):

<img width="1303" alt="Screenshot 2023-05-25 at 10 02 49" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/8777e884-1055-4981-8ce1-497c1e815c90">

How it should now look:

<img width="1223" alt="Screenshot 2023-05-25 at 10 01 45" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/1510bec1-17c4-4c5a-83ff-94358a4cf401">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
