### PR TITLE
fix: only report video error if type is not networkError [LESQ-423]

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -131,7 +131,13 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
       originalError,
       meta: metadata,
     });
-    reportError(error, { ...getState() });
+
+    // Don't report network errors
+    const networkError =
+      (evt as CustomEvent).detail?.data?.type === "networkError";
+    if (!networkError) {
+      reportError(error, { ...getState() });
+    }
   };
 
   if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## Description

- check the type of error being caught in the video `onError` callback and only report the error if it's not a network error

## Issue(s)

Fixes #
https://www.notion.so/oaknationalacademy/BugSnag-Report-VideoPlayer-network-error-e87be21fbb884fe6bf8373511a8fc17b?pvs=4 

## How to test

This is a bit finicky

1. Go to https://deploy-preview-2038--oak-web-application.netlify.thenational.academy and navigate to any lesson with a video
2. Go to the network tab and look for the video requests, they'll start with something like `0.vtt?skid=default...`
3. Right click and select 'Block Request Domain'
4. Now reload the page and try to play the video, if the correct domain was blocked the video should not play, and there should _not_ be a bugnsag report in the console that looks like this: 
<img width="503" alt="Screenshot 2023-10-19 at 14 54 07" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/803b6372-b1d9-4f9b-99de-3290b3adb19b">. 
5. Don't forget to unblock the domain afterwards lest your videos never play again

