### PR TITLE
chore(husbpot error): ignore hubspot error message

### DIFF
--- a/src/common-lib/error-reporter/errorReporter.ts
+++ b/src/common-lib/error-reporter/errorReporter.ts
@@ -29,6 +29,8 @@ export const matchesIgnoredError = (message: string) => {
     // https://github.com/oaknational/Oak-Web-Application/issues/999
     /Multiple lead flow scripts are trying to run on the current page/i,
     /t.report is not a function/i,
+    /null is not an object (evaluating 'e.portalId')/i,
+    /Hubspot script failed to load/i,
   ];
   return messagesToMatch.some((regex) => regex.test(message));
 };


### PR DESCRIPTION
## Description

- ignore [hubspot `null is not an object (evaluating 'e.portalId')` error](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/64ff0304fee41f000706a6b9?filters[error.status]=open&filters[event.since]=30d)

