### PR TITLE
[ENG-471] more data in auth errors for CMS preview API calls

### DIFF
--- a/src/pages/api/preview/[[...path]].ts
+++ b/src/pages/api/preview/[[...path]].ts
@@ -27,6 +27,10 @@ const preview: NextApiHandler = async (req, res) => {
     if (req.query.secret !== getServerConfig("sanityPreviewSecret")) {
       throw new OakError({
         code: "preview/invalid-token",
+        meta: {
+          badToken: req.query.secret,
+          userAgent: req.headers["user-agent"],
+        },
       });
     }
 


### PR DESCRIPTION
We're getting hundreds of invalid auth request a day, possibly Detectify, hence extra data to help with analysis.