### PR TITLE
fix: change oakGreen to oakGrey2

### DIFF
--- a/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListItem.tsx
+++ b/src/components/UnitAndLessonLists/UnitList/UnitListItem/UnitListItem.tsx
@@ -101,7 +101,7 @@ const UnitListItem: FC<UnitListItemProps> = (props) => {
   const { isHovered, primaryTargetProps, containerProps } =
     useClickableCard<HTMLAnchorElement>(firstItemRef);
 
-  let background: OakColorName = expired ? "oakGreen" : "teachersLilac";
+  let background: OakColorName = expired ? "oakGrey2" : "teachersLilac";
   let backgroundOnHover: OakColorName = "teachersPastelBlue";
 
   // This override is for the units on the early-release units page which use different shades of pink/blue


### PR DESCRIPTION
## Description

- Changes the background colour of expired unit list items

## How to test

1. Go to https://deploy-preview-2015--oak-web-application.netlify.thenational.academy/teachers/programmes/art-secondary-ks3-l/units
2. You should see the expired units have a grey background

## Screenshots

How it used to look (delete if n/a):
<img width="500" alt="Screenshot 2023-10-12 at 14 07 22" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/a835a183-6f63-4ecc-81d2-c1c8fdef28bb">

How it should now look:
<img width="500" alt="Screenshot 2023-10-12 at 14 07 59" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/54bd39ac-0d9a-48e9-90bc-af3de1192b93">

