### PR TITLE
Fix/lesq 203/default title logic

### DIFF
--- a/src/components/Button/ButtonAsLink.test.tsx
+++ b/src/components/Button/ButtonAsLink.test.tsx
@@ -1,0 +1,63 @@
+import renderWithTheme from "../../__tests__/__helpers__/renderWithTheme";
+
+import ButtonAsLink from ".";
+
+describe("ButtonAsLink", () => {
+  it("renders a button as a link", () => {
+    const { getByRole } = renderWithTheme(
+      <ButtonAsLink
+        label="Click me"
+        variant="minimal"
+        icon="arrow-right"
+        $iconPosition="trailing"
+        iconBackground="teachersHighlight"
+      />
+    );
+
+    const button = getByRole("button");
+    expect(button).toBeInTheDocument();
+  });
+
+  it("renders the label", () => {
+    const { getByText } = renderWithTheme(
+      <ButtonAsLink label="Click me" variant="minimal" />
+    );
+
+    const button = getByText("Click me");
+    expect(button).toBeInTheDocument();
+  });
+
+  it("uses the label as the default link title", () => {
+    const { getByRole } = renderWithTheme(
+      <ButtonAsLink label="Click me" variant="minimal" />
+    );
+
+    const button = getByRole("button");
+    expect(button).toHaveAttribute("title", "Click me");
+  });
+
+  it("uses the aria-label as the link title when provided", () => {
+    const { getByRole } = renderWithTheme(
+      <ButtonAsLink
+        label="Click me"
+        variant="minimal"
+        aria-label="Click me to do something"
+      />
+    );
+
+    const button = getByRole("button");
+    expect(button).toHaveAttribute("title", "Click me to do something");
+  });
+
+  it("appends the labelSuffixA11y to the label and uses it as a title", () => {
+    const { getByRole } = renderWithTheme(
+      <ButtonAsLink
+        label="Click me"
+        labelSuffixA11y="to do something"
+        variant="minimal"
+      />
+    );
+    const button = getByRole("button");
+    expect(button).toHaveAttribute("title", "Click me to do something");
+  });
+});

--- a/src/components/Button/ButtonAsLink.tsx
+++ b/src/components/Button/ButtonAsLink.tsx
@@ -43,9 +43,10 @@ const ButtonAsLink: FC<ButtonAsLinkProps> = (props) => {
   const { size, variant, $iconPosition, background } =
     getButtonStylesProps(transformedProps);
 
-  // QUESTION: I don't follow the logic of this. It can result in rendering undefined as a title.
+  // aria-label overrides label.
+  // If labelSuffixA11y is provided, it is appended to the label.
   const defaultTitle =
-    ariaLabel || labelSuffixA11y ? `${label} ${labelSuffixA11y}` : "";
+    ariaLabel || (labelSuffixA11y ? `${label} ${labelSuffixA11y}` : label);
 
   return (
     <Link {...nextLinkProps} passHref legacyBehavior>

--- a/src/components/Button/ButtonAsLink.tsx
+++ b/src/components/Button/ButtonAsLink.tsx
@@ -46,7 +46,7 @@ const ButtonAsLink: FC<ButtonAsLinkProps> = (props) => {
   // aria-label overrides label.
   // If labelSuffixA11y is provided, it is appended to the label.
   const defaultTitle =
-    ariaLabel || (labelSuffixA11y ? `${label} ${labelSuffixA11y}` : label);
+    ariaLabel ?? (labelSuffixA11y ? `${label} ${labelSuffixA11y}` : label);
 
   return (
     <Link {...nextLinkProps} passHref legacyBehavior>

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.test.ts
@@ -10,6 +10,8 @@ describe("lessonOverview()", () => {
         lessonOverview: jest.fn(() => Promise.resolve({ lesson: [] })),
       })({
         lessonSlug: "lesson-slug",
+        unitSlug: "unit-slug",
+        programmeSlug: "programme-slug",
       });
     }).rejects.toThrow(`Resource not found`);
   });
@@ -62,7 +64,9 @@ describe("lessonOverview()", () => {
         })
       ),
     })({
-      lessonSlug: "programme-slug",
+      lessonSlug: "lesson-slug",
+      unitSlug: "unit-slug",
+      programmeSlug: "programme-slug",
     });
     expect(lesson.programmeSlug).toEqual("programme-slug-0");
   });
@@ -102,6 +106,8 @@ describe("lessonOverview()", () => {
         ),
       })({
         lessonSlug: "lesson-slug",
+        unitSlug: "unit-slug",
+        programmeSlug: "programme-slug",
       });
     }).rejects.toThrow(`subjectSlug`);
   });


### PR DESCRIPTION
**Job Story:**

When *using buttonAsLink*, I want the title to render without risk of “undefined” being added as a suffix

**Detail:**

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/f64a3840-0b7b-402d-8d85-0ccdc5b773b0/Untitled.png)

I think the logic is *supposed* to be as follows (but sounds like the logic might not be reflected properly in the code).

- `defaultTitle` is the string passed to html title attr if `title` prop not passed
- it takes value `ariaLabel` if that prop is passed (if there's a need to pass a different `ariaLabel` than the visible label)
- otherwise it should take the visible `label` prop, and add a suffix of `labelSuffixA11y` if that is passed

Essentially, the advice of a11y experts is that ideally the screen reader label should be same as visible -- but in cases where there are visual cues which would add context to a sighted user, then it's best to add a suffix to add context for assistive tech. The label read allowed should *start with* the visible label. Apologies I can't find a reference for this right now.Looking at the code i think it's missing some brackets:

```
const defaultTitle =
    ariaLabel || (labelSuffixA11y ? `${label} ${labelSuffixA11y}` : "");
```

## Acceptance Criteria:

- [x ]  Fix logic so that it copes with ariaLabel , labelSuffixA11y or neither being defined
- [ x]  Add a unit test for this

## How to test

1. Go to https://deploy-preview-1784--oak-web-application.netlify.thenational.academy
2. Click on _______
3. You should see _______

