### PR TITLE
Fix/lesq 319/lessons plurality [LESQ-319]

### DIFF
--- a/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListItem.test.tsx
+++ b/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListItem.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/react";
 
 import UnitListItem from "./UnitListItem";
 
@@ -49,6 +50,25 @@ const render = renderWithProviders();
 describe("Unit List Item", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  test("It uses singular  form of lesson", () => {
+    const singular = Object.assign({}, props);
+    singular.lessonCount = 1;
+    singular.expiredLessonCount = 0;
+    render(<UnitListItem {...singular} />);
+
+    const lessonCountText = screen.getByText("1 lesson");
+    expect(lessonCountText).toBeInTheDocument();
+  });
+
+  test("It uses plural form of lessons", () => {
+    const plural = Object.assign({}, props);
+    plural.expiredLessonCount = 0;
+    render(<UnitListItem {...plural} />);
+
+    const lessonCountText = screen.getByText("5 lessons");
+    expect(lessonCountText).toBeInTheDocument();
   });
 
   test("It calls tracking.unitSelected with correct props when clicked", async () => {

--- a/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListLessonCount.tsx
+++ b/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListLessonCount.tsx
@@ -1,6 +1,6 @@
-import Flex from "../../../Flex";
-import Icon from "../../../Icon";
-import { Span } from "../../../Typography";
+import Flex from "@/components/Flex";
+import Icon from "@/components/Icon";
+import { Span } from "@/components/Typography";
 
 export interface IUnitListLessonCountProps {
   lessonCount: number | null;

--- a/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListLessonCount.tsx
+++ b/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListLessonCount.tsx
@@ -24,7 +24,8 @@ export const UnitListLessonCount = ({
           </Span>
         ) : (
           <Span $font={["body-3", "heading-light-7"]} $color={textColor}>
-            {!!lessonCount && `${lessonCount} lessons`}
+            {!!lessonCount &&
+              `${lessonCount} ${lessonCount > 1 ? "lessons" : "lesson"}`}
             {expired && ` Coming soon`}
           </Span>
         )}


### PR DESCRIPTION
## Description

- update `UnitListLessonCount` to display "lesson" when `lessonCount` is 1

## How to test

1. Go to https://deploy-preview-1927--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-foundation/units
2. You should see "1 lesson" for number 6 and plural "lessons" for the others

## ACs
- [ ]  For a unit with 1 lesson we show the detail on the card as 1 lesson
- [ ]  For a unit with more than 1 lesson, we show the detail on the card as X lessons