### PR TITLE
chore/remove-email-local-storage LESQ-431

### DIFF
--- a/src/components/DownloadAndShareComponents/DetailsCompleted/DetailsCompleted.tsx
+++ b/src/components/DownloadAndShareComponents/DetailsCompleted/DetailsCompleted.tsx
@@ -57,7 +57,6 @@ const DetailsCompleted: FC<DetailsCompletedProps> = ({
           $iconPosition="trailing"
           iconBackground="black"
           onClick={() => {
-            window.localStorage.removeItem("oak-downloads-email");
             onEditClick();
           }}
           $mt={8}

--- a/src/components/DownloadAndShareComponents/DetailsCompleted/DetailsCompleted.tsx
+++ b/src/components/DownloadAndShareComponents/DetailsCompleted/DetailsCompleted.tsx
@@ -43,13 +43,11 @@ const DetailsCompleted: FC<DetailsCompletedProps> = ({
             </Heading>
             <P $font={"body-2"}>{getSchoolName(school)}</P>
           </Flex>
-          <Flex $flexDirection="column" $gap={4}>
+          <Flex $flexDirection="column" $gap={4} $overflowWrap={"anywhere"}>
             <Heading tag="h3" $font="heading-7">
               Email
             </Heading>
-            <P $font={"body-2"} $wordWrap={"break-word"}>
-              {email ? email : "Not provided"}
-            </P>
+            <P $font={"body-2"}>{email ? email : "Not provided"}</P>
           </Flex>
         </Flex>
         <Button
@@ -58,7 +56,10 @@ const DetailsCompleted: FC<DetailsCompletedProps> = ({
           icon="edit"
           $iconPosition="trailing"
           iconBackground="black"
-          onClick={onEditClick}
+          onClick={() => {
+            window.localStorage.removeItem("oak-downloads-email");
+            onEditClick();
+          }}
           $mt={8}
           aria-label="Edit details"
         />

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -182,10 +182,6 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     if (schoolIdFromLocalStorage) {
       setValue("school", schoolIdFromLocalStorage);
     }
-
-    if (editDetailsClicked) {
-      console.log("EDIT DETAILS CLICKED");
-    }
   }, [
     setValue,
     emailFromLocalStorage,
@@ -194,23 +190,20 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     editDetailsClicked,
   ]);
 
-  // const shouldDisplayDetailsCompleted =
-  // !!hasDetailsFromLocalStorage && !editDetailsClicked;
+  const shouldDisplayDetailsCompleted =
+    !!hasDetailsFromLocalStorage && !editDetailsClicked;
 
-  const [shouldDisplayDetailsCompleted, setShouldDisplayDetailsCompleted] =
-    useState(!!hasDetailsFromLocalStorage && !editDetailsClicked);
+  // const [shouldDisplayDetailsCompleted, setShouldDisplayDetailsCompleted] =
+  //   useState(!!hasDetailsFromLocalStorage && !editDetailsClicked);
 
   const [localStorageDetails, setLocalStorageDetails] = useState(false);
 
   useEffect(() => {
     if (hasDetailsFromLocalStorage || shouldDisplayDetailsCompleted) {
       setLocalStorageDetails(true);
-      console.log("Is this one running?");
     }
     if (editDetailsClicked) {
       setLocalStorageDetails(false);
-      setShouldDisplayDetailsCompleted(false);
-      console.log("is this one running v2?");
     }
   }, [
     hasDetailsFromLocalStorage,
@@ -267,6 +260,11 @@ export function LessonDownloads(props: LessonDownloadsProps) {
         onSubmit,
       });
       setIsDownloadSuccessful(true);
+
+      if (editDetailsClicked && !data.email) {
+        window.localStorage.removeItem("oak-downloads-email");
+      }
+
       const {
         schoolOption,
         schoolName,
@@ -311,7 +309,6 @@ export function LessonDownloads(props: LessonDownloadsProps) {
   });
 
   const handleEditDetailsCompletedClick = () => {
-    console.log("INSIDE", emailFromLocalStorage);
     setEditDetailsClicked(true);
     setLocalStorageDetails(false);
     setValue("email", emailFromLocalStorage);

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -163,6 +163,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     schoolId: schoolIdFromLocalStorage,
   } = schoolFromLocalStorage;
 
+  const [editDetailsClicked, setEditDetailsClicked] = useState(false);
   const [isLocalStorageLoading, setIsLocalStorageLoading] = useState(true);
   useEffect(() => {
     setIsLocalStorageLoading(false);
@@ -181,25 +182,35 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     if (schoolIdFromLocalStorage) {
       setValue("school", schoolIdFromLocalStorage);
     }
+
+    if (editDetailsClicked) {
+      console.log("EDIT DETAILS CLICKED");
+    }
   }, [
     setValue,
     emailFromLocalStorage,
     termsFromLocalStorage,
     schoolIdFromLocalStorage,
+    editDetailsClicked,
   ]);
 
-  const [editDetailsClicked, setEditDetailsClicked] = useState(false);
+  // const shouldDisplayDetailsCompleted =
+  // !!hasDetailsFromLocalStorage && !editDetailsClicked;
 
-  const shouldDisplayDetailsCompleted =
-    !!hasDetailsFromLocalStorage && !editDetailsClicked;
+  const [shouldDisplayDetailsCompleted, setShouldDisplayDetailsCompleted] =
+    useState(!!hasDetailsFromLocalStorage && !editDetailsClicked);
+
   const [localStorageDetails, setLocalStorageDetails] = useState(false);
 
   useEffect(() => {
     if (hasDetailsFromLocalStorage || shouldDisplayDetailsCompleted) {
       setLocalStorageDetails(true);
+      console.log("Is this one running?");
     }
     if (editDetailsClicked) {
       setLocalStorageDetails(false);
+      setShouldDisplayDetailsCompleted(false);
+      console.log("is this one running v2?");
     }
   }, [
     hasDetailsFromLocalStorage,
@@ -300,8 +311,10 @@ export function LessonDownloads(props: LessonDownloadsProps) {
   });
 
   const handleEditDetailsCompletedClick = () => {
+    console.log("INSIDE", emailFromLocalStorage);
     setEditDetailsClicked(true);
     setLocalStorageDetails(false);
+    setValue("email", emailFromLocalStorage);
   };
 
   return (

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -156,6 +156,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     emailFromLocalStorage,
     termsFromLocalStorage,
     hasDetailsFromLocalStorage,
+    setEmailInLocalStorage,
   } = useLocalStorageForDownloads();
 
   const {
@@ -259,7 +260,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
       setIsDownloadSuccessful(true);
 
       if (editDetailsClicked && !data.email) {
-        window.localStorage.removeItem("oak-downloads-email");
+        setEmailInLocalStorage("");
       }
 
       const {

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -193,9 +193,6 @@ export function LessonDownloads(props: LessonDownloadsProps) {
   const shouldDisplayDetailsCompleted =
     !!hasDetailsFromLocalStorage && !editDetailsClicked;
 
-  // const [shouldDisplayDetailsCompleted, setShouldDisplayDetailsCompleted] =
-  //   useState(!!hasDetailsFromLocalStorage && !editDetailsClicked);
-
   const [localStorageDetails, setLocalStorageDetails] = useState(false);
 
   useEffect(() => {

--- a/src/styles/utils/typography.ts
+++ b/src/styles/utils/typography.ts
@@ -105,6 +105,7 @@ export type TypographyProps = FontProps & {
   >;
   $wordWrap?: ResponsiveValues<"normal" | "break-word" | "initial" | "inherit">;
   $textOverflow?: ResponsiveValues<"clip" | "ellipsis">;
+  $overflowWrap?: ResponsiveValues<"normal" | "break-word" | "anywhere">;
 };
 
 const typography = css<TypographyProps>`
@@ -114,6 +115,7 @@ const typography = css<TypographyProps>`
   ${responsive("white-space", (props) => props.$whiteSpace)}
   ${responsive("word-wrap", (props) => props.$wordWrap)}
   ${responsive("text-overflow", (props) => props.$textOverflow)}
+  ${responsive("overflow-wrap", (props) => props.$overflowWrap)}
 `;
 
 export default typography;


### PR DESCRIPTION
## Description

Music year: 1960

- Adds overflow-wrap attribute to css
- Removes email from local storage if it is deleted on download click

## Issue(s)

Fixes #LESQ-431

## How to test

1. Go to https://deploy-preview-2093--oak-web-application.netlify.thenational.academy/teachers/programmes/chemistry-secondary-ks4-l/units/atomic-structure-and-the-periodic-table-u68nqqc/lessons/atoms-elements-and-compounds-h3hasv/downloads?preselected=all (or any downloads page)
2. Add your email to local storage and download a resource
3. Return to a download page, edit and remove your email, then re-click download, email address will be removed from local storage
4. Return to a download page, should see not provided in the details completed box
5. If you click edit but don't delete your email, email continues to be stored, so when returning old email will still be there

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [x] Does this PR update a package with a breaking change
