### PR TITLE
feat(apis): generate mux tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@bugsnag/plugin-react": "^7.19.0",
         "@hookform/resolvers": "^3.3.1",
         "@hubspot/api-client": "^9.1.1",
+        "@mux/mux-node": "^7.3.2",
         "@mux/mux-player-react": "^1.14.2",
         "@portabletext/react": "^1.0.6",
         "@react-aria/aria-modal-polyfill": "^3.6.0",
@@ -6987,6 +6988,42 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@mux/mux-node": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-node/-/mux-node-7.3.2.tgz",
+      "integrity": "sha512-pa+gBqmlHsZv6K1cGVHUZQGtuWmy6oEA+5QyK1WSV7y0+ijwRD5RQRWVt59eS4FNL7aPwIrfOZ6Adb+++Bb1Kg==",
+      "dependencies": {
+        "axios": "^1.2.6",
+        "esdoc-ecmascript-proposal-plugin": "^1.0.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mux/mux-node/node_modules/axios": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@mux/mux-node/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@mux/mux-player": {
@@ -26068,8 +26105,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -29153,7 +29189,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -29832,6 +29867,14 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esdoc-ecmascript-proposal-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz",
+      "integrity": "sha512-PuaU/O8d+Sb0J6qQdyhmy74h/2cp/2kqsvPuoCiK+50Rw54nlGqXxvWNaaNikS5qntE0FfssnwZtUPa6q4RiXg==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/eslint": {
@@ -38696,7 +38739,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
       "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
-      "dev": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash": "^4.17.21",
@@ -38712,7 +38754,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -38723,7 +38764,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dev": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@bugsnag/plugin-react": "^7.19.0",
     "@hookform/resolvers": "^3.3.1",
     "@hubspot/api-client": "^9.1.1",
+    "@mux/mux-node": "^7.3.2",
     "@mux/mux-player-react": "^1.14.2",
     "@portabletext/react": "^1.0.6",
     "@react-aria/aria-modal-polyfill": "^3.6.0",

--- a/src/node-lib/getServerConfig.ts
+++ b/src/node-lib/getServerConfig.ts
@@ -143,6 +143,20 @@ const envVars = satisfies<Record<string, EnvVar>>()({
     availableInBrowser: false,
     default: null,
   },
+  muxSigningKey: {
+    value: process.env.MUX_SIGNING_KEY,
+    envName: "MUX_SIGNING_KEY",
+    required: true,
+    availableInBrowser: false,
+    default: null,
+  },
+  muxSigningSecret: {
+    value: process.env.MUX_SIGNING_SECRET,
+    envName: "MUX_SIGNING_SECRET",
+    required: true,
+    availableInBrowser: false,
+    default: null,
+  },
 });
 
 for (const [, envVarConfig] of Object.entries(envVars)) {

--- a/src/pages/api/video/signed_url/index.ts
+++ b/src/pages/api/video/signed_url/index.ts
@@ -1,0 +1,54 @@
+/**
+ * API route to generate a signed URL for a Mux video or thumbnail.
+ *
+ * e.g. /api/video/signed_url?id=abc&type=video
+ */
+
+import Mux from "@mux/mux-node";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import getServerConfig from "@/node-lib/getServerConfig";
+
+type Data = string;
+
+// Set some base options we can use for a few different signing types
+const baseOptions = {
+  keyId: getServerConfig("muxSigningKey"),
+  keySecret: getServerConfig("muxSigningSecret"),
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>,
+) {
+  return handleRequest(req, res);
+}
+
+async function handleRequest(
+  request: NextApiRequest,
+  response: NextApiResponse<Data>,
+) {
+  const { id, type } = request.query;
+
+  if (!id || !type) {
+    response.status(400).json("Must provide an id and a type query parameter");
+    return;
+  }
+
+  if (Array.isArray(id) || Array.isArray(type)) {
+    response
+      .status(400)
+      .json("Must provide a single id and a single type query parameter");
+    return;
+  }
+
+  const token = Mux.JWT.signPlaybackId(id, {
+    ...baseOptions,
+    type,
+    expiration: "6h",
+    // Probably only applies to thumbnails
+    params: { time: "1" },
+  });
+
+  response.json(JSON.stringify({ token }));
+}


### PR DESCRIPTION
create an API route that takes a Mux ID and asset type and returns a token for a signed Mux URL

See https://www.npmjs.com/package/@mux/mux-node

## To Do

- [ ] Add the Mux signing key and signing secret to the server config