### PR TITLE
chore: removes htmlFor as checkbox is a child component

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -186,6 +186,7 @@ const Checkbox: FC<CheckboxProps> = (props) => {
       >
         <ScreenReaderCheckbox
           type="checkbox"
+          id={id}
           value={id}
           name={name}
           onChange={onChange}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -186,7 +186,6 @@ const Checkbox: FC<CheckboxProps> = (props) => {
       >
         <ScreenReaderCheckbox
           type="checkbox"
-          id={id}
           value={id}
           name={name}
           onChange={onChange}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -178,7 +178,6 @@ const Checkbox: FC<CheckboxProps> = (props) => {
   return (
     <>
       <CheckboxLabel
-        htmlFor={id}
         checked={checked}
         disabled={disabled}
         variant={variant}


### PR DESCRIPTION
## Description

Music year: 2013

- Removes htmlFor attribute from checkboxes to fix accessibility bugs
https://www.geeksforgeeks.org/html-label-tag/

## Issue(s)

Fixes #LESQ-505

## How to test

1. Go to https://deploy-preview-2128--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
