### PR TITLE
fix(error-reporter): hubspot subdomain wildcards

### DIFF
--- a/src/common-lib/error-reporter/errorReporter.test.ts
+++ b/src/common-lib/error-reporter/errorReporter.test.ts
@@ -99,6 +99,13 @@ describe("common-lib/error-reporter", () => {
       });
       expect(shouldIgnore).toBe(true);
     });
+    it("returns true if the error should be ignored based on subdomains", () => {
+      const shouldIgnore = matchesIgnoredError({
+        errorMessage: "Proper error message",
+        stacktrace: [{ file: "https://something.hubspot.com/foo.js" }],
+      });
+      expect(shouldIgnore).toBe(true);
+    });
   });
   describe("Bugsnag onError handler", () => {
     it("Returns undefined for non-ignored error", () => {

--- a/src/common-lib/error-reporter/errorReporter.ts
+++ b/src/common-lib/error-reporter/errorReporter.ts
@@ -29,8 +29,8 @@ export const matchesIgnoredError = (error: {
     // Testing
     /OAK_TEST_ERROR_STACKTRACE_FILE/i,
     // Don't error external Hubspot script problems
-    /\/\/js\.hubspot\.com/i,
-    /\/\/js\.hsleadflows\.net/i,
+    /\/\/[a-zA-Z0-9-]+\.hubspot\.com/i,
+    /\/\/[a-zA-Z0-9-]+\.hsleadflows\.net/i,
   ];
   const messagesToMatch = [
     // Testing


### PR DESCRIPTION

## Description

- ignore errors on scripts from all subdomains of hubspot script domains

## How to test

1. Run tests
2. When deployed, should no longer get errors such as https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/642d66d7a5d87200087e3138?filters%5Berror.status%5D=open&filters%5Bevent.since%5D=30d&filters%5Bevent.unhandled%5D=true
