### PR TITLE
fix(curric): remove unit links from visualiser

### DIFF
--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.test.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.test.tsx
@@ -23,21 +23,6 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
     expect(unitCards).toHaveLength(curriculumUnitsTabFixture().units.length);
   });
 
-  test("builds links to unit lesson index", async () => {
-    const { findAllByTestId } = renderWithTheme(
-      <UnitsTab data={curriculumUnitsTabFixture()} />,
-    );
-    const unitLinks = await findAllByTestId("unit-link");
-    if (unitLinks.length === 0 || !unitLinks[0]) {
-      throw new Error("No unit links found");
-    }
-    const unit = curriculumUnitsTabFixture().units[0];
-    if (unit === undefined) {
-      throw new Error("Fixture unit missing");
-    }
-    expect(unitLinks[0].getAttribute("href")).toContain(unit.slug);
-  });
-
   test("user can see all the thread choices", async () => {
     const { findByTestId, findAllByTestId } = renderWithTheme(
       <UnitsTab data={curriculumUnitsTabFixture()} />,

--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
@@ -8,7 +8,6 @@ import Card from "@/components/Card/Card";
 import { CurriculumUnitsTabData } from "@/node-lib/curriculum-api-2023";
 import Icon from "@/components/Icon/Icon";
 import OutlineHeading from "@/components/OutlineHeading/OutlineHeading";
-import OakLink from "@/components/OakLink/OakLink";
 import Button from "@/components/Button/Button";
 import BrushBorders from "@/components/SpriteSheet/BrushSvgs/BrushBorders/BrushBorders";
 import GridArea from "@/components/Grid/GridArea";
@@ -167,17 +166,6 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
     useState<YearSelection>(initialYearSelection);
   const [selectedThread, setSelectedThread] = useState<Thread | null>(null);
   const [selectedYear, setSelectedYear] = useState<string | null>(null);
-
-  const buildProgrammeSlug = (unit: Unit) => {
-    let slug = `${unit.subject_slug}-${unit.phase_slug}-${unit.keystage_slug}`;
-    if (unit.tier_slug) {
-      slug = `${slug}-${unit.tier_slug}`;
-    }
-    if (unit.examboard_slug) {
-      slug = `${slug}-${unit.examboard_slug}`;
-    }
-    return slug;
-  };
 
   function handleSelectSubject(year: string, subject: Subject) {
     const selection = { ...yearSelection[year] };
@@ -481,7 +469,6 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                             $flexGrow={"unset"}
                             $mb={32}
                             $mr={28}
-                            $pb={64}
                             $position={"relative"}
                             $width={[
                               "100%",
@@ -513,26 +500,6 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
                               )}
                               {unit.title}
                             </Heading>
-                            <Box
-                              $position={"absolute"}
-                              $bottom={16}
-                              $right={16}
-                              $font={"body-2-bold"}
-                            >
-                              <OakLink
-                                page="lesson-index"
-                                viewType="teachers-2023"
-                                programmeSlug={buildProgrammeSlug(unit)}
-                                unitSlug={unit.slug}
-                                data-testid="unit-link"
-                              >
-                                Unit info
-                                <Icon
-                                  name="chevron-right"
-                                  verticalAlign="bottom"
-                                />
-                              </OakLink>
-                            </Box>
                           </Card>
                         );
                       })}


### PR DESCRIPTION
## Description
- Remove links to unit lesson list from unit cards in curriculum visualiser

1. Go to {owa_deployment_url}/teachers/curriculum/geography-primary/units
3. You should not see any links in the unit cards

## Screenshots

How it used to look (delete if n/a):
<img width="970" alt="Screenshot 2023-09-20 at 12 21 11" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/5268fd9c-8fc6-483e-8e87-993578362376">

How it should now look:
<img width="970" alt="Screenshot 2023-09-20 at 12 20 05" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/11ca634f-d7aa-4ff4-8f5e-4fed9ee4bac6">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
