### PR TITLE
fix: cms content snags

### DIFF
--- a/src/components/Posts/PostPortableText/PostCta.tsx
+++ b/src/components/Posts/PostPortableText/PostCta.tsx
@@ -12,6 +12,7 @@ const PostCta = (props: PortableTextComponentProps<CTA>) => {
 
   return (
     <ButtonAsLink
+      $mt={20}
       page={null}
       label={cta.label}
       href={getLinkHref(cta)}

--- a/src/components/Posts/PostPortableText/PostForm.tsx
+++ b/src/components/Posts/PostPortableText/PostForm.tsx
@@ -1,0 +1,24 @@
+import { PortableTextComponentProps } from "@portabletext/react";
+
+import Flex from "../../Flex";
+import { SignUpForm } from "../../pages/LandingPages/SignUpForm";
+
+type FormBlock = {
+  title: string;
+};
+
+const PostForm = (props: PortableTextComponentProps<FormBlock>) => {
+  if (!props.value) {
+    return null;
+  }
+
+  const params = props.value;
+
+  return (
+    <Flex $mv={56}>
+      <SignUpForm formTitle={params.title} />
+    </Flex>
+  );
+};
+
+export default PostForm;

--- a/src/components/Posts/PostPortableText/PostPortableText.test.tsx
+++ b/src/components/Posts/PostPortableText/PostPortableText.test.tsx
@@ -75,6 +75,29 @@ const callout = {
   ],
 };
 
+const form = {
+  title: "This is a form!",
+  formId: "c9ce863c-3772-43ab-9b2e-67d0a8f60427",
+  _type: "formWrapper",
+  _key: "12ff6959bfa1",
+  body: [
+    {
+      style: "normal",
+      _key: "2415bcf01eaa",
+      markDefs: [],
+      _type: "block",
+      children: [
+        {
+          marks: [],
+          text: "And here is the form",
+          _key: "aea98489d263",
+          _type: "span",
+        },
+      ],
+    },
+  ],
+};
+
 const withFootnotes = [
   {
     _key: "8ca83ed025d9",
@@ -171,6 +194,15 @@ describe("components/PostPortableText", () => {
 
     expect(calloutText).toHaveStyle("background-color: #f6e8a0");
   });
+  test("formWrapper renders a newsletter form", () => {
+    const { getByText } = render(<PostPortableText portableText={[form]} />);
+
+    const heading = getByText("This is a form!");
+    const submitButton = getByText("Sign up");
+
+    expect(heading).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
+  });
   describe("footnotes", () => {
     test("footnote links are rendered inline", () => {
       const { getAllByRole } = render(
@@ -185,7 +217,6 @@ describe("components/PostPortableText", () => {
         "#footnote-ref-FOOTNOTE_MARK_1"
       );
     });
-
     test("footnote references are rendered with backlinks", () => {
       const { getByRole } = render(
         <PostPortableText portableText={withFootnotes} />

--- a/src/components/Posts/PostPortableText/PostPortableText.tsx
+++ b/src/components/Posts/PostPortableText/PostPortableText.tsx
@@ -11,6 +11,7 @@ import { BasePortableTextProvider } from "../../PortableText";
 import PostBlockCallout from "./PostBlockCallout";
 import PostCallout from "./PostCallout";
 import PostCta from "./PostCta";
+import PostForm from "./PostForm";
 import PostImageWithAltText from "./PostImageWithAltText";
 import PostQuote from "./PostQuote";
 import PostSectionHeading from "./PostSectionHeading";
@@ -48,6 +49,7 @@ const postPortableTextComponents = ({
     imageWithAltText: PostImageWithAltText,
     video: PostVideo,
     textAndMedia: PostTextAndMedia,
+    formWrapper: PostForm,
     quote: PostQuote,
     callout: PostCallout,
     cta: PostCta,

--- a/src/components/Posts/PostPortableText/PostQuote.tsx
+++ b/src/components/Posts/PostPortableText/PostQuote.tsx
@@ -16,7 +16,7 @@ const PostQuote = (props: PortableTextComponentProps<Quote>) => {
         <blockquote>&ldquo;{props.value.text.trim()}&rdquo;</blockquote>
       </Box>
       <div>
-        <P $font={"body-1"} $mt={[16]} $textAlign="center">
+        <P $font={"body-1"} $mt={[16]}>
           <cite>{props.value?.attribution}</cite>
           {props.value.role && `, ${props.value.role}`}
         </P>

--- a/src/components/pages/LandingPages/LandingPageTextAndMedia.tsx
+++ b/src/components/pages/LandingPages/LandingPageTextAndMedia.tsx
@@ -2,7 +2,7 @@ import { PortableText, PortableTextComponents } from "@portabletext/react";
 import { FC } from "react";
 
 import { TextAndMedia } from "../../../common-lib/cms-types";
-import { getCTAHref } from "../../../utils/portableText/resolveInternalHref";
+import { getLinkHref } from "../../../utils/portableText/resolveInternalHref";
 import ButtonAsLink from "../../Button/ButtonAsLink";
 import Card from "../../Card";
 import CMSImage from "../../CMSImage";
@@ -88,7 +88,7 @@ export const LandingPageTextAndMedia: FC<TextAndMedia> = (props) => {
               $mt={[48, 32]}
               label={props.cta.label}
               page={null}
-              href={getCTAHref(props.cta)}
+              href={getLinkHref(props.cta)}
             />
           )}
         </div>

--- a/src/components/pages/LandingPages/LandingPageTextAndMedia.tsx
+++ b/src/components/pages/LandingPages/LandingPageTextAndMedia.tsx
@@ -2,6 +2,8 @@ import { PortableText, PortableTextComponents } from "@portabletext/react";
 import { FC } from "react";
 
 import { TextAndMedia } from "../../../common-lib/cms-types";
+import { getCTAHref } from "../../../utils/portableText/resolveInternalHref";
+import ButtonAsLink from "../../Button/ButtonAsLink";
 import Card from "../../Card";
 import CMSImage from "../../CMSImage";
 import CMSVideo from "../../CMSVideo";
@@ -77,6 +79,19 @@ export const LandingPageTextAndMedia: FC<TextAndMedia> = (props) => {
           components={landingPortableTextComponent}
           value={props.bodyPortableText}
         />
+
+        <div>
+          {props.cta && (
+            <ButtonAsLink
+              icon="arrow-right"
+              $iconPosition={"trailing"}
+              $mt={[48, 32]}
+              label={props.cta.label}
+              page={null}
+              href={getCTAHref(props.cta)}
+            />
+          )}
+        </div>
       </Flex>
     </Card>
   );

--- a/src/node-lib/sanity-graphql/generated/sdk.ts
+++ b/src/node-lib/sanity-graphql/generated/sdk.ts
@@ -445,7 +445,7 @@ export type Block = {
   style?: Maybe<Scalars['String']['output']>;
 };
 
-export type BlockOrCalloutOrCtaOrImageWithAltTextOrQuoteOrTextAndMediaOrVideo = Block | Callout | Cta | ImageWithAltText | Quote | TextAndMedia | Video;
+export type BlockOrCalloutOrCtaOrFormWrapperOrImageWithAltTextOrQuoteOrTextAndMediaOrVideo = Block | Callout | Cta | FormWrapper | ImageWithAltText | Quote | TextAndMedia | Video;
 
 export type BlockOrImage = Block | Image;
 
@@ -915,12 +915,6 @@ export type FormWrapper = {
   _key?: Maybe<Scalars['String']['output']>;
   _type?: Maybe<Scalars['String']['output']>;
   bodyRaw?: Maybe<Scalars['JSON']['output']>;
-  form?: Maybe<HubspotFormReference>;
-  /**
-   * The legacy implementation of the hubspot form is not
-   *       compatible with the sanity V3 upgrade.
-   *       Please fill out both fields until migration is complete.
-   */
   formId?: Maybe<Scalars['String']['output']>;
   title?: Maybe<Scalars['String']['output']>;
 };
@@ -928,7 +922,6 @@ export type FormWrapper = {
 export type FormWrapperFilter = {
   _key?: InputMaybe<StringFilter>;
   _type?: InputMaybe<StringFilter>;
-  form?: InputMaybe<HubspotFormReferenceFilter>;
   formId?: InputMaybe<StringFilter>;
   title?: InputMaybe<StringFilter>;
 };
@@ -936,7 +929,6 @@ export type FormWrapperFilter = {
 export type FormWrapperSorting = {
   _key?: InputMaybe<SortOrder>;
   _type?: InputMaybe<SortOrder>;
-  form?: InputMaybe<HubspotFormReferenceSorting>;
   formId?: InputMaybe<SortOrder>;
   title?: InputMaybe<SortOrder>;
 };


### PR DESCRIPTION
## Description

Some of the smaller sanity tweaks that don't need much consideration bundled together:

- Add the ability to render a newsletter form from within a blog post
- Fix alignment of quotes on blog posts
- Add missing spacing above CTAs on landing pages
- Add missing CTA to landing page Text & Media blocks
- Update the sanity graphql SDK

## Screenshots
A newsletter form in a blog post
<img width="500" alt="CleanShot 2023-05-23 at 15 53 35@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/661c1a06-7ba3-4c4f-8d77-0d8edd964ee4">

Before/after the CTA
<img width="200" alt="CleanShot 2023-04-26 at 16 33 48@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/cdb36689-9ffc-4208-8e94-32115e5cbd21">
<img width="200" alt="CleanShot 2023-04-26 at 16 33 52@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/16161cfc-c510-4a5b-a177-eb2cd2a9aeed">

Centered quote attribution now left aligned like the rest of the content
<img width="714" alt="CleanShot 2023-06-19 at 17 17 51@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/246a33a9-5e66-482f-87a9-96f977567642">

Text & media CTA now showing
<img width="887" alt="CleanShot 2023-06-19 at 17 17 18@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/0ebc556f-ce52-495a-abc0-30aaa8b3eb80">



## Checklist

- [ ] ~Added or updated tests where appropriate~
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
