### PR TITLE
fix: hide duplicate curriculum units

### DIFF
--- a/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.test.tsx
+++ b/src/components/pages/CurriculumInfo/tabs/UnitsTab/UnitsTab.test.tsx
@@ -33,7 +33,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
     expect(queryAllByTestId("unit-card")[0]).toBeInTheDocument();
   });
 
-  test("number of unit cards matches units", async () => {
+  test("number of unit cards matches expected units", async () => {
     const { findAllByTestId } = render(
       <UnitsTab data={curriculumUnitsTabFixture()} />,
     );
@@ -70,16 +70,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks1",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-            { title: "Lesson 6", slug: "lesson-6", order: 6 },
-            { title: "Lesson 7", slug: "lesson-7", order: 7 },
-            { title: "Lesson 8", slug: "lesson-8", order: 8 },
-          ],
+          lessons: [],
           phase: "Primary",
           phase_slug: "primary",
           slug: "word-class",
@@ -111,16 +102,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks1",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-            { title: "Lesson 6", slug: "lesson-6", order: 6 },
-            { title: "Lesson 7", slug: "lesson-7", order: 7 },
-            { title: "Lesson 8", slug: "lesson-8", order: 8 },
-          ],
+          lessons: [],
           phase: "Primary",
           phase_slug: "primary",
           slug: "a-superhero-like-you-reading-and-writing",
@@ -175,29 +157,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
     expect(threads).toHaveLength(threadSet.size);
   });
 
-  test("user can highlight units by threads", async () => {
-    const { queryByTestId, queryAllByTestId } = render(
-      <UnitsTab data={curriculumUnitsTabFixture()} />,
-    );
-    const threads = queryAllByTestId("thread-radio");
-    await act(async () => {
-      if (!threads[0]) {
-        throw new Error("No thread option found");
-      }
-      await userEvent.click(threads[0]);
-    });
-    const threadUnits = curriculumUnitsTabFixture().units.filter((unit) => {
-      return unit.threads.some(
-        (thread) => thread.slug === threads[0]?.getAttribute("value"),
-      );
-    });
-    const highlightedUnits = queryAllByTestId("highlighted-unit-card");
-    expect(threadUnits).toHaveLength(highlightedUnits.length);
-    const selectedThread = queryByTestId("selected-thread-radio");
-    expect(selectedThread).toBeInTheDocument();
-  });
-
-  test("user can see all the year group choices", async () => {
+  test("All the year group choices are visible", async () => {
     const { findByTestId, findAllByTestId } = render(
       <UnitsTab data={curriculumUnitsTabFixture()} />,
     );
@@ -221,6 +181,121 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
       return index === 0 || Number(array[index - 1]) <= year;
     });
     expect(isSorted).toBe(true);
+  });
+
+  test("duplicate units without examboard are filtered out", async () => {
+    const data = {
+      units: [
+        {
+          planned_number_of_lessons: 8,
+          domain: null,
+          domain_id: null,
+          connection_future_unit_description: null,
+          connection_prior_unit_description: null,
+          connection_future_unit_title: null,
+          connection_prior_unit_title: null,
+          examboard: "AQA",
+          examboard_slug: "aqa",
+          keystage_slug: "ks4",
+          lessons: [],
+          phase: "Secondary",
+          phase_slug: "secondary",
+          slug: "modern-text-first-study",
+          subject: "English",
+          subject_parent: null,
+          subject_parent_slug: null,
+          subject_slug: "english",
+          threads: [],
+          tier: null,
+          tier_slug: null,
+          title: "Modern text: first study",
+          unit_options: [
+            {
+              connection_future_unit_description: null,
+              connection_prior_unit_description: null,
+              connection_future_unit_title: null,
+              connection_prior_unit_title: null,
+              lessons: [],
+              title: "Animal Farm: the pigs and power",
+              unitvariant_id: 774,
+            },
+            {
+              connection_future_unit_description: null,
+              connection_prior_unit_description: null,
+              connection_future_unit_title: null,
+              connection_prior_unit_title: null,
+              lessons: [],
+              title: "Leave Taking: a sense of belonging",
+              unitvariant_id: 773,
+            },
+          ],
+          year: "10",
+        },
+        {
+          planned_number_of_lessons: 8,
+          domain: null,
+          domain_id: null,
+          connection_future_unit_description: null,
+          connection_prior_unit_description: null,
+          connection_future_unit_title: null,
+          connection_prior_unit_title: null,
+          examboard: null,
+          examboard_slug: null,
+          keystage_slug: "ks4",
+          lessons: [],
+          phase: "Secondary",
+          phase_slug: "secondary",
+          slug: "modern-text-first-study",
+          subject: "English",
+          subject_parent: null,
+          subject_parent_slug: null,
+          subject_slug: "english",
+          threads: [],
+          tier: null,
+          tier_slug: null,
+          title: "Modern text: first study",
+          unit_options: [
+            {
+              connection_future_unit_description: null,
+              connection_prior_unit_description: null,
+              connection_future_unit_title: null,
+              connection_prior_unit_title: null,
+              lessons: [],
+              title: "Animal Farm: the pigs and power",
+              unitvariant_id: 774,
+            },
+          ],
+          year: "10",
+        },
+      ],
+    };
+    const { findByTestId, findAllByTestId } = render(<UnitsTab data={data} />);
+    const unitCards = await findAllByTestId("unit-card");
+    expect(unitCards).toHaveLength(1);
+    const tag = await findByTestId("options-tag");
+    expect(tag).toHaveTextContent("2");
+  });
+
+  test("user can highlight units by threads", async () => {
+    const { queryByTestId, queryAllByTestId } = render(
+      <UnitsTab data={curriculumUnitsTabFixture()} />,
+    );
+    const threads = queryAllByTestId("thread-radio");
+    await act(async () => {
+      if (!threads[0]) {
+        throw new Error("No thread option found");
+      }
+      await userEvent.click(threads[0]);
+    });
+    const threadUnits = curriculumUnitsTabFixture().units.filter((unit) => {
+      return unit.threads.some(
+        (thread) => thread.slug === threads[0]?.getAttribute("value"),
+      );
+    });
+    const highlightedUnits = queryAllByTestId("highlighted-unit-card");
+    expect(threadUnits).toHaveLength(highlightedUnits.length);
+    const selectedThread = queryByTestId("selected-thread-radio");
+    expect(selectedThread).toBeInTheDocument();
   });
 
   test("user can filter by year group", async () => {
@@ -254,13 +329,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks4",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-          ],
+          lessons: [],
           phase: "Secondary",
           phase_slug: "secondary",
           planned_number_of_lessons: 5,
@@ -286,13 +355,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks4",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-          ],
+          lessons: [],
           phase: "Secondary",
           phase_slug: "secondary",
           planned_number_of_lessons: 5,
@@ -343,16 +406,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks1",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-            { title: "Lesson 6", slug: "lesson-6", order: 6 },
-            { title: "Lesson 7", slug: "lesson-7", order: 7 },
-            { title: "Lesson 8", slug: "lesson-8", order: 8 },
-          ],
+          lessons: [],
           phase: "Primary",
           phase_slug: "primary",
           slug: "word-class",
@@ -427,13 +481,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks4",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-          ],
+          lessons: [],
           phase: "Secondary",
           phase_slug: "secondary",
           slug: "cellular-respiration-and-atp",
@@ -491,13 +539,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks4",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-            { title: "Lesson 4", slug: "lesson-4", order: 4 },
-            { title: "Lesson 5", slug: "lesson-5", order: 5 },
-          ],
+          lessons: [],
           phase: "Secondary",
           phase_slug: "secondary",
           planned_number_of_lessons: 5,
@@ -546,11 +588,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
           examboard: null,
           examboard_slug: null,
           keystage_slug: "ks2",
-          lessons: [
-            { title: "Lesson 1", slug: "lesson-1", order: 1 },
-            { title: "Lesson 2", slug: "lesson-2", order: 2 },
-            { title: "Lesson 3", slug: "lesson-3", order: 3 },
-          ],
+          lessons: [],
           phase: "Primary",
           phase_slug: "primary",
           planned_number_of_lessons: 24,
@@ -569,10 +607,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
               connection_prior_unit_description: null,
               connection_future_unit_title: null,
               connection_prior_unit_title: null,
-              lessons: [
-                { title: "Lesson 1", slug: "lesson-1", order: 1 },
-                { title: "Lesson 2", slug: "lesson-2", order: 2 },
-              ],
+              lessons: [],
               title: "Antarctic Animals",
               unitvariant_id: 774,
             },
@@ -581,10 +616,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
               connection_prior_unit_description: null,
               connection_future_unit_title: null,
               connection_prior_unit_title: null,
-              lessons: [
-                { title: "Lesson 1", slug: "lesson-1", order: 1 },
-                { title: "Lesson 2", slug: "lesson-2", order: 2 },
-              ],
+              lessons: [],
               title: "Pandas",
               unitvariant_id: 773,
             },


### PR DESCRIPTION
## Description
- Hide duplicate units without examboard
- Simplify unit visualiser tests
- Add comments and re-order units tab code for clarity

## How to test

1. Go to https://deploy-preview-2101--oak-web-application.netlify.thenational.academy/teachers/curriculum/english-secondary-aqa/units
2. Scroll to Year 10
3. You should see only one unit titled "Modern text: first study" with 2 unit options

## Screenshots


How it used to look (delete if n/a):
<img width="949" alt="Screenshot 2023-11-17 at 11 04 28" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/abd591bc-d6c5-4af9-8c62-abedfa7771b3">

How it should now look:
<img width="949" alt="Screenshot 2023-11-17 at 11 04 47" src="https://github.com/oaknational/Oak-Web-Application/assets/421186/b066b2d5-87a1-4519-bbfb-1eb51df7dc90">

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [x] Does this PR update a package with a breaking change
