### PR TITLE
chore: increase warning threshold for OWA errors

### DIFF
--- a/infrastructure/web/main.tf
+++ b/infrastructure/web/main.tf
@@ -18,12 +18,17 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "google_cloud" {
+locals {
+  project_workspace_prefix = "gcp-project-superuser-"
+  project_env              = "prod" // For now all OWA resources are in the same project
+}
+
+data "terraform_remote_state" "google_project" {
   backend = "remote"
   config = {
     organization = "oak-national-academy"
     workspaces = {
-      name = "google-cloud-core"
+      name = "${local.project_workspace_prefix}${local.project_env}"
     }
   }
 }
@@ -33,7 +38,6 @@ provider "datadog" {
 }
 
 provider "google" {
-  // Currently we use the same project for all environments
-  project = data.terraform_remote_state.google_cloud.outputs.projects["prod"]
+  project = data.terraform_remote_state.google_project.outputs.project_id
   region  = var.region
 }

--- a/infrastructure/web/monitoring.tf
+++ b/infrastructure/web/monitoring.tf
@@ -15,7 +15,7 @@ locals {
       query   = "logs(\"source:netlify @http.url:(${local.url_string}) status:error\").index(\"*\").rollup(\"count\")"
 
       evaluate_period    = "5m"
-      warning_threshold  = 0
+      warning_threshold  = 3
       critical_threshold = 10
     },
     {


### PR DESCRIPTION
## Description

Music year: 1951

- Increases the threshold at which OWA errors spotted in the logs will trigger a notification in Slack

## How to test

1. Authenticate with correct Terraform workspace
2. Run `terraform plan` in the `infrastructure/web` directory
3. You should see a proposal to update the warn threshold for the existing "OWA log errors" Slack notification

## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
