### PR TITLE
feat: added help centre banner to new units page

### DIFF
--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.tsx
@@ -17,6 +17,7 @@ import RadioGroup from "@/components/RadioButtons/RadioGroup";
 import Sidebar from "@/components/Sidebar/Sidebar";
 import UnitModal from "@/components/UnitModal/UnitModal";
 import { TagFunctional } from "@/components/TagFunctional";
+import ButtonAsLink from "@/components/Button/ButtonAsLink";
 
 type UnitsTabProps = {
   data: CurriculumUnitsTabData;
@@ -271,309 +272,369 @@ const UnitsTab: FC<UnitsTabProps> = ({ data }) => {
   }
 
   return (
-    <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
-      <Card $background={"lemon30"} $pa={0} $pl={96} $mv={[16, 48]}>
-        <Box
-          $background={"lemon"}
-          $height={"100%"}
-          $left={0}
-          $position={"absolute"}
-          $top={0}
-          $width={[64, 96]}
-          $textAlign={"center"}
-        >
-          <Icon
-            name={"bell"}
-            size={[48]}
-            $position={"relative"}
-            $transform={"translateY(-50%)"}
-            $top={"50%"}
-          />
-        </Box>
-        <Box $pa={20}>
-          <Heading
-            tag={"h2"}
-            $font={"heading-7"}
-            $mb={12}
-            data-testid="units-heading"
+    <Box>
+      <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
+        <Card $background={"lemon30"} $pa={0} $pl={96} $mv={[16, 48]}>
+          <Box
+            $background={"lemon"}
+            $height={"100%"}
+            $left={0}
+            $position={"absolute"}
+            $top={0}
+            $width={[64, 96]}
+            $textAlign={"center"}
           >
-            Introducing our new curriculum sequence for 2023/2024!
-          </Heading>
-          <P>
-            Units that make up our curricula are fully sequenced, and aligned to
-            the national curriculum.
-          </P>
-        </Box>
-      </Card>
-
-      <Grid>
-        <GridArea $colSpan={[12, 3]}>
-          <Box $mr={16} $mb={32}>
-            <Heading tag={"h3"} $font={"heading-7"} $mb={12}>
-              Highlight a thread
-            </Heading>
-            <P $mb={12}>
-              Threads are groups of units across the curriculum that build a
-              common body of knowledge
-            </P>
-            <RadioGroup
-              aria-label="Highlight a thread"
-              value={selectedThread ? selectedThread.slug : ""}
-              onChange={handleSelectThread}
+            <Icon
+              name={"bell"}
+              size={[48]}
+              $position={"relative"}
+              $transform={"translateY(-50%)"}
+              $top={"50%"}
+            />
+          </Box>
+          <Box $pa={20}>
+            <Heading
+              tag={"h2"}
+              $font={"heading-7"}
+              $mb={12}
+              data-testid="units-heading"
             >
-              <Box $mv={16}>
-                <Radio
-                  aria-label={"None highlighted"}
-                  value={""}
-                  data-testid={"no-threads-radio"}
-                >
-                  None highlighted
-                </Radio>
-              </Box>
-              {threadOptions.map((threadOption) => {
-                const isSelected = isSelectedThread(threadOption);
-                const highlightedCount = highlightedUnitCount();
+              Introducing our new curriculum sequence for 2023/2024!
+            </Heading>
+            <P>
+              Units that make up our curricula are fully sequenced, and aligned
+              to the national curriculum.
+            </P>
+          </Box>
+        </Card>
+
+        <Grid>
+          <GridArea $colSpan={[12, 3]}>
+            <Box $mr={16} $mb={32}>
+              <Heading tag={"h3"} $font={"heading-7"} $mb={12}>
+                Highlight a thread
+              </Heading>
+              <P $mb={12}>
+                Threads are groups of units across the curriculum that build a
+                common body of knowledge
+              </P>
+              <RadioGroup
+                aria-label="Highlight a thread"
+                value={selectedThread ? selectedThread.slug : ""}
+                onChange={handleSelectThread}
+              >
+                <Box $mv={16}>
+                  <Radio
+                    aria-label={"None highlighted"}
+                    value={""}
+                    data-testid={"no-threads-radio"}
+                  >
+                    None highlighted
+                  </Radio>
+                </Box>
+                {threadOptions.map((threadOption) => {
+                  const isSelected = isSelectedThread(threadOption);
+                  const highlightedCount = highlightedUnitCount();
+                  return (
+                    <Box
+                      $ba={1}
+                      $background={isSelected ? "black" : "white"}
+                      $borderColor={isSelected ? "black" : "grey4"}
+                      $borderRadius={4}
+                      $color={isSelected ? "white" : "black"}
+                      $font={isSelected ? "heading-light-7" : "body-2"}
+                      $ph={12}
+                      $pt={12}
+                      $mb={8}
+                      key={threadOption.slug}
+                    >
+                      <Radio
+                        aria-label={threadOption.title}
+                        value={threadOption.slug}
+                        data-testid={
+                          isSelected ? "selected-thread-radio" : "thread-radio"
+                        }
+                      >
+                        {threadOption.title}
+                        {isSelected && (
+                          <>
+                            <br />
+                            {highlightedCount}
+                            {highlightedCount === 1 ? " unit " : " units "}
+                            highlighted
+                          </>
+                        )}
+                      </Radio>
+                    </Box>
+                  );
+                })}
+              </RadioGroup>
+            </Box>
+            <Box $mr={16} $mb={32}>
+              <Heading tag={"h3"} $font={"heading-7"} $mb={12}>
+                Year Group
+              </Heading>
+              <RadioGroup
+                aria-label="Select a year group"
+                value={selectedYear ?? ""}
+                onChange={handleSelectYear}
+              >
+                <Box $mb={16}>
+                  <Radio
+                    aria-label="All"
+                    value={""}
+                    data-testid={"all-years-radio"}
+                  >
+                    All
+                  </Radio>
+                </Box>
+                {yearOptions.map((yearOption) => (
+                  <Box key={yearOption} $mb={16}>
+                    <Radio
+                      aria-label={`Year ${yearOption}`}
+                      value={yearOption}
+                      data-testid={"year-radio"}
+                    >
+                      Year {yearOption}
+                    </Radio>
+                  </Box>
+                ))}
+              </RadioGroup>
+            </Box>
+          </GridArea>
+          <GridArea $colSpan={[12, 9]}>
+            {Object.keys(yearData)
+              .filter((year) => !selectedYear || selectedYear === year)
+              .map((year) => {
+                const { units, childSubjects, domains, tiers } = yearData[
+                  year
+                ] as (typeof yearData)[string];
                 return (
                   <Box
-                    $ba={1}
-                    $background={isSelected ? "black" : "white"}
-                    $borderColor={isSelected ? "black" : "grey4"}
+                    key={year}
+                    $background={"pink30"}
+                    $pt={32}
+                    $pl={30}
+                    $mb={32}
                     $borderRadius={4}
-                    $color={isSelected ? "white" : "black"}
-                    $font={isSelected ? "heading-light-7" : "body-2"}
-                    $ph={12}
-                    $pt={12}
-                    $mb={8}
-                    key={threadOption.slug}
                   >
-                    <Radio
-                      aria-label={threadOption.title}
-                      value={threadOption.slug}
-                      data-testid={
-                        isSelected ? "selected-thread-radio" : "thread-radio"
-                      }
+                    <Heading
+                      tag="h2"
+                      $font={"heading-4"}
+                      $mb={32}
+                      data-testid="year-heading"
                     >
-                      {threadOption.title}
-                      {isSelected && (
-                        <>
-                          <br />
-                          {highlightedCount}
-                          {highlightedCount === 1 ? " unit " : " units "}
-                          highlighted
-                        </>
-                      )}
-                    </Radio>
+                      Year {year}
+                    </Heading>
+                    {childSubjects.length > 0 && (
+                      <Box>
+                        {childSubjects.map((subject) => (
+                          <Button
+                            $mb={20}
+                            $mr={20}
+                            background={
+                              isSelectedSubject(year, subject)
+                                ? "black"
+                                : "white"
+                            }
+                            key={subject.subject_slug}
+                            label={subject.subject}
+                            onClick={() => handleSelectSubject(year, subject)}
+                            size="small"
+                            data-testid="subject-button"
+                          />
+                        ))}
+                      </Box>
+                    )}
+                    {domains.length > 0 && (
+                      <Box>
+                        {domains.map((domain) => (
+                          <Button
+                            $mb={20}
+                            $mr={20}
+                            background={
+                              isSelectedDomain(year, domain) ? "black" : "white"
+                            }
+                            key={domain.domain_id}
+                            label={domain.domain}
+                            onClick={() => handleSelectDomain(year, domain)}
+                            size="small"
+                            data-testid="domain-button"
+                          />
+                        ))}
+                      </Box>
+                    )}
+                    {tiers.length > 0 && (
+                      <Box>
+                        {tiers.map((tier) => (
+                          <Button
+                            $font={"heading-6"}
+                            $mb={20}
+                            $mr={24}
+                            key={tier.tier_slug}
+                            label={tier.tier}
+                            onClick={() => handleSelectTier(year, tier)}
+                            size="small"
+                            variant="minimal"
+                            isCurrent={isSelectedTier(year, tier)}
+                            currentStyles={["underline"]}
+                            data-testid="tier-button"
+                          />
+                        ))}
+                      </Box>
+                    )}
+                    <Flex $flexWrap={"wrap"} $mt={12} data-testid="unit-cards">
+                      {units
+                        .filter((unit) => isVisibleUnit(year, unit))
+                        .map((unit, index) => {
+                          const isHighlighted = isHighlightedUnit(unit);
+                          return (
+                            <Card
+                              key={unit.slug + index}
+                              $background={isHighlighted ? "black" : "white"}
+                              $color={isHighlighted ? "white" : "black"}
+                              $flexGrow={"unset"}
+                              $mb={32}
+                              $mr={28}
+                              $position={"relative"}
+                              $width={[
+                                "100%",
+                                "calc(50% - 28px)",
+                                "calc(33% - 26px)",
+                              ]}
+                              data-testid={
+                                isHighlighted
+                                  ? "highlighted-unit-card"
+                                  : "unit-card"
+                              }
+                              $justifyContent={"space-between"}
+                            >
+                              <Box>
+                                <OutlineHeading
+                                  tag={"div"}
+                                  $font={"heading-5"}
+                                  $fontSize={24}
+                                  $mb={12}
+                                >
+                                  {index + 1}
+                                </OutlineHeading>
+                                <Heading
+                                  tag={"h3"}
+                                  $font={"heading-7"}
+                                  $mb={16}
+                                >
+                                  {isHighlighted && (
+                                    <VisuallyHidden>
+                                      Highlighted:&nbsp;
+                                    </VisuallyHidden>
+                                  )}
+                                  {unit.title}
+                                </Heading>
+                                {unit.unit_options.length > 1 && (
+                                  <Box
+                                    $mt={12}
+                                    $mb={20}
+                                    $zIndex={"inFront"}
+                                    data-testid="options-tag"
+                                    $position={"relative"}
+                                  >
+                                    <TagFunctional
+                                      color="lavender"
+                                      text={`${unit.unit_options.length} unit options`}
+                                    />
+                                  </Box>
+                                )}
+                                <BrushBorders
+                                  color={isHighlighted ? "black" : "white"}
+                                />
+                              </Box>
+                              <Flex
+                                $flexDirection={"row"}
+                                $justifyContent={"flex-end"}
+                              >
+                                <Button
+                                  icon="chevron-right"
+                                  $iconPosition="trailing"
+                                  data-testid="unit-modal-button"
+                                  variant={isHighlighted ? "brush" : "minimal"}
+                                  background={
+                                    isHighlighted ? "black" : undefined
+                                  }
+                                  label="Unit info"
+                                  onClick={() => {
+                                    handleOpenModal();
+                                    setUnitData({ ...unit });
+                                  }}
+                                  ref={modalButtonRef}
+                                />
+                              </Flex>
+                            </Card>
+                          );
+                        })}
+                      <Sidebar
+                        displayModal={displayModal}
+                        onClose={handleCloseModal}
+                        unitData={unitData}
+                      >
+                        <UnitModal unitData={unitData} />
+                      </Sidebar>
+                    </Flex>
                   </Box>
                 );
               })}
-            </RadioGroup>
-          </Box>
-          <Box $mr={16} $mb={32}>
-            <Heading tag={"h3"} $font={"heading-7"} $mb={12}>
-              Year Group
-            </Heading>
-            <RadioGroup
-              aria-label="Select a year group"
-              value={selectedYear ?? ""}
-              onChange={handleSelectYear}
+          </GridArea>
+        </Grid>
+      </Box>
+      <Flex
+        $flexDirection={["column", "row"]}
+        $background={"mint"}
+        $mt={48}
+        $pa={48}
+        $gap={24}
+      >
+        <Flex
+          $flexDirection={["column", "row"]}
+          $alignItems={["flex-start", "flex-end"]}
+          $ma={"auto"}
+          $justifyContent={["space-evenly"]}
+          $gap={24}
+        >
+          <Flex $alignItems={"flex-start"} $flexDirection={["column", "row"]}>
+            <Icon
+              name="books"
+              size={92}
+              $background={"teachersRed"}
+              $mr={40}
+              $mb={[24, 0]}
+              $color={"black"}
+            />
+
+            <Flex
+              $width={["100%", "70%"]}
+              $gap={16}
+              $flexDirection={"column"}
+              $alignItems={"flex-start"}
             >
-              <Box $mb={16}>
-                <Radio
-                  aria-label="All"
-                  value={""}
-                  data-testid={"all-years-radio"}
-                >
-                  All
-                </Radio>
-              </Box>
-              {yearOptions.map((yearOption) => (
-                <Box key={yearOption} $mb={16}>
-                  <Radio
-                    aria-label={`Year ${yearOption}`}
-                    value={yearOption}
-                    data-testid={"year-radio"}
-                  >
-                    Year {yearOption}
-                  </Radio>
-                </Box>
-              ))}
-            </RadioGroup>
-          </Box>
-        </GridArea>
-        <GridArea $colSpan={[12, 9]}>
-          {Object.keys(yearData)
-            .filter((year) => !selectedYear || selectedYear === year)
-            .map((year) => {
-              const { units, childSubjects, domains, tiers } = yearData[
-                year
-              ] as (typeof yearData)[string];
-              return (
-                <Box
-                  key={year}
-                  $background={"pink30"}
-                  $pt={32}
-                  $pl={30}
-                  $mb={32}
-                  $borderRadius={4}
-                >
-                  <Heading
-                    tag="h2"
-                    $font={"heading-4"}
-                    $mb={32}
-                    data-testid="year-heading"
-                  >
-                    Year {year}
-                  </Heading>
-                  {childSubjects.length > 0 && (
-                    <Box>
-                      {childSubjects.map((subject) => (
-                        <Button
-                          $mb={20}
-                          $mr={20}
-                          background={
-                            isSelectedSubject(year, subject) ? "black" : "white"
-                          }
-                          key={subject.subject_slug}
-                          label={subject.subject}
-                          onClick={() => handleSelectSubject(year, subject)}
-                          size="small"
-                          data-testid="subject-button"
-                        />
-                      ))}
-                    </Box>
-                  )}
-                  {domains.length > 0 && (
-                    <Box>
-                      {domains.map((domain) => (
-                        <Button
-                          $mb={20}
-                          $mr={20}
-                          background={
-                            isSelectedDomain(year, domain) ? "black" : "white"
-                          }
-                          key={domain.domain_id}
-                          label={domain.domain}
-                          onClick={() => handleSelectDomain(year, domain)}
-                          size="small"
-                          data-testid="domain-button"
-                        />
-                      ))}
-                    </Box>
-                  )}
-                  {tiers.length > 0 && (
-                    <Box>
-                      {tiers.map((tier) => (
-                        <Button
-                          $font={"heading-6"}
-                          $mb={20}
-                          $mr={24}
-                          key={tier.tier_slug}
-                          label={tier.tier}
-                          onClick={() => handleSelectTier(year, tier)}
-                          size="small"
-                          variant="minimal"
-                          isCurrent={isSelectedTier(year, tier)}
-                          currentStyles={["underline"]}
-                          data-testid="tier-button"
-                        />
-                      ))}
-                    </Box>
-                  )}
-                  <Flex $flexWrap={"wrap"} $mt={12} data-testid="unit-cards">
-                    {units
-                      .filter((unit) => isVisibleUnit(year, unit))
-                      .map((unit, index) => {
-                        const isHighlighted = isHighlightedUnit(unit);
-                        return (
-                          <Card
-                            key={unit.slug + index}
-                            $background={isHighlighted ? "black" : "white"}
-                            $color={isHighlighted ? "white" : "black"}
-                            $flexGrow={"unset"}
-                            $mb={32}
-                            $mr={28}
-                            $position={"relative"}
-                            $width={[
-                              "100%",
-                              "calc(50% - 28px)",
-                              "calc(33% - 26px)",
-                            ]}
-                            data-testid={
-                              isHighlighted
-                                ? "highlighted-unit-card"
-                                : "unit-card"
-                            }
-                            $justifyContent={"space-between"}
-                          >
-                            <Box>
-                              <OutlineHeading
-                                tag={"div"}
-                                $font={"heading-5"}
-                                $fontSize={24}
-                                $mb={12}
-                              >
-                                {index + 1}
-                              </OutlineHeading>
-                              <Heading tag={"h3"} $font={"heading-7"} $mb={16}>
-                                {isHighlighted && (
-                                  <VisuallyHidden>
-                                    Highlighted:&nbsp;
-                                  </VisuallyHidden>
-                                )}
-                                {unit.title}
-                              </Heading>
-                              {unit.unit_options.length > 1 && (
-                                <Box
-                                  $mt={12}
-                                  $mb={20}
-                                  $zIndex={"inFront"}
-                                  data-testid="options-tag"
-                                  $position={"relative"}
-                                >
-                                  <TagFunctional
-                                    color="lavender"
-                                    text={`${unit.unit_options.length} unit options`}
-                                  />
-                                </Box>
-                              )}
-                              <BrushBorders
-                                color={isHighlighted ? "black" : "white"}
-                              />
-                            </Box>
-                            <Flex
-                              $flexDirection={"row"}
-                              $justifyContent={"flex-end"}
-                            >
-                              <Button
-                                icon="chevron-right"
-                                $iconPosition="trailing"
-                                data-testid="unit-modal-button"
-                                variant={isHighlighted ? "brush" : "minimal"}
-                                background={isHighlighted ? "black" : undefined}
-                                label="Unit info"
-                                onClick={() => {
-                                  handleOpenModal();
-                                  setUnitData({ ...unit });
-                                }}
-                                ref={modalButtonRef}
-                              />
-                            </Flex>
-                          </Card>
-                        );
-                      })}
-                    <Sidebar
-                      displayModal={displayModal}
-                      onClose={handleCloseModal}
-                      unitData={unitData}
-                    >
-                      <UnitModal unitData={unitData} />
-                    </Sidebar>
-                  </Flex>
-                </Box>
-              );
-            })}
-        </GridArea>
-      </Grid>
+              <Heading tag="h2" $font={["heading-5", "heading-4"]}>
+                Need help with our new curriculum?
+              </Heading>
+              <P $font={["body-2", "body-1"]}>
+                Visit our help centre for technical support as well as tips and
+                ideas to help you make the most of Oak.
+              </P>
+            </Flex>
+          </Flex>
+          <ButtonAsLink
+            label="Go to help centre"
+            variant={"brush"}
+            size={"large"}
+            page={"help"}
+            icon={"arrow-right"}
+            iconBackground="black"
+            $iconPosition="trailing"
+          />
+        </Flex>
+      </Flex>
     </Box>
   );
 };


### PR DESCRIPTION
## Description

- Help centre banner was accidentally written over by unit modal work on the curriculum units page

## How to test

1. Go to https://deploy-preview-1962--oak-web-application.netlify.thenational.academy
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
