### PR TITLE
fix(error reporter): report meta field from OakError

### DIFF
--- a/src/common-lib/error-reporter/errorReporter.ts
+++ b/src/common-lib/error-reporter/errorReporter.ts
@@ -166,6 +166,9 @@ const errorReporter = (context: string, metadata?: Record<string, unknown>) => {
         const originalError =
           maybeError instanceof OakError ? maybeError.originalError : undefined;
 
+        const oakErrorMeta =
+          maybeError instanceof OakError ? maybeError.meta : undefined;
+
         const { severity, groupingHash, ...metaFields } = {
           ...metadata,
           ...data,
@@ -180,6 +183,7 @@ const errorReporter = (context: string, metadata?: Record<string, unknown>) => {
         }
 
         metaFields.originalError = originalError;
+        metaFields.oakErrorMeta = oakErrorMeta;
 
         event.addMetadata("Meta", metaFields);
       });


### PR DESCRIPTION
## Description

- fix to the error reporter service so that it reports `OakError({ meta: {...fields} })`


## How to test

1. New instances of [this error](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/64a69d34152a2500081867d0?event_id=64eeef6900beb90d044a0000&i=sk&m=ef) should have extra context

