### PR TITLE
fix: decouple search and feature flag [LESQ-494]

### DIFF
--- a/src/context/Search/useSearch.ts
+++ b/src/context/Search/useSearch.ts
@@ -156,10 +156,10 @@ const useSearch = (props: UseSearchProps): UseSearchReturnType => {
   );
 
   useEffect(() => {
-    if (!query.term || use2023SearchApi === undefined) {
+    if (!query.term) {
       return;
     }
-    fetchResults(use2023SearchApi);
+    fetchResults(use2023SearchApi ?? false);
   }, [fetchResults, query, use2023SearchApi]);
 
   return {


### PR DESCRIPTION
## Description

Music year: 1962

- removes dependancy on 2023 search API feature flag for perfoming a search, as this flag requires requesting to posthog which is behind the user consent agreement
- there is now a delay when performing a search using the feature flag, initially only legacy api results show and then it should populate with the new search results
- it is now not possible to use the new search api with the feature flag if you have not consented to tracking cookies

## Issue(s)

Fixes #LESQ-494

## How to test

1. Go to https://deploy-preview-2129--oak-web-application.netlify.thenational.academy
2. Don't accept cookies
3. Perform a search and you should get results
