### PR TITLE
chore: expands width on mobiles LESQ-493

### DIFF
--- a/src/components/HomePageTabs/TeachersTab/TeachersTab.tsx
+++ b/src/components/HomePageTabs/TeachersTab/TeachersTab.tsx
@@ -43,7 +43,7 @@ const TeachersTab: FC<TeacherTabProps> = ({ keyStages }) => {
                 Get a head-start on your lesson planning using quality-checked
                 resources you can download and adapt for free.
               </Typography>
-              <Box $mt={16} $width={"90%"}>
+              <Box $mt={16} $width={["100%", "90%"]}>
                 <SearchForm
                   placeholderText="Search by keyword or topic"
                   searchTerm=""

--- a/src/components/HomePageTabs/TeachersTab/TeachersTab.tsx
+++ b/src/components/HomePageTabs/TeachersTab/TeachersTab.tsx
@@ -43,7 +43,7 @@ const TeachersTab: FC<TeacherTabProps> = ({ keyStages }) => {
                 Get a head-start on your lesson planning using quality-checked
                 resources you can download and adapt for free.
               </Typography>
-              <Box $mt={16} $width={["100%", "90%"]}>
+              <Box $mt={16} $width={["100%", "100%", "90%"]}>
                 <SearchForm
                   placeholderText="Search by keyword or topic"
                   searchTerm=""


### PR DESCRIPTION
## Description

Music year: 1975

- Changes width of search in put bar on mobile

## Acceptance Criteria:

- [x]  Text in search bar should be fully displayed at full widths

## Issue(s)

Fixes #LESQ-493

## How to test

1. Go to https://deploy-preview-2132--oak-web-application.netlify.thenational.academy
2. Look at search bar on mobile phone view

## Screenshots

How it used to look (delete if n/a):

<img width="381" alt="Screenshot 2023-12-13 at 15 08 20" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/bc6cae7d-3515-4fea-8cbf-33590d88dcdf">

How it should now look:

![Screenshot 2023-12-13 at 15 07 45](https://github.com/oaknational/Oak-Web-Application/assets/91190841/fe72b08c-db89-4d77-b4c9-ff911699e8c1)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
