### PR TITLE
[ENG-308] Feat/tighten server config

### DIFF
--- a/src/browser-lib/getBrowserConfig.test.ts
+++ b/src/browser-lib/getBrowserConfig.test.ts
@@ -23,6 +23,16 @@ describe("getBrowserConfig()", () => {
       "http://localhost:3000"
     );
   });
+  it("should return the default value for required values set to empty strings", async () => {
+    process.env.NEXT_PUBLIC_CLIENT_APP_BASE_URL = "";
+    const { default: getBrowserConfig } = await import(
+      "../browser-lib/getBrowserConfig"
+    );
+
+    expect(getBrowserConfig("clientAppBaseUrl")).toEqual(
+      "http://localhost:3000"
+    );
+  });
   it("should allow parsing numeric env vars", async () => {
     process.env.SANITY_REVALIDATE_SECONDS = "123";
     const { default: getBrowserConfig } = await import(

--- a/src/browser-lib/getBrowserConfig.ts
+++ b/src/browser-lib/getBrowserConfig.ts
@@ -318,13 +318,21 @@ type NonNullEnvValue<K extends ConfigKey> = NonNullable<
 >;
 
 const getBrowserConfig = <K extends ConfigKey>(key: K): NonNullEnvValue<K> => {
-  const { value, default: defaultValue, envName } = envVars[key] || {};
+  const {
+    value,
+    default: defaultValue,
+    envName,
+    required,
+    availableInBrowser,
+  } = envVars[key] || {};
 
   // Without parsing, undefined gets stringified as "undefined"
   const parsedValue = parseValue(value);
 
-  // Allow falsy values to be passed, but not `undefined`
-  if (parsedValue !== undefined) {
+  const shouldBePresent = required && (isBrowser ? availableInBrowser : true);
+
+  // Allow falsy values to be passed, but not `undefined`, don't allow empty strings for values that should be present.
+  if (parsedValue !== undefined && !(shouldBePresent && parsedValue === "")) {
     return parsedValue;
   }
 

--- a/src/node-lib/getServerConfig.test.ts
+++ b/src/node-lib/getServerConfig.test.ts
@@ -19,6 +19,30 @@ describe("getServerConfig()", () => {
 
     expect(getServerConfig("disableIsr")).toEqual(false);
   });
+  it("Should return the default value if a required env is set to undefined", async () => {
+    process.env.SANITY_DATASET_TAG = undefined;
+    const { default: getServerConfig } = await import(
+      "../node-lib/getServerConfig"
+    );
+
+    expect(getServerConfig("sanityDatasetTag")).toEqual("default");
+  });
+  it("Should return the default value if a required env is set to an empty string", async () => {
+    process.env.SANITY_DATASET_TAG = "";
+    const { default: getServerConfig } = await import(
+      "../node-lib/getServerConfig"
+    );
+
+    expect(getServerConfig("sanityDatasetTag")).toEqual("default");
+  });
+  it("Should return the set value if a required env is set to any other string", async () => {
+    process.env.SANITY_DATASET_TAG = "false";
+    const { default: getServerConfig } = await import(
+      "../node-lib/getServerConfig"
+    );
+
+    expect(getServerConfig("sanityDatasetTag")).toEqual("false");
+  });
 });
 
 export {};

--- a/src/node-lib/getServerConfig.ts
+++ b/src/node-lib/getServerConfig.ts
@@ -58,7 +58,7 @@ const envVars = satisfies<Record<string, EnvVar>>()({
   sanityDatasetTag: {
     value: process.env.SANITY_DATASET_TAG,
     envName: "SANITY_DATASET_TAG",
-    required: false,
+    required: true,
     availableInBrowser: false,
     default: "default", // Literally 'default', not a typo
   },

--- a/src/node-lib/getServerConfig.ts
+++ b/src/node-lib/getServerConfig.ts
@@ -149,7 +149,6 @@ for (const [, envVarConfig] of Object.entries(envVars)) {
   const {
     value: envValue,
     required,
-    availableInBrowser,
     default: defaultValue,
     envName,
   } = envVarConfig;
@@ -157,7 +156,7 @@ for (const [, envVarConfig] of Object.entries(envVars)) {
   // These secrets shouldn't be making it to the browser, so existence
   // checks will fail.
   if (!isBrowser) {
-    const shouldBePresent = required && (isBrowser ? availableInBrowser : true);
+    const shouldBePresent = required;
     const isPresent = Boolean(envValue || defaultValue);
 
     /**
@@ -189,13 +188,18 @@ type NonNullEnvValue<K extends ConfigKey> = NonNullable<
 >;
 
 const getServerConfig = <K extends ConfigKey>(key: K): NonNullEnvValue<K> => {
-  const { value, default: defaultValue, envName } = envVars[key] || {};
+  const {
+    value,
+    default: defaultValue,
+    envName,
+    required,
+  } = envVars[key] || {};
 
   // Without parsing, undefined gets stringified as "undefined"
   const parsedValue = parseValue(value);
 
-  // Allow falsy values to be passed, but not `undefined`
-  if (parsedValue !== undefined) {
+  // Allow falsy values to be passed, but not `undefined`, don't allow empty strings on required values.
+  if (parsedValue !== undefined && !(required && parsedValue === "")) {
     return parsedValue;
   }
 


### PR DESCRIPTION
We discovered that setting a branch value for an env in Netlify will set _an_ env value for all environments (prod, dev, etc), if you don't specify a value it will set that value to empty string `""`.

This change to the config value management is so that if an env has `required: true` then setting the value to an empty string will cause it to fall back to the default value.