### PR TITLE
fix: downloads failure [LESQ-465]

### DIFF
--- a/src/components/DownloadAndShareComponents/hooks/useResourceFormState.tsx
+++ b/src/components/DownloadAndShareComponents/hooks/useResourceFormState.tsx
@@ -54,7 +54,7 @@ export const useResourceFormState = (props: Props) => {
         .map((resource) => resource.type);
     } else {
       return (resources as LessonDownloadsData["downloads"])
-        .filter((resource) => resource.exists)
+        .filter((resource) => resource.exists && !resource.forbidden)
         .map((resource) => resource.type);
     }
   }, [resources, props.type]);


### PR DESCRIPTION
## Description

Music year: 2021

- Ensure downloads are not `forbidden` when adding to the list to be downloaded

## Issue(s)

Fixes #
https://app.bugsnag.com/oak-national-academy/oak-national-vercel-api/errors/6529a6980fe1a3000757d4d7?event_id=6554a2cf00ccc1377c1c0000&i=sk&m=ef

## How to test

1. Go to https://deploy-preview-2095--oak-web-application.netlify.thenational.academy//teachers/programmes/spanish-secondary-ks3-l/units/year-7-unit-1-33b9/lessons/saying-what-someone-is-like-in-general-part-12-c5gkcr/downloads?preselected=all
2. Click on Download button
3. You should see the download succeed
