### PR TITLE
chore(error reporter): ignore hubspot errors by stacktrace file

### DIFF
--- a/src/common-lib/error-reporter/errorReporter.test.ts
+++ b/src/common-lib/error-reporter/errorReporter.test.ts
@@ -79,13 +79,24 @@ describe("common-lib/error-reporter", () => {
   });
   describe("matchesIgnoredError", () => {
     it("returns false if the error should not be ignored", () => {
-      const shouldIgnore = matchesIgnoredError(
-        "Proper error that should be reported",
-      );
+      const shouldIgnore = matchesIgnoredError({
+        errorMessage: "Proper error that should be reported",
+        stacktrace: [],
+      });
       expect(shouldIgnore).toBe(false);
     });
-    it("returns true if the error should be ignored", () => {
-      const shouldIgnore = matchesIgnoredError("Test error");
+    it("returns true if the error should be ignored based on message", () => {
+      const shouldIgnore = matchesIgnoredError({
+        errorMessage: "Test error",
+        stacktrace: [],
+      });
+      expect(shouldIgnore).toBe(true);
+    });
+    it("returns true if the error should be ignored based on stacktrace", () => {
+      const shouldIgnore = matchesIgnoredError({
+        errorMessage: "Proper error message",
+        stacktrace: [{ file: "https://OAK_TEST_ERROR_STACKTRACE_FILE.js" }],
+      });
       expect(shouldIgnore).toBe(true);
     });
   });
@@ -96,6 +107,7 @@ describe("common-lib/error-reporter", () => {
         errors: [
           {
             errorMessage: "real error",
+            stacktrace: [{ file: "real file" }],
           },
         ],
       } as BugsnagEvent;
@@ -115,9 +127,10 @@ describe("common-lib/error-reporter", () => {
         errors: [
           {
             errorMessage: "Test error",
+            stacktrace: [],
           },
         ],
-      } as BugsnagEvent;
+      } as unknown as BugsnagEvent;
       const result = getBugsnagOnError({ logger })(event);
       expect(result).toBe(false);
     });

--- a/src/common-lib/error-reporter/errorReporter.ts
+++ b/src/common-lib/error-reporter/errorReporter.ts
@@ -21,7 +21,16 @@ export const matchesUserAgent = (ua: string) => {
   return userAgentsToMatch.some((regex) => regex.test(ua));
 };
 
-export const matchesIgnoredError = (message: string) => {
+export const matchesIgnoredError = (error: {
+  errorMessage: string;
+  stacktrace: { file: string }[];
+}) => {
+  const filesToMatch = [
+    // Testing
+    /OAK_TEST_ERROR_STACKTRACE_FILE/i,
+    // Don't error external Hubspot script problems
+    /\/\/js\.hubspot\.com/i,
+  ];
   const messagesToMatch = [
     // Testing
     /Test error/i,
@@ -32,7 +41,11 @@ export const matchesIgnoredError = (message: string) => {
     /null is not an object (evaluating 'e.portalId')/i,
     /Hubspot script failed to load/i,
   ];
-  return messagesToMatch.some((regex) => regex.test(message));
+  return (
+    filesToMatch.some((regex) =>
+      error.stacktrace.some((stacktrace) => regex.test(stacktrace.file)),
+    ) || messagesToMatch.some((regex) => regex.test(error.errorMessage))
+  );
 };
 
 export function getBugsnagOnError(
@@ -51,10 +64,9 @@ export function getBugsnagOnError(
     // Ignore some known errors that aren't user impacting but do mess up the stability metrics.
     const firstError = event?.errors[0];
     if (firstError !== undefined) {
-      const errorMessage = firstError.errorMessage;
-      const shouldIgnore = matchesIgnoredError(errorMessage);
+      const shouldIgnore = matchesIgnoredError(firstError);
       if (shouldIgnore) {
-        logger.warn(`Ignoring known issue: ${errorMessage}`);
+        logger.warn(`Ignoring known issue: ${firstError.errorMessage}`);
         return false;
       }
     }


### PR DESCRIPTION
## Description

- ignore errors whose stacktrace contains files matching `//js.hubspot.com` (they aren't impacting users, there's nothing to be done about them, and they are affecting our stability score on bugsnag)
