### PR TITLE
chore: update site footer copy LESQ-472

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": ">=8 <=9"
+        "npm": ">=8 <=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/components/SiteFooter/SiteFooter.tsx
+++ b/src/components/SiteFooter/SiteFooter.tsx
@@ -212,16 +212,41 @@ const SiteFooter: FC = () => {
               <FooterSectionLinks {...sections.legal} />
             </GridArea>
             <GridArea $colSpan={[12, 3]}>
-              <Flex $justifyContent={["left", "right"]} $mt={[40, 0]}>
-                <Logo variant="with text" height={66} width={150} />
+              <Flex $justifyContent={["left", "right"]} $mt={[32, 0]}>
+                <Box $display={["none", "block"]}>
+                  <Logo variant="with text" height={66} width={150} />
+                </Box>
+                <SocialButtons
+                  $display={["flex", "none"]}
+                  for="Oak National Academy"
+                  {...OAK_SOCIALS}
+                />
               </Flex>
             </GridArea>
           </Grid>
-          <Flex $mb={80} $mt={[172, 64]} $width={"100%"}>
-            <SocialButtons for="Oak National Academy" {...OAK_SOCIALS} />
-            <Flex $alignItems={"center"} $ml={[16]}>
-              <P $textAlign="center" $font={["body-4", "body-2"]}>
-                © Oak National Academy
+          <Flex
+            $mb={56}
+            $mt={[32, 64]}
+            $width={"100%"}
+            $justifyContent={["flex-start", "space-between"]}
+            $flexDirection={["column", "row"]}
+            $alignItems={["flex-start", "center"]}
+            $pt={[12, 0]}
+          >
+            <SocialButtons
+              $display={["none", "flex"]}
+              for="Oak National Academy"
+              {...OAK_SOCIALS}
+            />
+            <Box $ml={-4} $display={["block", "none"]}>
+              <Logo variant="with text" height={66} width={150} />
+            </Box>
+            <Flex $mt={[32, 0]} $flexDirection={"column"}>
+              <P $font={"body-3-bold"}>
+                © Oak National Academy Limited, No 14174888
+              </P>
+              <P $font={["body-4"]}>
+                1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
               </P>
             </Flex>
           </Flex>


### PR DESCRIPTION
## Description

Music year: 1971

- Change copy on site footer

## Acceptance Criteria:

- [x]  Copy in the footer on www. reads: ©Oak National Academy Limited
- [x]  Footer includes the company number next to the full company name: 14174888
- [x]  Registered address:  1 Scott Place, 2 Hardman Street, Manchester, M3 3AA

## Issue(s)

Fixes #LESQ-472

## How to test

1. Go to https://deploy-preview-2122--oak-web-application.netlify.thenational.academy
2. Scroll to bottom to see footer

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2023-12-06 at 16 24 19](https://github.com/oaknational/Oak-Web-Application/assets/91190841/566381e1-6f27-4cc6-8cbb-0e8a4b9b289f)
![Screenshot 2023-12-06 at 16 24 09](https://github.com/oaknational/Oak-Web-Application/assets/91190841/845b8c2b-9141-4eb1-8e35-da39d75aab6f)


How it should now look:
![Screenshot 2023-12-06 at 16 23 45](https://github.com/oaknational/Oak-Web-Application/assets/91190841/b801fcc4-c801-4fbf-8c20-40d84a73e498)
![Screenshot 2023-12-06 at 16 23 59](https://github.com/oaknational/Oak-Web-Application/assets/91190841/de7d5889-5d52-4f18-b237-9b132cd620e4)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
