### PR TITLE
chore(dependabot): always increase version requirement to match new version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Always increase the version requirement
+    # to match the new version.
+    versioning-strategy: increase


### PR DESCRIPTION

## Description

- update dependabot config so that we don't get package-lock version updates without updating the package.json version

## How to test

1. From now on, we should only get PRs from dependabot which update both package.json and package-lock.json

