### PR TITLE
fix: handle missing bios in leadership page

### DIFF
--- a/src/common-lib/cms-types/teamMember.ts
+++ b/src/common-lib/cms-types/teamMember.ts
@@ -15,7 +15,7 @@ export type TeamMemberSocials = z.infer<typeof teamMemberSocialsSchema>;
 export const teamMemberSchema = z
   .object({
     name: z.string(),
-    bioPortableText: portableTextSchema,
+    bioPortableText: portableTextSchema.nullish(),
     image: imageSchema.nullish(),
     id: z.string(),
     role: z.string().nullish(),

--- a/src/components/BioModal/BioModal.tsx
+++ b/src/components/BioModal/BioModal.tsx
@@ -160,15 +160,17 @@ const BioModal: FC<BioModalProps> = (props) => {
               </Box>
             </GridArea>
             <GridArea $colSpan={[12, 12, 5]} $order={[2, 2]}>
-              <Box
-                $ml={[0, 0, 72]}
-                $mb={[72]}
-                $mt={[0, 72, 0]}
-                $font={["body-2", "body-1"]}
-                $minHeight={["auto", 270]}
-              >
-                <PortableText value={bioPortableText} />
-              </Box>
+              {bioPortableText && (
+                <Box
+                  $ml={[0, 0, 72]}
+                  $mb={[72]}
+                  $mt={[0, 72, 0]}
+                  $font={["body-2", "body-1"]}
+                  $minHeight={["auto", 270]}
+                >
+                  <PortableText value={bioPortableText} />
+                </Box>
+              )}
             </GridArea>
           </Grid>
           <Flex

--- a/src/components/BioModal/BioModal.tsx
+++ b/src/components/BioModal/BioModal.tsx
@@ -29,7 +29,7 @@ export type BioData = {
   role?: string | null;
   image?: Image | null;
   socials?: TeamMemberSocials | null;
-  bioPortableText?: PortableTextJSON;
+  bioPortableText?: PortableTextJSON | null;
 };
 
 export type BioModalProps = {


### PR DESCRIPTION
## Description
- Allow nullish values for the leadership page bios to handle some data problems coming from the CMS
- Wrap the rendering of them in a conditional

## Issue(s)

Fixes #

## How to test
-  The deploy should work
- https://deploy-preview-1831--oak-web-application.netlify.thenational.academy/about-us/leadership should only show bios that exist in the CMS


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] ~Considered impact on accessibility~
- [ ] ~Design sign-off~
- [ ] ~Approved by product owner~
