### PR TITLE
fix(school-name): refactor the format school name so it doesnt live i…

### DIFF
--- a/src/components/DropdownSelect/ListBox.tsx
+++ b/src/components/DropdownSelect/ListBox.tsx
@@ -10,7 +10,6 @@ import Flex from "../Flex";
 import getColorByLocation from "../../styles/themeHelpers/getColorByLocation";
 import BoxBorders from "../SpriteSheet/BrushSvgs/BoxBorders";
 import { InputFocusUnderline } from "../Input/Input";
-import { formatSchoolName } from "../formatSchoolName";
 
 export type SelectListBoxConfig = {
   states: {
@@ -64,13 +63,11 @@ const ListItem = styled.li<ListItemProps>`
 interface ListBoxProps extends AriaListBoxOptions<unknown> {
   listBoxRef?: React.RefObject<HTMLUListElement>;
   state: ListState<unknown>;
-  inputValue?: string;
 }
 
 interface OptionProps {
   item: Node<unknown>;
   state: ListState<unknown>;
-  inputValue?: string;
 }
 
 interface ListItemProps {
@@ -80,18 +77,13 @@ interface ListItemProps {
 
 export function ListBox(props: ListBoxProps) {
   const ref = useRef<HTMLUListElement>(null);
-  const { listBoxRef = ref, state, inputValue } = props;
+  const { listBoxRef = ref, state } = props;
   const { listBoxProps } = useListBox(props, state, listBoxRef);
 
   return (
     <List {...listBoxProps} ref={listBoxRef}>
       {[...state.collection].map((item) => (
-        <Option
-          key={item.key}
-          item={item}
-          state={state}
-          inputValue={inputValue}
-        />
+        <Option key={item.key} item={item} state={state} />
       ))}
     </List>
   );
@@ -107,7 +99,7 @@ const OptionContext = createContext<OptionContextValue>({
   descriptionProps: {},
 });
 
-function Option({ item, state, inputValue }: OptionProps) {
+function Option({ item, state }: OptionProps) {
   const ref = useRef<HTMLLIElement>(null);
   const { optionProps, labelProps, descriptionProps, isSelected, isFocused } =
     useOption(
@@ -127,9 +119,7 @@ function Option({ item, state, inputValue }: OptionProps) {
     >
       <Flex $position={"relative"} $alignItems={"center"}>
         <OptionContext.Provider value={{ labelProps, descriptionProps }}>
-          {inputValue
-            ? formatSchoolName(item.rendered, inputValue)
-            : item.rendered}
+          {item.rendered}
         </OptionContext.Provider>
         <InputFocusUnderline aria-hidden="true" name={"underline-1"} />
       </Flex>

--- a/src/components/SchoolPicker/SchoolPicker.tsx
+++ b/src/components/SchoolPicker/SchoolPicker.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import { Item } from "react-stately";
 
 import SearchComboBox from "../SearchComboBox/SearchComboBox";
+import { formatSchoolName } from "../formatSchoolName";
 
 import { UseSchoolPickerReturnProps } from "./useSchoolPicker";
 
@@ -33,6 +34,7 @@ export type School = {
  * ## Usage
  * Used on downloads page
  */
+
 const SchoolPicker: FC<SchoolPickerProps> = (props) => {
   return (
     <SearchComboBox
@@ -47,7 +49,13 @@ const SchoolPicker: FC<SchoolPickerProps> = (props) => {
       {(item) => (
         <Item
           key={`${item.urn}-${item.name}`}
-        >{`${item.name}, ${item.la}, ${item.postcode}`}</Item>
+          textValue={`${item.name}, ${item.la}, ${item.postcode}`}
+        >
+          {formatSchoolName(
+            `${item.name}, ${item.la}, ${item.postcode}`,
+            props.schoolPickerInputValue,
+          )}
+        </Item>
       )}
     </SearchComboBox>
   );

--- a/src/components/SearchComboBox/SearchComboBox.tsx
+++ b/src/components/SearchComboBox/SearchComboBox.tsx
@@ -107,12 +107,7 @@ const SearchComboBox = <T extends School>(
           onClose={() => state.close}
           focusOn={false}
         >
-          <ListBox
-            {...listBoxProps}
-            listBoxRef={listBoxRef}
-            state={state}
-            inputValue={inputValue}
-          />
+          <ListBox {...listBoxProps} listBoxRef={listBoxRef} state={state} />
         </Popover>
       )}
     </Flex>


### PR DESCRIPTION
…n generic listbox

## Description

the formatSchoolName was being called in generic listbox component

so i have moved it further up to be called only by the schoolPicker

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on _______
3. You should see _______

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
