### PR TITLE
Feat/lesq 128/lesson navbar

### DIFF
--- a/src/components/AnchorTarget/AnchorTarget.tsx
+++ b/src/components/AnchorTarget/AnchorTarget.tsx
@@ -1,4 +1,6 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+import theme from "@/styles/theme";
 
 /**
  * AnchorTarget is a component to enable in-page linking to a particular section
@@ -12,10 +14,23 @@ import styled from "styled-components";
  * that this component is not reliable. We should set actual 'height' on the
  * site header.
  */
-const AnchorTarget = styled.span`
-  scroll-margin-top: ${({ theme }) => theme.header.height}px;
-  position: absolute;
-  top: 0;
+type AnchorTargetProps = {
+  $paddingTop?: number;
+};
+
+const anchorTarget = css<AnchorTargetProps>`
+  ${(props) =>
+    css`
+      scroll-margin-top: ${props.$paddingTop !== undefined
+        ? theme.header.height + props.$paddingTop
+        : theme.header.height}px;
+      position: absolute;
+      top: 0;
+    `}
+`;
+
+const AnchorTarget = styled.span<AnchorTargetProps>`
+  ${anchorTarget}
 `;
 
 export default AnchorTarget;

--- a/src/components/Button/ButtonAsLink.stories.tsx
+++ b/src/components/Button/ButtonAsLink.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Component> = {
       defaultValue: "Click me",
     },
     variant: {
-      defaultValue: "minimal",
+      defaultValue: "brushNav",
     },
     href: {
       defaultValue: "/",
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof Component>;
 export const ButtonAsLink: Story = {
   args: {
     label: "Click me",
-    variant: "minimal",
+    variant: "brushNav",
     href: "/",
   },
 };

--- a/src/components/Button/ButtonAsLink.tsx
+++ b/src/components/Button/ButtonAsLink.tsx
@@ -62,6 +62,7 @@ const ButtonAsLink: FC<ButtonAsLinkProps> = (props) => {
         disabled={disabled}
         // see: https://www.scottohara.me/blog/2021/05/28/disabled-links.html
         aria-disabled={disabled}
+        tabIndex={disabled ? -1 : undefined}
       >
         <ButtonInner
           label={label}

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -184,7 +184,9 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
       {(variant === "brush" || variant === "brushNav") && (
         <ButtonBorders background={background} />
       )}
+
       <ButtonFocusUnderline $color={underlineColor} name="underline-1" />
+
       {variant === "buttonStyledAsLink" && (
         <ButtonStyledAsLinkFocusUnderline $color={"black"} name="underline-1" />
       )}

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -14,16 +14,16 @@ import {
 } from "./common";
 import { IconFocusUnderline } from "./IconFocusUnderline";
 
-import { OakColorName } from "@/styles/theme";
 import Box from "@/components/Box";
 import Icon, { IconName } from "@/components/Icon";
 import ButtonBorders from "@/components/SpriteSheet/BrushSvgs/ButtonBorders";
 import Svg from "@/components/Svg";
-import getColorByName from "@/styles/themeHelpers/getColorByName";
+import SubjectIcon from "@/components/SubjectIcon";
 import ScreenReaderOnly from "@/components/ScreenReaderOnly";
+import getColorByName from "@/styles/themeHelpers/getColorByName";
+import { OakColorName } from "@/styles/theme";
 import { FontVariant } from "@/styles/utils/typography";
 import { ResponsiveValues } from "@/styles/utils/responsive";
-import SubjectIcon from "@/components/SubjectIcon";
 
 export const ButtonFocusUnderline = styled(Svg)<{
   $color: OakColorName;
@@ -133,7 +133,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
             variant="brush"
             name={icon}
             size={iconSize}
-            $background={iconBackground || defaultIconBackground}
+            $background={iconBackground ?? defaultIconBackground}
           />
           {(variant === "minimal" || variant === "minimalNav") && (
             <IconFocusUnderline $color={underlineColor} />

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -180,7 +180,9 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
           />
         )}
       </Box>
-      {variant === "brush" && <ButtonBorders background={background} />}
+      {(variant === "brush" || variant === "brushNav") && (
+        <ButtonBorders background={background} />
+      )}
       <ButtonFocusUnderline $color={underlineColor} name="underline-1" />
       {variant === "buttonStyledAsLink" && (
         <ButtonStyledAsLinkFocusUnderline $color={"black"} name="underline-1" />

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -87,7 +87,8 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
   const defaultIconBackground = getButtonIconBackground(background)({ theme });
 
   const defactoBackground =
-    ["minimal", "buttonStyledAsLink"].includes(variant) && iconBackground
+    ["minimal", "minimalNav", "buttonStyledAsLink"].includes(variant) &&
+    iconBackground
       ? iconBackground
       : background;
 
@@ -134,7 +135,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
             size={iconSize}
             $background={iconBackground || defaultIconBackground}
           />
-          {variant === "minimal" && (
+          {(variant === "minimal" || variant === "minimalNav") && (
             <IconFocusUnderline $color={underlineColor} />
           )}
         </Flex>
@@ -173,7 +174,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
             )}
           </ButtonLabel>
         </Box>
-        {variant === "minimal" && (
+        {(variant === "minimal" || variant === "minimalNav") && (
           <ButtonMinimalFocusUnderline
             $color={underlineColor}
             name="underline-1"

--- a/src/components/Button/IconButton.tsx
+++ b/src/components/Button/IconButton.tsx
@@ -6,14 +6,14 @@ import {
 } from "react";
 import styled from "styled-components";
 
-import UnstyledButton from "../UnstyledButton";
-
 import { CommonIconButtonProps } from "./common";
 import iconButtonStyles, {
   getIconButtonStylesProps,
   IconButtonStylesProps,
 } from "./iconButton.styles";
 import IconButtonInner from "./IconButtonInner";
+
+import UnstyledButton from "@/components/UnstyledButton";
 
 const StyledButton = styled(UnstyledButton)<IconButtonStylesProps>`
   transform: rotate(${(props) => props.rotate}deg);

--- a/src/components/Button/IconButtonInner.tsx
+++ b/src/components/Button/IconButtonInner.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useTheme } from "styled-components";
 
 import { OakColorName } from "../../styles/theme";
-import Icon, { IconName } from "../Icon";
+import Icon, { IconName, isIconVariant } from "../Icon";
 
 import {
   ButtonBackground,
@@ -30,6 +30,8 @@ export type IconButtonInnerProps = {
 const IconButtonInner: FC<IconButtonInnerProps> = (props) => {
   const { variant, size, background, icon, iconColorOverride, iconAnimateTo } =
     props;
+
+  const iconVariant = variant.replace("Nav", "");
   const theme = useTheme();
   const underlineColor =
     theme.buttonFocusUnderlineColors[background] || "black";
@@ -37,7 +39,7 @@ const IconButtonInner: FC<IconButtonInnerProps> = (props) => {
   return (
     <IconButtonWrapper size={size} variant={variant} background={background}>
       <Icon
-        variant={variant}
+        variant={isIconVariant(iconVariant) ? iconVariant : undefined}
         name={icon}
         size={getIconButtonHeight(size, variant)}
         $color={iconColorOverride}

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -41,7 +41,7 @@ export type ButtonStylesProps = OpacityProps &
     $fullWidth?: boolean;
     disabled?: boolean;
     $focusStyles?: [];
-    $hoverStyles?: [];
+    $hoverStyles?: string[];
     "aria-disabled"?: boolean;
   };
 export const getButtonStylesProps = (
@@ -153,7 +153,7 @@ const buttonStyles = css<ButtonStylesProps>`
     `}
 
   ${(props) =>
-    props.variant === "minimal" &&
+    (props.variant === "minimal" || props.variant === "minimalNav") &&
     css`
       & ${BackgroundIcon} {
         transition: filter 0.3s ease-in-out;
@@ -179,7 +179,7 @@ const buttonStyles = css<ButtonStylesProps>`
 
   ${(props) =>
     props.$hoverStyles &&
-    props.$hoverStyles.includes("underline-text") &&
+    props.$hoverStyles.includes("underline-link-text") &&
     !props.disabled &&
     css`
       :hover:not(:focus) ${ButtonLabel} {

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -41,6 +41,7 @@ export type ButtonStylesProps = OpacityProps &
     $fullWidth?: boolean;
     disabled?: boolean;
     $focusStyles?: [];
+    $hoverStyles?: [];
     "aria-disabled"?: boolean;
   };
 export const getButtonStylesProps = (
@@ -61,7 +62,7 @@ export const getButtonStylesProps = (
     $iconPosition,
     variant,
     $fullWidth,
-    background: disabled ? "grey6" : background,
+    background: disabled && variant !== "brushNav" ? "grey6" : background, // we don't discolor brushNav buttons when disabled
     $focusStyles,
     disabled,
   };
@@ -122,7 +123,7 @@ const buttonStyles = css<ButtonStylesProps>`
   }
 
   ${(props) =>
-    props.variant === "brush" &&
+    (props.variant === "brush" || props.variant == "brushNav") &&
     css`
       :hover {
         box-shadow: ${props["aria-disabled"]
@@ -172,7 +173,18 @@ const buttonStyles = css<ButtonStylesProps>`
       ${ButtonMinimalFocusUnderline} {
         filter: drop-shadow(1px 4px 0px rgb(0 0 0));
       }
+
       ${iconFocusUnderline}
+    `}
+
+  ${(props) =>
+    props.$hoverStyles &&
+    props.$hoverStyles.includes("underline-text") &&
+    !props.disabled &&
+    css`
+      :hover:not(:focus) ${ButtonLabel} {
+        text-decoration: underline;
+      }
     `}
 
   ${(props) =>

--- a/src/components/Button/common.ts
+++ b/src/components/Button/common.ts
@@ -16,6 +16,7 @@ export type ButtonVariant =
   | "brush"
   | "brushNav"
   | "minimal"
+  | "minimalNav"
   | "buttonStyledAsLink";
 export type ButtonBackground = OakColorName;
 export type IconPosition = "leading" | "trailing";
@@ -60,6 +61,18 @@ const BUTTON_CONFIGS: Record<
     iconInnerHeight: 30,
     paddingH: 0,
   },
+  "small-minimalNav-button": {
+    height: 44,
+    iconOuterHeight: 30,
+    iconInnerHeight: 20,
+    paddingH: 10,
+  },
+  "large-minimalNav-button": {
+    height: 50,
+    iconOuterHeight: 36,
+    iconInnerHeight: 30,
+    paddingH: 10,
+  },
   "small-buttonStyledAsLink-button": {
     height: 30,
     iconOuterHeight: 30,
@@ -103,6 +116,18 @@ const BUTTON_CONFIGS: Record<
     paddingH: 0,
   },
   "large-minimal-icon-button": {
+    height: 30,
+    iconOuterHeight: 30,
+    iconInnerHeight: 30,
+    paddingH: 0,
+  },
+  "small-minimalNav-icon-button": {
+    height: 20,
+    iconOuterHeight: 20,
+    iconInnerHeight: 20,
+    paddingH: 0,
+  },
+  "large-minimalNav-icon-button": {
     height: 30,
     iconOuterHeight: 30,
     iconInnerHeight: 30,
@@ -174,8 +199,8 @@ export const getButtonBackground = (
   variant: ButtonVariant,
   disabled?: boolean
 ) => {
-  if (variant === "minimal" || variant === "buttonStyledAsLink") {
-    return "tranparent";
+  if (variant === "minimal" || variant === "minimalNav" || variant === "buttonStyledAsLink") {
+    return "transparent";
   } else if (variant === "brush" && disabled) {
     return getColorByName("grey6");
   } else {
@@ -186,7 +211,7 @@ export const getButtonColor = (
   background: ButtonBackground,
   variant: ButtonVariant
 ) =>
-  variant === "minimal" || variant === "buttonStyledAsLink"
+  variant === "minimal" || variant === "buttonStyledAsLink" || variant === "minimalNav"
     ? "black"
     : getTextColorForBackground(background);
 export const getButtonIconBackground =

--- a/src/components/Button/common.ts
+++ b/src/components/Button/common.ts
@@ -4,13 +4,13 @@ import {
   AnchorHTMLAttributes,
 } from "react";
 
-import { OakColorName } from "../../styles/theme";
-import { PixelSpacing, PropsWithTheme } from "../../styles/theme/types";
-import getColorByName from "../../styles/themeHelpers/getColorByName";
-import getTextColorForBackground from "../../styles/themeHelpers/getTextColorForBackground";
-import { OpacityProps } from "../../styles/utils/opacity";
-import { MarginProps } from "../../styles/utils/spacing";
-import { IconName } from "../Icon";
+import { OakColorName } from "@/styles/theme";
+import { PixelSpacing, PropsWithTheme } from "@/styles/theme/types";
+import getColorByName from "@/styles/themeHelpers/getColorByName";
+import getTextColorForBackground from "@/styles/themeHelpers/getTextColorForBackground";
+import { OpacityProps } from "@/styles/utils/opacity";
+import { MarginProps } from "@/styles/utils/spacing";
+import { IconName } from "@/components/Icon";
 
 export type ButtonVariant =
   | "brush"
@@ -199,7 +199,11 @@ export const getButtonBackground = (
   variant: ButtonVariant,
   disabled?: boolean
 ) => {
-  if (variant === "minimal" || variant === "minimalNav" || variant === "buttonStyledAsLink") {
+  if (
+    variant === "minimal" ||
+    variant === "minimalNav" ||
+    variant === "buttonStyledAsLink"
+  ) {
     return "transparent";
   } else if (variant === "brush" && disabled) {
     return getColorByName("grey6");
@@ -211,7 +215,9 @@ export const getButtonColor = (
   background: ButtonBackground,
   variant: ButtonVariant
 ) =>
-  variant === "minimal" || variant === "buttonStyledAsLink" || variant === "minimalNav"
+  variant === "minimal" ||
+  variant === "buttonStyledAsLink" ||
+  variant === "minimalNav"
     ? "black"
     : getTextColorForBackground(background);
 export const getButtonIconBackground =

--- a/src/components/Button/common.ts
+++ b/src/components/Button/common.ts
@@ -12,7 +12,11 @@ import { OpacityProps } from "../../styles/utils/opacity";
 import { MarginProps } from "../../styles/utils/spacing";
 import { IconName } from "../Icon";
 
-export type ButtonVariant = "brush" | "minimal" | "buttonStyledAsLink";
+export type ButtonVariant =
+  | "brush"
+  | "brushNav"
+  | "minimal"
+  | "buttonStyledAsLink";
 export type ButtonBackground = OakColorName;
 export type IconPosition = "leading" | "trailing";
 export type ButtonSize = "small" | "large";
@@ -80,6 +84,18 @@ const BUTTON_CONFIGS: Record<
     iconInnerHeight: 30,
     paddingH: 10,
   },
+  "small-brushNav-button": {
+    height: 44,
+    iconOuterHeight: 30,
+    iconInnerHeight: 20,
+    paddingH: 10,
+  },
+  "large-brushNav-button": {
+    height: 50,
+    iconOuterHeight: 36,
+    iconInnerHeight: 30,
+    paddingH: 10,
+  },
   "small-minimal-icon-button": {
     height: 20,
     iconOuterHeight: 20,
@@ -111,6 +127,18 @@ const BUTTON_CONFIGS: Record<
     paddingH: 0,
   },
   "large-brush-icon-button": {
+    height: 36,
+    iconOuterHeight: 36,
+    iconInnerHeight: 30,
+    paddingH: 0,
+  },
+  "small-brushNav-icon-button": {
+    height: 30,
+    iconOuterHeight: 30,
+    iconInnerHeight: 20,
+    paddingH: 0,
+  },
+  "large-brushNav-icon-button": {
     height: 36,
     iconOuterHeight: 36,
     iconInnerHeight: 30,
@@ -216,6 +244,7 @@ export type CommonButtonProps = { children?: React.ReactNode } & OpacityProps &
     "aria-label"?: string;
     $fullWidth?: boolean;
     $focusStyles?: [];
+    $hoverStyles?: string[];
     disabled?: boolean;
   };
 export const defaultButtonProps: Partial<CommonButtonProps> = {

--- a/src/components/ButtonLinkNav/ButtonLinkNav.tsx
+++ b/src/components/ButtonLinkNav/ButtonLinkNav.tsx
@@ -19,13 +19,8 @@ type ButtonLinkNavProps = {
   arrowSuffix?: boolean;
 } & FlexProps;
 
-const NavLink = ({
-  label,
-  href,
-  isCurrentOverride,
-  arrowSuffix,
-}: LinkProps) => {
-  const isCurrent = useIsCurrent({ href }) || isCurrentOverride;
+const NavLink = ({ label, href, arrowSuffix }: LinkProps) => {
+  const isCurrent = useIsCurrent({ href });
 
   const htmlAnchorProps: HTMLAnchorProps = {
     "aria-current": isCurrent ? "page" : undefined,
@@ -75,7 +70,7 @@ const NavLink = ({
  *
  * ## Usage
  *
- * Used in the 'About Us' summary card
+ * Used in the 'About Us' summary card and lessons page.
  */
 const ButtonLinkNav: FC<ButtonLinkNavProps> = ({
   buttons,

--- a/src/components/ButtonLinkNav/ButtonLinkNav.tsx
+++ b/src/components/ButtonLinkNav/ButtonLinkNav.tsx
@@ -26,7 +26,8 @@ const NavLink = ({ label, href }: LinkProps) => {
       <Box $display={["none", "block"]}>
         <ButtonAsLink
           htmlAnchorProps={htmlAnchorProps}
-          variant={isCurrent ? "minimal" : "brush"}
+          variant={isCurrent ? "brushNav" : "minimal"}
+          $hoverStyles={["underline-text"]}
           label={label}
           href={href}
           page={null}

--- a/src/components/ButtonLinkNav/ButtonLinkNav.tsx
+++ b/src/components/ButtonLinkNav/ButtonLinkNav.tsx
@@ -11,15 +11,17 @@ type LinkProps = {
   href: string;
   isCurrentOverride?: boolean;
   arrowSuffix?: boolean;
+  shallow?: boolean;
 };
 
 type ButtonLinkNavProps = {
   ariaLabel: string;
   buttons: LinkProps[];
   arrowSuffix?: boolean;
+  shallow?: boolean;
 } & FlexProps;
 
-const NavLink = ({ label, href, arrowSuffix }: LinkProps) => {
+const NavLink = ({ label, href, arrowSuffix, shallow }: LinkProps) => {
   const isCurrent = useIsCurrent({ href });
 
   const htmlAnchorProps: HTMLAnchorProps = {
@@ -43,6 +45,8 @@ const NavLink = ({ label, href, arrowSuffix }: LinkProps) => {
           icon={isCurrent && arrowSuffix ? "arrow-right" : undefined}
           iconBackground={isCurrent && arrowSuffix ? "transparent" : undefined}
           $iconPosition="trailing"
+          shallow={shallow}
+          scroll={shallow}
         />
       </Box>
       {/* Mobile */}
@@ -76,6 +80,7 @@ const ButtonLinkNav: FC<ButtonLinkNavProps> = ({
   buttons,
   ariaLabel,
   arrowSuffix,
+  shallow,
   ...props
 }) => {
   return (
@@ -87,7 +92,12 @@ const ButtonLinkNav: FC<ButtonLinkNavProps> = ({
         {...props}
       >
         {buttons.map((button) => (
-          <NavLink key={button.href} arrowSuffix={arrowSuffix} {...button} />
+          <NavLink
+            key={button.href}
+            arrowSuffix={arrowSuffix}
+            shallow={shallow}
+            {...button}
+          />
         ))}
       </Flex>
     </nav>

--- a/src/components/ButtonLinkNav/ButtonLinkNav.tsx
+++ b/src/components/ButtonLinkNav/ButtonLinkNav.tsx
@@ -2,19 +2,30 @@ import { FC } from "react";
 
 import Box from "../Box";
 import ButtonAsLink from "../Button/ButtonAsLink";
-import { HTMLAnchorProps } from "../Button/common";
 import Flex, { FlexProps } from "../Flex";
 import useIsCurrent from "../MenuLinks/useIsCurrent";
+import { HTMLAnchorProps } from "../Button/common";
 
-type LinkProps = { label: string; href: string };
+type LinkProps = {
+  label: string;
+  href: string;
+  isCurrentOverride?: boolean;
+  arrowSuffix?: boolean;
+};
 
 type ButtonLinkNavProps = {
   ariaLabel: string;
   buttons: LinkProps[];
+  arrowSuffix?: boolean;
 } & FlexProps;
 
-const NavLink = ({ label, href }: LinkProps) => {
-  const isCurrent = useIsCurrent({ href });
+const NavLink = ({
+  label,
+  href,
+  isCurrentOverride,
+  arrowSuffix,
+}: LinkProps) => {
+  const isCurrent = useIsCurrent({ href }) || isCurrentOverride;
 
   const htmlAnchorProps: HTMLAnchorProps = {
     "aria-current": isCurrent ? "page" : undefined,
@@ -26,14 +37,17 @@ const NavLink = ({ label, href }: LinkProps) => {
       <Box $display={["none", "block"]}>
         <ButtonAsLink
           htmlAnchorProps={htmlAnchorProps}
-          variant={isCurrent ? "brushNav" : "minimal"}
-          $hoverStyles={["underline-text"]}
+          variant={isCurrent ? "brushNav" : "minimalNav"}
+          $hoverStyles={["underline-link-text"]}
           label={label}
           href={href}
           page={null}
           $mr={[0, 36]}
           disabled={isCurrent}
           isCurrent={isCurrent}
+          icon={isCurrent && arrowSuffix ? "arrow-right" : undefined}
+          iconBackground={isCurrent && arrowSuffix ? "transparent" : undefined}
+          $iconPosition="trailing"
         />
       </Box>
       {/* Mobile */}
@@ -66,6 +80,7 @@ const NavLink = ({ label, href }: LinkProps) => {
 const ButtonLinkNav: FC<ButtonLinkNavProps> = ({
   buttons,
   ariaLabel,
+  arrowSuffix,
   ...props
 }) => {
   return (
@@ -77,7 +92,7 @@ const ButtonLinkNav: FC<ButtonLinkNavProps> = ({
         {...props}
       >
         {buttons.map((button) => (
-          <NavLink key={button.href} {...button} />
+          <NavLink key={button.href} arrowSuffix={arrowSuffix} {...button} />
         ))}
       </Flex>
     </nav>

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -12,7 +12,11 @@ import { UiIconName } from "../../image-data";
 import useIconAnimation from "./useIconAnimation";
 
 export type IconName = UiIconName;
-type IconVariant = "minimal" | "brush" | "buttonStyledAsLink";
+export type IconVariant = "minimal" | "brush" | "buttonStyledAsLink";
+
+export const isIconVariant = (variant: string): variant is IconVariant =>
+  ["minimal", "brush", "buttonStyledAsLink"].includes(variant);
+
 type VerticalAlign = "baseline" | "bottom";
 
 type RotateValue = 0 | 180;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,2 +1,3 @@
 export { default } from "./Icon";
 export type { IconName, IconSize } from "./Icon";
+export { isIconVariant } from "./Icon";

--- a/src/components/LessonItemContainer/LessonItemContainer.stories.tsx
+++ b/src/components/LessonItemContainer/LessonItemContainer.stories.tsx
@@ -16,6 +16,7 @@ const props: LessonItemContainerProps = {
   title: "Slide deck",
   downloadable: true,
   slugs: { lessonSlug, unitSlug, programmeSlug },
+  anchorId: "slideDeck",
 };
 
 const meta: Meta<typeof LessonItemContainer> = {

--- a/src/components/LessonItemContainer/LessonItemContainer.test.tsx
+++ b/src/components/LessonItemContainer/LessonItemContainer.test.tsx
@@ -28,7 +28,7 @@ describe("LessonItemContainer", () => {
 
   it("renders the title with the correct level", () => {
     const { getAllByRole } = renderWithTheme(
-      <LessonItemContainer title={"Slide deck"}>
+      <LessonItemContainer title={"Slide deck"} anchorId={"slideDeck"}>
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>
           Inner content
         </Card>
@@ -39,7 +39,7 @@ describe("LessonItemContainer", () => {
 
   it("renders the children", () => {
     const { getByText } = renderWithTheme(
-      <LessonItemContainer title={"Slide deck"}>
+      <LessonItemContainer title={"Slide deck"} anchorId="slideDeck">
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>
           Inner content
         </Card>
@@ -53,6 +53,7 @@ describe("LessonItemContainer", () => {
       <LessonItemContainer
         title={"Slide deck"}
         downloadable={true}
+        anchorId={"slideDeck"}
         slugs={lessonOverview}
       >
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>
@@ -65,7 +66,11 @@ describe("LessonItemContainer", () => {
 
   it("doesn't render the download button without curriculum data", () => {
     const { getAllByRole } = renderWithTheme(
-      <LessonItemContainer title={"Slide deck"} downloadable={true}>
+      <LessonItemContainer
+        title={"Slide deck"}
+        downloadable={true}
+        anchorId="slideDeck"
+      >
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>
           Inner content
         </Card>
@@ -83,6 +88,7 @@ describe("LessonItemContainer", () => {
         downloadable={true}
         slugs={lessonOverview}
         title={"Video"}
+        anchorId={"video"}
         onDownloadButtonClick={onDownloadButtonClick}
       >
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>
@@ -102,6 +108,7 @@ describe("LessonItemContainer", () => {
       <LessonItemContainer
         title={"Worksheet"}
         downloadable={true}
+        anchorId="worksheet"
         slugs={lessonOverview}
       >
         <Card $background={"white"} $ba={3} $borderColor={"grey2"}>

--- a/src/components/LessonItemContainer/LessonItemContainer.tsx
+++ b/src/components/LessonItemContainer/LessonItemContainer.tsx
@@ -6,6 +6,7 @@ import { Heading, Hr } from "../Typography";
 import ButtonAsLink from "../Button/ButtonAsLink";
 import { containerTitleToPreselectMap } from "../DownloadComponents/downloads.types";
 import { LessonOverviewData } from "../../node-lib/curriculum-api";
+import AnchorTarget from "../AnchorTarget";
 
 /**
  * This replaces the old ExpandingContainer component on the lesson page. It should wrap each item of lesson content.
@@ -29,6 +30,7 @@ type Slugs = Pick<
 export interface LessonItemContainerProps {
   children?: React.ReactNode;
   title: LessonItemTitle;
+  anchorId: string;
   downloadable?: boolean;
   slugs?: Slugs;
   onDownloadButtonClick?: () => void;
@@ -39,18 +41,27 @@ const getPreselectedQueryFromTitle = (title: LessonItemTitle) => {
 };
 
 export const LessonItemContainer: FC<LessonItemContainerProps> = (props) => {
-  const { children, title, downloadable, onDownloadButtonClick, slugs } = props;
+  const {
+    children,
+    title,
+    downloadable,
+    onDownloadButtonClick,
+    slugs,
+    anchorId,
+  } = props;
   const preselected = getPreselectedQueryFromTitle(title);
 
   const lowerCaseTitle = title.toLowerCase();
 
   return (
-    <Flex $flexDirection="column">
+    <Flex $flexDirection="column" $position={"relative"}>
+      <AnchorTarget id={anchorId} $paddingTop={24} />
       <Flex
         $flexDirection={["column", "row"]}
         $alignItems={["start", "end"]}
         $gap={[12, 40]}
         $mb={[24]}
+        $position={"relative"}
       >
         {title && (
           <Heading $font={["heading-5", "heading-4"]} tag={"h2"}>

--- a/src/components/MenuLinks/useIsCurrent.ts
+++ b/src/components/MenuLinks/useIsCurrent.ts
@@ -1,6 +1,8 @@
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
-import { resolveOakHref } from "../../common-lib/urls";
+import { resolveOakHref } from "@/common-lib/urls";
+
 
 const isSubPath = ({
   currentPath,
@@ -14,6 +16,7 @@ const isSubPath = ({
   }
 
   const betaHomeHref = resolveOakHref({ page: "home", viewType: "teachers" });
+
   if (currentPath.startsWith(betaHomeHref + "/")) {
     return false;
   }
@@ -31,12 +34,18 @@ type UseIsCurrentProps = {
  */
 const useIsCurrent = (props: UseIsCurrentProps) => {
   const { href } = props;
-  const { pathname: currentPath } = useRouter();
+  const { pathname: currentPath, asPath } = useRouter();
+  const [isCurrent, setIsCurrent] = useState(false);
 
-  const isCurrent = isSubPath({
-    currentPath,
-    href,
-  });
+  // NB. We use useEffect here to avoid a server-side render error
+  useEffect(() => {
+    const hash = asPath.split("#")[1];
+    const isCurrentPath = isSubPath({
+      currentPath,
+      href,
+    });
+    setIsCurrent(isCurrentPath || hash === href.substring(1));
+  }, [currentPath, href, asPath]);
 
   return isCurrent;
 };

--- a/src/components/MenuLinks/useIsCurrent.ts
+++ b/src/components/MenuLinks/useIsCurrent.ts
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 
 import { resolveOakHref } from "@/common-lib/urls";
 
-
 const isSubPath = ({
   currentPath,
   href,

--- a/src/components/pages/TeachersLessonOverview/OverviewPresentation.tsx
+++ b/src/components/pages/TeachersLessonOverview/OverviewPresentation.tsx
@@ -1,11 +1,11 @@
-import { FC } from "react";
+import { FC, memo, useState } from "react";
 
 import AspectRatio from "../../AspectRatio";
 
 import Box from "@/components/Box";
 
 interface OverviewPresentationProps {
-  asset: string;
+  asset: string | null;
   title: string;
   isWorksheetLandscape?: boolean;
   isWorksheet: boolean;
@@ -17,7 +17,8 @@ const OverviewPresentation: FC<OverviewPresentationProps> = ({
   isWorksheetLandscape,
   isWorksheet,
 }) => {
-  const slidesId = asset.split("/")?.[5];
+  const [slidesId] = useState(asset ? asset.split("/")?.[5] : null);
+
   const isWorksheetPortrait = !isWorksheetLandscape && isWorksheet;
   return (
     <Box $ba={[3]} $width={"100%"}>
@@ -33,10 +34,11 @@ const OverviewPresentation: FC<OverviewPresentationProps> = ({
           style={{
             border: "none",
           }}
+          loading="eager"
         />
       </AspectRatio>
     </Box>
   );
 };
 
-export default OverviewPresentation;
+export default memo(OverviewPresentation);

--- a/src/components/pages/TeachersLessonOverview/OverviewVideo.tsx
+++ b/src/components/pages/TeachersLessonOverview/OverviewVideo.tsx
@@ -40,14 +40,16 @@ export const OverviewVideo: FC<OverviewVideoProps> = ({
 
   return (
     <Flex $flexDirection={"column"} $gap={[24]}>
-      <VideoPlayer
-        playbackId={
-          signLanguageVideo && signLanguageOn ? signLanguageVideo : video
-        }
-        playbackPolicy={"signed"}
-        title={title}
-        location={"lesson"}
-      />
+      {video && (
+        <VideoPlayer
+          playbackId={
+            signLanguageVideo && signLanguageOn ? signLanguageVideo : video
+          }
+          playbackPolicy={"signed"}
+          title={title}
+          location={"lesson"}
+        />
+      )}
 
       <Flex
         $flexDirection={["column-reverse", "row"]}

--- a/src/components/pages/TeachersLessonOverview/OverviewVideo.tsx
+++ b/src/components/pages/TeachersLessonOverview/OverviewVideo.tsx
@@ -7,7 +7,7 @@ import TranscriptViewer from "@/components/TranscriptViewer/TranscriptViewer";
 import Flex from "@/components/Flex";
 
 export interface OverviewVideoProps {
-  video: string;
+  video: string | null;
   signLanguageVideo: string | null;
   title: string;
   transcriptSentences?: string[] | null;

--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -147,11 +147,10 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
   const slugs = { unitSlug, lessonSlug, programmeSlug };
 
   const pageLinks = [
-    { label: "Slide deck", href: "#sideDeck" },
+    { label: "Slide deck", href: "#slideDeck" },
     {
       label: "Lesson details",
       href: "#lessonDetails",
-      isCurrentOverride: true,
     },
     { label: "Video", href: "#video" },
     { label: "Worksheet", href: "#worksheet" },
@@ -258,115 +257,118 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
             </Typography>
           </Box>
         ) : (
-          <>
-            <Grid $pt={[48]}>
-              <GridArea $colSpan={[12, 3]}>
-                <ButtonLinkNav
-                  ariaLabel="page navigation"
-                  buttons={pageLinks}
-                  $flexDirection={"column"}
-                  $alignItems={"flex-start"}
-                  $gap={[8]}
-                  arrowSuffix
-                />
-              </GridArea>
-              <GridArea $colSpan={[12, 9]}>
-                <Flex $flexDirection={"column"}>
-                  {presentationUrl && !hasCopyrightMaterial && (
-                    <LessonItemContainer
-                      title={"Slide deck"}
-                      downloadable={true}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "slide deck",
-                        });
-                      }}
-                      slugs={slugs}
-                    >
-                      <OverviewPresentation
-                        asset={presentationUrl}
-                        title={lessonTitle}
-                        isWorksheet={false}
-                      />
-                    </LessonItemContainer>
-                  )}
-
-                  <LessonItemContainer title={"Lesson details"}>
-                    <LessonDetails
-                      keyLearningPoints={keyLearningPoints}
-                      commonMisconceptions={misconceptionsAndCommonMistakes}
-                      keyWords={lessonKeywords}
-                      teacherTips={teacherTips}
+          <Grid $mt={[48]}>
+            <GridArea
+              $colSpan={[12, 3]}
+              $alignSelf={"start"}
+              $position={"sticky"}
+              $top={96} // FIXME: ideally we'd dynamically calculate this based on the height of the header using the next allowed size
+            >
+              <ButtonLinkNav
+                ariaLabel="page navigation"
+                buttons={pageLinks}
+                $flexDirection={"column"}
+                $alignItems={"flex-start"}
+                $gap={[8]}
+                arrowSuffix
+              />
+            </GridArea>
+            <GridArea $colSpan={[12, 9]}>
+              <Flex $flexDirection={"column"} $position={"relative"}>
+                {presentationUrl && !hasCopyrightMaterial && (
+                  <LessonItemContainer
+                    title={"Slide deck"}
+                    downloadable={true}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "slide deck",
+                      });
+                    }}
+                    slugs={slugs}
+                    anchorId="slideDeck"
+                  >
+                    <OverviewPresentation
+                      asset={presentationUrl}
+                      title={lessonTitle}
+                      isWorksheet={false}
                     />
                   </LessonItemContainer>
+                )}
 
-                  {videoMuxPlaybackId && (
-                    <LessonItemContainer title={"Video"}>
-                      <OverviewVideo
-                        video={videoMuxPlaybackId}
-                        signLanguageVideo={videoWithSignLanguageMuxPlaybackId}
-                        title={lessonTitle}
-                        transcriptSentences={transcriptSentences}
-                      />
-                    </LessonItemContainer>
-                  )}
-                  {worksheetUrl && (
-                    <ExpandingContainer
-                      downloadable={true}
-                      {...curriculumData}
-                      title={"Worksheet"}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "worksheet",
-                        });
-                      }}
-                    >
-                      <OverviewPresentation
-                        asset={worksheetUrl}
-                        title={lessonTitle}
-                        isWorksheetLandscape={isWorksheetLandscape}
-                        isWorksheet={true}
-                      />
-                    </ExpandingContainer>
-                  )}
-                  {introQuiz.length > 0 ? (
-                    <ExpandingContainer
-                      downloadable={true}
-                      {...curriculumData}
-                      title={"Starter quiz"}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "starter quiz",
-                        });
-                      }}
-                    >
-                      <QuizContainer
-                        questions={introQuiz}
-                        info={introQuizInfo}
-                      />
-                    </ExpandingContainer>
-                  ) : (
-                    ""
-                  )}
-                  {exitQuiz.length > 0 && (
-                    <ExpandingContainer
-                      downloadable={true}
-                      {...curriculumData}
-                      title={"Exit quiz"}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "exit quiz",
-                        });
-                      }}
-                    >
-                      <QuizContainer questions={exitQuiz} info={exitQuizInfo} />
-                    </ExpandingContainer>
-                  )}
-                </Flex>
-              </GridArea>
-              <GridArea $colSpan={[1]} />
-            </Grid>
-          </>
+                <LessonItemContainer
+                  title={"Lesson details"}
+                  anchorId="lessonDetails"
+                >
+                  <LessonDetails
+                    keyLearningPoints={keyLearningPoints}
+                    commonMisconceptions={misconceptionsAndCommonMistakes}
+                    keyWords={lessonKeywords}
+                    teacherTips={teacherTips}
+                  />
+                </LessonItemContainer>
+
+                {videoMuxPlaybackId && (
+                  <LessonItemContainer title={"Video"} anchorId="video">
+                    <OverviewVideo
+                      video={videoMuxPlaybackId}
+                      signLanguageVideo={videoWithSignLanguageMuxPlaybackId}
+                      title={lessonTitle}
+                      transcriptSentences={transcriptSentences}
+                    />
+                  </LessonItemContainer>
+                )}
+                {worksheetUrl && (
+                  <ExpandingContainer
+                    downloadable={true}
+                    {...curriculumData}
+                    title={"Worksheet"}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "worksheet",
+                      });
+                    }}
+                  >
+                    <OverviewPresentation
+                      asset={worksheetUrl}
+                      title={lessonTitle}
+                      isWorksheetLandscape={isWorksheetLandscape}
+                      isWorksheet={true}
+                    />
+                  </ExpandingContainer>
+                )}
+                {introQuiz.length > 0 ? (
+                  <ExpandingContainer
+                    downloadable={true}
+                    {...curriculumData}
+                    title={"Starter quiz"}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "starter quiz",
+                      });
+                    }}
+                  >
+                    <QuizContainer questions={introQuiz} info={introQuizInfo} />
+                  </ExpandingContainer>
+                ) : (
+                  ""
+                )}
+                {exitQuiz.length > 0 && (
+                  <ExpandingContainer
+                    downloadable={true}
+                    {...curriculumData}
+                    title={"Exit quiz"}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "exit quiz",
+                      });
+                    }}
+                  >
+                    <QuizContainer questions={exitQuiz} info={exitQuizInfo} />
+                  </ExpandingContainer>
+                )}
+              </Flex>
+            </GridArea>
+          </Grid>
         )}
       </MaxWidth>
       {!expired && (

--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -146,16 +146,29 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
 
   const slugs = { unitSlug, lessonSlug, programmeSlug };
 
-  const pageLinks = [
-    { label: "Slide deck", href: "#slideDeck" },
-    {
-      label: "Lesson details",
-      href: "#lessonDetails",
-    },
-    { label: "Video", href: "#video" },
-    { label: "Worksheet", href: "#worksheet" },
-    { label: "Exit Quiz", href: "#exitQuiz" },
-  ];
+  const pageLinks = [];
+
+  if (presentationUrl && !hasCopyrightMaterial) {
+    pageLinks.push({ label: "Slide deck", href: "#slideDeck" });
+  }
+
+  pageLinks.push({ label: "Lesson details", href: "#lessonDetails" });
+
+  if (videoMuxPlaybackId) {
+    pageLinks.push({ label: "Video", href: "#video" });
+  }
+
+  if (worksheetUrl) {
+    pageLinks.push({ label: "Worksheet", href: "#worksheet" });
+  }
+
+  if (introQuiz.length > 0) {
+    pageLinks.push({ label: "Starter quiz", href: "#starterQuiz" });
+  }
+
+  if (exitQuiz.length > 0) {
+    pageLinks.push({ label: "Exit quiz", href: "#exitQuiz" });
+  }
 
   return (
     <AppLayout
@@ -262,7 +275,8 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
               $colSpan={[12, 3]}
               $alignSelf={"start"}
               $position={"sticky"}
-              $top={96} // FIXME: ideally we'd dynamically calculate this based on the height of the header using the next allowed size
+              $display={["none", "block"]}
+              $top={96} // FIXME: ideally we'd dynamically calculate this based on the height of the header using the next allowed size. This could be achieved with a new helperFunction get nextAvailableSize
             >
               <ButtonLinkNav
                 ariaLabel="page navigation"
@@ -271,11 +285,12 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
                 $alignItems={"flex-start"}
                 $gap={[8]}
                 arrowSuffix
+                shallow
               />
             </GridArea>
             <GridArea $colSpan={[12, 9]}>
               <Flex $flexDirection={"column"} $position={"relative"}>
-                {presentationUrl && !hasCopyrightMaterial && (
+                {pageLinks.find((p) => p.label === "Slide deck") && (
                   <LessonItemContainer
                     title={"Slide deck"}
                     downloadable={true}
@@ -307,7 +322,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
                   />
                 </LessonItemContainer>
 
-                {videoMuxPlaybackId && (
+                {pageLinks.find((p) => p.label === "Video") && (
                   <LessonItemContainer title={"Video"} anchorId="video">
                     <OverviewVideo
                       video={videoMuxPlaybackId}
@@ -317,7 +332,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
                     />
                   </LessonItemContainer>
                 )}
-                {worksheetUrl && (
+                {pageLinks.find((p) => p.label === "Worksheet") && (
                   <ExpandingContainer
                     downloadable={true}
                     {...curriculumData}

--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -37,6 +37,7 @@ import { ViewType } from "@/common-lib/urls";
 import getPageProps from "@/node-lib/getPageProps";
 import LessonDetails from "@/components/LessonDetails/LessonDetails";
 import { LessonItemContainer } from "@/components/LessonItemContainer/LessonItemContainer";
+import ButtonLinkNav from "@/components/ButtonLinkNav/ButtonLinkNav";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewData;
@@ -145,6 +146,18 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
 
   const slugs = { unitSlug, lessonSlug, programmeSlug };
 
+  const pageLinks = [
+    { label: "Slide deck", href: "#sideDeck" },
+    {
+      label: "Lesson details",
+      href: "#lessonDetails",
+      isCurrentOverride: true,
+    },
+    { label: "Video", href: "#video" },
+    { label: "Worksheet", href: "#worksheet" },
+    { label: "Exit Quiz", href: "#exitQuiz" },
+  ];
+
   return (
     <AppLayout
       seoProps={{
@@ -247,7 +260,16 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
         ) : (
           <>
             <Grid $pt={[48]}>
-              <GridArea $colSpan={[12, 3]} />
+              <GridArea $colSpan={[12, 3]}>
+                <ButtonLinkNav
+                  ariaLabel="page navigation"
+                  buttons={pageLinks}
+                  $flexDirection={"column"}
+                  $alignItems={"flex-start"}
+                  $gap={[8]}
+                  arrowSuffix
+                />
+              </GridArea>
               <GridArea $colSpan={[12, 9]}>
                 <Flex $flexDirection={"column"}>
                   {presentationUrl && !hasCopyrightMaterial && (


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-1783--oak-web-application.netlify.thenational.academy/beta/teachers/programmes/science-secondary-ks3/units/cells-u2b1h4c/lessons/microscopes-lcj273#video
2. Click on left hand nav links
3. You should see the navigation happen

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Acceptance Criteria:

- [x]  Sticky to top of viewport
- [x]  Set column widths
- [x]  Change style on the button of the component you have selected
- [x]  Don’t display the nav menu in mobile (for now)
- [x]  Focus should move to the section you have navigated to rather than staying on the nav bar

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
