### PR TITLE
fix: non existence exit quizes

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -20,6 +20,7 @@ export type Scalars = {
   date: { input: any; output: any; }
   json: { input: any; output: any; }
   jsonb: { input: any; output: any; }
+  timestamp: { input: any; output: any; }
   timestamptz: { input: any; output: any; }
 };
 
@@ -3472,6 +3473,10 @@ export type Internal_Review_Lessons = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
   created_at?: Maybe<Scalars['timestamptz']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__firstapproval" */
+  firstapproval?: Maybe<Scalars['timestamp']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__lastapproval" */
+  lastapproval?: Maybe<Scalars['timestamp']['output']>;
   /** An object relationship */
   lesson?: Maybe<Lessons>;
   /** An array relationship */
@@ -3664,6 +3669,8 @@ export type Internal_Review_Lessons_Bool_Exp = {
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  firstapproval?: InputMaybe<Timestamp_Comparison_Exp>;
+  lastapproval?: InputMaybe<Timestamp_Comparison_Exp>;
   lesson?: InputMaybe<Lessons_Bool_Exp>;
   lesson_all_states?: InputMaybe<Lessons_Bool_Exp>;
   lesson_all_states_aggregate?: InputMaybe<Lessons_Aggregate_Bool_Exp>;
@@ -3867,6 +3874,8 @@ export type Internal_Review_Lessons_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
+  firstapproval?: InputMaybe<Order_By>;
+  lastapproval?: InputMaybe<Order_By>;
   lesson?: InputMaybe<Lessons_Order_By>;
   lesson_all_states_aggregate?: InputMaybe<Lessons_Aggregate_Order_By>;
   lesson_id?: InputMaybe<Order_By>;
@@ -4239,6 +4248,10 @@ export type Lessons = {
   __typename?: 'lessons';
   _cohort: Scalars['String']['output'];
   _deleted: Scalars['Boolean']['output'];
+  /** A computed field, executes function "function__lessons__latestversion" */
+  _latestversion?: Maybe<Scalars['Boolean']['output']>;
+  /** A computed field, executes function "function__lessons__preferredversion" */
+  _preferredversion?: Maybe<Scalars['Boolean']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
   asset_id_slidedeck?: Maybe<Scalars['Int']['output']>;
@@ -4771,8 +4784,10 @@ export type Lessons_Bool_Exp = {
   _and?: InputMaybe<Array<Lessons_Bool_Exp>>;
   _cohort?: InputMaybe<String_Comparison_Exp>;
   _deleted?: InputMaybe<Boolean_Comparison_Exp>;
+  _latestversion?: InputMaybe<Boolean_Comparison_Exp>;
   _not?: InputMaybe<Lessons_Bool_Exp>;
   _or?: InputMaybe<Array<Lessons_Bool_Exp>>;
+  _preferredversion?: InputMaybe<Boolean_Comparison_Exp>;
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
   asset_id_slidedeck?: InputMaybe<Int_Comparison_Exp>;
@@ -5062,6 +5077,8 @@ export type Lessons_On_Conflict = {
 export type Lessons_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _deleted?: InputMaybe<Order_By>;
+  _latestversion?: InputMaybe<Order_By>;
+  _preferredversion?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   asset_id_slidedeck?: InputMaybe<Order_By>;
@@ -13858,9 +13875,9 @@ export type Published_Mv_Downloads_3_0_0_Stream_Cursor_Value_Input = {
   unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** columns and relationships of "published.mv_downloads_7" */
-export type Published_Mv_Downloads_7 = {
-  __typename?: 'published_mv_downloads_7';
+/** columns and relationships of "published.mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1 = {
+  __typename?: 'published_mv_downloads_3_0_1';
   downloads?: Maybe<Scalars['jsonb']['output']>;
   examBoardSlug?: Maybe<Scalars['String']['output']>;
   examBoardTitle?: Maybe<Scalars['String']['output']>;
@@ -13879,38 +13896,38 @@ export type Published_Mv_Downloads_7 = {
 };
 
 
-/** columns and relationships of "published.mv_downloads_7" */
-export type Published_Mv_Downloads_7DownloadsArgs = {
+/** columns and relationships of "published.mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1DownloadsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** aggregated selection of "published.mv_downloads_7" */
-export type Published_Mv_Downloads_7_Aggregate = {
-  __typename?: 'published_mv_downloads_7_aggregate';
-  aggregate?: Maybe<Published_Mv_Downloads_7_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Downloads_7>;
+/** aggregated selection of "published.mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1_Aggregate = {
+  __typename?: 'published_mv_downloads_3_0_1_aggregate';
+  aggregate?: Maybe<Published_Mv_Downloads_3_0_1_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Downloads_3_0_1>;
 };
 
-/** aggregate fields of "published.mv_downloads_7" */
-export type Published_Mv_Downloads_7_Aggregate_Fields = {
-  __typename?: 'published_mv_downloads_7_aggregate_fields';
+/** aggregate fields of "published.mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1_Aggregate_Fields = {
+  __typename?: 'published_mv_downloads_3_0_1_aggregate_fields';
   count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Downloads_7_Max_Fields>;
-  min?: Maybe<Published_Mv_Downloads_7_Min_Fields>;
+  max?: Maybe<Published_Mv_Downloads_3_0_1_Max_Fields>;
+  min?: Maybe<Published_Mv_Downloads_3_0_1_Min_Fields>;
 };
 
 
-/** aggregate fields of "published.mv_downloads_7" */
-export type Published_Mv_Downloads_7_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Downloads_7_Select_Column>>;
+/** aggregate fields of "published.mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Select_Column>>;
   distinct?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-/** Boolean expression to filter rows from the table "published.mv_downloads_7". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Downloads_7_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Downloads_7_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Downloads_7_Bool_Exp>>;
+/** Boolean expression to filter rows from the table "published.mv_downloads_3_0_1". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Downloads_3_0_1_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Bool_Exp>>;
   downloads?: InputMaybe<Jsonb_Comparison_Exp>;
   examBoardSlug?: InputMaybe<String_Comparison_Exp>;
   examBoardTitle?: InputMaybe<String_Comparison_Exp>;
@@ -13929,8 +13946,8 @@ export type Published_Mv_Downloads_7_Bool_Exp = {
 };
 
 /** aggregate max on columns */
-export type Published_Mv_Downloads_7_Max_Fields = {
-  __typename?: 'published_mv_downloads_7_max_fields';
+export type Published_Mv_Downloads_3_0_1_Max_Fields = {
+  __typename?: 'published_mv_downloads_3_0_1_max_fields';
   examBoardSlug?: Maybe<Scalars['String']['output']>;
   examBoardTitle?: Maybe<Scalars['String']['output']>;
   keyStageSlug?: Maybe<Scalars['String']['output']>;
@@ -13947,8 +13964,8 @@ export type Published_Mv_Downloads_7_Max_Fields = {
 };
 
 /** aggregate min on columns */
-export type Published_Mv_Downloads_7_Min_Fields = {
-  __typename?: 'published_mv_downloads_7_min_fields';
+export type Published_Mv_Downloads_3_0_1_Min_Fields = {
+  __typename?: 'published_mv_downloads_3_0_1_min_fields';
   examBoardSlug?: Maybe<Scalars['String']['output']>;
   examBoardTitle?: Maybe<Scalars['String']['output']>;
   keyStageSlug?: Maybe<Scalars['String']['output']>;
@@ -13964,8 +13981,8 @@ export type Published_Mv_Downloads_7_Min_Fields = {
   unitTitle?: Maybe<Scalars['String']['output']>;
 };
 
-/** Ordering options when selecting data from "published.mv_downloads_7". */
-export type Published_Mv_Downloads_7_Order_By = {
+/** Ordering options when selecting data from "published.mv_downloads_3_0_1". */
+export type Published_Mv_Downloads_3_0_1_Order_By = {
   downloads?: InputMaybe<Order_By>;
   examBoardSlug?: InputMaybe<Order_By>;
   examBoardTitle?: InputMaybe<Order_By>;
@@ -13983,8 +14000,8 @@ export type Published_Mv_Downloads_7_Order_By = {
   unitTitle?: InputMaybe<Order_By>;
 };
 
-/** select columns of table "published.mv_downloads_7" */
-export enum Published_Mv_Downloads_7_Select_Column {
+/** select columns of table "published.mv_downloads_3_0_1" */
+export enum Published_Mv_Downloads_3_0_1_Select_Column {
   /** column name */
   Downloads = 'downloads',
   /** column name */
@@ -14017,16 +14034,16 @@ export enum Published_Mv_Downloads_7_Select_Column {
   UnitTitle = 'unitTitle'
 }
 
-/** Streaming cursor of the table "published_mv_downloads_7" */
-export type Published_Mv_Downloads_7_Stream_Cursor_Input = {
+/** Streaming cursor of the table "published_mv_downloads_3_0_1" */
+export type Published_Mv_Downloads_3_0_1_Stream_Cursor_Input = {
   /** Stream column input with initial value */
-  initial_value: Published_Mv_Downloads_7_Stream_Cursor_Value_Input;
+  initial_value: Published_Mv_Downloads_3_0_1_Stream_Cursor_Value_Input;
   /** cursor ordering */
   ordering?: InputMaybe<Cursor_Ordering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Published_Mv_Downloads_7_Stream_Cursor_Value_Input = {
+export type Published_Mv_Downloads_3_0_1_Stream_Cursor_Value_Input = {
   downloads?: InputMaybe<Scalars['jsonb']['input']>;
   examBoardSlug?: InputMaybe<Scalars['String']['input']>;
   examBoardTitle?: InputMaybe<Scalars['String']['input']>;
@@ -14684,266 +14701,6 @@ export type Published_Mv_Lesson_Listing_3_0_0_Variance_Fields = {
   lessonsCount?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15 = {
-  __typename?: 'published_mv_lesson_listing_15';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessons?: Maybe<Scalars['jsonb']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15LessonsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15_Aggregate = {
-  __typename?: 'published_mv_lesson_listing_15_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Listing_15_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Listing_15>;
-};
-
-/** aggregate fields of "published.mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Listing_15_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Listing_15_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Listing_15_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Listing_15_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Listing_15_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Listing_15_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Listing_15_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Listing_15_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Listing_15_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Listing_15_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Listing_15_Avg_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_avg_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_listing_15". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Listing_15_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Bool_Exp>>;
-  examboardSlug?: InputMaybe<String_Comparison_Exp>;
-  examboardTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonsCount?: InputMaybe<Bigint_Comparison_Exp>;
-  optionality?: InputMaybe<String_Comparison_Exp>;
-  phaseSlug?: InputMaybe<String_Comparison_Exp>;
-  phaseTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Listing_15_Max_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_max_fields';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Listing_15_Min_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_min_fields';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_listing_15". */
-export type Published_Mv_Lesson_Listing_15_Order_By = {
-  examboardSlug?: InputMaybe<Order_By>;
-  examboardTitle?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessons?: InputMaybe<Order_By>;
-  lessonsCount?: InputMaybe<Order_By>;
-  optionality?: InputMaybe<Order_By>;
-  phaseSlug?: InputMaybe<Order_By>;
-  phaseTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_listing_15" */
-export enum Published_Mv_Lesson_Listing_15_Select_Column {
-  /** column name */
-  ExamboardSlug = 'examboardSlug',
-  /** column name */
-  ExamboardTitle = 'examboardTitle',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  Lessons = 'lessons',
-  /** column name */
-  LessonsCount = 'lessonsCount',
-  /** column name */
-  Optionality = 'optionality',
-  /** column name */
-  PhaseSlug = 'phaseSlug',
-  /** column name */
-  PhaseTitle = 'phaseTitle',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Listing_15_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_stddev_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Listing_15_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_stddev_pop_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Listing_15_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_stddev_samp_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_listing_15" */
-export type Published_Mv_Lesson_Listing_15_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Listing_15_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Listing_15_Stream_Cursor_Value_Input = {
-  examboardSlug?: InputMaybe<Scalars['String']['input']>;
-  examboardTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessons?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonsCount?: InputMaybe<Scalars['bigint']['input']>;
-  optionality?: InputMaybe<Scalars['String']['input']>;
-  phaseSlug?: InputMaybe<Scalars['String']['input']>;
-  phaseTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Listing_15_Sum_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_sum_fields';
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Listing_15_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_var_pop_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Listing_15_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_var_samp_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Listing_15_Variance_Fields = {
-  __typename?: 'published_mv_lesson_listing_15_variance_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
 /** columns and relationships of "published.mv_lesson_overview_3_0_0" */
 export type Published_Mv_Lesson_Overview_3_0_0 = {
   __typename?: 'published_mv_lesson_overview_3_0_0';
@@ -15442,1508 +15199,6 @@ export type Published_Mv_Lesson_Overview_3_0_0_Variance_Fields = {
   unitVariantId?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11 = {
-  __typename?: 'published_mv_lesson_overview_11';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  teacherTips?: Maybe<Scalars['jsonb']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11ContentGuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11ExitQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11KeyLearningPointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11LessonEquipmentAndResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11LessonKeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11MisconceptionsAndCommonMistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11StarterQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11TeacherTipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11_Aggregate = {
-  __typename?: 'published_mv_lesson_overview_11_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Overview_11_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Overview_11>;
-};
-
-/** aggregate fields of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Overview_11_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Overview_11_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Overview_11_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Overview_11_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_11_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_11_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Overview_11_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Overview_11_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Overview_11_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Overview_11_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Overview_11_Avg_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_avg_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_overview_11". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Overview_11_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Bool_Exp>>;
-  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
-  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonId?: InputMaybe<Int_Comparison_Exp>;
-  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
-  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  presentationUrl?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
-  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
-  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
-  yearSlug?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Overview_11_Max_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_max_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Overview_11_Min_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_min_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_overview_11". */
-export type Published_Mv_Lesson_Overview_11_Order_By = {
-  additionalMaterialUrl?: InputMaybe<Order_By>;
-  contentGuidance?: InputMaybe<Order_By>;
-  copyrightContent?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  exitQuiz?: InputMaybe<Order_By>;
-  exitQuizId?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  keyLearningPoints?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonEquipmentAndResources?: InputMaybe<Order_By>;
-  lessonId?: InputMaybe<Order_By>;
-  lessonKeywords?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
-  nullUnitVariantId?: InputMaybe<Order_By>;
-  presentationUrl?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  pupilLessonOutcome?: InputMaybe<Order_By>;
-  starterQuiz?: InputMaybe<Order_By>;
-  starterQuizId?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  supervisionLevel?: InputMaybe<Order_By>;
-  teacherTips?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  transcriptSentences?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  unitVariantId?: InputMaybe<Order_By>;
-  videoMuxPlaybackId?: InputMaybe<Order_By>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
-  worksheetUrl?: InputMaybe<Order_By>;
-  yearSlug?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_overview_11" */
-export enum Published_Mv_Lesson_Overview_11_Select_Column {
-  /** column name */
-  AdditionalMaterialUrl = 'additionalMaterialUrl',
-  /** column name */
-  ContentGuidance = 'contentGuidance',
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  ExitQuiz = 'exitQuiz',
-  /** column name */
-  ExitQuizId = 'exitQuizId',
-  /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
-  /** column name */
-  KeyLearningPoints = 'keyLearningPoints',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
-  /** column name */
-  LessonId = 'lessonId',
-  /** column name */
-  LessonKeywords = 'lessonKeywords',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
-  /** column name */
-  NullUnitVariantId = 'nullUnitVariantId',
-  /** column name */
-  PresentationUrl = 'presentationUrl',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  PupilLessonOutcome = 'pupilLessonOutcome',
-  /** column name */
-  StarterQuiz = 'starterQuiz',
-  /** column name */
-  StarterQuizId = 'starterQuizId',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  SupervisionLevel = 'supervisionLevel',
-  /** column name */
-  TeacherTips = 'teacherTips',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  TranscriptSentences = 'transcriptSentences',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  UnitVariantId = 'unitVariantId',
-  /** column name */
-  VideoMuxPlaybackId = 'videoMuxPlaybackId',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
-  /** column name */
-  WorksheetUrl = 'worksheetUrl',
-  /** column name */
-  YearSlug = 'yearSlug',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Overview_11_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_stddev_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Overview_11_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_stddev_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Overview_11_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_stddev_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_overview_11" */
-export type Published_Mv_Lesson_Overview_11_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Overview_11_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Overview_11_Stream_Cursor_Value_Input = {
-  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
-  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonId?: InputMaybe<Scalars['Int']['input']>;
-  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
-  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  presentationUrl?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
-  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
-  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
-  yearSlug?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Overview_11_Sum_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_sum_fields';
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Overview_11_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_var_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Overview_11_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_var_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Overview_11_Variance_Fields = {
-  __typename?: 'published_mv_lesson_overview_11_variance_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12 = {
-  __typename?: 'published_mv_lesson_overview_12';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  teacherTips?: Maybe<Scalars['jsonb']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12ContentGuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12ExitQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12KeyLearningPointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12LessonEquipmentAndResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12LessonKeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12MisconceptionsAndCommonMistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12StarterQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12TeacherTipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12_Aggregate = {
-  __typename?: 'published_mv_lesson_overview_12_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Overview_12_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Overview_12>;
-};
-
-/** aggregate fields of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Overview_12_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Overview_12_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Overview_12_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Overview_12_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_12_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_12_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Overview_12_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Overview_12_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Overview_12_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Overview_12_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Overview_12_Avg_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_avg_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_overview_12". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Overview_12_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Bool_Exp>>;
-  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
-  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonId?: InputMaybe<Int_Comparison_Exp>;
-  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
-  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  presentationUrl?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
-  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
-  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  videoTitle?: InputMaybe<String_Comparison_Exp>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
-  yearSlug?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Overview_12_Max_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_max_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Overview_12_Min_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_min_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_overview_12". */
-export type Published_Mv_Lesson_Overview_12_Order_By = {
-  additionalMaterialUrl?: InputMaybe<Order_By>;
-  contentGuidance?: InputMaybe<Order_By>;
-  copyrightContent?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  exitQuiz?: InputMaybe<Order_By>;
-  exitQuizId?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  keyLearningPoints?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonEquipmentAndResources?: InputMaybe<Order_By>;
-  lessonId?: InputMaybe<Order_By>;
-  lessonKeywords?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
-  nullUnitVariantId?: InputMaybe<Order_By>;
-  presentationUrl?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  pupilLessonOutcome?: InputMaybe<Order_By>;
-  starterQuiz?: InputMaybe<Order_By>;
-  starterQuizId?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  supervisionLevel?: InputMaybe<Order_By>;
-  teacherTips?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  transcriptSentences?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  unitVariantId?: InputMaybe<Order_By>;
-  videoMuxPlaybackId?: InputMaybe<Order_By>;
-  videoTitle?: InputMaybe<Order_By>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
-  worksheetUrl?: InputMaybe<Order_By>;
-  yearSlug?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_overview_12" */
-export enum Published_Mv_Lesson_Overview_12_Select_Column {
-  /** column name */
-  AdditionalMaterialUrl = 'additionalMaterialUrl',
-  /** column name */
-  ContentGuidance = 'contentGuidance',
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  ExitQuiz = 'exitQuiz',
-  /** column name */
-  ExitQuizId = 'exitQuizId',
-  /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
-  /** column name */
-  KeyLearningPoints = 'keyLearningPoints',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
-  /** column name */
-  LessonId = 'lessonId',
-  /** column name */
-  LessonKeywords = 'lessonKeywords',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
-  /** column name */
-  NullUnitVariantId = 'nullUnitVariantId',
-  /** column name */
-  PresentationUrl = 'presentationUrl',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  PupilLessonOutcome = 'pupilLessonOutcome',
-  /** column name */
-  StarterQuiz = 'starterQuiz',
-  /** column name */
-  StarterQuizId = 'starterQuizId',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  SupervisionLevel = 'supervisionLevel',
-  /** column name */
-  TeacherTips = 'teacherTips',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  TranscriptSentences = 'transcriptSentences',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  UnitVariantId = 'unitVariantId',
-  /** column name */
-  VideoMuxPlaybackId = 'videoMuxPlaybackId',
-  /** column name */
-  VideoTitle = 'videoTitle',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
-  /** column name */
-  WorksheetUrl = 'worksheetUrl',
-  /** column name */
-  YearSlug = 'yearSlug',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Overview_12_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_stddev_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Overview_12_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_stddev_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Overview_12_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_stddev_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_overview_12" */
-export type Published_Mv_Lesson_Overview_12_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Overview_12_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Overview_12_Stream_Cursor_Value_Input = {
-  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
-  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonId?: InputMaybe<Scalars['Int']['input']>;
-  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
-  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  presentationUrl?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
-  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
-  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  videoTitle?: InputMaybe<Scalars['String']['input']>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
-  yearSlug?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Overview_12_Sum_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_sum_fields';
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Overview_12_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_var_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Overview_12_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_var_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Overview_12_Variance_Fields = {
-  __typename?: 'published_mv_lesson_overview_12_variance_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13 = {
-  __typename?: 'published_mv_lesson_overview_13';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  teacherTips?: Maybe<Scalars['jsonb']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13ContentGuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13ExitQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13KeyLearningPointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13LessonEquipmentAndResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13LessonKeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13MisconceptionsAndCommonMistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13StarterQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13TeacherTipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13_Aggregate = {
-  __typename?: 'published_mv_lesson_overview_13_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Overview_13_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Overview_13>;
-};
-
-/** aggregate fields of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Overview_13_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Overview_13_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Overview_13_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Overview_13_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_13_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_13_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Overview_13_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Overview_13_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Overview_13_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Overview_13_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Overview_13_Avg_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_avg_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_overview_13". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Overview_13_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Bool_Exp>>;
-  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
-  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonId?: InputMaybe<Int_Comparison_Exp>;
-  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
-  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  presentationUrl?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
-  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
-  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  videoTitle?: InputMaybe<String_Comparison_Exp>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
-  yearSlug?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Overview_13_Max_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_max_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Overview_13_Min_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_min_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_overview_13". */
-export type Published_Mv_Lesson_Overview_13_Order_By = {
-  additionalMaterialUrl?: InputMaybe<Order_By>;
-  contentGuidance?: InputMaybe<Order_By>;
-  copyrightContent?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  exitQuiz?: InputMaybe<Order_By>;
-  exitQuizId?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  keyLearningPoints?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonEquipmentAndResources?: InputMaybe<Order_By>;
-  lessonId?: InputMaybe<Order_By>;
-  lessonKeywords?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
-  nullUnitVariantId?: InputMaybe<Order_By>;
-  presentationUrl?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  pupilLessonOutcome?: InputMaybe<Order_By>;
-  starterQuiz?: InputMaybe<Order_By>;
-  starterQuizId?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  supervisionLevel?: InputMaybe<Order_By>;
-  teacherTips?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  transcriptSentences?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  unitVariantId?: InputMaybe<Order_By>;
-  videoMuxPlaybackId?: InputMaybe<Order_By>;
-  videoTitle?: InputMaybe<Order_By>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
-  worksheetUrl?: InputMaybe<Order_By>;
-  yearSlug?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_overview_13" */
-export enum Published_Mv_Lesson_Overview_13_Select_Column {
-  /** column name */
-  AdditionalMaterialUrl = 'additionalMaterialUrl',
-  /** column name */
-  ContentGuidance = 'contentGuidance',
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  ExitQuiz = 'exitQuiz',
-  /** column name */
-  ExitQuizId = 'exitQuizId',
-  /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
-  /** column name */
-  KeyLearningPoints = 'keyLearningPoints',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
-  /** column name */
-  LessonId = 'lessonId',
-  /** column name */
-  LessonKeywords = 'lessonKeywords',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
-  /** column name */
-  NullUnitVariantId = 'nullUnitVariantId',
-  /** column name */
-  PresentationUrl = 'presentationUrl',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  PupilLessonOutcome = 'pupilLessonOutcome',
-  /** column name */
-  StarterQuiz = 'starterQuiz',
-  /** column name */
-  StarterQuizId = 'starterQuizId',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  SupervisionLevel = 'supervisionLevel',
-  /** column name */
-  TeacherTips = 'teacherTips',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  TranscriptSentences = 'transcriptSentences',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  UnitVariantId = 'unitVariantId',
-  /** column name */
-  VideoMuxPlaybackId = 'videoMuxPlaybackId',
-  /** column name */
-  VideoTitle = 'videoTitle',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
-  /** column name */
-  WorksheetUrl = 'worksheetUrl',
-  /** column name */
-  YearSlug = 'yearSlug',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Overview_13_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_stddev_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Overview_13_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_stddev_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Overview_13_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_stddev_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_overview_13" */
-export type Published_Mv_Lesson_Overview_13_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Overview_13_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Overview_13_Stream_Cursor_Value_Input = {
-  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
-  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonId?: InputMaybe<Scalars['Int']['input']>;
-  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
-  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  presentationUrl?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
-  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
-  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  videoTitle?: InputMaybe<Scalars['String']['input']>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
-  yearSlug?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Overview_13_Sum_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_sum_fields';
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Overview_13_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_var_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Overview_13_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_var_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Overview_13_Variance_Fields = {
-  __typename?: 'published_mv_lesson_overview_13_variance_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3 = {
-  __typename?: 'published_mv_programme_listing_3';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmes?: Maybe<Scalars['jsonb']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3ProgrammesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
 /** columns and relationships of "published.mv_programme_listing_3_0_0" */
 export type Published_Mv_Programme_Listing_3_0_0 = {
   __typename?: 'published_mv_programme_listing_3_0_0';
@@ -17045,98 +15300,6 @@ export type Published_Mv_Programme_Listing_3_0_0_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Programme_Listing_3_0_0_Stream_Cursor_Value_Input = {
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  programmes?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3_Aggregate = {
-  __typename?: 'published_mv_programme_listing_3_aggregate';
-  aggregate?: Maybe<Published_Mv_Programme_Listing_3_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Programme_Listing_3>;
-};
-
-/** aggregate fields of "published.mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3_Aggregate_Fields = {
-  __typename?: 'published_mv_programme_listing_3_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Programme_Listing_3_Max_Fields>;
-  min?: Maybe<Published_Mv_Programme_Listing_3_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_programme_listing_3". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Programme_Listing_3_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Bool_Exp>>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  programmes?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Programme_Listing_3_Max_Fields = {
-  __typename?: 'published_mv_programme_listing_3_max_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Programme_Listing_3_Min_Fields = {
-  __typename?: 'published_mv_programme_listing_3_min_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_programme_listing_3". */
-export type Published_Mv_Programme_Listing_3_Order_By = {
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  programmes?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_programme_listing_3" */
-export enum Published_Mv_Programme_Listing_3_Select_Column {
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  Programmes = 'programmes',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle'
-}
-
-/** Streaming cursor of the table "published_mv_programme_listing_3" */
-export type Published_Mv_Programme_Listing_3_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Programme_Listing_3_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Programme_Listing_3_Stream_Cursor_Value_Input = {
   keyStageSlug?: InputMaybe<Scalars['String']['input']>;
   keyStageTitle?: InputMaybe<Scalars['String']['input']>;
   programmes?: InputMaybe<Scalars['jsonb']['input']>;
@@ -17254,6 +15417,206 @@ export type Published_Mv_Search_Page_1_Stream_Cursor_Input = {
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Search_Page_1_Stream_Cursor_Value_Input = {
   content_type?: InputMaybe<Scalars['json']['input']>;
+  key_stages?: InputMaybe<Scalars['json']['input']>;
+  subjects?: InputMaybe<Scalars['json']['input']>;
+};
+
+/** columns and relationships of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2 = {
+  __typename?: 'published_mv_search_page_2';
+  content_type?: Maybe<Scalars['json']['output']>;
+  exam_boards?: Maybe<Scalars['json']['output']>;
+  key_stages?: Maybe<Scalars['json']['output']>;
+  subjects?: Maybe<Scalars['json']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2Content_TypeArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2Exam_BoardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2Key_StagesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2SubjectsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2_Aggregate = {
+  __typename?: 'published_mv_search_page_2_aggregate';
+  aggregate?: Maybe<Published_Mv_Search_Page_2_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Search_Page_2>;
+};
+
+/** aggregate fields of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2_Aggregate_Fields = {
+  __typename?: 'published_mv_search_page_2_aggregate_fields';
+  count: Scalars['Int']['output'];
+};
+
+
+/** aggregate fields of "published.mv_search_page_2" */
+export type Published_Mv_Search_Page_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Search_Page_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_search_page_2". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Search_Page_2_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Search_Page_2_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Search_Page_2_Bool_Exp>>;
+  content_type?: InputMaybe<Json_Comparison_Exp>;
+  exam_boards?: InputMaybe<Json_Comparison_Exp>;
+  key_stages?: InputMaybe<Json_Comparison_Exp>;
+  subjects?: InputMaybe<Json_Comparison_Exp>;
+};
+
+/** Ordering options when selecting data from "published.mv_search_page_2". */
+export type Published_Mv_Search_Page_2_Order_By = {
+  content_type?: InputMaybe<Order_By>;
+  exam_boards?: InputMaybe<Order_By>;
+  key_stages?: InputMaybe<Order_By>;
+  subjects?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_search_page_2" */
+export enum Published_Mv_Search_Page_2_Select_Column {
+  /** column name */
+  ContentType = 'content_type',
+  /** column name */
+  ExamBoards = 'exam_boards',
+  /** column name */
+  KeyStages = 'key_stages',
+  /** column name */
+  Subjects = 'subjects'
+}
+
+/** Streaming cursor of the table "published_mv_search_page_2" */
+export type Published_Mv_Search_Page_2_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Search_Page_2_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Search_Page_2_Stream_Cursor_Value_Input = {
+  content_type?: InputMaybe<Scalars['json']['input']>;
+  exam_boards?: InputMaybe<Scalars['json']['input']>;
+  key_stages?: InputMaybe<Scalars['json']['input']>;
+  subjects?: InputMaybe<Scalars['json']['input']>;
+};
+
+/** columns and relationships of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3 = {
+  __typename?: 'published_mv_search_page_3';
+  content_type?: Maybe<Scalars['json']['output']>;
+  exam_boards?: Maybe<Scalars['json']['output']>;
+  key_stages?: Maybe<Scalars['json']['output']>;
+  subjects?: Maybe<Scalars['json']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3Content_TypeArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3Exam_BoardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3Key_StagesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3SubjectsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3_Aggregate = {
+  __typename?: 'published_mv_search_page_3_aggregate';
+  aggregate?: Maybe<Published_Mv_Search_Page_3_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Search_Page_3>;
+};
+
+/** aggregate fields of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3_Aggregate_Fields = {
+  __typename?: 'published_mv_search_page_3_aggregate_fields';
+  count: Scalars['Int']['output'];
+};
+
+
+/** aggregate fields of "published.mv_search_page_3" */
+export type Published_Mv_Search_Page_3_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Search_Page_3_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_search_page_3". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Search_Page_3_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Search_Page_3_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Search_Page_3_Bool_Exp>>;
+  content_type?: InputMaybe<Json_Comparison_Exp>;
+  exam_boards?: InputMaybe<Json_Comparison_Exp>;
+  key_stages?: InputMaybe<Json_Comparison_Exp>;
+  subjects?: InputMaybe<Json_Comparison_Exp>;
+};
+
+/** Ordering options when selecting data from "published.mv_search_page_3". */
+export type Published_Mv_Search_Page_3_Order_By = {
+  content_type?: InputMaybe<Order_By>;
+  exam_boards?: InputMaybe<Order_By>;
+  key_stages?: InputMaybe<Order_By>;
+  subjects?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_search_page_3" */
+export enum Published_Mv_Search_Page_3_Select_Column {
+  /** column name */
+  ContentType = 'content_type',
+  /** column name */
+  ExamBoards = 'exam_boards',
+  /** column name */
+  KeyStages = 'key_stages',
+  /** column name */
+  Subjects = 'subjects'
+}
+
+/** Streaming cursor of the table "published_mv_search_page_3" */
+export type Published_Mv_Search_Page_3_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Search_Page_3_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Search_Page_3_Stream_Cursor_Value_Input = {
+  content_type?: InputMaybe<Scalars['json']['input']>;
+  exam_boards?: InputMaybe<Scalars['json']['input']>;
   key_stages?: InputMaybe<Scalars['json']['input']>;
   subjects?: InputMaybe<Scalars['json']['input']>;
 };
@@ -17425,118 +15788,6 @@ export type Published_Mv_Subject_Listing_3_0_0_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Subject_Listing_3_0_0_Stream_Cursor_Value_Input = {
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStages?: InputMaybe<Scalars['jsonb']['input']>;
-  subjects?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectsUnavailable?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** columns and relationships of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5 = {
-  __typename?: 'published_mv_subject_listing_5';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  keyStages?: Maybe<Scalars['jsonb']['output']>;
-  subjects?: Maybe<Scalars['jsonb']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5KeyStagesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5SubjectsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5_Aggregate = {
-  __typename?: 'published_mv_subject_listing_5_aggregate';
-  aggregate?: Maybe<Published_Mv_Subject_Listing_5_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Subject_Listing_5>;
-};
-
-/** aggregate fields of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5_Aggregate_Fields = {
-  __typename?: 'published_mv_subject_listing_5_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Subject_Listing_5_Max_Fields>;
-  min?: Maybe<Published_Mv_Subject_Listing_5_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_subject_listing_5". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Subject_Listing_5_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Bool_Exp>>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStages?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjects?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectsUnavailable?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Subject_Listing_5_Max_Fields = {
-  __typename?: 'published_mv_subject_listing_5_max_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Subject_Listing_5_Min_Fields = {
-  __typename?: 'published_mv_subject_listing_5_min_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_subject_listing_5". */
-export type Published_Mv_Subject_Listing_5_Order_By = {
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  keyStages?: InputMaybe<Order_By>;
-  subjects?: InputMaybe<Order_By>;
-  subjectsUnavailable?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_subject_listing_5" */
-export enum Published_Mv_Subject_Listing_5_Select_Column {
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  KeyStages = 'keyStages',
-  /** column name */
-  Subjects = 'subjects',
-  /** column name */
-  SubjectsUnavailable = 'subjectsUnavailable'
-}
-
-/** Streaming cursor of the table "published_mv_subject_listing_5" */
-export type Published_Mv_Subject_Listing_5_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Subject_Listing_5_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Subject_Listing_5_Stream_Cursor_Value_Input = {
   keyStageSlug?: InputMaybe<Scalars['String']['input']>;
   keyStageTitle?: InputMaybe<Scalars['String']['input']>;
   keyStages?: InputMaybe<Scalars['jsonb']['input']>;
@@ -17937,234 +16188,6 @@ export type Published_Mv_Unit_Listing_Page_3_0_0_Var_Samp_Fields = {
 /** aggregate variance on columns */
 export type Published_Mv_Unit_Listing_Page_3_0_0_Variance_Fields = {
   __typename?: 'published_mv_unit_listing_page_3_0_0_variance_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13 = {
-  __typename?: 'published_mv_unit_listing_page_13';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  learningThemes?: Maybe<Scalars['jsonb']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tiers?: Maybe<Scalars['jsonb']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-  units?: Maybe<Scalars['jsonb']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13LearningThemesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13TiersArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13UnitsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13_Aggregate = {
-  __typename?: 'published_mv_unit_listing_page_13_aggregate';
-  aggregate?: Maybe<Published_Mv_Unit_Listing_Page_13_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Unit_Listing_Page_13>;
-};
-
-/** aggregate fields of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13_Aggregate_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_aggregate_fields';
-  avg?: Maybe<Published_Mv_Unit_Listing_Page_13_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Unit_Listing_Page_13_Max_Fields>;
-  min?: Maybe<Published_Mv_Unit_Listing_Page_13_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Unit_Listing_Page_13_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Unit_Listing_Page_13_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Unit_Listing_Page_13_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Unit_Listing_Page_13_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Unit_Listing_Page_13_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Unit_Listing_Page_13_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Unit_Listing_Page_13_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Unit_Listing_Page_13_Avg_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_avg_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_unit_listing_page_13". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Unit_Listing_Page_13_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Bool_Exp>>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  learningThemes?: InputMaybe<Jsonb_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tiers?: InputMaybe<Jsonb_Comparison_Exp>;
-  unitCount?: InputMaybe<Bigint_Comparison_Exp>;
-  units?: InputMaybe<Jsonb_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Unit_Listing_Page_13_Max_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Unit_Listing_Page_13_Min_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_unit_listing_page_13". */
-export type Published_Mv_Unit_Listing_Page_13_Order_By = {
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  learningThemes?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tiers?: InputMaybe<Order_By>;
-  unitCount?: InputMaybe<Order_By>;
-  units?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_unit_listing_page_13" */
-export enum Published_Mv_Unit_Listing_Page_13_Select_Column {
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LearningThemes = 'learningThemes',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  Tiers = 'tiers',
-  /** column name */
-  UnitCount = 'unitCount',
-  /** column name */
-  Units = 'units'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Unit_Listing_Page_13_Stddev_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_stddev_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Unit_Listing_Page_13_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_stddev_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Unit_Listing_Page_13_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_stddev_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_unit_listing_page_13" */
-export type Published_Mv_Unit_Listing_Page_13_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Unit_Listing_Page_13_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Unit_Listing_Page_13_Stream_Cursor_Value_Input = {
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  learningThemes?: InputMaybe<Scalars['jsonb']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tiers?: InputMaybe<Scalars['jsonb']['input']>;
-  unitCount?: InputMaybe<Scalars['bigint']['input']>;
-  units?: InputMaybe<Scalars['jsonb']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Unit_Listing_Page_13_Sum_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_sum_fields';
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Unit_Listing_Page_13_Var_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_var_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Unit_Listing_Page_13_Var_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_var_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Unit_Listing_Page_13_Variance_Fields = {
-  __typename?: 'published_mv_unit_listing_page_13_variance_fields';
   unitCount?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -20937,10 +18960,10 @@ export type Query_Root = {
   published_mv_downloads_3_0_0: Array<Published_Mv_Downloads_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_downloads_3_0_0" */
   published_mv_downloads_3_0_0_aggregate: Published_Mv_Downloads_3_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_downloads_7" */
-  published_mv_downloads_7: Array<Published_Mv_Downloads_7>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_7" */
-  published_mv_downloads_7_aggregate: Published_Mv_Downloads_7_Aggregate;
+  /** fetch data from the table: "published.mv_downloads_3_0_1" */
+  published_mv_downloads_3_0_1: Array<Published_Mv_Downloads_3_0_1>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_1" */
+  published_mv_downloads_3_0_1_aggregate: Published_Mv_Downloads_3_0_1_Aggregate;
   /** fetch data from the table: "published.mv_homepage_2" */
   published_mv_homepage_2: Array<Published_Mv_Homepage_2>;
   /** fetch aggregated fields from the table: "published.mv_homepage_2" */
@@ -20957,50 +18980,34 @@ export type Query_Root = {
   published_mv_lesson_listing_3_0_0: Array<Published_Mv_Lesson_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_listing_3_0_0" */
   published_mv_lesson_listing_3_0_0_aggregate: Published_Mv_Lesson_Listing_3_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_listing_15" */
-  published_mv_lesson_listing_15: Array<Published_Mv_Lesson_Listing_15>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_listing_15" */
-  published_mv_lesson_listing_15_aggregate: Published_Mv_Lesson_Listing_15_Aggregate;
   /** fetch data from the table: "published.mv_lesson_overview_3_0_0" */
   published_mv_lesson_overview_3_0_0: Array<Published_Mv_Lesson_Overview_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_3_0_0" */
   published_mv_lesson_overview_3_0_0_aggregate: Published_Mv_Lesson_Overview_3_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_overview_11" */
-  published_mv_lesson_overview_11: Array<Published_Mv_Lesson_Overview_11>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_11" */
-  published_mv_lesson_overview_11_aggregate: Published_Mv_Lesson_Overview_11_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_overview_12" */
-  published_mv_lesson_overview_12: Array<Published_Mv_Lesson_Overview_12>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_12" */
-  published_mv_lesson_overview_12_aggregate: Published_Mv_Lesson_Overview_12_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_overview_13" */
-  published_mv_lesson_overview_13: Array<Published_Mv_Lesson_Overview_13>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_13" */
-  published_mv_lesson_overview_13_aggregate: Published_Mv_Lesson_Overview_13_Aggregate;
-  /** fetch data from the table: "published.mv_programme_listing_3" */
-  published_mv_programme_listing_3: Array<Published_Mv_Programme_Listing_3>;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0_aggregate: Published_Mv_Programme_Listing_3_0_0_Aggregate;
-  /** fetch aggregated fields from the table: "published.mv_programme_listing_3" */
-  published_mv_programme_listing_3_aggregate: Published_Mv_Programme_Listing_3_Aggregate;
   /** fetch data from the table: "published.mv_search_page" */
   published_mv_search_page: Array<Published_Mv_Search_Page>;
   /** fetch data from the table: "published.mv_search_page_1" */
   published_mv_search_page_1: Array<Published_Mv_Search_Page_1>;
   /** fetch aggregated fields from the table: "published.mv_search_page_1" */
   published_mv_search_page_1_aggregate: Published_Mv_Search_Page_1_Aggregate;
+  /** fetch data from the table: "published.mv_search_page_2" */
+  published_mv_search_page_2: Array<Published_Mv_Search_Page_2>;
+  /** fetch aggregated fields from the table: "published.mv_search_page_2" */
+  published_mv_search_page_2_aggregate: Published_Mv_Search_Page_2_Aggregate;
+  /** fetch data from the table: "published.mv_search_page_3" */
+  published_mv_search_page_3: Array<Published_Mv_Search_Page_3>;
+  /** fetch aggregated fields from the table: "published.mv_search_page_3" */
+  published_mv_search_page_3_aggregate: Published_Mv_Search_Page_3_Aggregate;
   /** fetch aggregated fields from the table: "published.mv_search_page" */
   published_mv_search_page_aggregate: Published_Mv_Search_Page_Aggregate;
   /** fetch data from the table: "published.mv_subject_listing_3_0_0" */
   published_mv_subject_listing_3_0_0: Array<Published_Mv_Subject_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_subject_listing_3_0_0" */
   published_mv_subject_listing_3_0_0_aggregate: Published_Mv_Subject_Listing_3_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_subject_listing_5" */
-  published_mv_subject_listing_5: Array<Published_Mv_Subject_Listing_5>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_5" */
-  published_mv_subject_listing_5_aggregate: Published_Mv_Subject_Listing_5_Aggregate;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -21009,10 +19016,6 @@ export type Query_Root = {
   published_mv_unit_listing_page_3_0_0: Array<Published_Mv_Unit_Listing_Page_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_unit_listing_page_3_0_0" */
   published_mv_unit_listing_page_3_0_0_aggregate: Published_Mv_Unit_Listing_Page_3_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_unit_listing_page_13" */
-  published_mv_unit_listing_page_13: Array<Published_Mv_Unit_Listing_Page_13>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_13" */
-  published_mv_unit_listing_page_13_aggregate: Published_Mv_Unit_Listing_Page_13_Aggregate;
   /** fetch data from the table: "published.view_quiz_question_details" */
   published_view_quiz_question_details: Array<Published_View_Quiz_Question_Details>;
   /** fetch data from the table: "published.view_quiz_question_details_1" */
@@ -21085,9 +19088,9 @@ export type Query_Root = {
   quizzes_aggregate: Quizzes_Aggregate;
   /** fetch data from the table: "quizzes" using primary key columns */
   quizzes_by_pk?: Maybe<Quizzes>;
-  /** fetch data from the table: "thirdpartycontent" */
+  /** An array relationship */
   thirdpartycontent: Array<Thirdpartycontent>;
-  /** fetch aggregated fields from the table: "thirdpartycontent" */
+  /** An aggregate relationship */
   thirdpartycontent_aggregate: Thirdpartycontent_Aggregate;
   /** fetch data from the table: "thirdpartycontent" using primary key columns */
   thirdpartycontent_by_pk?: Maybe<Thirdpartycontent>;
@@ -21726,21 +19729,21 @@ export type Query_RootPublished_Mv_Downloads_3_0_0_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Downloads_7Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_7_Select_Column>>;
+export type Query_RootPublished_Mv_Downloads_3_0_1Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_7_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
 };
 
 
-export type Query_RootPublished_Mv_Downloads_7_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_7_Select_Column>>;
+export type Query_RootPublished_Mv_Downloads_3_0_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_7_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
 };
 
 
@@ -21816,24 +19819,6 @@ export type Query_RootPublished_Mv_Lesson_Listing_3_0_0_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Lesson_Listing_15Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Listing_15_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-};
-
-
 export type Query_RootPublished_Mv_Lesson_Overview_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -21852,69 +19837,6 @@ export type Query_RootPublished_Mv_Lesson_Overview_3_0_0_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Lesson_Overview_11Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_11_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_12Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_12_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_13Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_13_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Programme_Listing_3Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
-};
-
-
 export type Query_RootPublished_Mv_Programme_Listing_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -21930,15 +19852,6 @@ export type Query_RootPublished_Mv_Programme_Listing_3_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_3_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Programme_Listing_3_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Programme_Listing_3_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
 };
 
 
@@ -21969,6 +19882,42 @@ export type Query_RootPublished_Mv_Search_Page_1_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Search_Page_2Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Search_Page_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Search_Page_3Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Search_Page_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Search_Page_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -21993,24 +19942,6 @@ export type Query_RootPublished_Mv_Subject_Listing_3_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_3_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Subject_Listing_3_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Subject_Listing_5Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Subject_Listing_5_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
 };
 
 
@@ -22047,24 +19978,6 @@ export type Query_RootPublished_Mv_Unit_Listing_Page_3_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_3_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Unit_Listing_Page_3_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Unit_Listing_Page_13Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Unit_Listing_Page_13_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
 };
 
 
@@ -24581,12 +22494,12 @@ export type Subscription_Root = {
   published_mv_downloads_3_0_0_aggregate: Published_Mv_Downloads_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_0" */
   published_mv_downloads_3_0_0_stream: Array<Published_Mv_Downloads_3_0_0>;
-  /** fetch data from the table: "published.mv_downloads_7" */
-  published_mv_downloads_7: Array<Published_Mv_Downloads_7>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_7" */
-  published_mv_downloads_7_aggregate: Published_Mv_Downloads_7_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_downloads_7" */
-  published_mv_downloads_7_stream: Array<Published_Mv_Downloads_7>;
+  /** fetch data from the table: "published.mv_downloads_3_0_1" */
+  published_mv_downloads_3_0_1: Array<Published_Mv_Downloads_3_0_1>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_1" */
+  published_mv_downloads_3_0_1_aggregate: Published_Mv_Downloads_3_0_1_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_1" */
+  published_mv_downloads_3_0_1_stream: Array<Published_Mv_Downloads_3_0_1>;
   /** fetch data from the table: "published.mv_homepage_2" */
   published_mv_homepage_2: Array<Published_Mv_Homepage_2>;
   /** fetch aggregated fields from the table: "published.mv_homepage_2" */
@@ -24611,48 +22524,18 @@ export type Subscription_Root = {
   published_mv_lesson_listing_3_0_0_aggregate: Published_Mv_Lesson_Listing_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_3_0_0" */
   published_mv_lesson_listing_3_0_0_stream: Array<Published_Mv_Lesson_Listing_3_0_0>;
-  /** fetch data from the table: "published.mv_lesson_listing_15" */
-  published_mv_lesson_listing_15: Array<Published_Mv_Lesson_Listing_15>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_listing_15" */
-  published_mv_lesson_listing_15_aggregate: Published_Mv_Lesson_Listing_15_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_15" */
-  published_mv_lesson_listing_15_stream: Array<Published_Mv_Lesson_Listing_15>;
   /** fetch data from the table: "published.mv_lesson_overview_3_0_0" */
   published_mv_lesson_overview_3_0_0: Array<Published_Mv_Lesson_Overview_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_3_0_0" */
   published_mv_lesson_overview_3_0_0_aggregate: Published_Mv_Lesson_Overview_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_3_0_0" */
   published_mv_lesson_overview_3_0_0_stream: Array<Published_Mv_Lesson_Overview_3_0_0>;
-  /** fetch data from the table: "published.mv_lesson_overview_11" */
-  published_mv_lesson_overview_11: Array<Published_Mv_Lesson_Overview_11>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_11" */
-  published_mv_lesson_overview_11_aggregate: Published_Mv_Lesson_Overview_11_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_11" */
-  published_mv_lesson_overview_11_stream: Array<Published_Mv_Lesson_Overview_11>;
-  /** fetch data from the table: "published.mv_lesson_overview_12" */
-  published_mv_lesson_overview_12: Array<Published_Mv_Lesson_Overview_12>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_12" */
-  published_mv_lesson_overview_12_aggregate: Published_Mv_Lesson_Overview_12_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_12" */
-  published_mv_lesson_overview_12_stream: Array<Published_Mv_Lesson_Overview_12>;
-  /** fetch data from the table: "published.mv_lesson_overview_13" */
-  published_mv_lesson_overview_13: Array<Published_Mv_Lesson_Overview_13>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_13" */
-  published_mv_lesson_overview_13_aggregate: Published_Mv_Lesson_Overview_13_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_13" */
-  published_mv_lesson_overview_13_stream: Array<Published_Mv_Lesson_Overview_13>;
-  /** fetch data from the table: "published.mv_programme_listing_3" */
-  published_mv_programme_listing_3: Array<Published_Mv_Programme_Listing_3>;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0_aggregate: Published_Mv_Programme_Listing_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0_stream: Array<Published_Mv_Programme_Listing_3_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_programme_listing_3" */
-  published_mv_programme_listing_3_aggregate: Published_Mv_Programme_Listing_3_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_programme_listing_3" */
-  published_mv_programme_listing_3_stream: Array<Published_Mv_Programme_Listing_3>;
   /** fetch data from the table: "published.mv_search_page" */
   published_mv_search_page: Array<Published_Mv_Search_Page>;
   /** fetch data from the table: "published.mv_search_page_1" */
@@ -24661,6 +22544,18 @@ export type Subscription_Root = {
   published_mv_search_page_1_aggregate: Published_Mv_Search_Page_1_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_search_page_1" */
   published_mv_search_page_1_stream: Array<Published_Mv_Search_Page_1>;
+  /** fetch data from the table: "published.mv_search_page_2" */
+  published_mv_search_page_2: Array<Published_Mv_Search_Page_2>;
+  /** fetch aggregated fields from the table: "published.mv_search_page_2" */
+  published_mv_search_page_2_aggregate: Published_Mv_Search_Page_2_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_search_page_2" */
+  published_mv_search_page_2_stream: Array<Published_Mv_Search_Page_2>;
+  /** fetch data from the table: "published.mv_search_page_3" */
+  published_mv_search_page_3: Array<Published_Mv_Search_Page_3>;
+  /** fetch aggregated fields from the table: "published.mv_search_page_3" */
+  published_mv_search_page_3_aggregate: Published_Mv_Search_Page_3_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_search_page_3" */
+  published_mv_search_page_3_stream: Array<Published_Mv_Search_Page_3>;
   /** fetch aggregated fields from the table: "published.mv_search_page" */
   published_mv_search_page_aggregate: Published_Mv_Search_Page_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_search_page" */
@@ -24671,12 +22566,6 @@ export type Subscription_Root = {
   published_mv_subject_listing_3_0_0_aggregate: Published_Mv_Subject_Listing_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_subject_listing_3_0_0" */
   published_mv_subject_listing_3_0_0_stream: Array<Published_Mv_Subject_Listing_3_0_0>;
-  /** fetch data from the table: "published.mv_subject_listing_5" */
-  published_mv_subject_listing_5: Array<Published_Mv_Subject_Listing_5>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_5" */
-  published_mv_subject_listing_5_aggregate: Published_Mv_Subject_Listing_5_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_subject_listing_5" */
-  published_mv_subject_listing_5_stream: Array<Published_Mv_Subject_Listing_5>;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -24689,12 +22578,6 @@ export type Subscription_Root = {
   published_mv_unit_listing_page_3_0_0_aggregate: Published_Mv_Unit_Listing_Page_3_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_3_0_0" */
   published_mv_unit_listing_page_3_0_0_stream: Array<Published_Mv_Unit_Listing_Page_3_0_0>;
-  /** fetch data from the table: "published.mv_unit_listing_page_13" */
-  published_mv_unit_listing_page_13: Array<Published_Mv_Unit_Listing_Page_13>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_13" */
-  published_mv_unit_listing_page_13_aggregate: Published_Mv_Unit_Listing_Page_13_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_13" */
-  published_mv_unit_listing_page_13_stream: Array<Published_Mv_Unit_Listing_Page_13>;
   /** fetch data from the table: "published.view_quiz_question_details" */
   published_view_quiz_question_details: Array<Published_View_Quiz_Question_Details>;
   /** fetch data from the table: "published.view_quiz_question_details_1" */
@@ -24799,9 +22682,9 @@ export type Subscription_Root = {
   quizzes_by_pk?: Maybe<Quizzes>;
   /** fetch data from the table in a streaming manner: "quizzes" */
   quizzes_stream: Array<Quizzes>;
-  /** fetch data from the table: "thirdpartycontent" */
+  /** An array relationship */
   thirdpartycontent: Array<Thirdpartycontent>;
-  /** fetch aggregated fields from the table: "thirdpartycontent" */
+  /** An aggregate relationship */
   thirdpartycontent_aggregate: Thirdpartycontent_Aggregate;
   /** fetch data from the table: "thirdpartycontent" using primary key columns */
   thirdpartycontent_by_pk?: Maybe<Thirdpartycontent>;
@@ -25638,28 +23521,28 @@ export type Subscription_RootPublished_Mv_Downloads_3_0_0_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_7Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_7_Select_Column>>;
+export type Subscription_RootPublished_Mv_Downloads_3_0_1Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_7_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_7_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_7_Select_Column>>;
+export type Subscription_RootPublished_Mv_Downloads_3_0_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_7_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_7_StreamArgs = {
+export type Subscription_RootPublished_Mv_Downloads_3_0_1_StreamArgs = {
   batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Downloads_7_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Downloads_7_Bool_Exp>;
+  cursor: Array<InputMaybe<Published_Mv_Downloads_3_0_1_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
 };
 
 
@@ -25763,31 +23646,6 @@ export type Subscription_RootPublished_Mv_Lesson_Listing_3_0_0_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Lesson_Listing_15Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Listing_15_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_15_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Listing_15_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Listing_15_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_15_Bool_Exp>;
-};
-
-
 export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -25813,90 +23671,6 @@ export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_0_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Lesson_Overview_11Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_11_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_11_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_11_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_11_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_11_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_12Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_12_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_12_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_12_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_12_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_12_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_13Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_13_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_13_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_13_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_13_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_3Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
-};
-
-
 export type Subscription_RootPublished_Mv_Programme_Listing_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -25919,22 +23693,6 @@ export type Subscription_RootPublished_Mv_Programme_Listing_3_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Programme_Listing_3_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Programme_Listing_3_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_3_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_3_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_3_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Programme_Listing_3_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_3_Bool_Exp>;
 };
 
 
@@ -25969,6 +23727,56 @@ export type Subscription_RootPublished_Mv_Search_Page_1_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Search_Page_1_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Search_Page_1_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_2Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_2_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Search_Page_2_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Search_Page_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_3Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Search_Page_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Search_Page_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Search_Page_3_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Search_Page_3_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
 };
 
 
@@ -26010,31 +23818,6 @@ export type Subscription_RootPublished_Mv_Subject_Listing_3_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Subject_Listing_3_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Subject_Listing_3_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Subject_Listing_5_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_Bool_Exp>;
 };
 
 
@@ -26085,31 +23868,6 @@ export type Subscription_RootPublished_Mv_Unit_Listing_Page_3_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_3_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Unit_Listing_Page_3_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_13Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_13_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_13_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_13_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_13_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_13_Bool_Exp>;
 };
 
 
@@ -26868,6 +24626,33 @@ export type Thirdpartycontent_Aggregate = {
   nodes: Array<Thirdpartycontent>;
 };
 
+export type Thirdpartycontent_Aggregate_Bool_Exp = {
+  bool_and?: InputMaybe<Thirdpartycontent_Aggregate_Bool_Exp_Bool_And>;
+  bool_or?: InputMaybe<Thirdpartycontent_Aggregate_Bool_Exp_Bool_Or>;
+  count?: InputMaybe<Thirdpartycontent_Aggregate_Bool_Exp_Count>;
+};
+
+export type Thirdpartycontent_Aggregate_Bool_Exp_Bool_And = {
+  arguments: Thirdpartycontent_Select_Column_Thirdpartycontent_Aggregate_Bool_Exp_Bool_And_Arguments_Columns;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+  filter?: InputMaybe<Thirdpartycontent_Bool_Exp>;
+  predicate: Boolean_Comparison_Exp;
+};
+
+export type Thirdpartycontent_Aggregate_Bool_Exp_Bool_Or = {
+  arguments: Thirdpartycontent_Select_Column_Thirdpartycontent_Aggregate_Bool_Exp_Bool_Or_Arguments_Columns;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+  filter?: InputMaybe<Thirdpartycontent_Bool_Exp>;
+  predicate: Boolean_Comparison_Exp;
+};
+
+export type Thirdpartycontent_Aggregate_Bool_Exp_Count = {
+  arguments?: InputMaybe<Array<Thirdpartycontent_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+  filter?: InputMaybe<Thirdpartycontent_Bool_Exp>;
+  predicate: Int_Comparison_Exp;
+};
+
 /** aggregate fields of "thirdpartycontent" */
 export type Thirdpartycontent_Aggregate_Fields = {
   __typename?: 'thirdpartycontent_aggregate_fields';
@@ -26911,6 +24696,13 @@ export type Thirdpartycontent_Append_Input = {
   content_details?: InputMaybe<Scalars['jsonb']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   terms?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** input type for inserting array relation for remote table "thirdpartycontent" */
+export type Thirdpartycontent_Arr_Rel_Insert_Input = {
+  data: Array<Thirdpartycontent_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Thirdpartycontent_On_Conflict>;
 };
 
 /** aggregate avg on columns */
@@ -27246,6 +25038,26 @@ export enum Thirdpartycontent_Select_Column {
   UnitId = 'unit_id',
   /** column name */
   UpdatedAt = 'updated_at'
+}
+
+/** select "thirdpartycontent_aggregate_bool_exp_bool_and_arguments_columns" columns of table "thirdpartycontent" */
+export enum Thirdpartycontent_Select_Column_Thirdpartycontent_Aggregate_Bool_Exp_Bool_And_Arguments_Columns {
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  FairDealing = 'fair_dealing',
+  /** column name */
+  LoginRequired = 'login_required'
+}
+
+/** select "thirdpartycontent_aggregate_bool_exp_bool_or_arguments_columns" columns of table "thirdpartycontent" */
+export enum Thirdpartycontent_Select_Column_Thirdpartycontent_Aggregate_Bool_Exp_Bool_Or_Arguments_Columns {
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  FairDealing = 'fair_dealing',
+  /** column name */
+  LoginRequired = 'login_required'
 }
 
 /** input type for updating data in table "thirdpartycontent" */
@@ -28768,6 +26580,19 @@ export type Threads_Variance_Order_By = {
   thread_id?: InputMaybe<Order_By>;
 };
 
+/** Boolean expression to compare columns of type "timestamp". All fields are combined with logical 'AND'. */
+export type Timestamp_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars['timestamp']['input']>;
+  _gt?: InputMaybe<Scalars['timestamp']['input']>;
+  _gte?: InputMaybe<Scalars['timestamp']['input']>;
+  _in?: InputMaybe<Array<Scalars['timestamp']['input']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
+  _lt?: InputMaybe<Scalars['timestamp']['input']>;
+  _lte?: InputMaybe<Scalars['timestamp']['input']>;
+  _neq?: InputMaybe<Scalars['timestamp']['input']>;
+  _nin?: InputMaybe<Array<Scalars['timestamp']['input']>>;
+};
+
 /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
 export type Timestamptz_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -28821,6 +26646,10 @@ export type Units = {
   prior_knowledge_requirements?: Maybe<Scalars['json']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   tags?: Maybe<Scalars['json']['output']>;
+  /** An array relationship */
+  thirdpartycontent: Array<Thirdpartycontent>;
+  /** An aggregate relationship */
+  thirdpartycontent_aggregate: Thirdpartycontent_Aggregate;
   title?: Maybe<Scalars['String']['output']>;
   unit_id: Scalars['Int']['output'];
   /** An array relationship */
@@ -28939,6 +26768,26 @@ export type UnitsPrior_Knowledge_RequirementsArgs = {
 /** columns and relationships of "units" */
 export type UnitsTagsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "units" */
+export type UnitsThirdpartycontentArgs = {
+  distinct_on?: InputMaybe<Array<Thirdpartycontent_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thirdpartycontent_Order_By>>;
+  where?: InputMaybe<Thirdpartycontent_Bool_Exp>;
+};
+
+
+/** columns and relationships of "units" */
+export type UnitsThirdpartycontent_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Thirdpartycontent_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thirdpartycontent_Order_By>>;
+  where?: InputMaybe<Thirdpartycontent_Bool_Exp>;
 };
 
 
@@ -29211,6 +27060,8 @@ export type Units_Bool_Exp = {
   prior_knowledge_requirements?: InputMaybe<Json_Comparison_Exp>;
   slug?: InputMaybe<String_Comparison_Exp>;
   tags?: InputMaybe<Json_Comparison_Exp>;
+  thirdpartycontent?: InputMaybe<Thirdpartycontent_Bool_Exp>;
+  thirdpartycontent_aggregate?: InputMaybe<Thirdpartycontent_Aggregate_Bool_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
   unit_id?: InputMaybe<Int_Comparison_Exp>;
   unit_programmes?: InputMaybe<Programme_Units_Bool_Exp>;
@@ -29290,6 +27141,7 @@ export type Units_Insert_Input = {
   prior_knowledge_requirements?: InputMaybe<Scalars['json']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   tags?: InputMaybe<Scalars['json']['input']>;
+  thirdpartycontent?: InputMaybe<Thirdpartycontent_Arr_Rel_Insert_Input>;
   title?: InputMaybe<Scalars['String']['input']>;
   unit_id?: InputMaybe<Scalars['Int']['input']>;
   unit_programmes?: InputMaybe<Programme_Units_Arr_Rel_Insert_Input>;
@@ -29441,6 +27293,7 @@ export type Units_Order_By = {
   prior_knowledge_requirements?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   tags?: InputMaybe<Order_By>;
+  thirdpartycontent_aggregate?: InputMaybe<Thirdpartycontent_Aggregate_Order_By>;
   title?: InputMaybe<Order_By>;
   unit_id?: InputMaybe<Order_By>;
   unit_programmes_aggregate?: InputMaybe<Programme_Units_Aggregate_Order_By>;
@@ -32401,7 +30254,7 @@ export type LessonDownloadsQueryVariables = Exact<{
 }>;
 
 
-export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_0', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_0', lessons?: any | null }> };
+export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_1', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_0', lessons?: any | null }> };
 
 export type LessonDownloadsCanonicalQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -32449,7 +30302,7 @@ export type PupilLessonOverviewQueryVariables = Exact<{
 }>;
 
 
-export type PupilLessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_0', lessonSlug?: string | null, lessonTitle?: string | null, programmeSlug?: string | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, examBoardTitle?: string | null, tierTitle?: string | null, misconceptionsAndCommonMistakes?: any | null, lessonEquipmentAndResources?: any | null, teacherTips?: any | null, keyLearningPoints?: any | null, pupilLessonOutcome?: string | null, lessonKeywords?: any | null, copyrightContent?: any | null, contentGuidance?: any | null, additionalMaterialUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, presentationUrl?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, yearTitle?: string | null, hasDownloadableResources?: boolean | null, videoTitle?: string | null }> };
+export type PupilLessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_0', starterQuiz?: any | null }> };
 
 export type SearchPageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -32526,7 +30379,7 @@ export const CurriculumUnitsDocument = gql`
     `;
 export const LessonDownloadsDocument = gql`
     query lessonDownloads($lessonSlug: String!, $programmeSlug: String!, $unitSlug: String!) {
-  downloads: published_mv_downloads_3_0_0(
+  downloads: published_mv_downloads_3_0_1(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
     downloads
@@ -32682,37 +30535,7 @@ export const PupilLessonOverviewDocument = gql`
   lesson: published_mv_lesson_overview_3_0_0(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
-    lessonSlug
-    lessonTitle
-    programmeSlug
-    unitSlug
-    unitTitle
-    keyStageSlug
-    keyStageTitle
-    subjectSlug
-    subjectTitle
-    examBoardTitle
-    tierTitle
-    misconceptionsAndCommonMistakes
-    lessonEquipmentAndResources
-    teacherTips
-    keyLearningPoints
-    pupilLessonOutcome
-    lessonKeywords
-    copyrightContent
-    contentGuidance
-    additionalMaterialUrl
-    supervisionLevel
-    worksheetUrl
-    presentationUrl
-    videoMuxPlaybackId
-    videoWithSignLanguageMuxPlaybackId
-    transcriptSentences
     starterQuiz
-    exitQuiz
-    yearTitle
-    hasDownloadableResources
-    videoTitle
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
@@ -3,7 +3,7 @@ query lessonDownloads(
   $programmeSlug: String!
   $unitSlug: String!
 ) {
-  downloads: published_mv_downloads_3_0_0(
+  downloads: published_mv_downloads_3_0_1(
     where: {
       lessonSlug: { _eq: $lessonSlug }
       programmeSlug: { _eq: $programmeSlug }


### PR DESCRIPTION
## Description

Some of the lessons that were released yesterday had no data (intentionally) in their exit quizzes. Unfortunately, the PDFs are generated regardless of whether there is data in the quizzes. This meant the lesson page in OWA knew there wasn’t a quiz because there was no quiz data, but the downloads page, that only checks to see if a PDF exists, does see a PDF so offers it for download. 

Connects up new downloads mv to fix the issue

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2150--oak-web-application.netlify.thenational.academy/teachers/programmes/english-primary-ks1/units/writing-lower-case-letters-in-print/lessons/introduction-to-skills-and-patterns

There should be no exit quiz in this download

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
