### PR TITLE
fix: change learning themes to threads [LESQ-289]

### DIFF
--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
@@ -196,7 +196,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                 {learningThemes?.length > 1 && (
                   <MobileFilters
                     providedId={learningThemesFilterId}
-                    label="Learning threads"
+                    label="Threads"
                     $mt={0}
                   >
                     <LearningThemeFilters

--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
@@ -155,6 +155,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                     $font="body-3"
                     $mb={16}
                   >
+                    {/* Though still called "Learning themes" internally, these should be referred to as "Threads" in user facing displays */}
                     Threads
                   </Heading>
                   <LearningThemeFilters

--- a/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/beta/[viewType]/programmes/[programmeSlug]/units.tsx
@@ -155,7 +155,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                     $font="body-3"
                     $mb={16}
                   >
-                    Learning themes
+                    Threads
                   </Heading>
                   <LearningThemeFilters
                     labelledBy={learningThemesId}
@@ -196,7 +196,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                 {learningThemes?.length > 1 && (
                   <MobileFilters
                     providedId={learningThemesFilterId}
-                    label="Learning themes"
+                    label="Learning threads"
                     $mt={0}
                   >
                     <LearningThemeFilters


### PR DESCRIPTION
## Description

- [LESQ-89](https://www.notion.so/oaknationalacademy/Change-learning-themes-to-threads-on-unit-listing-page-834547d634d34270889ee9a9fce3a734?pvs=4) 
- change `Learning themes` to `Threads` in the units component
- there are a few variables using the `learningThemes` naming but I've left these as they are 

## How to test

1. Go to https://deploy-preview-1892--oak-web-application.netlify.thenational.academy
2. Navigate to a unit page (eg KS3 Music)
3. You should see `Threads` in the sidebar instead of `Learning themes`

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
