### PR TITLE
Fix/i don't want to see markdown notation in quizzes#1581

### DIFF
--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.test.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.test.tsx
@@ -116,6 +116,17 @@ describe("QuestionListItem", () => {
 
     expect(questionItemTitle).toHaveTextContent("what is a question");
   });
+  it("renders title without markdown **text**", () => {
+    testProps.choices = [];
+    const { getByTestId } = renderWithTheme(
+      <QuestionListItem
+        {...{ ...testProps, title: "what is **a** question" }}
+      />
+    );
+    const questionItemTitle = getByTestId("title-div");
+
+    expect(questionItemTitle).toHaveTextContent("what is a question");
+  });
   it("renders correctly where correct answer doesnt have an image and incorrect choice does have image", () => {
     testProps.choices = [
       {

--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
@@ -8,7 +8,7 @@ import OakImage from "../../OakImage";
 import Typography, { Heading } from "../../Typography";
 import { QuizQuestionListProps } from "../QuestionsList/QuestionsList";
 
-import { shortAnswerTitleFormatter } from "./quizUtils";
+import { shortAnswerTitleFormatter , removeMarkdown } from "./quizUtils";
 
 export type QuestionListItemProps = QuizQuestionListProps["questions"][number];
 
@@ -146,7 +146,16 @@ const choiceIsInAnswerArray = (
 };
 
 const QuestionListItem: FC<QuestionListItemProps> = (props) => {
-  const { title, images, choices, answer, type, displayNumber } = props;
+  const {
+    title: markdownTitle,
+    images,
+    choices,
+    answer,
+    type,
+    displayNumber,
+  } = props;
+
+  const title = removeMarkdown(markdownTitle);
 
   const joinAnswer = type === "short-answer" && Array.isArray(answer);
   const joinedAnswer = joinAnswer ? answer.join(", ") : "";

--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
@@ -8,7 +8,7 @@ import OakImage from "../../OakImage";
 import Typography, { Heading } from "../../Typography";
 import { QuizQuestionListProps } from "../QuestionsList/QuestionsList";
 
-import { shortAnswerTitleFormatter , removeMarkdown } from "./quizUtils";
+import { shortAnswerTitleFormatter, removeMarkdown } from "./quizUtils";
 
 export type QuestionListItemProps = QuizQuestionListProps["questions"][number];
 

--- a/src/components/QuizContainer/QuestionListItem/quizUtils/index.test.tsx
+++ b/src/components/QuizContainer/QuestionListItem/quizUtils/index.test.tsx
@@ -1,7 +1,7 @@
 import renderWithTheme from "../../../../__tests__/__helpers__/renderWithTheme";
 import QuestionListItem from "../QuestionListItem";
 
-import { shortAnswerTitleFormatter } from ".";
+import { removeMarkdown, shortAnswerTitleFormatter } from ".";
 
 describe("shortAnswerTitleFormatter", () => {
   it("when passed an empty str returns an empty string", () => {
@@ -76,5 +76,40 @@ describe("shortAnswerTitleFormatter", () => {
       <QuestionListItem {...testProps} />
     );
     expect(getByTestId("underline")).toBeInTheDocument();
+  });
+});
+
+describe("removeMarkdown", () => {
+  it("when passed an empty str returns an empty string", () => {
+    const result = removeMarkdown("");
+    expect(result).toBe("");
+  });
+  it("when passed null returns an empty string", () => {
+    const result = removeMarkdown(null);
+    expect(result).toBe("");
+  });
+  it("when passed undefined returns an empty string", () => {
+    const result = removeMarkdown(undefined);
+    expect(result).toBe("");
+  });
+  it("when passed string returns string without '*'s for this pattern - *text*", () => {
+    const result = removeMarkdown("*text*");
+    expect(result).toBe("text");
+  });
+  it("when passed string returns string without '*'s for this pattern - **text**", () => {
+    const result = removeMarkdown("**text**");
+    expect(result).toBe("text");
+  });
+  it("when passed string returns string without '*'s example question title", () => {
+    const result = removeMarkdown(
+      "Which of the following is **not** found in an animal cell"
+    );
+    expect(result).toBe(
+      "Which of the following is not found in an animal cell"
+    );
+  });
+  it("does not remove * on there own", () => {
+    const result = removeMarkdown("300 * 100");
+    expect(result).toBe("300 * 100");
   });
 });

--- a/src/components/QuizContainer/QuestionListItem/quizUtils/index.tsx
+++ b/src/components/QuizContainer/QuestionListItem/quizUtils/index.tsx
@@ -18,3 +18,7 @@ export const shortAnswerTitleFormatter = (
     return title;
   }
 };
+
+export const removeMarkdown = (title: string | null | undefined): string => {
+  return title ? title.replace(/\*{1,2}(.*?)\*{1,2}/g, "$1") : "";
+};


### PR DESCRIPTION
## Description

- removes **text** or *text* from title
- adds tests

## Issue(s)

Fixes #1581 

## How to test
beta/teachers/programmes/science-secondary-ks3/units/cells-u2b1h4c/lessons/organisation-mbx95u
Starter q 4

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
