### PR TITLE
chore(build): don't trigger releases on sonar config changing

### DIFF
--- a/.github/workflows/create_semantic_release.yml
+++ b/.github/workflows/create_semantic_release.yml
@@ -20,6 +20,7 @@ on:
     # events, to avoid this exact situation).
     paths-ignore:
       - "CHANGE_LOG.md"
+      - "sonar-project.properties"
 jobs:
   semantic_release:
     name: semantic release


### PR DESCRIPTION
Otherwise we risk getting into an infinite loop where the release creation process causes a change on `main` that triggers the release creation process.