### PR TITLE
Feat/lesq 404/streamlined select all [LESQ-404]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -258,14 +258,15 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       expect(exitQuizAnswers).toBeChecked();
     });
 
-    it.skip("should deselect all resources if user deselects 'Select all'", async () => {
-      const { getByTestId, getByText } = render(
+    it("should deselect all resources if user deselects 'Select all'", async () => {
+      const { getByTestId, getByRole } = render(
         <LessonDownloadsPage {...props} />,
       );
 
-      const deselectAllButton = getByText("Deselect all");
+      const selectAllCheckbox = getByRole("checkbox", { name: "Select all" });
       const user = userEvent.setup();
-      await user.click(deselectAllButton);
+      await user.click(selectAllCheckbox);
+      await user.click(selectAllCheckbox);
 
       const selectedResourcesCount = getByTestId("selectedResourcesCount");
       expect(selectedResourcesCount).toHaveTextContent("0/2 files selected");

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -238,14 +238,15 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       expect(selectedResourcesCount).toHaveTextContent("1/2 files selected");
     });
 
-    it("should select all resources if user clicks 'Select all'", async () => {
-      const { getByTestId, getByText } = render(
+    it("should select all resources if user checks 'Select all'", async () => {
+      const { getByTestId, getByRole } = render(
         <LessonDownloadsPage {...props} />,
       );
 
-      const selectAllButton = getByText("Select all");
+      const selectAllCheckbox = getByRole("checkbox", { name: "Select all" });
       const user = userEvent.setup();
-      await user.click(selectAllButton);
+      await user.click(selectAllCheckbox);
+      expect(selectAllCheckbox).toBeChecked();
 
       const selectedResourcesCount = getByTestId("selectedResourcesCount");
       expect(selectedResourcesCount).toHaveTextContent("2/2 files selected");
@@ -257,7 +258,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       expect(exitQuizAnswers).toBeChecked();
     });
 
-    it("should deselect all resources if user clicks 'Deselect all'", async () => {
+    it.skip("should deselect all resources if user deselects 'Select all'", async () => {
       const { getByTestId, getByText } = render(
         <LessonDownloadsPage {...props} />,
       );

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -80,13 +80,10 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
     const { getByText } = render(<LessonDownloadsPage {...props} />);
 
     await act(async () => {
-      const selectAllButton = getByText("Select all");
       const downloadButton = getByText("Download .zip");
       const user = userEvent.setup();
-      await user.click(selectAllButton);
       await waitForNextTick();
 
-      console.log(downloadButton);
       await user.click(downloadButton);
       await waitForNextTick();
     });
@@ -244,8 +241,6 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       );
 
       const selectAllCheckbox = getByRole("checkbox", { name: "Select all" });
-      const user = userEvent.setup();
-      await user.click(selectAllCheckbox);
       expect(selectAllCheckbox).toBeChecked();
 
       const selectedResourcesCount = getByTestId("selectedResourcesCount");
@@ -265,7 +260,6 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
 
       const selectAllCheckbox = getByRole("checkbox", { name: "Select all" });
       const user = userEvent.setup();
-      await user.click(selectAllCheckbox);
       await user.click(selectAllCheckbox);
 
       const selectedResourcesCount = getByTestId("selectedResourcesCount");

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -225,7 +225,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       expect(selectedResourcesCount).toHaveTextContent("2/2 files selected");
     });
 
-    it.skip("should display correct count of selected and all downloadable resources if some resources are selected", async () => {
+    it("should display correct count of selected and all downloadable resources if some resources are selected", async () => {
       const { getByTestId, getByLabelText } = render(
         <LessonDownloadsPage {...props} />,
       );

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -181,7 +181,7 @@ describe("Checkbox", () => {
         id="unique-123"
         checked
         onChange={jest.fn()}
-        variant="cardCheckbox"
+        variant="withoutLabel"
       >
         <p>Test download resource</p>
       </Checkbox>,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -21,7 +21,7 @@ export type CheckboxConfig = {
   };
 };
 
-export type CheckboxVariant = "cardCheckbox" | "terms";
+export type CheckboxVariant = "withoutLabel" | "withLabel";
 
 export type CheckboxProps = {
   labelText?: string;
@@ -108,7 +108,7 @@ const checkboxHoverStyles = css`
 const CheckboxLabel = styled.label<CheckboxLabelProps>`
   position: relative;
   display: ${(props) =>
-    props.variant !== "cardCheckbox" ? "flex" : "initial"};
+    props.variant !== "withoutLabel" ? "flex" : "initial"};
   align-items: center;
   margin-bottom: 16px;
   cursor: ${(props) => !props.disabled && "pointer"};
@@ -196,17 +196,17 @@ const Checkbox: FC<CheckboxProps> = (props) => {
           hasError={hasError}
         />
         {/* card checkbox */}
-        {!labelText && variant === "cardCheckbox" && children}
+        {!labelText && variant === "withoutLabel" && children}
         {/* basic label checkbox */}
 
-        {labelText && variant !== "cardCheckbox" && (
+        {labelText && variant !== "withoutLabel" && (
           <>
             <CheckboxLabelText>{labelText}</CheckboxLabelText>{" "}
             <FocusUnderline $color={"teachersYellow"} />
           </>
         )}
       </CheckboxLabel>
-      {variant !== "terms" && (
+      {variant !== "withLabel" && (
         <FieldError id={errorId} withoutMarginBottom>
           {error}
         </FieldError>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -38,6 +38,7 @@ export type CheckboxProps = {
   inputRef?: RefCallBack;
   onBlur?: () => void;
   hasError?: boolean;
+  labelFontWeight?: 400 | 600;
 } & SpacingProps;
 
 type CheckboxLabelProps = {
@@ -138,10 +139,10 @@ const ScreenReaderCheckbox = styled.input.attrs({ type: "checkbox" })<{
   opacity: 0;
 `;
 
-const CheckboxLabelText = styled.span`
+const CheckboxLabelText = styled.span<{ fontWeight: 400 | 600 }>`
   margin-left: 8px;
   margin-right: 16px;
-  font-weight: 400;
+  font-weight: ${(props) => props.fontWeight};
 `;
 
 const Checkbox: FC<CheckboxProps> = (props) => {
@@ -160,6 +161,7 @@ const Checkbox: FC<CheckboxProps> = (props) => {
     variant,
     inputRef,
     onBlur,
+    labelFontWeight,
     ...spacingProps
   } = props;
 
@@ -201,7 +203,9 @@ const Checkbox: FC<CheckboxProps> = (props) => {
 
         {labelText && variant !== "withoutLabel" && (
           <>
-            <CheckboxLabelText>{labelText}</CheckboxLabelText>{" "}
+            <CheckboxLabelText fontWeight={labelFontWeight ?? 400}>
+              {labelText}
+            </CheckboxLabelText>{" "}
             <FocusUnderline $color={"teachersYellow"} />
           </>
         )}

--- a/src/components/Checkbox/VisualCheckbox.tsx
+++ b/src/components/Checkbox/VisualCheckbox.tsx
@@ -31,9 +31,9 @@ const getBorderColor = (props: VisualCheckboxProps) => {
 
 const VisualCheckboxWrapper = styled.span<VisualCheckboxWrapper>`
   position: ${(props) =>
-    props?.variant === "cardCheckbox" ? "absolute" : "relative"};
-  left: ${(props) => (props?.variant === "cardCheckbox" ? "12px" : "initial")};
-  top: ${(props) => (props?.variant === "cardCheckbox" ? "12px" : "initial")};
+    props?.variant === "withoutLabel" ? "absolute" : "relative"};
+  left: ${(props) => (props?.variant === "withoutLabel" ? "12px" : "initial")};
+  top: ${(props) => (props?.variant === "withoutLabel" ? "12px" : "initial")};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/DownloadComponents/DownloadCard/DownloadCard.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCard.tsx
@@ -103,7 +103,7 @@ const DownloadCard: FC<DownloadCardProps> = (props) => {
         name={name}
         checked={checked}
         onChange={onChange}
-        variant={"cardCheckbox"}
+        variant={"withoutLabel"}
         ariaLabel={label}
         onBlur={onBlur}
         hasError={hasError}

--- a/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.test.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";
+import userEvent from "@testing-library/user-event";
 
 import renderWithTheme from "../../../__tests__/__helpers__/renderWithTheme";
 import { DownloadFormProps } from "../downloads.types";
@@ -8,8 +9,9 @@ import DownloadCardGroup from "./DownloadCardGroup";
 
 const selectAll = jest.fn;
 const deselectAll = jest.fn;
+
 describe("DownloadCardGroup", () => {
-  it("renders a select all checkbox", () => {
+  it("renders a toggleable select all checkbox", async () => {
     const { result } = renderHook(() => useForm<DownloadFormProps>());
     renderWithTheme(
       <DownloadCardGroup
@@ -26,5 +28,9 @@ describe("DownloadCardGroup", () => {
 
     expect(selectAllCheckbox).toBeInTheDocument();
     expect(selectAllCheckbox).toBeChecked();
+
+    const user = userEvent.setup();
+    await user.click(selectAllCheckbox);
+    expect(selectAllCheckbox).not.toBeChecked();
   });
 });

--- a/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.test.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+
+import renderWithTheme from "../../../__tests__/__helpers__/renderWithTheme";
+import { DownloadFormProps } from "../downloads.types";
+
+import DownloadCardGroup from "./DownloadCardGroup";
+
+const selectAll = jest.fn;
+const deselectAll = jest.fn;
+describe("DownloadCardGroup", () => {
+  it("renders a select all checkbox", () => {
+    const { result } = renderHook(() => useForm<DownloadFormProps>());
+    renderWithTheme(
+      <DownloadCardGroup
+        control={result.current.control}
+        onSelectAllClick={selectAll}
+        onDeselectAllClick={deselectAll}
+        preselectAll={true}
+      />,
+    );
+
+    const selectAllCheckbox = screen.getByRole("checkbox", {
+      name: "Select all",
+    });
+
+    expect(selectAllCheckbox).toBeInTheDocument();
+    expect(selectAllCheckbox).toBeChecked();
+  });
+});

--- a/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from "react";
+import React, { ChangeEvent, FC, useState } from "react";
 import { Control, Controller } from "react-hook-form";
 
 import type {
@@ -12,9 +12,8 @@ import { LessonDownloadsData } from "@/node-lib/curriculum-api";
 import { GridArea } from "@/components/Grid";
 import Flex from "@/components/Flex";
 import { Heading } from "@/components/Typography";
-import Box from "@/components/Box";
-import Button from "@/components/Button";
 import FieldError from "@/components/FormFields/FieldError";
+import Checkbox from "@/components/Checkbox";
 
 type DownloadCardGroupProps = {
   downloads?: LessonDownloadsData["downloads"];
@@ -23,6 +22,7 @@ type DownloadCardGroupProps = {
   errorMessage?: string;
   onSelectAllClick: () => void;
   onDeselectAllClick: () => void;
+  preselectAll: boolean;
 };
 
 const DownloadCardGroup: FC<DownloadCardGroupProps> = ({
@@ -32,7 +32,19 @@ const DownloadCardGroup: FC<DownloadCardGroupProps> = ({
   errorMessage,
   onSelectAllClick,
   onDeselectAllClick,
+  preselectAll,
 }) => {
+  const [selectAllChecked, setSelectAllChecked] = useState(preselectAll);
+  const handleToggleSelectAll = () => {
+    if (selectAllChecked) {
+      onDeselectAllClick();
+      setSelectAllChecked(false);
+    } else {
+      onSelectAllClick();
+      setSelectAllChecked(true);
+    }
+  };
+
   return (
     <>
       <GridArea $colSpan={[12]}>
@@ -44,19 +56,14 @@ const DownloadCardGroup: FC<DownloadCardGroupProps> = ({
           <Heading tag="h2" $font={"heading-5"} $mb={[16, 8]}>
             Lesson resources
           </Heading>
-          <Box $ml={[0, 48]}>
-            <Button
-              label="Select all"
-              variant="minimal"
-              onClick={() => onSelectAllClick()}
-            />
-            <Button
-              label="Deselect all"
-              variant="minimal"
-              onClick={() => onDeselectAllClick()}
-              $ml={24}
-            />
-          </Box>
+          <Checkbox
+            checked={selectAllChecked}
+            onChange={handleToggleSelectAll}
+            id="select-all"
+            name="select-all"
+            variant="withLabel"
+            labelText="Select all"
+          />
         </Flex>
         <FieldError id={"downloads-error"}>{errorMessage}</FieldError>
       </GridArea>

--- a/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, useState } from "react";
+import React, { ChangeEvent, FC, useEffect, useState } from "react";
 import { Control, Controller } from "react-hook-form";
 
 import type {
@@ -34,7 +34,14 @@ const DownloadCardGroup: FC<DownloadCardGroupProps> = ({
   onDeselectAllClick,
   preselectAll,
 }) => {
-  const [selectAllChecked, setSelectAllChecked] = useState(preselectAll);
+  const [selectAllChecked, setSelectAllChecked] = useState(false);
+
+  useEffect(() => {
+    if (preselectAll) {
+      setSelectAllChecked(true);
+    }
+  }, [preselectAll]);
+
   const handleToggleSelectAll = () => {
     if (selectAllChecked) {
       onDeselectAllClick();

--- a/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
+++ b/src/components/DownloadComponents/DownloadCard/DownloadCardGroup.tsx
@@ -63,6 +63,7 @@ const DownloadCardGroup: FC<DownloadCardGroupProps> = ({
             name="select-all"
             variant="withLabel"
             labelText="Select all"
+            labelFontWeight={600}
           />
         </Flex>
         <FieldError id={"downloads-error"}>{errorMessage}</FieldError>

--- a/src/components/DownloadComponents/TermsAndConditionsCheckbox/TermsAndConditionsCheckbox.tsx
+++ b/src/components/DownloadComponents/TermsAndConditionsCheckbox/TermsAndConditionsCheckbox.tsx
@@ -34,7 +34,7 @@ const TermsAndConditionsCheckbox: FC<TermsAndConditionsCheckboxProps> = ({
         required
         error={errorMessage}
         hasError={Boolean(errorMessage)}
-        variant="terms"
+        variant="withLabel"
         {...props}
       />
     </Box>

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -95,6 +95,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
       resolver: zodResolver(schema),
       mode: "onBlur",
     });
+  const [preselectAll, setPreselectAll] = useState(false);
 
   const getInitialResourcesToDownloadState = useCallback(() => {
     return downloads
@@ -115,6 +116,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     const preselected = getPreselectedDownloadResourceTypes(preselectedQuery());
 
     if (preselected) {
+      setPreselectAll(preselected === "all");
       preselected === "all"
         ? setValue("downloads", getInitialResourcesToDownloadState())
         : setValue("downloads", preselected);
@@ -416,6 +418,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
                 errorMessage={errors?.downloads?.message}
                 onSelectAllClick={() => onSelectAllClick()}
                 onDeselectAllClick={() => onDeselectAllClick()}
+                preselectAll={preselectAll}
               />
 
               <GridArea $colSpan={[12]}>


### PR DESCRIPTION
## Description

- Remove the select all and deselect all buttons
- Replace with a Checkbox that respects preselections
- Update Checkbox component to accept optional fontWeight param
- Refactor Checkbox variants to be more descriptive

## How to test

1. Go to {owa_deployment_url}/teachers/programmes/chemistry-secondary-ks4-l/units/atomic-structure-and-the-periodic-table-u68nqqc/lessons/atoms-elements-and-compounds-h3hasv/downloads
2. Click on Select all
3. You should see the downloads becoming deselected/selected along with the select all checkbox

## Screenshots

How it used to look (delete if n/a):
<img width="500" alt="Screenshot 2023-10-23 at 14 55 58" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/e7895d1b-cbaf-45a4-8b44-6af6b847895e">


How it should now look:
<img width="500" alt="Screenshot 2023-10-23 at 14 55 35" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/95ebfc56-28f6-4f1f-a180-bdd4fd50ac21">


## ACs
- [ ]  Go to the single checkbox for select all (instead of the two buttons)
- [ ]  tick to select all
- [ ]  tick again to de-select all
- [ ]  Copy ‘Select all’ stays the same