### PR TITLE
chore: url error logging

### DIFF
--- a/src/errors/OakError.ts
+++ b/src/errors/OakError.ts
@@ -151,7 +151,7 @@ const errorConfigs: Record<ErrorCode, ErrorConfig> = {
   },
   "urls/failed-to-resolve": {
     message:
-      "Failed to resolve URL. Likely caused by a mismatch between the TS types and the pathPattern",
+      "Failed to resolve URL. Likely caused by either an empty param (e.g. slug) or a mismatch between the TS types and the pathPattern",
     shouldNotify: true,
   },
   "downloads/failed-to-fetch": {


### PR DESCRIPTION
## Description

- one of the main causes of url errors is from params (e.g. slugs coming through as empty strings)
- this PR updates the messaging for the resolveUrl function, so that it's clearer what the underlying cause could be 
