### PR TITLE
[ENG-137] feat: allow creating and linking to anchors within a CMS controlled page

### DIFF
--- a/src/common-lib/cms-types/cta.ts
+++ b/src/common-lib/cms-types/cta.ts
@@ -14,7 +14,14 @@ const linkTypeExternal = z.object({
 
 const linkTypeAnchor = z.object({
   linkType: z.literal("anchor"),
-  anchor: z.literal("formBlock"),
+  /**
+   * Allow lowercase alphanumeric with dashes (like a slug)
+   * with the formBlock fallback for back-compat
+   */
+  anchor: z
+    .string()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+    .or(z.literal("formBlock")),
 });
 
 export const linkSchema = z.discriminatedUnion("linkType", [

--- a/src/components/PortableText/PortableText.test.tsx
+++ b/src/components/PortableText/PortableText.test.tsx
@@ -76,8 +76,23 @@ describe("PortableText", () => {
       expect(link).toHaveAttribute("href", "/legal/some-policy");
     });
 
+    it("renders nothing when not passed a reference", () => {
+      const { container } = renderWithTheme(
+        <PTInternalLink
+          children={["Some internal link"]}
+          text="Some internal link"
+          markType="internalLink"
+          value={{ _type: "internalLink", reference: undefined }}
+          renderNode={() => undefined}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+
     it("renders nothing and warns when passed an un-resolved ref", () => {
-      const { queryByRole } = renderWithTheme(
+      const { container } = renderWithTheme(
         <PTInternalLink
           children={["Some internal link"]}
           text="Some internal link"
@@ -89,9 +104,7 @@ describe("PortableText", () => {
           renderNode={() => undefined}
         />
       );
-
-      const link = queryByRole("link");
-      expect(link).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
 
       expect(consoleWarnSpy).toHaveBeenCalled();
       expect(reportError).toHaveBeenCalledWith(
@@ -103,7 +116,7 @@ describe("PortableText", () => {
     });
 
     it("renders nothing and warns when it can't resolve a href", () => {
-      const { queryByRole } = renderWithTheme(
+      const { container } = renderWithTheme(
         <PTInternalLink
           children={["Some internal link"]}
           text="Some internal link"
@@ -116,8 +129,7 @@ describe("PortableText", () => {
         />
       );
 
-      const link = queryByRole("link");
-      expect(link).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
 
       expect(consoleWarnSpy).toHaveBeenCalled();
       expect(reportError).toHaveBeenCalledWith(
@@ -180,10 +192,23 @@ describe("PortableText", () => {
       expect(link).toHaveAccessibleName("An anchor link");
       expect(link).toHaveAttribute("href", "#a-section-of-the-page");
     });
+
+    it("renders nothing when not passed an anchor", async () => {
+      const { container } = renderWithTheme(
+        <PTAnchorLink
+          children={["An anchor link"]}
+          text="An anchor link"
+          markType="anchor"
+          renderNode={() => undefined}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 
   describe("PTAnchorTarget", () => {
-    it("renders an anchor target  ", async () => {
+    it("renders an anchor target", async () => {
       const { getByText, container } = renderWithTheme(
         <PTAnchorTarget
           children={["An anchor target"]}
@@ -203,6 +228,19 @@ describe("PortableText", () => {
       ) as HTMLElement;
 
       expect(tag).toContainElement(anchorTarget);
+    });
+
+    it("renders nothing when not passed an anchor", async () => {
+      const { container } = renderWithTheme(
+        <PTAnchorTarget
+          children={["An anchor target"]}
+          text="An anchor target"
+          markType="anchorTarget"
+          renderNode={() => undefined}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
     });
   });
 

--- a/src/components/PortableText/PortableText.test.tsx
+++ b/src/components/PortableText/PortableText.test.tsx
@@ -8,6 +8,8 @@ import { useCookieConsent } from "../../browser-lib/cookie-consent/CookieConsent
 
 import {
   BasePortableTextProvider,
+  PTAnchorLink,
+  PTAnchorTarget,
   PTExternalLink,
   PTInternalLink,
 } from "./PortableText";
@@ -15,7 +17,6 @@ import { PTActionTrigger } from "./PTActionTrigger";
 import portableTextFixture from "./portableTextFixture.json";
 
 const consoleWarnSpy = jest.spyOn(console, "warn");
-consoleWarnSpy.mockImplementation(noop);
 
 jest.mock("../../browser-lib/cookie-consent/CookieConsentProvider");
 
@@ -32,6 +33,8 @@ describe("PortableText", () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();
+
+    consoleWarnSpy.mockImplementation(noop);
   });
 
   describe("PTExternalLink", () => {
@@ -47,6 +50,7 @@ describe("PortableText", () => {
       );
 
       const link = getByRole("link");
+
       expect(link).toHaveAccessibleName("Some link");
       expect(link).toHaveAttribute("href", "https://example.com");
     });
@@ -154,6 +158,51 @@ describe("PortableText", () => {
       await waitFor(() => {
         expect(showConsentManager).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("PTAnchorLink", () => {
+    it("renders an anchor link  ", async () => {
+      const { getByRole } = renderWithTheme(
+        <PTAnchorLink
+          children={["An anchor link"]}
+          text="An anchor link"
+          markType="anchor"
+          value={{
+            _type: "anchor",
+            anchor: "a-section-of-the-page",
+          }}
+          renderNode={() => undefined}
+        />
+      );
+
+      const link = getByRole("link");
+      expect(link).toHaveAccessibleName("An anchor link");
+      expect(link).toHaveAttribute("href", "#a-section-of-the-page");
+    });
+  });
+
+  describe("PTAnchorTarget", () => {
+    it("renders an anchor target  ", async () => {
+      const { getByText, container } = renderWithTheme(
+        <PTAnchorTarget
+          children={["An anchor target"]}
+          text="An anchor target"
+          markType="anchorTarget"
+          value={{
+            _type: "anchorTarget",
+            anchor: "a-section-of-the-page",
+          }}
+          renderNode={() => undefined}
+        />
+      );
+
+      const tag = getByText("An anchor target");
+      const anchorTarget = container.querySelector(
+        "#a-section-of-the-page"
+      ) as HTMLElement;
+
+      expect(tag).toContainElement(anchorTarget);
     });
   });
 

--- a/src/components/PortableText/PortableText.tsx
+++ b/src/components/PortableText/PortableText.tsx
@@ -12,6 +12,8 @@ import { CTAInternalLinkEntry } from "../../common-lib/cms-types";
 import { LI, OL, P, Span } from "../Typography";
 import OakLink from "../OakLink";
 import getProxiedSanityAssetUrl from "../../common-lib/urls/getProxiedSanityAssetUrl";
+import AnchorTarget from "../AnchorTarget";
+import Box from "../Box";
 
 import { PTActionTrigger } from "./PTActionTrigger";
 
@@ -119,6 +121,23 @@ export const PTAnchorLink: PortableTextMarkComponent<{
   );
 };
 
+export const PTAnchorTarget: PortableTextMarkComponent<{
+  _type: "anchorTarget";
+  anchor: string;
+}> = (props) => {
+  if (!props.value?.anchor) {
+    return null;
+  }
+
+  return (
+    <Box as="span" $position="relative">
+      <AnchorTarget id={props.value.anchor} />
+
+      {props.children}
+    </Box>
+  );
+};
+
 const BodyP = styled(P)`
   &:first-child {
     margin-top: 0;
@@ -157,6 +176,7 @@ export const basePortableTextComponents: PortableTextComponents = {
     internalLink: PTInternalLink,
     link: PTExternalLink,
     anchorLink: PTAnchorLink,
+    anchorTarget: PTAnchorTarget,
     action: PTActionTrigger,
   },
 };

--- a/src/components/PortableText/PortableText.tsx
+++ b/src/components/PortableText/PortableText.tsx
@@ -7,11 +7,7 @@ import {
 import styled from "styled-components";
 
 import errorReporter from "../../common-lib/error-reporter";
-import {
-  anchorMap,
-  resolveInternalHref,
-  anchorKeys,
-} from "../../utils/portableText/resolveInternalHref";
+import { resolveInternalHref } from "../../utils/portableText/resolveInternalHref";
 import { CTAInternalLinkEntry } from "../../common-lib/cms-types";
 import { LI, OL, P, Span } from "../Typography";
 import OakLink from "../OakLink";
@@ -110,14 +106,14 @@ export const PTExternalLink: PortableTextMarkComponent<{
 
 export const PTAnchorLink: PortableTextMarkComponent<{
   _type: "anchor";
-  anchor: anchorKeys;
+  anchor: string;
 }> = (props) => {
-  if (!props.value) {
+  if (!props.value?.anchor) {
     return null;
   }
 
   return (
-    <OakLink page={null} href={`#${anchorMap[props.value.anchor]}`} $isInline>
+    <OakLink page={null} href={`#${props.value.anchor}`} $isInline>
       {props.children}
     </OakLink>
   );

--- a/src/components/pages/LandingPages/SignUpForm.tsx
+++ b/src/components/pages/LandingPages/SignUpForm.tsx
@@ -5,7 +5,6 @@ import Box from "../../Box";
 import NewsletterForm, { useNewsletterForm } from "../../Forms/NewsletterForm";
 import AnchorTarget from "../../AnchorTarget";
 import CardTitle from "../../Card/CardComponents/CardTitle";
-import { anchorMap } from "../../../utils/portableText/resolveInternalHref";
 
 export const SignUpForm: FC<{ formTitle: string }> = ({ formTitle }) => {
   const { onSubmit } = useNewsletterForm();
@@ -20,7 +19,14 @@ export const SignUpForm: FC<{ formTitle: string }> = ({ formTitle }) => {
       $background={"white"}
       $dropShadow={"notificationCard"}
     >
-      <AnchorTarget id={anchorMap["formBlock"]} />
+      {/**
+       * We previously constrained editors to a pre-set list of possible anchors
+       * within the CMS, although "formBlock" was the only option. Now that editors
+       * can select any, we have this redundancy to avoid the need to map
+       * "formBlock"->"form-block" until all instances are updated in the CMS
+       */}
+      <AnchorTarget id={"formBlock"} />
+      <AnchorTarget id={"form-block"} />
 
       <CardTitle
         icon="magic-carpet"

--- a/src/utils/portableText/resolveInternalHref.ts
+++ b/src/utils/portableText/resolveInternalHref.ts
@@ -58,17 +58,11 @@ export const resolveInternalHref = (entry: CTAInternalLinkEntry): string => {
   }
 };
 
-export const anchorMap = {
-  formBlock: "form-block",
-} as const;
-
-export type anchorKeys = keyof typeof anchorMap;
-
 export const getLinkHref = (ctaOrLink: CTA | Link): string => {
   if (ctaOrLink.linkType === "internal") {
     return resolveInternalHref(ctaOrLink.internal);
   } else if (ctaOrLink.linkType === "external") {
     return ctaOrLink.external;
   }
-  return `#${anchorMap[ctaOrLink.anchor]}`;
+  return `#${ctaOrLink.anchor}`;
 };


### PR DESCRIPTION
## Description
Allow creating links to anchors and their associated targets from within the CMS.

Previously editors could create links to a predefined anchor (`#form-block`, for the landing page forms). This loosens that to any slug-like string, but with the caveat that there's no strong validation that the anchors exist on the page. This does not include the ability to link across pages to anchors, unless the whole URL is entered (instead of an `internal` `linkType`)

Twin PR from CMS repo: https://github.com/oaknational/CMS/pull/95

## Issue(s)

Fixes ENG-137

## How to test

1. Go to our [testing blog post](https://deploy-preview-1726--oak-web-application.netlify.thenational.academy/api/preview/blog/some-blog-post?secret=wsJ3DpANkjZQk9z)
2. Click on the link with the text "A link to an anchor within this page"
3. You should be jumped to an anchor below, at the correct offset

n.b. lazy loading seems to interrupt the distance scrolled on the first click. Not sure what to do about this tbh.

Landing page buttons and CTAs that jump to the form (many of them, most of the top right corner CTAs) should also still work

## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] ~Design sign-off~
- [ ] ~Approved by product owner~
