### PR TITLE
[CUR-284] fix: hamburger nav visible on overview and unit pages

### DIFF
--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -77,11 +77,7 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
   }
 
   return (
-    <AppLayout
-      seoProps={BETA_SEO_PROPS}
-      $background={"white"}
-      headerVariant="landing-pages"
-    >
+    <AppLayout seoProps={BETA_SEO_PROPS} $background={"white"}>
       <CurriculumHeader
         subjectPhaseOptions={subjectPhaseOptions}
         curriculumSelectionSlugs={curriculumSelectionSlugs}


### PR DESCRIPTION
## Issue(s)
- The hamburger nav was not visible for curriculum overview and units 

Fixes #
- Updated the tab component to remove header variant so the hamburger nav will be visible

## How to test

1. Go to {owa_deployment_url}
2. Click on any subject phase combination
3. You should see the hamburger nav for both mobile and desktop views

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2023-09-28 at 16 25 54](https://github.com/oaknational/Oak-Web-Application/assets/32605982/78727619-34d6-4c39-a316-9f921053397e)

How it should now look:
![Screenshot 2023-09-28 at 16 25 14](https://github.com/oaknational/Oak-Web-Application/assets/32605982/5c82f8d6-c93c-42e3-91b4-a495b60fffda)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
