### PR TITLE
Fix/newsletter error message LESQ-157

### DIFF
--- a/src/components/Forms/NewsletterForm/NewsletterForm.test.tsx
+++ b/src/components/Forms/NewsletterForm/NewsletterForm.test.tsx
@@ -66,7 +66,7 @@ describe("NewsletterForm", () => {
     await waitForNextTick();
 
     const description = computeAccessibleDescription(input);
-    expect(description).toBe("Name can't be empty");
+    expect(description).toBe("Enter a name");
   });
   test("should display error hint on blur if name more than 60 chars", async () => {
     const { getByPlaceholderText } = render(
@@ -101,7 +101,7 @@ describe("NewsletterForm", () => {
     await waitForNextTick();
 
     const description = computeAccessibleDescription(input);
-    expect(description).toBe("Email can't be empty");
+    expect(description).toBe("Enter an email");
   });
   test("should display error hint on blur email not formatted correctly", async () => {
     const { getByPlaceholderText } = render(
@@ -118,7 +118,7 @@ describe("NewsletterForm", () => {
     await waitForNextTick();
 
     const description = computeAccessibleDescription(input);
-    expect(description).toBe("Email not valid");
+    expect(description).toBe("Enter a valid email");
   });
   test("form cannot be submitted if not complete", async () => {
     const onSubmit = jest.fn();

--- a/src/components/Forms/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/Forms/NewsletterForm/NewsletterForm.tsx
@@ -21,15 +21,15 @@ const reportError = errorReporter("NewsletterForm.tsx");
 const schema = z.object({
   name: z
     .string()
-    .min(1, { message: "Name can't be empty" })
+    .min(1, { message: "Enter a name" })
     .max(60, "Name must contain fewer than 60 charaters"),
   email: z
     .string()
     .min(1, {
-      message: "Email can't be empty",
+      message: "Enter an email",
     })
     .email({
-      message: "Email not valid",
+      message: "Enter a valid email",
     }),
   userRole: z.union([z.enum(USER_ROLES), z.literal("")]),
 });


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Changes error message and test files

# Acceptance Criteria:

- [x]  “Name can’t be empty” should be changed to “Enter a name”
- [x]  “Email can’t be empty” should be changed to “Enter an email”
- [x]  “Email not valid” should be changed to “Enter a valid email”

## Issue(s)

Fixes #LESQ-157

## How to test

1. Go to https://deploy-preview-2140--oak-web-application.netlify.thenational.academy
2. Select newsletter form inputs and then unselect error messages will appear
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="581" alt="Screenshot 2023-12-20 at 16 19 40" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/5fe097ce-3dbb-41f5-80c5-fdbc0c296114">

How it should now look:
<img width="723" alt="Screenshot 2023-12-20 at 16 19 16" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/15a3187c-b8dc-4678-a863-a84c80e98536">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
