### PR TITLE
fix(curric): update filter spacing

### DIFF
--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
@@ -416,10 +416,10 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     Year {year}
                   </Heading>
                   {childSubjects.length > 0 && (
-                    <Box $mb={16}>
+                    <Box>
                       {childSubjects.map((subject) => (
                         <Button
-                          $mb={16}
+                          $mb={20}
                           $mr={20}
                           background={
                             isSelectedSubject(year, subject) ? "black" : "white"
@@ -434,10 +434,10 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     </Box>
                   )}
                   {domains.length > 0 && (
-                    <Box $mb={16}>
+                    <Box>
                       {domains.map((domain) => (
                         <Button
-                          $mb={16}
+                          $mb={20}
                           $mr={20}
                           background={
                             isSelectedDomain(year, domain) ? "black" : "white"
@@ -452,11 +452,12 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     </Box>
                   )}
                   {tiers.length > 0 && (
-                    <Box $mb={16}>
+                    <Box>
                       {tiers.map((tier) => (
                         <Button
-                          $mb={16}
-                          $mr={16}
+                          $font={"heading-6"}
+                          $mb={20}
+                          $mr={24}
                           key={tier.tier_slug}
                           label={tier.tier}
                           onClick={() => handleSelectTier(year, tier)}
@@ -469,7 +470,7 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                       ))}
                     </Box>
                   )}
-                  <Flex $flexWrap={"wrap"} data-testid="unit-cards">
+                  <Flex $flexWrap={"wrap"} $mt={12} data-testid="unit-cards">
                     {units
                       .filter((unit) => isVisibleUnit(year, unit))
                       .map((unit, index) => {

--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
@@ -416,11 +416,11 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     Year {year}
                   </Heading>
                   {childSubjects.length > 0 && (
-                    <Box>
+                    <Box $mb={16}>
                       {childSubjects.map((subject) => (
                         <Button
-                          $mr={20}
                           $mb={16}
+                          $mr={20}
                           background={
                             isSelectedSubject(year, subject) ? "black" : "white"
                           }
@@ -434,11 +434,11 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     </Box>
                   )}
                   {domains.length > 0 && (
-                    <Box>
+                    <Box $mb={16}>
                       {domains.map((domain) => (
                         <Button
-                          $mr={20}
                           $mb={16}
+                          $mr={20}
                           background={
                             isSelectedDomain(year, domain) ? "black" : "white"
                           }
@@ -452,9 +452,10 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                     </Box>
                   )}
                   {tiers.length > 0 && (
-                    <Box $mb={32}>
+                    <Box $mb={16}>
                       {tiers.map((tier) => (
                         <Button
+                          $mb={16}
                           $mr={16}
                           key={tier.tier_slug}
                           label={tier.tier}


### PR DESCRIPTION
## Description
- Update spacing of child subjects, domain and tier filters in sequence visualiser / unit grid

## How to test

1. Go to [teachers/curriculum/science-secondary/units](https://deploy-preview-1916--oak-web-application.netlify.thenational.academy/teachers/curriculum/science-secondary/units)
2. Scroll down to Year 10 unit section
3. You should see correct spacing for child subject and tier filter buttons
4. You should see correct sizing for tier filter buttons
5. Go to [teachers/curriculum/english-primary/units](https://deploy-preview-1916--oak-web-application.netlify.thenational.academy/teachers/curriculum/english-primary/units)
6. You should correct spacing for domain buttons

## Screenshots

How it used to look (delete if n/a):
<img width="970" alt="Screenshot 2023-09-20 at 11 59 58" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/a3ec9ef6-33c4-40f5-a1fe-ea613946fbd1">
<img width="970" alt="Screenshot 2023-09-20 at 12 01 41" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/25d50708-588e-41ef-ade8-d4c637729b02">

How it should now look:
<img width="970" alt="Screenshot 2023-09-20 at 11 59 37" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/41eafc21-ceab-43b7-b966-52c6cc46e3b0">
<img width="970" alt="Screenshot 2023-09-20 at 12 01 06" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/abcb6716-e42a-4be4-bcdb-6c1a3bf5f064">

## Checklist


- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
