### PR TITLE
LESQ-118 fix(headerListing): remove curriculum map link from new content

### DIFF
--- a/src/components/HeaderListing/HeaderListing.tsx
+++ b/src/components/HeaderListing/HeaderListing.tsx
@@ -29,6 +29,7 @@ export type HeaderListingProps = {
   isNew?: boolean;
   title: string;
   programmeFactor: string;
+  hasCurriculumDownload?: boolean;
 };
 
 const HeaderListing: FC<HeaderListingProps> = (props) => {
@@ -44,6 +45,7 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
     breadcrumbs,
     background,
     tierSlug,
+    hasCurriculumDownload = true,
   } = props;
 
   return (
@@ -69,25 +71,29 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
               {title}
             </Heading>
             <Flex $display={["none", "flex"]}>
-              <CurriculumDownloadButton
-                keyStageSlug={keyStageSlug}
-                keyStageTitle={keyStageTitle}
-                subjectSlug={subjectSlug}
-                subjectTitle={subjectTitle}
-                tier={tierSlug}
-              />
+              {hasCurriculumDownload && (
+                <CurriculumDownloadButton
+                  keyStageSlug={keyStageSlug}
+                  keyStageTitle={keyStageTitle}
+                  subjectSlug={subjectSlug}
+                  subjectTitle={subjectTitle}
+                  tier={tierSlug}
+                />
+              )}
             </Flex>
           </Flex>
         </Flex>
       </Flex>
       <Flex $background={background} $display={["inline", "none"]}>
-        <CurriculumDownloadButton
-          keyStageSlug={keyStageSlug}
-          keyStageTitle={keyStageTitle}
-          subjectSlug={subjectSlug}
-          subjectTitle={subjectTitle}
-          tier={tierSlug}
-        />
+        {hasCurriculumDownload && (
+          <CurriculumDownloadButton
+            keyStageSlug={keyStageSlug}
+            keyStageTitle={keyStageTitle}
+            subjectSlug={subjectSlug}
+            subjectTitle={subjectTitle}
+            tier={tierSlug}
+          />
+        )}
       </Flex>
     </HeaderWrapper>
   );

--- a/src/pages/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/programmes.tsx
+++ b/src/pages/teachers/key-stages/[keyStageSlug]/subjects/[subjectSlug]/programmes.tsx
@@ -20,6 +20,8 @@ const ProgrammesListingPage: NextPage<ProgrammeListingPageData> = (props) => {
   const { programmes, keyStageSlug, subjectSlug, keyStageTitle, subjectTitle } =
     props;
 
+  const firstProgrammeSlug = programmes[0]?.programmeSlug ?? "";
+
   if (!programmes[0]) {
     throw new Error("No programmes");
   }
@@ -62,6 +64,7 @@ const ProgrammesListingPage: NextPage<ProgrammeListingPageData> = (props) => {
         subjectIconBackgroundColor={"lavender"}
         title={subjectTitle}
         programmeFactor={keyStageTitle}
+        hasCurriculumDownload={isSlugLegacy(firstProgrammeSlug)}
         {...props}
       />
       <MaxWidth $mt={[56, 72]} $ph={16}>

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -131,6 +131,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
         title={`${subjectTitle} ${examBoardTitle ? examBoardTitle : ""}`}
         programmeFactor={keyStageTitle}
         isNew={!isSlugLegacy(programmeSlug)}
+        hasCurriculumDownload={isSlugLegacy(programmeSlug)}
         {...curriculumData}
       />
       <MaxWidth $ph={16}>

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -116,6 +116,7 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
         title={unitTitle}
         programmeFactor={keyStageTitle} // this should be changed to year LESQ-242
         isNew={!isSlugLegacy(programmeSlug)}
+        hasCurriculumDownload={isSlugLegacy(programmeSlug)}
         {...curriculumData}
       />
       <MaxWidth $ph={16}>


### PR DESCRIPTION
## Description

remove curriculum map link from new content pages

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-1930--oak-web-application.netlify.thenational.academy
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
