### PR TITLE
feat: send hubspot share data LESQ-484

### DIFF
--- a/src/components/DownloadAndShareComponents/hooks/useResourceFormSubmit.ts
+++ b/src/components/DownloadAndShareComponents/hooks/useResourceFormSubmit.ts
@@ -66,26 +66,25 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
         props.isLegacyDownload,
       );
     }
-    if (props.type === "share" || props.type === "download") {
-      const downloadsPayload = getHubspotDownloadsFormPayload({
-        hutk,
-        data: {
-          ...data,
-          ...utmParams,
-          oakUserId: posthogDistinctId ? posthogDistinctId : undefined,
-          schoolName:
-            schoolId === "homeschool" || schoolId === "notListed"
-              ? schoolId
-              : schoolName,
-        },
-      });
-      const hubspotFormResponse = await hubspotSubmitForm({
-        hubspotFormId: hubspotDownloadsFormId,
-        payload: downloadsPayload,
-      });
 
-      return hubspotFormResponse;
-    }
+    const downloadsPayload = getHubspotDownloadsFormPayload({
+      hutk,
+      data: {
+        ...data,
+        ...utmParams,
+        oakUserId: posthogDistinctId ? posthogDistinctId : undefined,
+        schoolName:
+          schoolId === "homeschool" || schoolId === "notListed"
+            ? schoolId
+            : schoolName,
+      },
+    });
+    const hubspotFormResponse = await hubspotSubmitForm({
+      hubspotFormId: hubspotDownloadsFormId,
+      payload: downloadsPayload,
+    });
+
+    return hubspotFormResponse;
   };
 
   return { onSubmit };

--- a/src/components/DownloadAndShareComponents/hooks/useResourceFormSubmit.ts
+++ b/src/components/DownloadAndShareComponents/hooks/useResourceFormSubmit.ts
@@ -60,6 +60,13 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
       setTermsInLocalStorage(terms);
     }
     if (props.type === "download") {
+      await downloadLessonResources(
+        slug,
+        downloads as DownloadResourceType[],
+        props.isLegacyDownload,
+      );
+    }
+    if (props.type === "share" || props.type === "download") {
       const downloadsPayload = getHubspotDownloadsFormPayload({
         hutk,
         data: {
@@ -77,11 +84,6 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
         payload: downloadsPayload,
       });
 
-      await downloadLessonResources(
-        slug,
-        downloads as DownloadResourceType[],
-        props.isLegacyDownload,
-      );
       return hubspotFormResponse;
     }
   };


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

-Sends data to HubSpot from share page on submit.

## Issue(s)



## How to test

1. Go to https://deploy-preview-2107--oak-web-application.netlify.thenational.academy
any share page, share resources, check HubStop received event
download events should still be captured


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
