### PR TITLE
Fix/1613 order questions styling

### DIFF
--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.test.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.test.tsx
@@ -21,12 +21,12 @@ describe("CorrectAnswer", () => {
 
   it("renders the correct choice for non-match type", () => {
     const { getByText } = renderWithTheme(<CorrectAnswer {...mockProps} />);
-    expect(getByText("A")).toBeInTheDocument();
+    expect(getByText("- A")).toBeInTheDocument();
   });
 
   it("renders the correct index for order type", () => {
     const { getByText } = renderWithTheme(<CorrectAnswer {...mockProps} />);
-    expect(getByText("1 -")).toBeInTheDocument();
+    expect(getByText("1")).toBeInTheDocument();
   });
 
   it("renders the correct choice and answer for match type", () => {

--- a/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
+++ b/src/components/QuizContainer/QuestionListItem/QuestionListItem.tsx
@@ -93,7 +93,13 @@ export const CorrectAnswer: FC<AnswerProps> = ({
       }
     } else {
       if (answerIsArray) {
-        return <Typography $font={["body-1"]}> {answer[index]}</Typography>;
+        return (
+          <Typography $font={["body-1"]}>
+            {" "}
+            {"- "}
+            {answer[index]}
+          </Typography>
+        );
       } else {
         return <Typography $font={["body-1"]}> {choice}</Typography>;
       }
@@ -108,12 +114,13 @@ export const CorrectAnswer: FC<AnswerProps> = ({
         $borderRadius={8}
         $mb={6}
         $ph={10}
+        $alignItems={"center"}
       >
         {" "}
         <Icon name={"tick"} $mr={16} />
         {type === "order" && (
           <Heading $font={"heading-7"} tag={"h6"} $ma={0} $mr={6}>
-            {index + 1} -
+            {index + 1}
           </Heading>
         )}
         {getTypeAnswers(type, answer)}


### PR DESCRIPTION
## Fixes short order styling

- centres the answers
- de-capitalises the hyphen

## Issue(s)

Fixes #1613

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:

<img width="589" alt="Screenshot 2023-06-01 at 12 45 18" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/1cead62a-1264-413f-9b31-cbc9c9de78bc">
s

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
