### PR TITLE
Feat: update number of lessons for music unit [LESQ-376]

### DIFF
--- a/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
+++ b/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
@@ -321,7 +321,7 @@ const earlyReleaseExemplarUnitsFixture = (
           expired: false,
           expiredLessonCount: 0,
           index: 7,
-          lessonCount: 6, //holding number
+          lessonCount: 4,
         },
         {
           title: "Perimeter and area",

--- a/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
+++ b/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
@@ -78,7 +78,7 @@ const earlyReleaseExemplarUnitsFixture = (
           index: 2,
         },
         {
-          title: "South America: Why does the Amazon matter?",
+          title: "South America: why does the Amazon matter?",
           lessonCount: 8,
           keyStageSlug: "ks2",
           yearTitle: "Year 5",

--- a/src/pages/teachers/early-release-units.tsx
+++ b/src/pages/teachers/early-release-units.tsx
@@ -16,8 +16,6 @@ import AnchorTarget from "@/components/AnchorTarget";
 
 const EarlyReleaseUnits: NextPage = () => {
   const exemplarUnitsFixture = earlyReleaseExemplarUnitsFixture();
-  const primary = exemplarUnitsFixture.primary;
-  const secondary = exemplarUnitsFixture.secondary;
   return (
     <AppLayout seoProps={BETA_SEO_PROPS}>
       <EarlyReleaseUnitsHeader />
@@ -74,14 +72,14 @@ const EarlyReleaseUnits: NextPage = () => {
       </MaxWidth>
       <Box $position={"relative"}>
         <AnchorTarget id={"primary"} />
-        <EarlyReleaseExemplarUnits {...primary} />
+        <EarlyReleaseExemplarUnits {...exemplarUnitsFixture.primary} />
       </Box>
       <Box $background={"lavender"}>
         <Hr thickness={4} $mt={0} $mb={0} />
       </Box>
       <Box $position={"relative"}>
         <AnchorTarget id={"secondary"} />
-        <EarlyReleaseExemplarUnits {...secondary} />
+        <EarlyReleaseExemplarUnits {...exemplarUnitsFixture.secondary} />
       </Box>
     </AppLayout>
   );

--- a/src/pages/teachers/early-release-units.tsx
+++ b/src/pages/teachers/early-release-units.tsx
@@ -15,8 +15,9 @@ import MaxWidth from "@/components/MaxWidth/MaxWidth";
 import AnchorTarget from "@/components/AnchorTarget";
 
 const EarlyReleaseUnits: NextPage = () => {
-  const primary = earlyReleaseExemplarUnitsFixture().primary;
-  const secondary = earlyReleaseExemplarUnitsFixture().secondary;
+  const exemplarUnitsFixture = earlyReleaseExemplarUnitsFixture();
+  const primary = exemplarUnitsFixture.primary;
+  const secondary = exemplarUnitsFixture.secondary;
   return (
     <AppLayout seoProps={BETA_SEO_PROPS}>
       <EarlyReleaseUnitsHeader />


### PR DESCRIPTION
## Description

- Updates the lesson count for music unit in the exemplar units fixture
- Removes capitalisation of why in the geography unit "South America: why does the Amazon matter?"

## How to test

1. Go to https://deploy-preview-1993--oak-web-application.netlify.thenational.academy/teachers/early-release-units
2. Scroll down to secondary and the music unit 'Keyboard fundamentals'
3. You should see the lesson count as 4, and clicking into the unit also shows 4 lessons
