### PR TITLE
fix(teachers homepage): hide teachers home page

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,3 @@
 module.exports = {
-  "*.{js,jsx,ts,tsx}": [
-    "npm run format:precommit",
-    "npm run lint:precommit",
-    "npm run lint:styles:precommit",
-  ],
+  "*.{js,jsx,ts,tsx}": ["npm run format:precommit", "npm run lint:precommit"],
 };

--- a/src/__tests__/pages/[viewType]/index.test.tsx
+++ b/src/__tests__/pages/[viewType]/index.test.tsx
@@ -130,7 +130,11 @@ describe("pages/beta/[viewType]/index.tsx", () => {
         mockPost,
         mockPost2,
       ]);
-      const result = (await getStaticProps({})) as { props: HomePageProps };
+      const result = (await getStaticProps({
+        params: {
+          viewType: "teachers",
+        },
+      })) as { props: HomePageProps };
 
       expect(result.props?.posts).toHaveLength(4);
     });
@@ -141,7 +145,11 @@ describe("pages/beta/[viewType]/index.tsx", () => {
         { ...mockPost, id: "3", date: new Date("2021-01-01") },
         { ...mockPost, id: "1", date: new Date("2023-01-01") },
       ]);
-      const result = (await getStaticProps({})) as { props: HomePageProps };
+      const result = (await getStaticProps({
+        params: {
+          viewType: "teachers",
+        },
+      })) as { props: HomePageProps };
 
       const postIds = result.props.posts.map((p) => p.id);
       expect(postIds).toEqual(["1", "2", "3"]);
@@ -153,7 +161,11 @@ describe("pages/beta/[viewType]/index.tsx", () => {
         { ...mockPost3, id: "3", date: new Date("2021-01-01") },
         { ...mockPost3, id: "1", date: new Date("4023-01-01") },
       ]);
-      const result = (await getStaticProps({})) as { props: HomePageProps };
+      const result = (await getStaticProps({
+        params: {
+          viewType: "teachers",
+        },
+      })) as { props: HomePageProps };
 
       const postIds = result.props.posts.map((p) => p.id as string);
       expect(postIds).toEqual(["2", "3"]);
@@ -161,7 +173,11 @@ describe("pages/beta/[viewType]/index.tsx", () => {
 
     it("Should not fetch draft content by default", async () => {
       mockCMSClient.blogPosts.mockResolvedValueOnce([mockPost]);
-      await getStaticProps({});
+      await getStaticProps({
+        params: {
+          viewType: "teachers",
+        },
+      });
 
       expect(mockCMSClient.blogPosts).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/pages/[viewType]/index.tsx
+++ b/src/pages/[viewType]/index.tsx
@@ -213,6 +213,15 @@ export const getStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<HomePageProps> = async (
   context,
 ) => {
+  if (
+    context?.params?.viewType !== "teachers" &&
+    context?.params?.viewType !== "teachers-2023"
+  ) {
+    return {
+      notFound: true,
+    };
+  }
+
   return getPageProps({
     page: "teachers-home-page::getStaticProps",
     context,


### PR DESCRIPTION
## Description

hide teacher home page for all urls other then teachers

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-1911--oak-web-application.netlify.thenational.academy
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
