### PR TITLE
style: changes to footer

### DIFF
--- a/src/browser-lib/fixtures/footerSections.ts
+++ b/src/browser-lib/fixtures/footerSections.ts
@@ -3,36 +3,73 @@ import { FooterSections } from "../../components/SiteFooter/SiteFooter";
 const footerSections: FooterSections = {
   pupils: {
     title: "Pupils",
-    links: [{ text: "Classroom", type: "pupils-link" }],
+    links: [
+      {
+        text: "Learn online",
+        type: "page",
+        page: "classroom",
+        icon: "external",
+      },
+    ],
   },
   teachers: {
     title: "Teachers",
     links: [
-      { text: "Teacher Hub", type: "teachers-link" },
-      { text: "Plan a lesson", href: "/lesson-planning" },
-      { text: "Develop your curriculum", href: "/develop-your-curriculum" },
-      { text: "Support your team", href: "/support-your-team" },
+      // {  // Commented out until launch
+      //   text: "Key stage 1",
+      //   href: "/teachers/key-stages/ks1/subjects",
+      // },
+      // {
+      //   text: "Key stage 2",
+      //   href: "/teachers/key-stages/ks2/subjects",
+      // },
+      // {
+      //   text: "Key stage 3",
+      //   href: "/teachers/key-stages/ks3/subjects",
+      // },
+      // {
+      //   text: "Key stage 4",
+      //   href: "/teachers/key-stages/ks4/subjects",
+      // },
+
+      // {
+      //   text: "Curriculum plans",
+      //   type: "page",
+      //   page: "curriculum-landing-page",
+      // },
+      { text: "Plan a lesson", type: "page", page: "lesson-planning" },
+      { text: "Support your team", type: "page", page: "support-your-team" },
+      {
+        text: "Teacher Hub (old)",
+        type: "page",
+        page: "teacher-hub",
+        icon: "external",
+      },
     ],
   },
   oak: {
     title: "Oak",
     links: [
-      { text: "Home", href: "/" },
-      { text: "About us", href: "/about-us/who-we-are" },
+      { text: "Home", type: "page", page: "home" },
+      { text: "About us", type: "page", page: "about-who-we-are" },
       {
         text: "Careers",
         href: "https://jobs.thenational.academy",
+        icon: "external",
       },
-      { text: "Contact us", href: "/contact-us" },
+      { text: "Contact us", type: "page", page: "contact" },
       {
         text: "Help",
-        href: "https://support.thenational.academy",
+        type: "page",
+        page: "help",
+        icon: "external",
       },
-      { text: "Blog", href: "/blog" },
-      { text: "Webinars", href: "/webinars" },
+      { text: "Blog", type: "page", page: "blog-index" },
+      { text: "Webinars", type: "page", page: "webinar-index" },
       {
         text: "Status",
         href: "https://status.thenational.academy",
+        icon: "external",
       },
     ],
   },

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -168,7 +168,7 @@ type CurriculumDownloadsLinkProps = {
   subjectPhaseSlug: string;
 };
 
-type OakLinkProps =
+export type OakLinkProps =
   | SubjectListingLinkProps
   | LandingPageLinkProps
   | LessonDownloadsLinkProps
@@ -250,7 +250,6 @@ type OakPages = {
   "curriculum-units": OakPageConfig<CurriculumUnitsLinkProps>;
   "curriculum-downloads": OakPageConfig<CurriculumDownloadsLinkProps>;
 };
-
 type OakPageConfig<
   ResolveHrefProps extends {
     page: string;

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 import { useRouter } from "next/router";
 
 import Flex from "../Flex";
@@ -8,17 +8,23 @@ import Logo from "../Logo";
 import SocialButtons from "../SocialButtons";
 import Box from "../Box";
 import { useCookieConsent } from "../../browser-lib/cookie-consent/CookieConsentProvider";
-import useAnalytics from "../../context/Analytics/useAnalytics";
-import UnstyledButton from "../UnstyledButton";
-import footerSections from "../../browser-lib/fixtures/footerSections";
 import Grid, { GridArea } from "../Grid";
 import OakLink from "../OakLink";
 import Svg from "../Svg";
 import { OAK_SOCIALS } from "../SocialButtons/SocialButtons";
 import FooterSignpost from "../FooterSignpost/FooterSignpost";
+import { IconName } from "../Icon";
+import Icon from "../Icon/Icon";
+import Button from "../Button";
+
+import footerSections from "@/browser-lib/fixtures/footerSections";
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import { OakLinkProps } from "@/common-lib/urls";
+import useClickableCard from "@/hooks/useClickableCard";
 
 type FooterLinkProps = {
   text: string;
+  icon?: IconName;
 } & (
   | {
       href: string;
@@ -27,55 +33,106 @@ type FooterLinkProps = {
   | {
       type: "consent-manager-toggle";
     }
-  | {
-      type: "pupils-link";
-    }
-  | {
-      type: "teachers-link";
-    }
+  | ({
+      type: "page";
+    } & OakLinkProps)
 );
+
+type FooterLinkIconWrapperProps = {
+  children: ReactNode;
+  containerProps: ReturnType<typeof useClickableCard>["containerProps"];
+} & FooterLinkProps;
+
+const FooterLinkIconWrapper: React.FC<FooterLinkIconWrapperProps> = (props) => {
+  const { containerProps, icon, children } = props;
+  return (
+    <Flex $display={"inline-flex"} {...containerProps}>
+      {children}
+      {icon && <Icon name={icon} $ml={8} />}
+    </Flex>
+  );
+};
 
 const FooterLink: FC<FooterLinkProps> = (props) => {
   const { track } = useAnalytics();
   const { showConsentManager } = useCookieConsent();
+  const { containerProps, primaryTargetProps } =
+    useClickableCard<HTMLAnchorElement>();
 
   if (props.type === "consent-manager-toggle") {
     return (
-      <UnstyledButton onClick={showConsentManager}>{props.text}</UnstyledButton>
+      <Button
+        variant="minimal"
+        $font={"body-2"}
+        label={props.text}
+        onClick={showConsentManager}
+      >
+        {props.text}
+      </Button>
     );
   }
 
-  if (props.type === "pupils-link") {
+  if (props.type === "page" && props.page == "classroom") {
     return (
-      <OakLink
-        page="classroom"
-        htmlAnchorProps={{
-          onClick: () => track.classroomSelected({ navigatedFrom: "footer" }),
-        }}
-      >
-        {props.text}
-      </OakLink>
+      <FooterLinkIconWrapper containerProps={containerProps} {...props}>
+        <OakLink
+          {...props}
+          {...primaryTargetProps}
+          $focusStyles={["underline"]}
+          htmlAnchorProps={{
+            onClick: () => track.classroomSelected({ navigatedFrom: "footer" }),
+          }}
+        >
+          {props.text}
+        </OakLink>
+      </FooterLinkIconWrapper>
     );
   }
 
-  if (props.type === "teachers-link") {
+  if (props.type === "page" && props.page == "teacher-hub") {
     return (
-      <OakLink
-        page="teacher-hub"
-        htmlAnchorProps={{
-          onClick: () => track.teacherHubSelected({ navigatedFrom: "footer" }),
-        }}
-      >
-        {props.text}
-      </OakLink>
+      <FooterLinkIconWrapper containerProps={containerProps} {...props}>
+        <OakLink
+          {...props}
+          {...primaryTargetProps}
+          $focusStyles={["underline"]}
+          htmlAnchorProps={{
+            onClick: () =>
+              track.teacherHubSelected({ navigatedFrom: "footer" }),
+          }}
+        >
+          {props.text}
+        </OakLink>
+      </FooterLinkIconWrapper>
     );
   }
-  // TODO: change data to have "page"
-  return (
-    <OakLink page={null} href={props.href}>
-      {props.text}
-    </OakLink>
-  );
+  if (props.type === "page") {
+    return (
+      <FooterLinkIconWrapper containerProps={containerProps} {...props}>
+        <OakLink
+          {...primaryTargetProps}
+          $focusStyles={["underline"]}
+          {...props}
+        >
+          {props.text}
+        </OakLink>
+      </FooterLinkIconWrapper>
+    );
+  }
+  if (props.href) {
+    return (
+      <FooterLinkIconWrapper containerProps={containerProps} {...props}>
+        <OakLink
+          {...primaryTargetProps}
+          $focusStyles={["underline"]}
+          page={null}
+          href={props.href}
+        >
+          {props.text}
+        </OakLink>
+      </FooterLinkIconWrapper>
+    );
+  }
 };
 
 export type FooterSection = {
@@ -85,10 +142,10 @@ export type FooterSection = {
 const FooterSectionLinks: FC<FooterSection> = ({ title, links }) => {
   return (
     <Flex $flexDirection="column" $mt={[32, 0]}>
-      <Heading $mb={8} $font="body-2" $color="grey9" tag="h2">
+      <Heading $mb={8} $font="heading-7" $color="black" tag="h2">
         {title}
       </Heading>
-      <Typography $font={"heading-7"}>
+      <Typography $color={"black"} $font={"body-2"}>
         <ul role="list">
           {links.map((link) => (
             <LI key={link.text} $mt={12}>
@@ -168,7 +225,7 @@ const SiteFooter: FC = () => {
       </nav>
       <Svg
         name="looping-line-3"
-        $color={"pupilsPink"}
+        $color={"pupilsLimeGreen"}
         $zIndex={"behind"}
         $display={["none", "block"]}
         $transform={[


### PR DESCRIPTION
## Description

- Updates footer link fixtures
- Refactors footer to use page prop

- [ ]  New links
    - [ ]  Hover, focus.    @Monika-Koziol "Just make is an underline on hover. For focus… use our standard double line'
- [ ]  New tab icon next to Teacher Hub (old)
- [ ]  Green squiggle if we have time ⌛

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
