### PR TITLE
chore(Pa11y): deal with slow preview deployments

### DIFF
--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -21,6 +21,7 @@ if (!isLocalHost && (!CfAccessClientId || !CfAccessClientSecret)) {
 // https://github.com/pa11y/pa11y-ci#configuration
 const config = {
   defaults: {
+    timeout: 120000,
     runners: ["axe"],
     hideElements:
       /**


### PR DESCRIPTION
Sometimes the Netlify Preview deployments are slow, this increases the Pa11y timeout