### PR TITLE
fix(curric): remove downloads tab

### DIFF
--- a/src/__tests__/pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -10,7 +10,6 @@ import CurriculumInfoPage, {
 import { fetchSubjectPhasePickerData } from "@/pages/beta/[viewType]/curriculum";
 import curriculumOverviewTabFixture from "@/node-lib/curriculum-api-2023/fixtures/curriculumOverview.fixture";
 import curriculumUnitsTabFixture from "@/node-lib/curriculum-api-2023/fixtures/curriculumUnits.fixture";
-import curriculumDownloadsTabFixture from "@/node-lib/curriculum-api-2023/fixtures/curriculumDownloads.fixture";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import subjectPhaseOptions from "@/browser-lib/fixtures/subjectPhaseOptions";
 
@@ -19,7 +18,6 @@ jest.mock("next/router");
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   curriculumOverview: jest.fn(),
   curriculumUnits: jest.fn(),
-  curriculumDownloads: jest.fn(),
 }));
 const mockedCurriculumOverview =
   curriculumApi.curriculumOverview as MockedFunction<
@@ -28,10 +26,6 @@ const mockedCurriculumOverview =
 const mockedCurriculumUnits = curriculumApi.curriculumUnits as MockedFunction<
   typeof curriculumApi.curriculumUnits
 >;
-const mockedCurriculumDownloads =
-  curriculumApi.curriculumDownloads as MockedFunction<
-    typeof curriculumApi.curriculumDownloads
-  >;
 const mockedFetchSubjectPhasePickerData =
   fetchSubjectPhasePickerData as MockedFunction<
     typeof fetchSubjectPhasePickerData
@@ -52,6 +46,7 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
         examboardSlug: "aqa",
       });
     });
+
     it("should reject an invalid slug", () => {
       const slug = "not_a_valid_slug";
       expect(() => parseSubjectPhaseSlug(slug)).toThrow(
@@ -75,7 +70,6 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
           subjectPhaseOptions={subjectPhaseOptions}
           curriculumOverviewTabData={curriculumOverviewTabFixture()}
           curriculumUnitsTabData={curriculumUnitsTabFixture()}
-          curriculumDownloadsTabData={curriculumDownloadsTabFixture()}
         />,
       );
       expect(queryByTestId("tabularNav")).toBeInTheDocument();
@@ -95,7 +89,6 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
           subjectPhaseOptions={subjectPhaseOptions}
           curriculumOverviewTabData={curriculumOverviewTabFixture()}
           curriculumUnitsTabData={curriculumUnitsTabFixture()}
-          curriculumDownloadsTabData={curriculumDownloadsTabFixture()}
         />,
       );
       expect(queryByTestId("intent-heading")).toBeInTheDocument();
@@ -116,31 +109,10 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
           subjectPhaseOptions={subjectPhaseOptions}
           curriculumOverviewTabData={curriculumOverviewTabFixture()}
           curriculumUnitsTabData={curriculumUnitsTabFixture()}
-          curriculumDownloadsTabData={curriculumDownloadsTabFixture()}
         />,
       );
       expect(queryByTestId("units-heading")).toBeInTheDocument();
       expect(queryAllByTestId("unit-cards")[0]).toBeInTheDocument();
-    });
-
-    it("renders the Curriculum Downloads Tab", () => {
-      (useRouter as jest.Mock).mockReturnValue({
-        query: { tab: "downloads" },
-        isPreview: false,
-        pathname:
-          "/beta/teachers-2023/curriculum/english-secondary-aqa/overview",
-      });
-      const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
-      const { queryByTestId } = render(
-        <CurriculumInfoPage
-          curriculumSelectionSlugs={slugs}
-          subjectPhaseOptions={subjectPhaseOptions}
-          curriculumOverviewTabData={curriculumOverviewTabFixture()}
-          curriculumUnitsTabData={curriculumUnitsTabFixture()}
-          curriculumDownloadsTabData={curriculumDownloadsTabFixture()}
-        />,
-      );
-      expect(queryByTestId("downloads-heading")).toBeInTheDocument();
     });
   });
 
@@ -156,11 +128,7 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
         curriculumOverviewTabFixture(),
       );
       mockedCurriculumUnits.mockResolvedValue(curriculumUnitsTabFixture());
-      mockedCurriculumDownloads.mockResolvedValue(
-        curriculumDownloadsTabFixture(),
-      );
       mockedFetchSubjectPhasePickerData.mockResolvedValue(subjectPhaseOptions);
-
       const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
       const props = await getStaticProps({
         params: {
@@ -169,15 +137,12 @@ describe("pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab]", () => {
           viewType: "teachers-2023",
         },
       });
-
-      // Note: If decorateWithIsr modifies the results, you'll need to account for that in your expected output.
       expect(props).toEqual({
         props: {
           curriculumSelectionSlugs: slugs,
           subjectPhaseOptions: subjectPhaseOptions,
           curriculumOverviewTabData: curriculumOverviewTabFixture(),
           curriculumUnitsTabData: curriculumUnitsTabFixture(),
-          curriculumDownloadsTabData: curriculumDownloadsTabFixture(),
         },
       });
     });

--- a/src/components/pages/CurriculumInfo/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/pages/CurriculumInfo/CurriculumHeader/CurriculumHeader.tsx
@@ -140,14 +140,6 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
               isCurrent: tab === "units",
               currentStyles: ["underline"],
             },
-            {
-              label: "Downloads",
-              page: "curriculum-downloads",
-              viewType: "teachers",
-              subjectPhaseSlug: subjectPhaseSlug,
-              isCurrent: tab === "downloads",
-              currentStyles: ["underline"],
-            },
           ]}
           data-testid="tabularNav"
         />

--- a/src/pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/beta/[viewType]/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -10,11 +10,9 @@ import { useRouter } from "next/router";
 import CurriculumHeader from "@/components/pages/CurriculumInfo/CurriculumHeader/CurriculumHeader";
 import OverviewTab from "@/components/pages/CurriculumInfo/tabs/OverviewTab/OverviewTab";
 import UnitsTab from "@/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab";
-import DownloadsTab from "@/components/pages/CurriculumInfo/tabs/DownloadsTab/DownloadsTab";
 import AppLayout from "@/components/AppLayout/AppLayout";
 import Box from "@/components/Box/Box";
 import curriculumApi, {
-  CurriculumDownloadsTabData,
   CurriculumOverviewTabData,
   CurriculumUnitsTabData,
 } from "@/node-lib/curriculum-api-2023";
@@ -41,10 +39,9 @@ export type CurriculumInfoPageProps = {
   subjectPhaseOptions: SubjectPhasePickerData;
   curriculumOverviewTabData: CurriculumOverviewTabData;
   curriculumUnitsTabData: CurriculumUnitsTabData;
-  curriculumDownloadsTabData: CurriculumDownloadsTabData;
 };
 
-const VALID_TABS = ["overview", "units", "downloads"] as const;
+const VALID_TABS = ["overview", "units"] as const;
 export type CurriculumTab = (typeof VALID_TABS)[number];
 
 const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
@@ -52,7 +49,6 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
   subjectPhaseOptions,
   curriculumOverviewTabData,
   curriculumUnitsTabData,
-  curriculumDownloadsTabData,
 }) => {
   const router = useRouter();
   const tab = router.query.tab as CurriculumTab;
@@ -64,9 +60,6 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
       break;
     case "units":
       tabContent = <UnitsTab data={curriculumUnitsTabData} />;
-      break;
-    case "downloads":
-      tabContent = <DownloadsTab data={curriculumDownloadsTabData} />;
       break;
     default:
       throw new Error("Not a valid tab");
@@ -91,7 +84,7 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
 };
 
 export type URLParams = {
-  tab: "units" | "overview" | "downloads";
+  tab: "units" | "overview";
   viewType: ViewType;
   subjectPhaseSlug: string;
 };
@@ -154,8 +147,6 @@ export const getStaticProps: GetStaticProps<
       const curriculumOverviewTabData =
         await curriculumApi.curriculumOverview(slugs);
       const curriculumUnitsTabData = await curriculumApi.curriculumUnits(slugs);
-      const curriculumDownloadsTabData =
-        await curriculumApi.curriculumDownloads(slugs);
       const subjectPhaseOptions = await fetchSubjectPhasePickerData();
       const results: GetStaticPropsResult<CurriculumInfoPageProps> = {
         props: {
@@ -163,7 +154,6 @@ export const getStaticProps: GetStaticProps<
           subjectPhaseOptions,
           curriculumOverviewTabData,
           curriculumUnitsTabData,
-          curriculumDownloadsTabData,
         },
       };
       const resultsWithIsr = decorateWithIsr(results);


### PR DESCRIPTION
## Description

- Removed downloads tab from visible curriculum tabs.

## How to test

1. Go to {owa_deployment_url}/beta/teachers-2023/curriculum/geography-primary/units
2. Scroll down to the tabs below the Subject Phase Picker and Title
3. You should see Overview and Unit Sequence only, not Downloads

## Screenshots
How it used to look:
<img width="1076" alt="Screenshot 2023-09-11 at 14 57 45" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/a953501d-4591-4d2a-8b16-cd0fda2eecf8">

How it should now look:
<img width="1076" alt="Screenshot 2023-09-11 at 14 57 11" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/55e47285-fd10-431f-8ecb-9864f98a3af8">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
