### PR TITLE
Fix: checkbox z index [LESQ-449]

### DIFF
--- a/src/components/DownloadComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/DownloadComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -186,6 +186,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
                                 onBlur={onBlur}
                                 id={"terms"}
                                 errorMessage={props.errors?.terms?.message}
+                                zIndex={"neutral"}
                               />
                             );
                           }}


### PR DESCRIPTION
## Description

- give the terms and conditions checkbox a neutral z index

## How to test

1. Go to https://deploy-preview-2083--oak-web-application.netlify.thenational.academy/teachers/programmes/chemistry-secondary-ks4-l/units/atomic-structure-and-the-periodic-table-u68nqqc/lessons/atoms-elements-and-compounds-h3hasv/downloads?preselected=all
2. Type in the school picker
3. You should see the dropdown appears over the checkbox (and all other elements)

## Screenshots

How it used to look (delete if n/a):
<img width="500" alt="Screenshot 2023-11-08 at 08 57 18" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/9367a9d0-ad0c-44eb-b381-1a2621b3c64e">

How it should now look:
<img width="500" alt="Screenshot 2023-11-08 at 13 18 12" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/cda9461a-85ca-4106-ac38-d7eff75570a7">

## ACs
The school picker should be above all other checkboxes

