### PR TITLE
[LESQ-163] Fix/lesq 163/a11y labels

### DIFF
--- a/src/__tests__/pages/contact-us.test.tsx
+++ b/src/__tests__/pages/contact-us.test.tsx
@@ -43,9 +43,9 @@ describe("pages/contact-us.tsx", () => {
 
     expect(
       getByRole("button", {
-        name: /sign up/i,
+        name: /Sign up to the newsletter/i,
       }),
-    ).toHaveAccessibleName("Sign up");
+    ).toHaveAccessibleName("Sign up to the newsletter");
   });
 
   describe("SEO", () => {

--- a/src/components/Forms/NewsletterForm/NewsletterForm.test.tsx
+++ b/src/components/Forms/NewsletterForm/NewsletterForm.test.tsx
@@ -129,7 +129,7 @@ describe("NewsletterForm", () => {
     const user = userEvent.setup();
     const email = getByPlaceholderText("anna@amail.com");
 
-    const submit = getByRole("button", { name: "Sign up" });
+    const submit = getByRole("button", { name: "Sign up to the newsletter" });
     await user.type(email, "joebloggs@example.com");
 
     await user.click(submit);
@@ -141,7 +141,7 @@ describe("NewsletterForm", () => {
       <NewsletterForm descriptionId="id1" id={"1"} onSubmit={onSubmit} />,
     );
 
-    const submit = getByRole("button", { name: "Sign up" });
+    const submit = getByRole("button", { name: "Sign up to the newsletter" });
     const user = userEvent.setup();
     await user.click(submit);
 
@@ -159,7 +159,7 @@ describe("NewsletterForm", () => {
     await user.type(name, "joe bloggs");
     const email = getByPlaceholderText("anna@amail.com");
     await user.type(email, "joebloggs@example.com");
-    const submit = getByRole("button", { name: "Sign up" });
+    const submit = getByRole("button", { name: "Sign up to the newsletter" });
     await user.click(submit);
 
     // HACK: wait for next tick
@@ -181,7 +181,7 @@ describe("NewsletterForm", () => {
     await user.type(name, "joe bloggs");
     const email = getByPlaceholderText("anna@amail.com");
     await user.type(email, "joebloggs@example.com");
-    const submit = getByRole("button", { name: "Sign up" });
+    const submit = getByRole("button", { name: "Sign up to the newsletter" });
     await user.click(submit);
 
     // HACK: wait for next tick

--- a/src/components/Forms/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/Forms/NewsletterForm/NewsletterForm.tsx
@@ -132,7 +132,7 @@ const NewsletterForm: FC<NewsletterFormProps> = ({
       />
       <Button
         $mt={24}
-        label="Sign up"
+        label="Sign up to the newsletter"
         $fullWidth
         htmlButtonProps={{ disabled: loading }}
         background="black"

--- a/src/components/Posts/PostPortableText/PostPortableText.test.tsx
+++ b/src/components/Posts/PostPortableText/PostPortableText.test.tsx
@@ -198,7 +198,7 @@ describe("components/PostPortableText", () => {
     const { getByText } = render(<PostPortableText portableText={[form]} />);
 
     const heading = getByText("This is a form!");
-    const submitButton = getByText("Sign up");
+    const submitButton = getByText("Sign up to the newsletter");
 
     expect(heading).toBeInTheDocument();
     expect(submitButton).toBeInTheDocument();

--- a/src/components/Posts/WebinarRegistration/WebinarRegistration.test.tsx
+++ b/src/components/Posts/WebinarRegistration/WebinarRegistration.test.tsx
@@ -32,7 +32,7 @@ describe("WebinarRegistration", () => {
       <WebinarRegistration {...props} onSubmit={onSubmit} />,
     );
 
-    const button = getByRole("button", { name: "Sign up" });
+    const button = getByRole("button", { name: "Sign up to the newsletter" });
     const user = userEvent.setup();
     await user.click(button);
     expect(onSubmit).not.toHaveBeenCalled();
@@ -50,7 +50,9 @@ describe("WebinarRegistration", () => {
     const email = getByPlaceholderText("anna@amail.com");
     await user.type(email, "joebloggs@example.com");
 
-    await user.click(getByRole("button", { name: "Sign up" }));
+    await user.click(
+      getByRole("button", { name: "Sign up to the newsletter" }),
+    );
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
   test("button has a11y name with enough context", async () => {
@@ -60,7 +62,7 @@ describe("WebinarRegistration", () => {
       <WebinarRegistration {...props} onSubmit={onSubmit} />,
     );
 
-    const button = getByRole("button", { name: "Sign up" });
-    expect(button).toHaveAccessibleName("Sign up");
+    const button = getByRole("button", { name: "Sign up to the newsletter" });
+    expect(button).toHaveAccessibleName("Sign up to the newsletter");
   });
 });


### PR DESCRIPTION
## Description

Music year: 1992

[Ticket](https://www.notion.so/oaknationalacademy/Buttons-and-links-should-inform-a-user-what-they-are-7c4d319f0c83439a916a26b311fd451e?pvs=4)

- Update the copy on the newsletter 'sign up' button to 'Sign up for the newsletter
- The other two changes in the ticket are controlled by Sanity and have been updated there:
    - "Get started" -> "View curriculum"
    - "Sign up" -> "Become a subject expert" 

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2137--oak-web-application.netlify.thenational.academy
2. Check the newsletter form at the bottom of the page

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2023-12-19 at 15 16 42](https://github.com/oaknational/Oak-Web-Application/assets/45038878/6cbadb20-f6b3-4b2b-9ad3-4f3e551e77a5)


How it should now look:
![Screenshot 2023-12-19 at 15 15 47](https://github.com/oaknational/Oak-Web-Application/assets/45038878/d296d829-596d-446e-9d0e-9561e7e687db)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
