### PR TITLE
fix: omissions and errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create an environment configuration file by running:
 touch .env
 ```
 
-Now populate the file with secret manager services and the Oak config location. See [here](https://www.notion.so/oaknationalacademy/How-to-set-up-OWA-21ae880e58bb40bfaaa289030e984abd?pvs=4) for further details.
+Now populate the file with secret manager services and the Oak config location. Fill in other values, if required, by asking another member of the team.
 
 Now install dependencies
 

--- a/README.md
+++ b/README.md
@@ -35,27 +35,27 @@ Other documentation can be found in standalone READMEs:
 
 ## Getting started
 
-First, run the following to create a local environment file:
-
-```bash
-cp .env.test .env.development.local
-```
-
-and fill in any values, if required, by asking another member of the team.
-
-Next, run:
+Create an environment configuration file by running:
 
 ```bash
 touch .env
 ```
 
-to create an environment file containing secret manager services and the Oak config location. See [here](https://www.notion.so/oaknationalacademy/How-to-set-up-OWA-21ae880e58bb40bfaaa289030e984abd?pvs=4) for further details.
+Now populate the file with secret manager services and the Oak config location. See [here](https://www.notion.so/oaknationalacademy/How-to-set-up-OWA-21ae880e58bb40bfaaa289030e984abd?pvs=4) for further details.
+
+Now install dependencies
+
+```bash
+npm install
+```
 
 Then, run the development server:
 
 ```bash
-npm run dev 
+npm run dev
 ```
+
+If successful two further config files `.env.development.local` and `.env.local` will have been automatically generated. You can access the running web app on `http://localhost:3000`
 
 ## Automatic Checks
 


### PR DESCRIPTION
## Description

Some omissions in the Getting started section of the readme

## Issue(s)
- missing ‘npm install’
- potentially missing a requirement to run ‘npm run dev’ x 2 (first time is to auto-generate .env.development.local) ???
- potentially requirement to create .env.development.local is unecessary - if so remove

Fixes #
- information on how to run `npm install` to the getting started section.
- If needed - instructions on running 'npm run dev' twice to generate the .env.development.local file.
- If correct - remove redundant instruction to create the local .env.development file

## How to test
n/a

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
