### PR TITLE
[ENG-144] feat: improve sharability of pages in preview mode

### DIFF
--- a/src/components/Button/CopyLinkButton/CopyLinkButton.test.tsx
+++ b/src/components/Button/CopyLinkButton/CopyLinkButton.test.tsx
@@ -39,4 +39,36 @@ describe("Copy link button", () => {
     const clickedButton = getByLabelText("Copied to clipboard");
     expect(clickedButton).toBeInTheDocument();
   });
+
+  it("copies the current URL to the clipboard by default", async () => {
+    const { getByLabelText } = renderWithTheme(
+      <ToastProvider>
+        <CopyLinkButton />
+      </ToastProvider>
+    );
+
+    const user = userEvent.setup();
+
+    const button = getByLabelText("Copy to clipboard");
+    await user.click(button);
+
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe("http://localhost/");
+  });
+
+  it("copies the provided URL to the clipboard", async () => {
+    const { getByLabelText } = renderWithTheme(
+      <ToastProvider>
+        <CopyLinkButton href="https://example.com" />
+      </ToastProvider>
+    );
+
+    const user = userEvent.setup();
+
+    const button = getByLabelText("Copy to clipboard");
+    await user.click(button);
+
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe("https://example.com");
+  });
 });

--- a/src/components/Button/CopyLinkButton/CopyLinkButton.tsx
+++ b/src/components/Button/CopyLinkButton/CopyLinkButton.tsx
@@ -3,7 +3,11 @@ import { FC, useEffect, useState } from "react";
 import { useToastContext, SHOW_DURATION } from "../../../context/Toast";
 import IconButton from "../IconButton";
 
-const CopyLinkButton: FC = () => {
+type CopyLinkButtonProps = {
+  href?: string;
+};
+
+const CopyLinkButton: FC<CopyLinkButtonProps> = (props) => {
   const [label, setLabel] = useState("Copy to clipboard");
   const { showToast } = useToastContext();
   const [active, setActive] = useState(false);
@@ -19,7 +23,9 @@ const CopyLinkButton: FC = () => {
 
   const copyLink = () => {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(window.location.href);
+      const urlToCopy = props.href || window.location.href;
+      navigator.clipboard.writeText(urlToCopy);
+
       const copyMessage = "Copied to clipboard";
       setLabel(copyMessage);
       showToast(copyMessage, "alert");

--- a/src/components/PreviewControls/PreviewControls.tsx
+++ b/src/components/PreviewControls/PreviewControls.tsx
@@ -1,30 +1,60 @@
 import { FC } from "react";
 import { useRouter } from "next/router";
-import styled from "styled-components";
 
 import ButtonAsLink from "../Button/ButtonAsLink";
+import CopyLinkButton from "../Button/CopyLinkButton";
+import BrushBorders from "../SpriteSheet/BrushSvgs/BrushBorders";
+import Flex from "../Flex";
+import { Span } from "../Typography";
 
-const PreviewWrapper = styled.div`
-  position: fixed;
-  bottom: 20px;
-  left: 20px;
-`;
-
+/**
+ * A small toast-like banner in the bottom left corner to inform
+ * users they're viewing the site in preview mode
+ */
 const PreviewControls: FC = () => {
   const router = useRouter();
 
+  let previewURL;
+  if (typeof window !== "undefined") {
+    /**
+     * To trigger preview mode the user has to navigate to `/api/preview/$thePath?secret=$previewSecret`
+     * This link construction relies on the user currently being in preview mode and having the ?secret=
+     * query param in the URL.
+     *
+     * The preview secret should only be accessible server side so we can't read it from the env in
+     * the context of this component. In future if this turns out to be a problem, we can pass it securely
+     * via cookie with `res.setPreviewData({ previewSecret  })` within the API endpoint, however passing
+     * it to this component would require changes to every single CMS-controlled page's getStaticProps.
+     */
+    const currentUrl = new URL(window.location.href);
+    currentUrl.pathname = `/api/preview${currentUrl.pathname}`;
+    previewURL = currentUrl.toString();
+  }
+
   return (
-    <PreviewWrapper>
-      <span>Preview mode enabled</span>
+    <Flex
+      $position="fixed"
+      $bottom={20}
+      $left={20}
+      $pa={6}
+      $alignItems="center"
+      $color="black"
+      $background="white"
+    >
+      <Span $mr={24}>Preview mode enabled</Span>
 
       <ButtonAsLink
         page={null}
         label="Exit preview"
         href={`/api/exit-preview${router.asPath}`}
         variant="minimal"
-        $ml={24}
+        $mr={24}
       />
-    </PreviewWrapper>
+
+      <CopyLinkButton href={previewURL} />
+
+      <BrushBorders color="white" />
+    </Flex>
   );
 };
 


### PR DESCRIPTION
## Description
Allow the user to copy the current URL in preview mode (aka with `/api/preview` prepended).

School support keep running into the issue where they share a link that looks like a preview one (has `?secret=xxx` appended) but the actual preview link should start with `/api/preview`). Hopefully this makes their lives a bit easier.

As per this comment in the code
```
   /**
     * To trigger preview mode the user has to navigate to `/api/preview/$thePath?secret=$previewSecret`
     * This link construction relies on the user currently being in preview mode and having the ?secret=
     * query param in the URL.
     *
     * The preview secret should only be accessible server side so we can't read it from the env in
     * the context of this component. In future if this turns out to be a problem, we can pass it securely
     * via cookie with `res.setPreviewData({ previewSecret  })` within the API endpoint, however passing
     * it to this component would require changes to every single CMS-controlled page's getStaticProps.
     */
```
This basically means if the user is clicking around between pages and the `?secret=` param is lost from the URL, the button will disappear.
This was a tradeoff between the confusion caused by school support copying non-preview URLs currently, and a decent chunk more dev work. To make it work on every page while in preview mode we would have to pass it from every page to the component.

n.b. I hate the white background but spent a while fighting `ButtonAsLink` trying to get the minimal variant to have a different foreground color, as the regular variant has a bit too much padding for the location IMO. If I'm being dense and missing something obvious I'd hapilly change it to a color that sticks out a bit more

## Issue(s)

Fixes ENG-144

## How to test

1. Go to {cloud link}
2. Click on _______
3. You should see _______

## Screenshots
<img width="403" alt="CleanShot 2023-06-21 at 15 31 33@2x" src="https://github.com/oaknational/Oak-Web-Application/assets/2717635/99019e9b-28e7-4874-a1e1-0d91c1ac909f">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
