### PR TITLE
Fix/answer spaces should be rendered when there is copy between curly braces

### DIFF
--- a/src/components/QuizContainer/QuestionListItem/quizUtils/index.test.tsx
+++ b/src/components/QuizContainer/QuestionListItem/quizUtils/index.test.tsx
@@ -49,4 +49,32 @@ describe("shortAnswerTitleFormatter", () => {
     );
     expect(getByTestId("underline")).toBeInTheDocument();
   });
+  it("when passed a string with {{some text}} pattern returns the string with underscores component replacing the pattern", () => {
+    const testProps = {
+      active: true,
+      answer: [],
+      choices: [],
+      images: [],
+      displayNumber: "Q2.",
+      feedbackCorrect: "Well done!",
+      feedbackIncorrect: "Incorrect",
+      keyStageSlug: "ks3",
+      keyStageTitle: "Key stage 3",
+      order: 2,
+      points: 1,
+      quizType: "exit",
+      required: true,
+      subjectSlug: "maths",
+      subjectTitle: "Maths",
+      title: "Given that a = 3b, fill in the gap: a + 3b = {{hello!}}b.",
+      type: "short-answer",
+      unitSlug: "expressions-equations-and-inequalities-7d65",
+      unitTitle: "Expression, Equations and Inequalities",
+    };
+
+    const { getByTestId } = renderWithTheme(
+      <QuestionListItem {...testProps} />
+    );
+    expect(getByTestId("underline")).toBeInTheDocument();
+  });
 });

--- a/src/components/QuizContainer/QuestionListItem/quizUtils/index.tsx
+++ b/src/components/QuizContainer/QuestionListItem/quizUtils/index.tsx
@@ -5,7 +5,7 @@ import Underline from "../../../Underline";
 export const shortAnswerTitleFormatter = (
   title: string | null | undefined
 ): string | React.ReactNode => {
-  const shortAnswerRegex = /\{\{\}\}/g;
+  const shortAnswerRegex = /\{\{(.+?)\}\}|(\{\{\}\})/g;
   if (!title) return "";
   if (shortAnswerRegex.test(title)) {
     return reactStringReplace(title, shortAnswerRegex, (match, i) => (


### PR DESCRIPTION
## Description

- Updates regex to match {{some text in here!}}

## Issue(s)

Fixes #1633 

## How to test

beta/teachers/programmes/science-secondary-ks3/units/cells-u2b1h4c/lessons/unicellular-organisms-m0vvmx

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}
![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/daecd82d-7cb7-4d65-918d-55e2b1c0b0a2)


How it should now look:
{screenshots}

![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/6556bc6f-94ac-45dd-bda8-eeb063739296)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
