### PR TITLE
fix(curric): updated max height for button subject svg

### DIFF
--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -151,8 +151,8 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
           <SubjectIcon
             subjectSlug={subjectIcon}
             $ml={-8}
-            height={40}
-            width={40}
+            $maxHeight={40}
+            $maxWidth={40}
           />
         </Flex>
       )}


### PR DESCRIPTION
## Description

- Updated max height of subject icon in ButtonInner component, which was instead sizing by height / width

## Issue(s)

The curriculum phase selector had oversized and misaligned subject icons 

## How to test

1. Go to [https://deploy-preview-1787--oak-web-application.netlify.thenational.academy/beta/teachers/curriculum]
2. Open the subject phase selector
3. You should see all correctly aligned subject icons in the buttons 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
