### PR TITLE
chore: fix highlighting of key words

### DIFF
--- a/src/components/SearchResultsItem/SearchResultsItem.tsx
+++ b/src/components/SearchResultsItem/SearchResultsItem.tsx
@@ -104,16 +104,15 @@ const SearchResultsItem: FC<SearchResultsItemProps> = (props) => {
         <Heading tag={"h2"} $font={["heading-6", "heading-5"]}>
           {title}
         </Heading>
-        {description ||
-          (pupilLessonOutcome && (
-            <P
-              dangerouslySetInnerHTML={{
-                __html: searchHitDescription,
-              }}
-              $mt={16}
-              $font={"body-2"}
-            />
-          ))}
+        {searchHitDescription && (
+          <P
+            dangerouslySetInnerHTML={{
+              __html: searchHitDescription,
+            }}
+            $mt={16}
+            $font={"body-2"}
+          />
+        )}
       </Flex>
       <Flex $mb={20}>
         {isPathwaySearchHit ? (


### PR DESCRIPTION
## Description

Music year: 1985

- Fixes bolding on search descriptions 

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2156--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
