### PR TITLE
fix: update year for primary science exemplar unit [LESQ-399]

### DIFF
--- a/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
+++ b/src/node-lib/curriculum-api/fixtures/earlyReleaseExemplarUnits.fixture.ts
@@ -159,7 +159,7 @@ const earlyReleaseExemplarUnitsFixture = (
           title: "Growing plants",
           lessonCount: 7,
           keyStageSlug: "ks1",
-          yearTitle: "Year 1",
+          yearTitle: "Year 2",
           keyStageTitle: "Key stage 1",
           subjectTitle: "Science",
           subjectSlug: "science",


### PR DESCRIPTION
## Description

-Change year 1 to year 2 in primary science unit 'Growing Plants'

## How to test

1. Go to https://deploy-preview-2016--oak-web-application.netlify.thenational.academy/teachers/early-release-units
