### PR TITLE
chore: adds alt text to hexagon image LESQ-166

### DIFF
--- a/src/pages/develop-your-curriculum.tsx
+++ b/src/pages/develop-your-curriculum.tsx
@@ -180,6 +180,7 @@ const Curriculum: NextPage<CurriculumPageProps> = ({ pageData }) => {
                 $objectFit="contain"
                 $objectPosition={"center"}
                 fill
+                alt="Our guiding curriculum principles summarise the important features of great curricula. They are: flexible, accessible, diverse, evidence informed, knowledge and vocabulary rich, sequenced and coherent"
               />
             </Cover>
           </Flex>

--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -96,6 +96,7 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
                   $objectFit="contain"
                   $objectPosition={"center"}
                   fill
+                  alt="Our guiding curriculum principles summarise the important features of great curricula. They are: flexible, accessible, diverse, evidence informed, knowledge and vocabulary rich, sequenced and coherent"
                 />
               </Cover>
             </Box>


### PR DESCRIPTION
## Description

Music year: 1993

- Adds alt text to hexagon image on curriculum and develop your curriculum pages

## Issue(s)

Fixes #LESQ-166

## How to test

1. Go to https://deploy-preview-2133--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):

<img width="487" alt="Screenshot 2023-12-13 at 15 41 40" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/8264c587-3f01-448f-b480-ab91d85a1c35">

How it should now look:

<img width="467" alt="Screenshot 2023-12-13 at 15 41 56" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/863e081d-5985-41cd-a131-b60d8da86c8d">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
