### PR TITLE
chore: removes duplicate content labels

### DIFF
--- a/src/components/LessonRequirements/LessonRequirements.tsx
+++ b/src/components/LessonRequirements/LessonRequirements.tsx
@@ -32,6 +32,15 @@ const LessonRequirements: FC<LessonRequirementsProps> = ({
   if (!contentGuidance && !equipment && !supervisionLevel) {
     return null;
   }
+
+  const removedGuidanceDuplicates = Array.from(
+    new Set(
+      contentGuidance?.map(
+        (guidance: ContentGuidance) => guidance.contentGuidanceLabel
+      )
+    )
+  );
+
   return (
     <Flex $flexDirection={"column"} $justifyContent={"center"} $gap={8}>
       <Flex $flexDirection={"row"} $alignItems={"center"}>
@@ -42,10 +51,10 @@ const LessonRequirements: FC<LessonRequirementsProps> = ({
       </Flex>
       {contentGuidance && (
         <UL $reset>
-          {contentGuidance.map((guidance: ContentGuidance) => {
+          {removedGuidanceDuplicates.map((guidance: string) => {
             return (
-              <LI $font={"body-2"} key={guidance.contentGuidanceLabel}>
-                {guidance.contentGuidanceLabel}
+              <LI $font={"body-2"} key={guidance}>
+                {guidance}
               </LI>
             );
           })}


### PR DESCRIPTION
## Description

- Removes duplicate content label

## Issue(s)

Fixes # LESQ-204

## How to test

1. Go to {owa_deployment_url}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):

<img width="240" alt="Screenshot 2023-08-21 at 18 41 47" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/b4191504-2990-4c28-9bf3-2019fdb5e100">


How it should now look:
<img width="234" alt="Screenshot 2023-08-21 at 18 41 10" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/0243789b-6b3b-4ff1-a064-2b3de150b691">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
