### PR TITLE
fix: sort subjects by slug on subject page [LESQ-285]

### DIFF
--- a/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
+++ b/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
@@ -138,13 +138,15 @@ export const getStaticProps: GetStaticProps<
           };
         })
         // Filter out subjects that don't exist in either curriculum
-        .filter((subject) => subject.old || subject.new);
+        .filter((subject) => subject.old || subject.new)
+        // sort by slug so the old and new subjects are intermingled
+        .sort((a, b) => (a.subjectSlug > b.subjectSlug ? 1 : -1));
 
       const results = {
         props: {
           keyStageSlug,
           keyStageTitle,
-          subjects: subjects,
+          subjects,
           keyStages,
         },
       };


### PR DESCRIPTION
## Description

- Adds a sort to subjects in `getStaticProps`, based on slug

## Issue(s)

Fixes #
- subjects with only new content being shown after old content regardless of alphabet

## How to test

1. Go to https://deploy-preview-1923--oak-web-application.netlify.thenational.academy/teachers/key-stages/ks4/subjects
2. You should see alphabetically ordered subjects


## ACs

- [ ]  All subjects should be shown in alphabetical order, regardless of whether they are legacy or new
- [ ]  When there is legacy and new content for a subject, they should be displayed in the same box (currently happening)
