### PR TITLE
[ENG-521] build(merges): workflow to enable merge queue checks

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -2,6 +2,11 @@ name: Code checks
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   lint_test_sonar:


### PR DESCRIPTION
Runs the code check tests when a PR merge queue is created or updated. The merge queue functionality needs to be turned on separately via the GH UI under branch rules (done).