### PR TITLE
ENGD-82 allow Netlify plugins to be disabled with envs

### DIFF
--- a/netlify/plugins/README.md
+++ b/netlify/plugins/README.md
@@ -1,0 +1,5 @@
+# Custom Netlify Plugins
+
+We have two custom Netlify build plugins, one for reporting builds into GitHub, and one for reporting builds into Slack.
+
+They can be disabled (e.g. for temporary custom builds in new Netlify projects) by setting the env variables `PLUGIN_GITHUB_DEPLOYMENTS_DISABLED=true` or `PLUGIN_SLACK_DISABLED=true`.

--- a/netlify/plugins/lib/index.js
+++ b/netlify/plugins/lib/index.js
@@ -56,4 +56,24 @@ module.exports = {
     console.log(`Determined app version: ${appVersion}`);
     return appVersion;
   },
+
+  /**
+   * We need to disable plugins for some custom builds.
+   *
+   * @param {string} envName The name of the environment variable to check. Only "true" will disable the plugin.
+   * @returns A function to exit the process if the appropriate environment variable is set to true.
+   */
+  getExitIfPluginDisabled: function (envName) {
+    if (!envName) {
+      throw new TypeError(
+        "Attempted to get disabled plugin function without specifying an env variable name.",
+      );
+    }
+    return function disablePlug() {
+      if (process.env[envName] === "true") {
+        console.log(`Plugin controlled by ${envName}: disabled.`);
+        process.exit(0);
+      }
+    };
+  },
 };

--- a/netlify/plugins/slack-reporting/index.js
+++ b/netlify/plugins/slack-reporting/index.js
@@ -1,4 +1,4 @@
-const { getAppVersion } = require("../lib");
+const { getAppVersion, getExitIfPluginDisabled } = require("../lib");
 
 const {
   createBuildStartedSlackMessage,
@@ -22,8 +22,15 @@ module.exports = function slackBuildReporterPlugin() {
     dev: "dev",
   };
 
+  /**
+   * We need to disable plugins for some custom builds.
+   */
+  const exitIfDisabled = getExitIfPluginDisabled("PLUGIN_SLACK_DISABLED");
+
   return {
     onPreBuild: async ({ netlifyConfig, utils }) => {
+      exitIfDisabled();
+
       // Extract the data required to interact with the GitHub deployments rest API.
       const buildContext = netlifyConfig.build.environment.CONTEXT;
       const originalDeploymentUrl = process.env.DEPLOY_PRIME_URL;
@@ -113,6 +120,8 @@ module.exports = function slackBuildReporterPlugin() {
      * Set deployment status failure.
      */
     onError: async ({ utils }) => {
+      exitIfDisabled();
+
       // Early exits
       // Only report on production builds for now.
       if (!sharedInfo.isProduction) {
@@ -156,6 +165,8 @@ module.exports = function slackBuildReporterPlugin() {
      * Set deployment status success.
      */
     onSuccess: async ({ utils }) => {
+      exitIfDisabled();
+
       // Early exits
       // Only report on production builds for now.
       if (!sharedInfo.isProduction) {


### PR DESCRIPTION
Allow Netlify plugins to be disabled with env variable switches so we can avoid PR event pollution from temporary Netlify projects building this repo, e.g. owa-migration

[ENGD-82](https://www.notion.so/oaknationalacademy/Create-a-new-environment-within-Netlify-for-the-migration-QA-environment-a1d1a1660c4e4de7b5c12e80ab737e11)