### PR TITLE
[CUR-261] Updated 'intent' to 'explainer' on overview page

### DIFF
--- a/src/components/pages/CurriculumInfo/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/pages/CurriculumInfo/CurriculumHeader/CurriculumHeader.tsx
@@ -117,7 +117,11 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
                   data-testid="subjectIcon"
                 />
               </Box>
-              <Heading tag={"h1"} $font={"heading-4"} $mv={"auto"}>
+              <Heading
+                tag={"h1"}
+                $font={["heading-4", "heading-3"]}
+                $mv={"auto"}
+              >
                 {pageTitle}
               </Heading>
             </Flex>

--- a/src/components/pages/CurriculumInfo/tabs/OverviewTab/OverviewTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/OverviewTab/OverviewTab.tsx
@@ -32,6 +32,8 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
             tag="h2"
             $font={["heading-5", "heading-4"]}
             data-testid="intent-heading"
+            $mb={20}
+            line-height={48}
           >
             Curriculum explainer
           </Heading>
@@ -107,7 +109,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         <Flex $justifyContent={"center"} $pa={16}>
           <AvatarImage $background={"grey1"} $ma={"auto"} $ml={20} $mr={20} />
           <Box>
-            <Heading tag="h2" $font={["heading-5", "heading-4"]}>
+            <Heading tag="h2" $font={["heading-5", "heading-4"]} $mb={20}>
               Our curriculum partner
             </Heading>
             <Typography $font={"body-1"}>{partnerBio}</Typography>

--- a/src/components/pages/CurriculumInfo/tabs/OverviewTab/OverviewTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/OverviewTab/OverviewTab.tsx
@@ -30,10 +30,10 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         >
           <Heading
             tag="h2"
-            $font={["heading-5", "heading-6"]}
+            $font={["heading-5", "heading-4"]}
             data-testid="intent-heading"
           >
-            Curriculum intent
+            Curriculum explainer
           </Heading>
           <Typography
             $font={["body-2", "body-1"]}
@@ -73,7 +73,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
       >
         <BrushBorders color={"aqua30"} />
         <Box $ma={16}>
-          <Heading tag="h2" $font={["heading-5", "heading-6"]}>
+          <Heading tag="h2" $font={["heading-5", "heading-4"]}>
             Subject principles
           </Heading>
           <UL $reset={true} $mt={24}>
@@ -107,7 +107,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         <Flex $justifyContent={"center"} $pa={16}>
           <AvatarImage $background={"grey1"} $ma={"auto"} $ml={20} $mr={20} />
           <Box>
-            <Heading tag="h2" $font={"heading-5"}>
+            <Heading tag="h2" $font={["heading-5", "heading-4"]}>
               Our curriculum partner
             </Heading>
             <Typography $font={"body-1"}>{partnerBio}</Typography>


### PR DESCRIPTION
## Description

- Updated the title of curriculum intent to curriculum explainer
- Updated font sizes for all headings across overview tab and curriculum header


## How to test

1. Go to https://deploy-preview-1914--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Go to any subject/phase combination
3. You should see 'Curriculum explainer' instead of 'Curriculum intent'

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2023-09-19 at 17 14 03](https://github.com/oaknational/Oak-Web-Application/assets/32605982/7f36993f-e517-4ff0-97d9-1ca76d0ceabe)

How it should now look:
![Screenshot 2023-09-19 at 17 13 37](https://github.com/oaknational/Oak-Web-Application/assets/32605982/5e24b547-12c0-4404-a040-0fc353f03725)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
