### PR TITLE
refactor: move mathjax context to page level - LESQ-400

### DIFF
--- a/src/components/Lesson/LessonOverview/LessonOverview.page.tsx
+++ b/src/components/Lesson/LessonOverview/LessonOverview.page.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from "react";
+import { MathJaxContext } from "better-react-mathjax";
 
 import {
   getCommonPathway,
@@ -120,211 +121,214 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
 
   return (
     <>
-      <HeaderLesson
-        {...lesson}
-        {...commonPathway}
-        breadcrumbs={[
-          ...getBreadcrumbsForLessonPathway(commonPathway),
-          getLessonOverviewBreadCrumb({
-            lessonTitle,
-            lessonSlug,
-            unitSlug,
-            programmeSlug,
-            disabled: true,
-          }),
-        ]}
-        background={"pink30"}
-        subjectIconBackgroundColor={"pink"}
-        track={track}
-        analyticsUseCase={analyticsUseCase}
-        isNew={!isLegacyLicense}
-      />
-      <MaxWidth $ph={16} $pb={80}>
-        {expired ? (
-          <Box $pa={16} $mb={64}>
-            <Heading $font={"heading-7"} tag={"h2"} $mb={16}>
-              No lesson available
-            </Heading>
-            <Typography $font={"body-1"}>
-              Sorry, this lesson no longer exists.
-            </Typography>
-          </Box>
-        ) : (
-          <Grid $mt={[48]}>
-            <GridArea
-              $colSpan={[12, 3]}
-              $alignSelf={"start"}
-              $position={"sticky"}
-              $display={["none", "block"]}
-              $top={96} // FIXME: ideally we'd dynamically calculate this based on the height of the header using the next allowed size. This could be achieved with a new helperFunction get nextAvailableSize
-            >
-              <Flex
-                as="nav"
-                aria-label="page navigation"
-                $flexDirection={"column"}
-                $alignItems={"flex-start"}
-                $gap={[8]}
-                $pr={[16]}
+      <MathJaxContext version={3} src={"/mathjax/tex-mml-chtml.js"}>
+        <HeaderLesson
+          {...lesson}
+          {...commonPathway}
+          breadcrumbs={[
+            ...getBreadcrumbsForLessonPathway(commonPathway),
+            getLessonOverviewBreadCrumb({
+              lessonTitle,
+              lessonSlug,
+              unitSlug,
+              programmeSlug,
+              disabled: true,
+            }),
+          ]}
+          background={"pink30"}
+          subjectIconBackgroundColor={"pink"}
+          track={track}
+          analyticsUseCase={analyticsUseCase}
+          isNew={!isLegacyLicense}
+        />
+        <MaxWidth $ph={16} $pb={80}>
+          {expired ? (
+            <Box $pa={16} $mb={64}>
+              <Heading $font={"heading-7"} tag={"h2"} $mb={16}>
+                No lesson available
+              </Heading>
+              <Typography $font={"body-1"}>
+                Sorry, this lesson no longer exists.
+              </Typography>
+            </Box>
+          ) : (
+            <Grid $mt={[48]}>
+              <GridArea
+                $colSpan={[12, 3]}
+                $alignSelf={"start"}
+                $position={"sticky"}
+                $display={["none", "block"]}
+                $top={96} // FIXME: ideally we'd dynamically calculate this based on the height of the header using the next allowed size. This could be achieved with a new helperFunction get nextAvailableSize
               >
-                <LessonAnchorLinks
-                  links={pageLinks}
-                  currentSectionId={currentSectionId}
-                />
-              </Flex>
-            </GridArea>
-            <GridArea $colSpan={[12, 9]}>
-              <Flex $flexDirection={"column"} $position={"relative"}>
-                {pageLinks.find((p) => p.label === "Slide deck") && (
-                  <LessonItemContainer
-                    ref={slideDeckSectionRef}
-                    title={"Slide deck"}
-                    downloadable={true}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "slide deck",
-                      });
-                    }}
-                    slugs={slugs}
-                    anchorId="slide-deck"
-                  >
-                    <OverviewPresentation
-                      asset={presentationUrl}
-                      title={lessonTitle}
-                      isWorksheet={false}
-                    />
-                  </LessonItemContainer>
-                )}
-
-                <LessonItemContainer
-                  ref={lessonDetailsSectionRef}
-                  title={"Lesson details"}
-                  anchorId="lesson-details"
+                <Flex
+                  as="nav"
+                  aria-label="page navigation"
+                  $flexDirection={"column"}
+                  $alignItems={"flex-start"}
+                  $gap={[8]}
+                  $pr={[16]}
                 >
-                  <LessonDetails
-                    keyLearningPoints={keyLearningPoints}
-                    commonMisconceptions={misconceptionsAndCommonMistakes}
-                    keyWords={lessonKeywords}
-                    teacherTips={teacherTips}
-                    equipmentAndResources={lessonEquipmentAndResources}
-                    contentGuidance={contentGuidance}
-                    supervisionLevel={supervisionLevel}
-                    isLegacyLicense={isLegacyLicense}
+                  <LessonAnchorLinks
+                    links={pageLinks}
+                    currentSectionId={currentSectionId}
                   />
-                </LessonItemContainer>
+                </Flex>
+              </GridArea>
+              <GridArea $colSpan={[12, 9]}>
+                <Flex $flexDirection={"column"} $position={"relative"}>
+                  {pageLinks.find((p) => p.label === "Slide deck") && (
+                    <LessonItemContainer
+                      ref={slideDeckSectionRef}
+                      title={"Slide deck"}
+                      downloadable={true}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "slide deck",
+                        });
+                      }}
+                      slugs={slugs}
+                      anchorId="slide-deck"
+                    >
+                      <OverviewPresentation
+                        asset={presentationUrl}
+                        title={lessonTitle}
+                        isWorksheet={false}
+                      />
+                    </LessonItemContainer>
+                  )}
 
-                {pageLinks.find((p) => p.label === "Video") && (
                   <LessonItemContainer
-                    ref={videoSectionRef}
-                    title={"Video"}
-                    anchorId="video"
-                    isFinalElement={
-                      pageLinks.findIndex((p) => p.label === "Video") ===
-                      pageLinks.length - 1
-                    }
+                    ref={lessonDetailsSectionRef}
+                    title={"Lesson details"}
+                    anchorId="lesson-details"
                   >
-                    <OverviewVideo
-                      video={videoMuxPlaybackId}
-                      signLanguageVideo={videoWithSignLanguageMuxPlaybackId}
-                      title={lessonTitle}
-                      transcriptSentences={transcriptSentences}
-                      isLegacy={isSlugLegacy(
-                        programmeSlug ?? subjectSlug ?? "",
+                    <LessonDetails
+                      keyLearningPoints={keyLearningPoints}
+                      commonMisconceptions={misconceptionsAndCommonMistakes}
+                      keyWords={lessonKeywords}
+                      teacherTips={teacherTips}
+                      equipmentAndResources={lessonEquipmentAndResources}
+                      contentGuidance={contentGuidance}
+                      supervisionLevel={supervisionLevel}
+                      isLegacyLicense={isLegacyLicense}
+                    />
+                  </LessonItemContainer>
+
+                  {pageLinks.find((p) => p.label === "Video") && (
+                    <LessonItemContainer
+                      ref={videoSectionRef}
+                      title={"Video"}
+                      anchorId="video"
+                      isFinalElement={
+                        pageLinks.findIndex((p) => p.label === "Video") ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      <OverviewVideo
+                        video={videoMuxPlaybackId}
+                        signLanguageVideo={videoWithSignLanguageMuxPlaybackId}
+                        title={lessonTitle}
+                        transcriptSentences={transcriptSentences}
+                        isLegacy={isSlugLegacy(
+                          programmeSlug ?? subjectSlug ?? "",
+                        )}
+                      />
+                    </LessonItemContainer>
+                  )}
+                  {pageLinks.find((p) => p.label === "Worksheet") && (
+                    <LessonItemContainer
+                      ref={worksheetSectionRef}
+                      title={"Worksheet"}
+                      anchorId="worksheet"
+                      downloadable={true}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "worksheet",
+                        });
+                      }}
+                      slugs={slugs}
+                      isFinalElement={
+                        pageLinks.findIndex((p) => p.label === "Worksheet") ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      <OverviewPresentation
+                        asset={worksheetUrl}
+                        title={lessonTitle}
+                        isWorksheetLandscape={!!isWorksheetLandscape}
+                        isWorksheet={true}
+                      />
+                    </LessonItemContainer>
+                  )}
+
+                  {pageLinks.find((p) => p.label === "Starter quiz") && (
+                    <LessonItemContainer
+                      ref={starterQuizSectionRef}
+                      title={"Starter quiz"}
+                      anchorId="starter-quiz"
+                      downloadable={true}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "starter quiz",
+                        });
+                      }}
+                      slugs={slugs}
+                      isFinalElement={
+                        pageLinks.findIndex(
+                          (p) => p.label === "Starter quiz",
+                        ) ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      {starterQuiz && (
+                        <QuizContainerNew questions={starterQuiz} />
                       )}
-                    />
-                  </LessonItemContainer>
-                )}
-                {pageLinks.find((p) => p.label === "Worksheet") && (
-                  <LessonItemContainer
-                    ref={worksheetSectionRef}
-                    title={"Worksheet"}
-                    anchorId="worksheet"
-                    downloadable={true}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "worksheet",
-                      });
-                    }}
-                    slugs={slugs}
-                    isFinalElement={
-                      pageLinks.findIndex((p) => p.label === "Worksheet") ===
-                      pageLinks.length - 1
-                    }
-                  >
-                    <OverviewPresentation
-                      asset={worksheetUrl}
-                      title={lessonTitle}
-                      isWorksheetLandscape={!!isWorksheetLandscape}
-                      isWorksheet={true}
-                    />
-                  </LessonItemContainer>
-                )}
-
-                {pageLinks.find((p) => p.label === "Starter quiz") && (
-                  <LessonItemContainer
-                    ref={starterQuizSectionRef}
-                    title={"Starter quiz"}
-                    anchorId="starter-quiz"
-                    downloadable={true}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "starter quiz",
-                      });
-                    }}
-                    slugs={slugs}
-                    isFinalElement={
-                      pageLinks.findIndex((p) => p.label === "Starter quiz") ===
-                      pageLinks.length - 1
-                    }
-                  >
-                    {starterQuiz && (
-                      <QuizContainerNew questions={starterQuiz} />
-                    )}
-                  </LessonItemContainer>
-                )}
-                {pageLinks.find((p) => p.label === "Exit quiz") && (
-                  <LessonItemContainer
-                    ref={exitQuizSectionRef}
-                    title={"Exit quiz"}
-                    anchorId="exit-quiz"
-                    downloadable={true}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "exit quiz",
-                      });
-                    }}
-                    slugs={slugs}
-                    isFinalElement={
-                      pageLinks.findIndex((p) => p.label === "Exit quiz") ===
-                      pageLinks.length - 1
-                    }
-                  >
-                    {exitQuiz && <QuizContainerNew questions={exitQuiz} />}
-                  </LessonItemContainer>
-                )}
-                {pageLinks.find((p) => p.label === "Additional material") && (
-                  <LessonItemContainer
-                    ref={additionalMaterialSectionRef}
-                    title={"Additional material"}
-                    anchorId="additional-material"
-                    downloadable={true}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "additional material",
-                      });
-                    }}
-                    slugs={slugs}
-                    isFinalElement={
-                      pageLinks.findIndex(
-                        (p) => p.label === "Additional material",
-                      ) ===
-                      pageLinks.length - 1
-                    }
-                  >
-                    <Typography $font={"body-1"}>
-                      We're sorry, but preview is not currently available.
-                      Download to see additional material.
-                    </Typography>
-                    {/* 
+                    </LessonItemContainer>
+                  )}
+                  {pageLinks.find((p) => p.label === "Exit quiz") && (
+                    <LessonItemContainer
+                      ref={exitQuizSectionRef}
+                      title={"Exit quiz"}
+                      anchorId="exit-quiz"
+                      downloadable={true}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "exit quiz",
+                        });
+                      }}
+                      slugs={slugs}
+                      isFinalElement={
+                        pageLinks.findIndex((p) => p.label === "Exit quiz") ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      {exitQuiz && <QuizContainerNew questions={exitQuiz} />}
+                    </LessonItemContainer>
+                  )}
+                  {pageLinks.find((p) => p.label === "Additional material") && (
+                    <LessonItemContainer
+                      ref={additionalMaterialSectionRef}
+                      title={"Additional material"}
+                      anchorId="additional-material"
+                      downloadable={true}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "additional material",
+                        });
+                      }}
+                      slugs={slugs}
+                      isFinalElement={
+                        pageLinks.findIndex(
+                          (p) => p.label === "Additional material",
+                        ) ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      <Typography $font={"body-1"}>
+                        We're sorry, but preview is not currently available.
+                        Download to see additional material.
+                      </Typography>
+                      {/* 
                     Temporary fix for additional material due to unexpected poor rendering of google docs
                     <OverviewPresentation
                       asset={additionalMaterialUrl}
@@ -333,13 +337,14 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                       isWorksheetLandscape={isWorksheetLandscape}
                       isWorksheet={true}
                     /> */}
-                  </LessonItemContainer>
-                )}
-              </Flex>
-            </GridArea>
-          </Grid>
-        )}
-      </MaxWidth>
+                    </LessonItemContainer>
+                  )}
+                </Flex>
+              </GridArea>
+            </Grid>
+          )}
+        </MaxWidth>
+      </MathJaxContext>
     </>
   );
 }

--- a/src/components/QuizContainerNew/QuestionsListNew/QuestionsList.tsx
+++ b/src/components/QuizContainerNew/QuestionsListNew/QuestionsList.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import { MathJaxContext } from "better-react-mathjax";
 
 import { QuizProps } from "../QuizContainerNew";
 
@@ -20,19 +19,18 @@ const QuestionsList: FC<QuizQuestionListProps> = (props) => {
       <Heading $font={"heading-5"} tag={"h3"}>
         {questionCount} Questions
       </Heading>
-      <MathJaxContext version={3} src={"/mathjax/tex-mml-chtml.js"}>
-        <Flex $flexDirection={"column"} $gap={56} role="list">
-          {questions.map((question, i) => {
-            return (
-              <QuestionListItem
-                key={`QuestionsList-UL-QuestionListItem-${i}`}
-                question={question}
-                index={i}
-              />
-            );
-          })}
-        </Flex>
-      </MathJaxContext>
+
+      <Flex $flexDirection={"column"} $gap={56} role="list">
+        {questions.map((question, i) => {
+          return (
+            <QuestionListItem
+              key={`QuestionsList-UL-QuestionListItem-${i}`}
+              question={question}
+              index={i}
+            />
+          );
+        })}
+      </Flex>
     </MaxWidth>
   );
 };


### PR DESCRIPTION
## Description

- Moves mathjax provider to lesson level
- Mathjax should still render quizes
- No errors in console

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2020--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-higher/units/surds/lessons/simplifying-surds#starter-quiz
Quizzes still show mathjax

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
