### PR TITLE
[CUR-315] Fix subject-phase picker focus

### DIFF
--- a/src/components/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -396,10 +396,10 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
               <BoxBorders />
 
               <FocusOn
+                autoFocus={false}
                 onClickOutside={() => setShowSubjects(false)}
                 onEscapeKey={() => setShowSubjects(false)}
                 scrollLock={false}
-                returnFocus={false}
               >
                 {showSubjectError && (
                   <Flex $flexDirection={"row"} $mb={20}>
@@ -558,10 +558,10 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
               >
                 <BoxBorders />
                 <FocusOn
+                  autoFocus={false}
                   onClickOutside={() => setShowPhases(false)}
                   onEscapeKey={() => setShowPhases(false)}
                   scrollLock={false}
-                  returnFocus={false}
                 >
                   {showPhaseError && (
                     <Flex $flexDirection={"row"} $mb={20}>


### PR DESCRIPTION
## Description
- Prevent automatic focus to buttons inside subject-phase picker when opening subject or phase controls

## How to test
1. Go to https://deploy-preview-2063--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Click on `Subject`
3. You should see that the first subject button is *not* focused

## Screenshots

How it used to look (delete if n/a):
<img width="989" alt="Screenshot 2023-10-31 at 16 09 04" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/3aea5643-a6ed-474e-8669-7d9a88e4900c">

How it should now look:
<img width="989" alt="Screenshot 2023-10-31 at 16 08 44" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/c3efe35a-9dbe-466d-a7c6-64c2ca7648e4">

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [x] Does this PR update a package with a breaking change
