### PR TITLE
chore: optional rendering of threads title CUR-310

### DIFF
--- a/src/components/CurriculumUnitDetails/CurriculumUnitDetails.tsx
+++ b/src/components/CurriculumUnitDetails/CurriculumUnitDetails.tsx
@@ -43,26 +43,28 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
         {lessonsInUnit}
       </P>
 
-      <Box $mb={[24, 32]}>
-        <Heading tag="h3" $font={"heading-6"} $mb={8}>
-          Threads
-        </Heading>
-        <Flex
-          $flexDirection={["column", "row"]}
-          $flexWrap={"wrap"}
-          $gap={8}
-          $alignItems={"flex-start"}
-        >
-          {uniqueThreadsArray.map((thread) => (
-            <TagFunctional
-              key={thread}
-              text={thread}
-              color={"grey"}
-              data-testid="thread-tag"
-            />
-          ))}
-        </Flex>
-      </Box>
+      {uniqueThreadsArray.length >= 1 && (
+        <Box $mb={[24, 32]}>
+          <Heading tag="h3" $font={"heading-6"} $mb={8}>
+            Threads
+          </Heading>
+          <Flex
+            $flexDirection={["column", "row"]}
+            $flexWrap={"wrap"}
+            $gap={8}
+            $alignItems={"flex-start"}
+          >
+            {uniqueThreadsArray.map((thread) => (
+              <TagFunctional
+                key={thread}
+                text={thread}
+                color={"grey"}
+                data-testid="thread-tag"
+              />
+            ))}
+          </Flex>
+        </Box>
+      )}
       <Flex $flexDirection={"column"}>
         {numberOfLessons >= 1 && (
           <Accordion title="Lessons in unit" lastAccordion={true}>


### PR DESCRIPTION
## Description

- Optionally render threads title when there are no threads i.e. KS3 / 4 Music

## Issue(s)

Fixes #CUR-310

## How to test

1. Go to {owa_deployment_url}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
