### PR TITLE
fix: downloads error alignment [LESQ-452]

### DIFF
--- a/src/components/DownloadAndShareComponents/ResourcePageLayout/ResourcePageLayout.stories.tsx
+++ b/src/components/DownloadAndShareComponents/ResourcePageLayout/ResourcePageLayout.stories.tsx
@@ -51,6 +51,13 @@ export const Layout: Story = {
     onEditClick: () => {},
     setSchool: () => {},
     cta: <button>CTA</button>,
+    apiError: null,
+  },
+  argTypes: {
+    apiError: {
+      control: "radio",
+      options: [null, "error"],
+    },
   },
   render: (args) => {
     return <Wrapper {...args} />;

--- a/src/components/DownloadAndShareComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/DownloadAndShareComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -47,6 +47,7 @@ export type ResourcePageLayoutProps = DetailsCompletedProps &
     page: "share" | "download";
     resourcesHeader: string;
     triggerForm: UseFormTrigger<ResourceFormProps>;
+    apiError?: string | null;
   };
 
 const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
@@ -227,6 +228,17 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
               </Flex>
             )}
             {props.cta}
+
+            {props.apiError && !hasFormErrors && (
+              <FieldError
+                id="download-error"
+                data-testid="download-error"
+                variant={"large"}
+                withoutMarginBottom
+              >
+                {props.apiError}
+              </FieldError>
+            )}
           </Flex>
         </Flex>
       </Flex>

--- a/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
+++ b/src/components/Lesson/LessonDownloads/LessonDownloads.page.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 
-import Flex from "@/components/Flex";
 import Box from "@/components/Box";
 import MaxWidth from "@/components/MaxWidth/MaxWidth";
 import { Hr } from "@/components/Typography";
@@ -16,7 +15,6 @@ import {
 } from "@/components/DownloadAndShareComponents/downloadsAndShare.types";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import DownloadCardGroup from "@/components/DownloadAndShareComponents/DownloadCardGroup/DownloadCardGroup";
-import FieldError from "@/components/FormFields/FieldError";
 import debouncedSubmit from "@/components/DownloadAndShareComponents/helpers/downloadDebounceSubmit";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
 import {
@@ -216,71 +214,51 @@ export function LessonDownloads(props: LessonDownloadsProps) {
           />
         </Box>
         {!isDownloadSuccessful && (
-          <>
-            <ResourcePageLayout
-              page={"download"}
-              errors={form.errors}
-              handleToggleSelectAll={handleToggleSelectAll}
-              selectAllChecked={selectAllChecked}
-              header="Download"
-              showNoResources={!hasResources}
-              showLoading={isLocalStorageLoading}
-              email={emailFromLocalStorage}
-              school={schoolNameFromLocalStorage}
-              schoolId={schoolIdFromLocalStorage}
-              setSchool={setSchool}
-              showSavedDetails={shouldDisplayDetailsCompleted}
-              onEditClick={handleEditDetailsCompletedClick}
-              register={form.register}
-              control={form.control}
-              showPostAlbCopyright={!isLegacy}
-              resourcesHeader="Lesson resources"
-              triggerForm={form.trigger}
-              cardGroup={
-                <DownloadCardGroup
-                  control={form.control}
-                  downloads={downloads}
-                  hasError={form.errors?.resources ? true : false}
-                  triggerForm={form.trigger}
-                />
-              }
-              cta={
-                <LoadingButton
-                  type="button"
-                  onClick={
-                    (event) => void form.handleSubmit(onFormSubmit)(event) // https://github.com/orgs/react-hook-form/discussions/8622}
-                  }
-                  text={"Download .zip"}
-                  icon={"download"}
-                  isLoading={isAttemptingDownload}
-                  disabled={
-                    hasFormErrors ||
-                    (!form.formState.isValid && !localStorageDetails)
-                  }
-                  loadingText={"Downloading..."}
-                />
-              }
-            />
-
-            <Flex
-              $flexDirection={["column", "row"]}
-              $justifyContent={"right"}
-              $alignItems={"center"}
-            >
-              {apiError && !hasFormErrors && (
-                <Box $mr={24} $textAlign={"left"}>
-                  <FieldError
-                    id="download-error"
-                    data-testid="download-error"
-                    variant={"large"}
-                    withoutMarginBottom
-                  >
-                    {apiError}
-                  </FieldError>
-                </Box>
-              )}
-            </Flex>
-          </>
+          <ResourcePageLayout
+            page={"download"}
+            errors={form.errors}
+            handleToggleSelectAll={handleToggleSelectAll}
+            selectAllChecked={selectAllChecked}
+            header="Download"
+            showNoResources={!hasResources}
+            showLoading={isLocalStorageLoading}
+            email={emailFromLocalStorage}
+            school={schoolNameFromLocalStorage}
+            schoolId={schoolIdFromLocalStorage}
+            setSchool={setSchool}
+            showSavedDetails={shouldDisplayDetailsCompleted}
+            onEditClick={handleEditDetailsCompletedClick}
+            register={form.register}
+            control={form.control}
+            showPostAlbCopyright={!isLegacy}
+            resourcesHeader="Lesson resources"
+            triggerForm={form.trigger}
+            apiError={apiError}
+            cardGroup={
+              <DownloadCardGroup
+                control={form.control}
+                downloads={downloads}
+                hasError={form.errors?.resources ? true : false}
+                triggerForm={form.trigger}
+              />
+            }
+            cta={
+              <LoadingButton
+                type="button"
+                onClick={
+                  (event) => void form.handleSubmit(onFormSubmit)(event) // https://github.com/orgs/react-hook-form/discussions/8622}
+                }
+                text={"Download .zip"}
+                icon={"download"}
+                isLoading={isAttemptingDownload}
+                disabled={
+                  hasFormErrors ||
+                  (!form.formState.isValid && !localStorageDetails)
+                }
+                loadingText={"Downloading..."}
+              />
+            }
+          />
         )}
       </MaxWidth>
     </Box>


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- move download error message within right hand column of layout


## How to test

1. Go to {owa_deployment_url}/teachers/programmes/combined-science-secondary-ks4-foundation-ocr/units/measuring-waves/lessons/transverse-waves/downloads?preselected=all
2. Block the download request
3. Click download button
4. You should see the error message aligned properly

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2023-11-15 at 16 02 19](https://github.com/oaknational/Oak-Web-Application/assets/45038878/e552be4d-43a1-4df3-a91c-1ca0becdd612)

How it should now look:
![Screenshot 2023-11-15 at 16 02 01](https://github.com/oaknational/Oak-Web-Application/assets/45038878/fabaa39c-05fb-4526-8a45-35034ebd6c12)




