### PR TITLE
Feat/lesq 417/integrate sanity fields [LESQ-417]

### DIFF
--- a/src/__tests__/pages/lesson-planning.test.tsx
+++ b/src/__tests__/pages/lesson-planning.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 
 import PlanALesson from "../../pages/lesson-planning";
-import { PlanningPage } from "../../common-lib/cms-types";
+import { CTA, PlanningPage } from "../../common-lib/cms-types";
 import renderWithProviders from "../__helpers__/renderWithProviders";
 import {
   mockImageAsset,
@@ -76,6 +76,12 @@ const testPlanningPageData: PlanningPage = {
   seo: mockSeo(),
 };
 
+const testInternalLessonElementsCta: CTA = {
+  linkType: "internal",
+  label: "internal cta",
+  internal: { contentType: "aboutCorePage.whoWeAre", id: "1" },
+};
+
 const getPageData = jest.fn(() => testPlanningPageData);
 
 const render = renderWithProviders();
@@ -133,6 +139,69 @@ describe("pages/lesson-planning.tsx", () => {
       expect(propsResult).toMatchObject({
         notFound: true,
       });
+    });
+  });
+
+  describe("CTA links", () => {
+    it.todo("should use pageData for the search CTA");
+    it("should use pageData for lesson elements CTA", () => {
+      render(<PlanALesson pageData={testPlanningPageData} />);
+      const lessonElementsCta = screen.getAllByRole("link", {
+        name: testPlanningPageData.lessonElementsCTA.label,
+      });
+      const externalLink =
+        testPlanningPageData.lessonElementsCTA.linkType === "external"
+          ? testPlanningPageData.lessonElementsCTA.external
+          : null;
+      if (!externalLink) {
+        throw new Error("This should never happen - check the test data");
+      }
+      expect(lessonElementsCta[0]).toHaveAttribute("href", externalLink);
+    });
+    it("should open external links in a new tab", () => {
+      render(<PlanALesson pageData={testPlanningPageData} />);
+      const lessonElementsCta = screen.getAllByRole("link", {
+        name: testPlanningPageData.lessonElementsCTA.label,
+      });
+      const externalLink =
+        testPlanningPageData.lessonElementsCTA.linkType === "external"
+          ? testPlanningPageData.lessonElementsCTA.external
+          : null;
+      if (!externalLink) {
+        throw new Error("This should never happen - check the test data");
+      }
+      expect(lessonElementsCta[0]).toHaveAttribute("target", "_blank");
+    });
+    it("should link to internal pages", () => {
+      render(
+        <PlanALesson
+          pageData={{
+            ...testPlanningPageData,
+            lessonElementsCTA: testInternalLessonElementsCta,
+          }}
+        />,
+      );
+      const lessonElementsCta = screen.getAllByRole("link", {
+        name: testInternalLessonElementsCta.label,
+      });
+      expect(lessonElementsCta[0]).toHaveAttribute(
+        "href",
+        "/about-us/who-we-are",
+      );
+    });
+    it("should open internal pages in the same tab", () => {
+      render(
+        <PlanALesson
+          pageData={{
+            ...testPlanningPageData,
+            lessonElementsCTA: testInternalLessonElementsCta,
+          }}
+        />,
+      );
+      const lessonElementsCta = screen.getAllByRole("link", {
+        name: testInternalLessonElementsCta.label,
+      });
+      expect(lessonElementsCta[0]).not.toHaveAttribute("target", "_blank");
     });
   });
 });

--- a/src/__tests__/pages/lesson-planning.test.tsx
+++ b/src/__tests__/pages/lesson-planning.test.tsx
@@ -143,7 +143,13 @@ describe("pages/lesson-planning.tsx", () => {
   });
 
   describe("CTA links", () => {
-    it.todo("should use pageData for the search CTA");
+    it("should use pageData for the search CTA", () => {
+      render(<PlanALesson pageData={testPlanningPageData} />);
+      const searchCta = screen.getByRole("link", {
+        name: "Search our lessons",
+      });
+      expect(searchCta).toHaveAttribute("href", "/");
+    });
     it("should use pageData for lesson elements CTA", () => {
       render(<PlanALesson pageData={testPlanningPageData} />);
       const lessonElementsCta = screen.getAllByRole("link", {

--- a/src/__tests__/pages/lesson-planning.test.tsx
+++ b/src/__tests__/pages/lesson-planning.test.tsx
@@ -164,20 +164,6 @@ describe("pages/lesson-planning.tsx", () => {
       }
       expect(lessonElementsCta[0]).toHaveAttribute("href", externalLink);
     });
-    it("should open external links in a new tab", () => {
-      render(<PlanALesson pageData={testPlanningPageData} />);
-      const lessonElementsCta = screen.getAllByRole("link", {
-        name: testPlanningPageData.lessonElementsCTA.label,
-      });
-      const externalLink =
-        testPlanningPageData.lessonElementsCTA.linkType === "external"
-          ? testPlanningPageData.lessonElementsCTA.external
-          : null;
-      if (!externalLink) {
-        throw new Error("This should never happen - check the test data");
-      }
-      expect(lessonElementsCta[0]).toHaveAttribute("target", "_blank");
-    });
     it("should link to internal pages", () => {
       render(
         <PlanALesson
@@ -195,7 +181,7 @@ describe("pages/lesson-planning.tsx", () => {
         "/about-us/who-we-are",
       );
     });
-    it("should open internal pages in the same tab", () => {
+    it("should open links in the same tab", () => {
       render(
         <PlanALesson
           pageData={{

--- a/src/__tests__/pages/lesson-planning.test.tsx
+++ b/src/__tests__/pages/lesson-planning.test.tsx
@@ -146,7 +146,7 @@ describe("pages/lesson-planning.tsx", () => {
     it("should use pageData for the search CTA", () => {
       render(<PlanALesson pageData={testPlanningPageData} />);
       const searchCta = screen.getByRole("link", {
-        name: "Search our lessons",
+        name: testPlanningPageData.stepsCTA.label,
       });
       expect(searchCta).toHaveAttribute("href", "/");
     });

--- a/src/components/Sanity/TextBlock/TextBlockCardImageCta.tsx
+++ b/src/components/Sanity/TextBlock/TextBlockCardImageCta.tsx
@@ -60,6 +60,7 @@ const TextBlockCardImageCta: FC<
               label={cta.label}
               icon={"arrow-right"}
               $iconPosition={"trailing"}
+              htmlAnchorProps={{ target: "_self" }}
               // @TODO: This link is dynamic, not always a support link
               // so we may not always want to open it in a new tab
               // See owa issue #619

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -179,10 +179,6 @@ const generateCtaProps = (cta: CTA) => {
 };
 
 const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
-  const lessonElementsCta = generateCtaProps(pageData.lessonElementsCTA);
-
-  const searchCta = generateCtaProps(pageData.stepsCTA);
-
   return (
     <Layout seoProps={getSeoProps(pageData.seo)} $background={"white"}>
       <MaxWidth $pt={[72, 80, 80]}>
@@ -279,7 +275,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                   icon="search"
                   $iconPosition="trailing"
                   label={pageData.lessonElementsCTA.label}
-                  {...lessonElementsCta}
+                  {...generateCtaProps(pageData.lessonElementsCTA)}
                 />
               </Card>
             </GridArea>
@@ -347,7 +343,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                               $iconPosition="trailing"
                               $mt={24}
                               label={"Search our lessons"}
-                              {...searchCta}
+                              {...generateCtaProps(pageData.stepsCTA)}
                             />
                           </Flex>
                         )}
@@ -466,7 +462,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                 icon="search"
                 $iconPosition="trailing"
                 label={pageData.lessonElementsCTA.label}
-                {...lessonElementsCta}
+                {...generateCtaProps(pageData.lessonElementsCTA)}
               />
             </Card>
           </Card>

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -3,7 +3,7 @@ import { NextPage, GetStaticProps, GetStaticPropsResult } from "next";
 import { PortableText } from "@portabletext/react";
 
 import CMSClient from "../node-lib/cms";
-import { PlanningPage, PortableTextJSON } from "../common-lib/cms-types";
+import { CTA, PlanningPage, PortableTextJSON } from "../common-lib/cms-types";
 import Card, { CardProps } from "../components/Card";
 import Flex from "../components/Flex";
 import Grid, { GridArea } from "../components/Grid";
@@ -165,17 +165,23 @@ const LessonElementsCard: FC<CardProps> = (props) => (
   />
 );
 
-const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
-  const lessonElementsCta = {
+const generateCtaProps = (cta: CTA) => {
+  return {
     page: null,
-    href: getLinkHref(pageData.lessonElementsCTA),
+    href: getLinkHref(cta),
     htmlAnchorProps:
-      pageData.lessonElementsCTA.linkType === "external"
+      cta.linkType === "external"
         ? {
             target: "_blank",
           }
         : undefined,
   };
+};
+
+const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
+  const lessonElementsCta = generateCtaProps(pageData.lessonElementsCTA);
+
+  const searchCta = generateCtaProps(pageData.stepsCTA);
 
   return (
     <Layout seoProps={getSeoProps(pageData.seo)} $background={"white"}>
@@ -341,10 +347,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                               $iconPosition="trailing"
                               $mt={24}
                               label={"Search our lessons"}
-                              page="teacher-hub" // TODO: integrate sanity link
-                              htmlAnchorProps={{
-                                target: "_blank",
-                              }}
+                              {...searchCta}
                             />
                           </Flex>
                         )}

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -28,7 +28,7 @@ import { IllustrationSlug } from "../image-data";
 import { getSizes } from "../components/CMSImage/getSizes";
 import getPageProps from "../node-lib/getPageProps";
 
-import { resolveInternalHref } from "@/utils/portableText/resolveInternalHref";
+import { getLinkHref } from "@/utils/portableText/resolveInternalHref";
 
 export type PlanALessonProps = {
   pageData: PlanningPage;
@@ -166,21 +166,16 @@ const LessonElementsCard: FC<CardProps> = (props) => (
 );
 
 const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
-  const lessonElementsCta =
-    pageData.lessonElementsCTA.linkType === "internal"
-      ? {
-          href: resolveInternalHref(pageData.lessonElementsCTA.internal),
-          page: null,
-        }
-      : pageData.lessonElementsCTA.linkType === "external"
-      ? {
-          page: null,
-          href: pageData.lessonElementsCTA.external,
-          htmlAnchorProps: {
+  const lessonElementsCta = {
+    page: null,
+    href: getLinkHref(pageData.lessonElementsCTA),
+    htmlAnchorProps:
+      pageData.lessonElementsCTA.linkType === "external"
+        ? {
             target: "_blank",
-          },
-        }
-      : { page: "teacher-hub" as const }; // fallback
+          }
+        : undefined,
+  };
 
   return (
     <Layout seoProps={getSeoProps(pageData.seo)} $background={"white"}>

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -170,12 +170,9 @@ const generateCtaProps = (cta: CTA) => {
     page: null,
     href: getLinkHref(cta),
     label: cta.label,
-    htmlAnchorProps:
-      cta.linkType === "external"
-        ? {
-            target: "_blank",
-          }
-        : undefined,
+    htmlAnchorProps: {
+      target: "_self",
+    },
   };
 };
 

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -169,6 +169,7 @@ const generateCtaProps = (cta: CTA) => {
   return {
     page: null,
     href: getLinkHref(cta),
+    label: cta.label,
     htmlAnchorProps:
       cta.linkType === "external"
         ? {
@@ -274,7 +275,6 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                 <ButtonAsLink
                   icon="search"
                   $iconPosition="trailing"
-                  label={pageData.lessonElementsCTA.label}
                   {...generateCtaProps(pageData.lessonElementsCTA)}
                 />
               </Card>
@@ -342,7 +342,6 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                               icon="search"
                               $iconPosition="trailing"
                               $mt={24}
-                              label={"Search our lessons"}
                               {...generateCtaProps(pageData.stepsCTA)}
                             />
                           </Flex>
@@ -461,7 +460,6 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
               <ButtonAsLink
                 icon="search"
                 $iconPosition="trailing"
-                label={pageData.lessonElementsCTA.label}
                 {...generateCtaProps(pageData.lessonElementsCTA)}
               />
             </Card>

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -28,6 +28,8 @@ import { IllustrationSlug } from "../image-data";
 import { getSizes } from "../components/CMSImage/getSizes";
 import getPageProps from "../node-lib/getPageProps";
 
+import { resolveInternalHref } from "@/utils/portableText/resolveInternalHref";
+
 export type PlanALessonProps = {
   pageData: PlanningPage;
 };
@@ -164,6 +166,22 @@ const LessonElementsCard: FC<CardProps> = (props) => (
 );
 
 const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
+  const lessonElementsCta =
+    pageData.lessonElementsCTA.linkType === "internal"
+      ? {
+          href: resolveInternalHref(pageData.lessonElementsCTA.internal),
+          page: null,
+        }
+      : pageData.lessonElementsCTA.linkType === "external"
+      ? {
+          page: null,
+          href: pageData.lessonElementsCTA.external,
+          htmlAnchorProps: {
+            target: "_blank",
+          },
+        }
+      : { page: "teacher-hub" as const }; // fallback
+
   return (
     <Layout seoProps={getSeoProps(pageData.seo)} $background={"white"}>
       <MaxWidth $pt={[72, 80, 80]}>
@@ -260,10 +278,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                   icon="search"
                   $iconPosition="trailing"
                   label={pageData.lessonElementsCTA.label}
-                  page="teacher-hub"
-                  htmlAnchorProps={{
-                    target: "_blank",
-                  }}
+                  {...lessonElementsCta}
                 />
               </Card>
             </GridArea>
@@ -331,7 +346,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                               $iconPosition="trailing"
                               $mt={24}
                               label={"Search our lessons"}
-                              page="teacher-hub"
+                              page="teacher-hub" // TODO: integrate sanity link
                               htmlAnchorProps={{
                                 target: "_blank",
                               }}
@@ -453,10 +468,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
                 icon="search"
                 $iconPosition="trailing"
                 label={pageData.lessonElementsCTA.label}
-                page="teacher-hub"
-                htmlAnchorProps={{
-                  target: "_blank",
-                }}
+                {...lessonElementsCta}
               />
             </Card>
           </Card>

--- a/src/pages/support-your-team.tsx
+++ b/src/pages/support-your-team.tsx
@@ -66,7 +66,7 @@ const Support: NextPage<SupportPageProps> = ({ pageData }) => {
           <ButtonAsLink
             $mt={32}
             $mb={92}
-            page={"teacher-hub"}
+            page={"home"}
             label={"Search our lessons"}
             icon={"arrow-right"}
             $iconPosition={"trailing"}
@@ -124,7 +124,7 @@ const Support: NextPage<SupportPageProps> = ({ pageData }) => {
             <ButtonAsLink
               $mt={32}
               $mb={92}
-              page={"teacher-hub"}
+              page={"home"}
               label={"Search our lessons"}
               icon={"arrow-right"}
               $iconPosition={"trailing"}


### PR DESCRIPTION
## Description

- use CTAs from the data that is passed in on the lesson planning page
- update the link for the search cta on support your team page to the new home

## Issue(s)

Fixes #
Unable to update links via Sanity CMS

## How to test

1. Go to https://deploy-preview-2036--oak-web-application.netlify.thenational.academy/lesson-planning
2. Click on "Find teaching resources" or any CTA
3. You should see the link goes to the location defined in Sanity

## Checklist
- [ ]  Sanity users can change links in CTA buttons on our core pages
- [ ]  When changes are published in Sanity, the changes to the links and button copy are pulled through on the front end
