### PR TITLE
fix(subject listing): hide new content

### DIFF
--- a/src/pages/beta/[viewType]/key-stages/[keyStageSlug]/subjects/index.tsx
+++ b/src/pages/beta/[viewType]/key-stages/[keyStageSlug]/subjects/index.tsx
@@ -128,10 +128,11 @@ export const getStaticProps: GetStaticProps<
             curriculumData.subjects.find(
               (subject) => subject.subjectSlug === subjectSlug
             ) || null,
-          new:
-            curriculumData2023.subjects.find(
-              (subject) => subject.subjectSlug === subjectSlug
-            ) || null,
+          new: null,
+          // new:
+          //   curriculumData2023.subjects.find(
+          //     (subject) => subject.subjectSlug === subjectSlug
+          //   ) || null,
         };
       });
 


### PR DESCRIPTION
## Description

- hide new content on subject listing page


## How to test

1. Go to {owa_deployment_url}/beta/teachers/key-stages/ks3/subjects
3. You should see no new content

## Screenshots

<img width="1407" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/12934669/808a8731-9ddd-4e9f-af53-fbc342e6f710">

