### PR TITLE
fix: only allow mathjax on client LESQ-422

### DIFF
--- a/src/browser-lib/mathjax/MathJaxProvider.tsx
+++ b/src/browser-lib/mathjax/MathJaxProvider.tsx
@@ -2,8 +2,14 @@
 import React, { PropsWithChildren } from "react";
 import { MathJaxContext } from "better-react-mathjax";
 
-const MathJaxProvider = ({ children }: PropsWithChildren) => (
-  <MathJaxContext src={"/mathjax/tex-chtml.js"}>{children}</MathJaxContext>
-);
+const MathJaxProvider = ({ children }: PropsWithChildren) => {
+  if (typeof window === "undefined") {
+    return children;
+  } else {
+    return (
+      <MathJaxContext src={"/mathjax/tex-chtml.js"}>{children}</MathJaxContext>
+    );
+  }
+};
 
 export { MathJaxProvider };

--- a/src/browser-lib/mathjax/MathJaxWrap.tsx
+++ b/src/browser-lib/mathjax/MathJaxWrap.tsx
@@ -3,11 +3,15 @@ import { MathJax } from "better-react-mathjax";
 import React from "react";
 
 const MathJaxWrap = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <MathJax hideUntilTypeset="every" dynamic>
-      {children}
-    </MathJax>
-  );
+  if (typeof window === "undefined") {
+    return children;
+  } else {
+    return (
+      <MathJax hideUntilTypeset="every" dynamic>
+        {children}
+      </MathJax>
+    );
+  }
 };
 
 export { MathJaxWrap };


### PR DESCRIPTION
## Description

- Check `typeof window === "undefined"` 
- Only provide Mathjax on client


## How to test
Check surds lessons - should be rendered mathjax quiz
Check another lesson - should be rendering correctly

1. Go to https://deploy-preview-2060--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-higher/units/surds/lessons/accuracy-of-final-answers#starter-quiz


## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
