### PR TITLE
chore(copy): update curricula

### DIFF
--- a/src/components/pages/LandingPages/CurriculumLandingHero.tsx
+++ b/src/components/pages/LandingPages/CurriculumLandingHero.tsx
@@ -24,7 +24,7 @@ const CurriculumLandingHero: FC<CurriculumLandingHeroProps> = (props) => {
             Oak's curricula
           </Heading>
           <P $font={["body-2", "body-1"]}>
-            Our curricula covers all the national curriculum subjects across
+            Oak's curricula cover all the national curriculum subjects across
             primary and secondary. Use our fully-sequenced units of lessons as
             high-quality models that represent great design from across the
             sector.


### PR DESCRIPTION
## Description

- Minor copy update on /teachers/curriculum

## Issue(s)

## How to test

1. Go to https://owa.thenational.academy/teachers/curriculum
2. You should see "Oak's curricula cover" in the hero

## Screenshots

How it used to look:
<img width="880" alt="Screenshot 2023-09-28 at 11 28 27" src="https://github.com/oaknational/Oak-Web-Application/assets/4476971/3058ea98-8678-490e-97dd-746ceb75dd47">

How it should now look:
<img width="880" alt="Screenshot 2023-09-28 at 11 32 59" src="https://github.com/oaknational/Oak-Web-Application/assets/4476971/7597884d-cd31-4269-a926-d886c7e37fde">

## Checklist

- [x] Approved by product owner
