### PR TITLE
Feat/lesq 305/blog breadcrumbs relocation [LESQ-305]

### DIFF
--- a/src/components/Posts/PostHeader/PostHeader.tsx
+++ b/src/components/Posts/PostHeader/PostHeader.tsx
@@ -22,11 +22,7 @@ const PostHeader: FC<PostHeaderProps> = ({ post, page }) => {
   const formattedDate = formatDate(post.date);
   return (
     <>
-      <Flex
-        $mt={[40, 12]}
-        $justifyContent="space-between"
-        $flexDirection={["column", "row"]}
-      >
+      <Flex $justifyContent="space-between" $flexDirection={["column", "row"]}>
         <Heading tag={"h2"} $color="hyperlink" $font={["heading-7"]}>
           <OakLink page={page} categorySlug={post.category.slug}>
             {post.category.title}

--- a/src/components/Posts/PostHeader/PostHeader.tsx
+++ b/src/components/Posts/PostHeader/PostHeader.tsx
@@ -1,15 +1,16 @@
 import { FC } from "react";
 
-import { SerializedWebinar } from "../../../pages/webinars/[webinarSlug]";
-import { SerializedBlog } from "../../../pages/blog/[blogSlug]";
-import formatDate from "../../../utils/formatDate";
-import AvatarImage from "../../AvatarImage";
-import Box from "../../Box";
-import CopyLinkButton from "../../Button/CopyLinkButton";
-import Flex from "../../Flex";
-import OakLink from "../../OakLink";
-import { Heading, P, Span } from "../../Typography";
 import { PostCategoryPage } from "../PostCategoryList/PostCategoryList";
+
+import { SerializedWebinar } from "@/pages/webinars/[webinarSlug]";
+import { SerializedBlog } from "@/pages/blog/[blogSlug]";
+import formatDate from "@/utils/formatDate";
+import AvatarImage from "@/components/AvatarImage";
+import Box from "@/components/Box";
+import CopyLinkButton from "@/components/Button/CopyLinkButton";
+import Flex from "@/components/Flex";
+import OakLink from "@/components/OakLink";
+import { Heading, P, Span } from "@/components/Typography";
 
 type PostHeaderProps = {
   post: SerializedBlog | SerializedWebinar;

--- a/src/components/Posts/PostHeader/PostHeader.tsx
+++ b/src/components/Posts/PostHeader/PostHeader.tsx
@@ -22,7 +22,7 @@ const PostHeader: FC<PostHeaderProps> = ({ post, page }) => {
   return (
     <>
       <Flex
-        $mt={[40, 72]}
+        $mt={[40, 12]}
         $justifyContent="space-between"
         $flexDirection={["column", "row"]}
       >

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -70,7 +70,7 @@ const PostListing: FC<PostListingProps> = ({
         $pt={20}
         $gap={20}
         $flexDirection="column"
-        $display={["none", "block"]}
+        $display={["none", "flex"]}
       >
         <Breadcrumbs
           breadcrumbs={getBlogWebinarListBreadcrumbs(

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -28,6 +28,8 @@ import {
   webinarToPostListItem,
 } from "../pages/WebinarsIndex.page";
 import Breadcrumbs from "../Breadcrumbs/Breadcrumbs";
+import Flex from "../Flex/Flex";
+import Svg from "../Svg/Svg";
 
 import PostCategoryList, {
   PostCategoryPage,
@@ -68,15 +70,25 @@ const PostListing: FC<PostListingProps> = ({
 
   return (
     <Layout seoProps={getSeoProps(seo)} $background="white">
-      <Breadcrumbs
-        breadcrumbs={getBlogWebinarListBreadcrumbs(
-          categories,
-          categorySlug,
-          variant.slug,
-          variant.title,
-        )}
-      />
-      <MaxWidth $pt={[0, 80, 80]}>
+      <MaxWidth>
+        <Flex
+          $pt={20}
+          $gap={20}
+          $flexDirection="column"
+          $display={["none", "block"]}
+        >
+          <Breadcrumbs
+            breadcrumbs={getBlogWebinarListBreadcrumbs(
+              categories,
+              categorySlug,
+              variant.slug,
+              variant.title,
+            )}
+          />
+          <Svg name="header-underline" $color="grey3" $height={4} />
+        </Flex>
+      </MaxWidth>
+      <MaxWidth $pt={[0, 26, 26]}>
         <SummaryCard
           {...pageData}
           heading={categoryHeading || pageData.heading}

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -29,9 +29,7 @@ import {
   webinarToPostListItem,
 } from "@/components/pages/WebinarsIndex.page";
 import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
-import Flex from "@/components/Flex/Flex";
 import Svg from "@/components/Svg/Svg";
-
 
 type PostListingProps = {
   seo: SeoProps;
@@ -68,23 +66,21 @@ const PostListing: FC<PostListingProps> = ({
 
   return (
     <Layout seoProps={getSeoProps(seo)} $background="white">
-      <MaxWidth>
-        <Flex
-          $pt={20}
-          $gap={20}
-          $flexDirection="column"
-          $display={["none", "block"]}
-        >
-          <Breadcrumbs
-            breadcrumbs={getBlogWebinarListBreadcrumbs(
-              categories,
-              categorySlug,
-              variant.slug,
-              variant.title,
-            )}
-          />
-          <Svg name="header-underline" $color="grey3" $height={4} />
-        </Flex>
+      <MaxWidth
+        $pt={20}
+        $gap={20}
+        $flexDirection="column"
+        $display={["none", "block"]}
+      >
+        <Breadcrumbs
+          breadcrumbs={getBlogWebinarListBreadcrumbs(
+            categories,
+            categorySlug,
+            variant.slug,
+            variant.title,
+          )}
+        />
+        <Svg name="header-underline" $color="grey3" $height={4} />
       </MaxWidth>
       <MaxWidth $pt={[0, 26, 26]}>
         <SummaryCard

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -1,39 +1,37 @@
 import { FC, useId } from "react";
 
-import { PostListJsonLd } from "../../browser-lib/seo/getJsonLd";
-import { getSeoProps } from "../../browser-lib/seo/getSeoProps";
-import { SeoProps } from "../../browser-lib/seo/Seo";
-import {
-  PostListingPage,
-  BlogWebinarCategory,
-} from "../../common-lib/cms-types";
-import { WebinarsListingPage } from "../../common-lib/cms-types/webinarsListingPage";
-import PostListAndCategories from "../Posts/PostListAndCategories";
+import PostCategoryList, {
+  PostCategoryPage,
+} from "./PostCategoryList/PostCategoryList";
+
+import { PostListJsonLd } from "@/browser-lib/seo/getJsonLd";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { SeoProps } from "@/browser-lib/seo/Seo";
+import { PostListingPage, BlogWebinarCategory } from "@/common-lib/cms-types";
+import { WebinarsListingPage } from "@/common-lib/cms-types/webinarsListingPage";
+import PostListAndCategories from "@/components/Posts/PostListAndCategories";
 import {
   CrumbPageVariant,
   getBlogWebinarListBreadcrumbs,
-} from "../Breadcrumbs/getBreadcrumbs";
-import SummaryCard from "../Card/SummaryCard";
-import Layout from "../Layout";
-import MaxWidth from "../MaxWidth/MaxWidth";
-import MobileFilters from "../MobileFilters";
+} from "@/components/Breadcrumbs/getBreadcrumbs";
+import SummaryCard from "@/components/Card/SummaryCard";
+import Layout from "@/components/Layout";
+import MaxWidth from "@/components/MaxWidth/MaxWidth";
+import MobileFilters from "@/components/MobileFilters";
 import {
   PostListingPageProps,
   blogToPostListItem,
   SerializedBlogPostPreview,
-} from "../pages/BlogIndex.page";
+} from "@/components/pages/BlogIndex.page";
 import {
   SerializedWebinarPreview,
   WebinarListingPageProps,
   webinarToPostListItem,
-} from "../pages/WebinarsIndex.page";
-import Breadcrumbs from "../Breadcrumbs/Breadcrumbs";
-import Flex from "../Flex/Flex";
-import Svg from "../Svg/Svg";
+} from "@/components/pages/WebinarsIndex.page";
+import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
+import Flex from "@/components/Flex/Flex";
+import Svg from "@/components/Svg/Svg";
 
-import PostCategoryList, {
-  PostCategoryPage,
-} from "./PostCategoryList/PostCategoryList";
 
 type PostListingProps = {
   seo: SeoProps;

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -27,6 +27,7 @@ import {
   WebinarListingPageProps,
   webinarToPostListItem,
 } from "../pages/WebinarsIndex.page";
+import Breadcrumbs from "../Breadcrumbs/Breadcrumbs";
 
 import PostCategoryList, {
   PostCategoryPage,
@@ -66,16 +67,15 @@ const PostListing: FC<PostListingProps> = ({
   );
 
   return (
-    <Layout
-      seoProps={getSeoProps(seo)}
-      $background="white"
-      breadcrumbs={getBlogWebinarListBreadcrumbs(
-        categories,
-        categorySlug,
-        variant.slug,
-        variant.title,
-      )}
-    >
+    <Layout seoProps={getSeoProps(seo)} $background="white">
+      <Breadcrumbs
+        breadcrumbs={getBlogWebinarListBreadcrumbs(
+          categories,
+          categorySlug,
+          variant.slug,
+          variant.title,
+        )}
+      />
       <MaxWidth $pt={[0, 80, 80]}>
         <SummaryCard
           {...pageData}

--- a/src/components/Posts/PostListing.tsx
+++ b/src/components/Posts/PostListing.tsx
@@ -29,7 +29,6 @@ import {
   webinarToPostListItem,
 } from "@/components/pages/WebinarsIndex.page";
 import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
-import Svg from "@/components/Svg/Svg";
 
 type PostListingProps = {
   seo: SeoProps;
@@ -66,12 +65,7 @@ const PostListing: FC<PostListingProps> = ({
 
   return (
     <Layout seoProps={getSeoProps(seo)} $background="white">
-      <MaxWidth
-        $pt={20}
-        $gap={20}
-        $flexDirection="column"
-        $display={["none", "flex"]}
-      >
+      <MaxWidth $pt={20} $display={["none", "flex"]}>
         <Breadcrumbs
           breadcrumbs={getBlogWebinarListBreadcrumbs(
             categories,
@@ -80,7 +74,6 @@ const PostListing: FC<PostListingProps> = ({
             variant.title,
           )}
         />
-        <Svg name="header-underline" $color="grey3" $height={4} />
       </MaxWidth>
       <MaxWidth $pt={[0, 26, 26]}>
         <SummaryCard

--- a/src/components/Posts/PostSingleLayout.tsx
+++ b/src/components/Posts/PostSingleLayout.tsx
@@ -8,6 +8,9 @@ import Grid, { GridArea } from "../Grid";
 import MaxWidth from "../MaxWidth/MaxWidth";
 import MobileFilters from "../MobileFilters";
 import { Heading } from "../Typography";
+import Breadcrumbs, { Breadcrumb } from "../Breadcrumbs/Breadcrumbs";
+import Svg from "../Svg/Svg";
+import Flex from "../Flex/Flex";
 
 import PostCategoryList from "./PostCategoryList";
 import { PostCategoryPage } from "./PostCategoryList/PostCategoryList";
@@ -17,10 +20,11 @@ import BlogHeader from "./PostHeader/PostHeader";
 type PostSingleLayoutProps = {
   children?: ReactNode;
   content: BlogSinglePageProps | WebinarSinglePageProps;
+  breadcrumbs: Breadcrumb[];
 };
 
 const PostSingleLayout: FC<PostSingleLayoutProps> = (props) => {
-  const { content, children } = props;
+  const { content, children, breadcrumbs } = props;
   const { categories } = content;
   const triggerId = useId();
   const post = "blog" in content ? content.blog : content.webinar;
@@ -34,6 +38,15 @@ const PostSingleLayout: FC<PostSingleLayoutProps> = (props) => {
   return (
     <>
       <MaxWidth>
+        <Flex
+          $pv={20}
+          $gap={20}
+          $flexDirection="column"
+          $display={["none", "block"]}
+        >
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+          <Svg name="header-underline" $color="grey3" $height={4} />
+        </Flex>
         <Grid $ph={[12, 0]}>
           <GridArea $colSpan={[12]}>
             <MobileFilters page={page} withBackButton label={"Categories"}>

--- a/src/components/Posts/PostSingleLayout.tsx
+++ b/src/components/Posts/PostSingleLayout.tsx
@@ -1,21 +1,22 @@
 import { FC, ReactNode, useId } from "react";
 
-import { WebinarSinglePageProps } from "../../pages/webinars/[webinarSlug]";
-import { BlogSinglePageProps } from "../../pages/blog/[blogSlug]";
-import theme from "../../styles/theme";
-import Box from "../Box";
-import Grid, { GridArea } from "../Grid";
-import MaxWidth from "../MaxWidth/MaxWidth";
-import MobileFilters from "../MobileFilters";
-import { Heading } from "../Typography";
-import Breadcrumbs, { Breadcrumb } from "../Breadcrumbs/Breadcrumbs";
-import Svg from "../Svg/Svg";
-import Flex from "../Flex/Flex";
-
 import PostCategoryList from "./PostCategoryList";
 import { PostCategoryPage } from "./PostCategoryList/PostCategoryList";
 import usePostCategoryList from "./PostCategoryList/usePostCategoryList";
 import BlogHeader from "./PostHeader/PostHeader";
+
+import { WebinarSinglePageProps } from "@/pages/webinars/[webinarSlug]";
+import { BlogSinglePageProps } from "@/pages/blog/[blogSlug]";
+import theme from "@/styles/theme";
+import Box from "@/components/Box";
+import Grid, { GridArea } from "@/components/Grid";
+import MaxWidth from "@/components/MaxWidth/MaxWidth";
+import MobileFilters from "@/components/MobileFilters";
+import { Heading } from "@/components/Typography";
+import Breadcrumbs, { Breadcrumb } from "@/components/Breadcrumbs/Breadcrumbs";
+import Svg from "@/components/Svg/Svg";
+import Flex from "@/components/Flex/Flex";
+
 
 type PostSingleLayoutProps = {
   children?: ReactNode;

--- a/src/components/Posts/PostSingleLayout.tsx
+++ b/src/components/Posts/PostSingleLayout.tsx
@@ -64,7 +64,7 @@ const PostSingleLayout: FC<PostSingleLayoutProps> = (props) => {
               $display={["none", "block"]}
               $position={[null, "sticky"]}
               $top={[null, HEADER_HEIGHT]}
-              $pt={[48, 72]}
+              $pt={[48, 12]}
             >
               <Heading
                 tag="h3"

--- a/src/components/Posts/PostSingleLayout.tsx
+++ b/src/components/Posts/PostSingleLayout.tsx
@@ -8,15 +8,12 @@ import BlogHeader from "./PostHeader/PostHeader";
 import { WebinarSinglePageProps } from "@/pages/webinars/[webinarSlug]";
 import { BlogSinglePageProps } from "@/pages/blog/[blogSlug]";
 import theme from "@/styles/theme";
-import Box from "@/components/Box";
 import Grid, { GridArea } from "@/components/Grid";
 import MaxWidth from "@/components/MaxWidth/MaxWidth";
 import MobileFilters from "@/components/MobileFilters";
 import { Heading } from "@/components/Typography";
 import Breadcrumbs, { Breadcrumb } from "@/components/Breadcrumbs/Breadcrumbs";
 import Svg from "@/components/Svg/Svg";
-import Flex from "@/components/Flex/Flex";
-
 
 type PostSingleLayoutProps = {
   children?: ReactNode;
@@ -39,17 +36,8 @@ const PostSingleLayout: FC<PostSingleLayoutProps> = (props) => {
   return (
     <>
       <MaxWidth>
-        <Flex
-          $pv={20}
-          $gap={20}
-          $flexDirection="column"
-          $display={["none", "block"]}
-        >
-          <Breadcrumbs breadcrumbs={breadcrumbs} />
-          <Svg name="header-underline" $color="grey3" $height={4} />
-        </Flex>
         <Grid $ph={[12, 0]}>
-          <GridArea $colSpan={[12]}>
+          <GridArea $colSpan={[12, 0]}>
             <MobileFilters page={page} withBackButton label={"Categories"}>
               <PostCategoryList
                 labelledBy={triggerId}
@@ -60,30 +48,40 @@ const PostSingleLayout: FC<PostSingleLayoutProps> = (props) => {
               />
             </MobileFilters>
           </GridArea>
-          <GridArea $order={[0, 2]} $colSpan={[12, 3]}>
-            <Box
-              $display={["none", "block"]}
-              $position={[null, "sticky"]}
-              $top={[null, HEADER_HEIGHT]}
-              $pt={[48, 12]}
+          <GridArea
+            $colSpan={[0, 12]}
+            $display={["none", "flex"]}
+            $flexDirection="column"
+            $mv={20}
+            $gap={20}
+          >
+            <Breadcrumbs breadcrumbs={breadcrumbs} />
+            <Svg name="header-underline" $color="grey3" $height={4} />
+          </GridArea>
+          <GridArea
+            $order={[0, 2]}
+            $colSpan={[12, 3]}
+            $mt={[48, 12]}
+            $display={["none", "block"]}
+            $position={[null, "sticky"]}
+            $top={[null, HEADER_HEIGHT]}
+          >
+            <Heading
+              tag="h3"
+              $font="body-3"
+              id={postCategoriesListProps.labelId}
             >
-              <Heading
-                tag="h3"
-                $font="body-3"
-                id={postCategoriesListProps.labelId}
-              >
-                Categories
-              </Heading>
-              <PostCategoryList
-                labelledBy={postCategoriesListProps.labelId}
-                $mt={24}
-                categories={categories}
-                page={page}
-              />
-            </Box>
+              Categories
+            </Heading>
+            <PostCategoryList
+              labelledBy={postCategoriesListProps.labelId}
+              $mt={24}
+              categories={categories}
+              page={page}
+            />
           </GridArea>
           <GridArea $order={[0, 1]} $colSpan={[12, 2]} />
-          <GridArea $order={[1, 0]} $colSpan={[12, 7]}>
+          <GridArea $order={[1, 0]} $colSpan={[12, 7]} $mt={[40, 12]}>
             <BlogHeader post={post} page={page} />
             {children}
           </GridArea>

--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -8,21 +8,21 @@ import {
 import { useNextSanityImage } from "next-sanity-image";
 import { uniqBy } from "lodash/fp";
 
-import Layout from "../../components/Layout";
-import CMSClient from "../../node-lib/cms";
-import { BlogPost } from "../../common-lib/cms-types";
+import Layout from "@/components/Layout";
+import CMSClient from "@/node-lib/cms";
+import { BlogPost } from "@/common-lib/cms-types";
 import {
   getFallbackBlockingConfig,
   shouldSkipInitialBuild,
-} from "../../node-lib/isr";
-import Box from "../../components/Box";
-import { BlogJsonLd } from "../../browser-lib/seo/getJsonLd";
-import BlogPortableText from "../../components/Posts/PostPortableText/PostPortableText";
-import { getSeoProps } from "../../browser-lib/seo/getSeoProps";
-import { sanityClientLike } from "../../components/CMSImage";
-import { getBlogWebinarPostBreadcrumbs } from "../../components/Breadcrumbs/getBreadcrumbs";
-import PostSingleLayout from "../../components/Posts/PostSingleLayout";
-import getPageProps from "../../node-lib/getPageProps";
+} from "@/node-lib/isr";
+import Box from "@/components/Box";
+import { BlogJsonLd } from "@/browser-lib/seo/getJsonLd";
+import BlogPortableText from "@/components/Posts/PostPortableText/PostPortableText";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { sanityClientLike } from "@/components/CMSImage";
+import { getBlogWebinarPostBreadcrumbs } from "@/components/Breadcrumbs/getBreadcrumbs";
+import PostSingleLayout from "@/components/Posts/PostSingleLayout";
+import getPageProps from "@/node-lib/getPageProps";
 
 export type SerializedBlog = Omit<BlogPost, "date"> & {
   date: string;

--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -24,6 +24,8 @@ import { getBlogWebinarPostBreadcrumbs } from "../../components/Breadcrumbs/getB
 import PostSingleLayout from "../../components/Posts/PostSingleLayout";
 import getPageProps from "../../node-lib/getPageProps";
 
+import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
+
 export type SerializedBlog = Omit<BlogPost, "date"> & {
   date: string;
 };
@@ -60,13 +62,15 @@ const BlogSinglePage: NextPage<BlogSinglePageProps> = (props) => {
         imageUrl: sharingImage.src,
       })}
       $background="white"
-      breadcrumbs={getBlogWebinarPostBreadcrumbs(
-        categories,
-        blog,
-        "blog",
-        "Blog",
-      )}
     >
+      <Breadcrumbs
+        breadcrumbs={getBlogWebinarPostBreadcrumbs(
+          categories,
+          blog,
+          "blog",
+          "Blog",
+        )}
+      />
       <PostSingleLayout content={props}>
         <Box $mt={[48]}>
           <BlogPortableText portableText={props.blog.contentPortableText} />

--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -24,8 +24,6 @@ import { getBlogWebinarPostBreadcrumbs } from "../../components/Breadcrumbs/getB
 import PostSingleLayout from "../../components/Posts/PostSingleLayout";
 import getPageProps from "../../node-lib/getPageProps";
 
-import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
-
 export type SerializedBlog = Omit<BlogPost, "date"> & {
   date: string;
 };
@@ -63,15 +61,15 @@ const BlogSinglePage: NextPage<BlogSinglePageProps> = (props) => {
       })}
       $background="white"
     >
-      <Breadcrumbs
+      <PostSingleLayout
+        content={props}
         breadcrumbs={getBlogWebinarPostBreadcrumbs(
           categories,
           blog,
           "blog",
           "Blog",
         )}
-      />
-      <PostSingleLayout content={props}>
+      >
         <Box $mt={[48]}>
           <BlogPortableText portableText={props.blog.contentPortableText} />
         </Box>

--- a/src/pages/webinars/[webinarSlug].tsx
+++ b/src/pages/webinars/[webinarSlug].tsx
@@ -7,24 +7,24 @@ import {
 import { useEffect } from "react";
 import { uniqBy } from "lodash/fp";
 
-import { getSeoProps } from "../../browser-lib/seo/getSeoProps";
-import Layout from "../../components/Layout";
-import CMSClient from "../../node-lib/cms";
-import { TeamMemberPreview, Webinar } from "../../common-lib/cms-types";
-import { getBlogWebinarPostBreadcrumbs } from "../../components/Breadcrumbs/getBreadcrumbs";
-import Box from "../../components/Box";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import Layout from "@/components/Layout";
+import CMSClient from "@/node-lib/cms";
+import { TeamMemberPreview, Webinar } from "@/common-lib/cms-types";
+import { getBlogWebinarPostBreadcrumbs } from "@/components/Breadcrumbs/getBreadcrumbs";
+import Box from "@/components/Box";
 import {
   getFallbackBlockingConfig,
   shouldSkipInitialBuild,
-} from "../../node-lib/isr";
-import BlogPortableText from "../../components/Posts/PostPortableText/PostPortableText";
-import Flex from "../../components/Flex";
-import WebinarVideo from "../../components/Posts/WebinarVideo";
-import { BlogJsonLd } from "../../browser-lib/seo/getJsonLd";
-import { getVideoThumbnail } from "../../components/VideoPlayer/getVideoThumbnail";
-import useAnalytics from "../../context/Analytics/useAnalytics";
-import PostSingleLayout from "../../components/Posts/PostSingleLayout";
-import getPageProps from "../../node-lib/getPageProps";
+} from "@/node-lib/isr";
+import BlogPortableText from "@/components/Posts/PostPortableText/PostPortableText";
+import Flex from "@/components/Flex";
+import WebinarVideo from "@/components/Posts/WebinarVideo";
+import { BlogJsonLd } from "@/browser-lib/seo/getJsonLd";
+import { getVideoThumbnail } from "@/components/VideoPlayer/getVideoThumbnail";
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import PostSingleLayout from "@/components/Posts/PostSingleLayout";
+import getPageProps from "@/node-lib/getPageProps";
 
 export type SerializedWebinar = Omit<Webinar, "date"> & {
   date: string;

--- a/src/pages/webinars/[webinarSlug].tsx
+++ b/src/pages/webinars/[webinarSlug].tsx
@@ -26,8 +26,6 @@ import useAnalytics from "../../context/Analytics/useAnalytics";
 import PostSingleLayout from "../../components/Posts/PostSingleLayout";
 import getPageProps from "../../node-lib/getPageProps";
 
-import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
-
 export type SerializedWebinar = Omit<Webinar, "date"> & {
   date: string;
   author: TeamMemberPreview | undefined;
@@ -63,15 +61,15 @@ const WebinarSinglePage: NextPage<WebinarSinglePageProps> = (props) => {
       })}
       $background="white"
     >
-      <Breadcrumbs
+      <PostSingleLayout
+        content={props}
         breadcrumbs={getBlogWebinarPostBreadcrumbs(
           categories,
           webinar,
           "webinars",
           "Webinars",
         )}
-      />
-      <PostSingleLayout content={props}>
+      >
         <Flex $position={"relative"} $mt={56}>
           <WebinarVideo webinar={webinar} />
         </Flex>

--- a/src/pages/webinars/[webinarSlug].tsx
+++ b/src/pages/webinars/[webinarSlug].tsx
@@ -26,6 +26,8 @@ import useAnalytics from "../../context/Analytics/useAnalytics";
 import PostSingleLayout from "../../components/Posts/PostSingleLayout";
 import getPageProps from "../../node-lib/getPageProps";
 
+import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
+
 export type SerializedWebinar = Omit<Webinar, "date"> & {
   date: string;
   author: TeamMemberPreview | undefined;
@@ -60,13 +62,15 @@ const WebinarSinglePage: NextPage<WebinarSinglePageProps> = (props) => {
         }),
       })}
       $background="white"
-      breadcrumbs={getBlogWebinarPostBreadcrumbs(
-        categories,
-        webinar,
-        "webinars",
-        "Webinars",
-      )}
     >
+      <Breadcrumbs
+        breadcrumbs={getBlogWebinarPostBreadcrumbs(
+          categories,
+          webinar,
+          "webinars",
+          "Webinars",
+        )}
+      />
       <PostSingleLayout content={props}>
         <Flex $position={"relative"} $mt={56}>
           <WebinarVideo webinar={webinar} />


### PR DESCRIPTION
## Description
Ticket: [Move blog breadcrumb out of nav bar](https://www.notion.so/oaknationalacademy/Move-blog-breadcrumb-out-of-nav-bar-c4452ab6611c4093bb77bcabe76cc63b?pvs=4)  
   
Changes:
- Removed breadcrumbs from nav bar on blog/webinar listing and post pages
- Added breadcrumb into these pages directly above content
- Mobile view should be unchanged 
  
## How to test

1. Go to https://deploy-preview-1912--oak-web-application.netlify.thenational.academy/blog
2. See the breadcrumbs below the nav
3. Click on a blog post
4. You should see the breadcrumbs below the nav bar

## Screenshots

How it used to look:
<img width="400" alt="Screenshot 2023-09-19 at 13 22 05" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/5a3fa093-44ce-4ab1-a7c7-6d436f41d5b2">
<img width="400" alt="Screenshot 2023-09-19 at 13 22 12" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/49e021d4-61e6-4ce7-939f-245cad759e2a">


How it should now look:
<img width="400" alt="Screenshot 2023-09-19 at 13 21 34" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/8dcae1a1-3543-49d1-85c8-e564a04446cb">
<img width="400" alt="Screenshot 2023-09-19 at 13 21 42" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/06350733-bedc-4dac-b612-ee59042097eb">
