### PR TITLE
fix: landing page header bug fixed

### DIFF
--- a/src/pages/beta/[viewType]/curriculum/index.tsx
+++ b/src/pages/beta/[viewType]/curriculum/index.tsx
@@ -72,6 +72,7 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
           </Flex>
         </MaxWidth>
       </Flex>
+
       <Flex $background={"white"} $justifyContent={"center"}>
         <MaxWidth>
           <Flex
@@ -139,12 +140,17 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
           </Flex>
           <Flex
             $background={"grey1"}
-            $position={"relative"}
             $minHeight={812}
             $ml={[0, 12, 0]}
             $mr={[0, 12, 0]}
           >
-            <Box $pl={[24, 48]} $pr={[24, 48]} $pt={48} $mb={[48, 0]}>
+            <Box
+              $pl={[24, 48]}
+              $pr={[24, 48]}
+              $pt={48}
+              $mb={[48, 0]}
+              $position={"relative"}
+            >
               <Heading tag="h2" $font={"heading-4"} $mb={24}>
                 Our blogs on curriculum design
               </Heading>
@@ -169,8 +175,8 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
                   {<Hr thickness={4} $mt={32} $mb={0} />}
                 </>
               ) : null}
+              <BrushBorders color="grey1" hideOnMobileH />
             </Box>
-            <BrushBorders color="grey1" />
           </Flex>
         </MaxWidth>
       </Flex>


### PR DESCRIPTION
## Description

- Fixes width bug on landing page phone view

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
<img width="377" alt="Screenshot 2023-09-13 at 16 14 08" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/d1468aaa-65c6-48b8-bf40-4e3b888f2995">


How it should now look:
<img width="372" alt="Screenshot 2023-09-13 at 16 13 57" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/f350962a-a22c-4688-8f09-524953ca6d95">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
