### PR TITLE
fix(generate-sprite): filter only icons which have both slug and imag…

### DIFF
--- a/scripts/build/image_data/generate_sprite.js
+++ b/scripts/build/image_data/generate_sprite.js
@@ -26,7 +26,12 @@ async function main() {
   }`);
 
   function getSlugs({ assets }) {
-    return assets.map((asset) => asset.slug.current);
+    return (
+      assets
+        // filter to only have assets with an image url and a slug
+        .filter((asset) => asset.image?.asset?.url && asset.slug?.current)
+        .map((asset) => asset.slug.current)
+    );
   }
 
   /**

--- a/scripts/build/image_data/generate_sprite.js
+++ b/scripts/build/image_data/generate_sprite.js
@@ -59,11 +59,13 @@ async function main() {
   const spriter = getSpriterInstance({ mode: "symbol" });
 
   for (const spriteIcon of [...uiIconsRes, ...uiGraphicsRes]) {
-    await fetchSvgAndAddToSprite({
-      url: spriteIcon.image.asset.url,
-      name: spriteIcon.slug.current,
-      spriter,
-    });
+    if (spriteIcon?.image?.asset?.url && spriteIcon?.slug?.current) {
+      await fetchSvgAndAddToSprite({
+        url: spriteIcon.image.asset.url,
+        name: spriteIcon.slug.current,
+        spriter,
+      });
+    }
   }
   const spritePath = getPublicSpritePath({ fileName: "sprite.svg" });
 


### PR DESCRIPTION

## Description

- it's happened in the past when a published (icon) asset in sanity doesn't have an image (although there is a constraint in sanity to say it is required)
- therefore we must filter out icons which don't have an image
