### PR TITLE
fix(subject listing): don't show subject card unless there is content

### DIFF
--- a/src/pages/beta/[viewType]/key-stages/[keyStageSlug]/subjects/index.tsx
+++ b/src/pages/beta/[viewType]/key-stages/[keyStageSlug]/subjects/index.tsx
@@ -121,20 +121,24 @@ export const getStaticProps: GetStaticProps<
         ...new Set(subjectSlugs.concat(subjectSlugs2023)),
       ];
 
-      const subjects = uniqueSubjectSlugs.map((subjectSlug) => {
-        return {
-          subjectSlug,
-          old:
-            curriculumData.subjects.find(
-              (subject) => subject.subjectSlug === subjectSlug
-            ) || null,
-          new: null,
-          // new:
-          //   curriculumData2023.subjects.find(
-          //     (subject) => subject.subjectSlug === subjectSlug
-          //   ) || null,
-        };
-      });
+      const subjects = uniqueSubjectSlugs
+        .map((subjectSlug) => {
+          return {
+            subjectSlug,
+            old:
+              curriculumData.subjects.find(
+                (subject) => subject.subjectSlug === subjectSlug
+              ) || null,
+            // Temporarily disable new curriculum (was being leaked to public)
+            new: null,
+            // new:
+            //   curriculumData2023.subjects.find(
+            //     (subject) => subject.subjectSlug === subjectSlug
+            //   ) || null,
+          };
+        })
+        // Filter out subjects that don't exist in either curriculum
+        .filter((subject) => subject.old || subject.new);
 
       const results = {
         props: {


### PR DESCRIPTION
## Description

- hides subject cards if no content is found


## How to test

1. Go to https://deploy-preview-1826--oak-web-application.netlify.thenational.academy
2. Click on _______
3. You should see _______


