### PR TITLE
Fix/lesq 367/downloads count

### DIFF
--- a/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.test.tsx
+++ b/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.test.tsx
@@ -12,13 +12,14 @@ const resources: Partial<Record<DownloadResourceType, boolean>> = {
   "worksheet-pdf": true,
 };
 
-const getDownloadResourcesExistenceData = {
-  resources,
-};
+const getDownloadResourcesExistenceData = Object.entries(resources).map((v) => [
+  v[0],
+  { exists: v[1] },
+]);
 
-const getDownloadResourcesExistenceMock = jest.fn(
-  () => getDownloadResourcesExistenceData,
-);
+const getDownloadResourcesExistenceMock = jest.fn(() => ({
+  resources: getDownloadResourcesExistenceData,
+}));
 
 jest.mock("../helpers/getDownloadResourcesExistence", () => ({
   __esModule: true,
@@ -71,10 +72,10 @@ describe("useDownloadExistenceCheck", () => {
     const onComplete = jest.fn();
 
     getDownloadResourcesExistenceMock.mockImplementationOnce(() => ({
-      resources: {
-        "exit-quiz-answers": false,
-        "worksheet-pdf": true,
-      },
+      resources: [
+        ["exit-quiz-answers", { exists: false }],
+        ["worksheet-pdf", { exists: true }],
+      ],
     }));
     const isLegacyDownload = true;
 
@@ -83,7 +84,6 @@ describe("useDownloadExistenceCheck", () => {
         lessonSlug,
         resourcesToCheck,
         onComplete,
-
         isLegacyDownload,
       }),
     );

--- a/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.tsx
+++ b/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.tsx
@@ -36,21 +36,24 @@ const useDownloadExistenceCheck = (props: UseDownloadExistenceCheckProps) => {
           await getDownloadResourcesExistence(
             lessonSlug,
             resourceTypesAsString,
-
             isLegacyDownload,
           );
 
-        const resourcesExistenceAsArray = resourceExistence
-          ? Object.entries(
-              resourceExistence as Partial<
-                Record<DownloadResourceType, boolean>
-              >,
-            )
-          : [];
+        const resourcesExistenceAsArray: {
+          item: DownloadResourceType;
+          exists: boolean;
+        }[] = resourceExistence.map((r: unknown[]) => {
+          const k = r[0] as DownloadResourceType;
+          const v = r[1] as Record<string, unknown>;
+          return {
+            item: k,
+            exists: v.exists as boolean,
+          };
+        });
 
         const filteredResourcesExistenceAsArray = resourcesExistenceAsArray
-          .map(([key, value]) => {
-            if (value === true) return key;
+          .map((r) => {
+            if (r.exists) return r.item;
           })
           .filter((resource) => resource !== undefined);
 

--- a/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.tsx
+++ b/src/components/DownloadComponents/hooks/useDownloadExistenceCheck.tsx
@@ -39,6 +39,8 @@ const useDownloadExistenceCheck = (props: UseDownloadExistenceCheckProps) => {
             isLegacyDownload,
           );
 
+        console.log({ resourceExistence });
+
         const resourcesExistenceAsArray: {
           item: DownloadResourceType;
           exists: boolean;
@@ -50,6 +52,8 @@ const useDownloadExistenceCheck = (props: UseDownloadExistenceCheckProps) => {
             exists: v.exists as boolean,
           };
         });
+
+        console.log({ resourcesExistenceAsArray });
 
         const filteredResourcesExistenceAsArray = resourcesExistenceAsArray
           .map((r) => {


### PR DESCRIPTION
## Description

The count of how many resources selected for download on the downloads page is wrong for new content


## How to test

1. Go to {owa_deployment_url}
2. Navigate to any lesson (try legacy as well)
3. You should see the correct number of resources displayed


- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
