### PR TITLE
Feat/mathjax in lesson information LESQ-525 LESQ-507

### DIFF
--- a/src/components/TeacherComponents/LessonOverviewCommonMisconceptions/LessonOverviewCommonMisconceptions.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewCommonMisconceptions/LessonOverviewCommonMisconceptions.test.tsx
@@ -2,6 +2,12 @@ import LessonOverviewCommonMisconceptions from "./LessonOverviewCommonMisconcept
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
+jest.mock("better-react-mathjax", () => ({
+  MathJax: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
 describe("LessonOverviewCommonMisconceptions component", () => {
   it("should render with correct heading", () => {
     const commonMisconceptions = [
@@ -12,7 +18,7 @@ describe("LessonOverviewCommonMisconceptions component", () => {
         commonMisconceptions={commonMisconceptions}
       />,
     );
-    const componentTitle = getByText("Common misconceptions");
+    const componentTitle = getByText("Common misconception");
     expect(getByTestId("heading")).toBeInTheDocument();
     expect(componentTitle).toBeInTheDocument();
   });

--- a/src/components/TeacherComponents/LessonOverviewCommonMisconceptions/LessonOverviewCommonMisconceptions.tsx
+++ b/src/components/TeacherComponents/LessonOverviewCommonMisconceptions/LessonOverviewCommonMisconceptions.tsx
@@ -30,7 +30,7 @@ const LessonOverviewCommonMisconceptions = ({
       $justifyContent={"center"}
     >
       <Heading $font={"heading-5"} $mb={24} data-testid={"heading"} tag="h3">
-        Common misconceptions
+        Common misconception
       </Heading>
       {commonMisconceptions?.map(
         (commonMisconception: LessonOverviewCommonMisconception, i: number) => {

--- a/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.test.tsx
@@ -2,6 +2,12 @@ import LessonOverviewDetails from "./LessonOverviewDetails";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
+jest.mock("better-react-mathjax", () => ({
+  MathJax: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
 describe("LessonOverviewDetails component", () => {
   const keyLearningPoints = [{ keyLearningPoint: "test" }];
   const commonMisconceptions = [
@@ -65,7 +71,7 @@ describe("LessonOverviewDetails component", () => {
       />,
     );
 
-    const commonMisconceptionsComponent = getByText("Common misconceptions");
+    const commonMisconceptionsComponent = getByText("Common misconception");
     expect(commonMisconceptionsComponent).toBeInTheDocument();
   });
 

--- a/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.tsx
@@ -19,6 +19,7 @@ import {
   ContentGuidance,
   Equipment,
 } from "@/components/TeacherComponents/LessonOverviewRequirements/LessonOverviewRequirements";
+import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
 
 type LessonOverviewDetailsProps = {
   keyLearningPoints: LessonOverviewKeyLearningPointProps[] | null | undefined;
@@ -42,54 +43,62 @@ const LessonOverviewDetails: FC<LessonOverviewDetailsProps> = ({
   isLegacyLicense,
 }) => {
   return (
-    <Flex
-      $flexDirection={"row"}
-      $flexWrap={["wrap", "nowrap"]}
-      $justifyContent={["center", "normal"]}
-      $alignItems={"flex-start"}
-    >
-      <Flex $flexDirection={"column"} $flexGrow={1} $mr={16} $gap={48} $mb={24}>
-        {keyLearningPoints && (
-          <Box>
-            <LessonOverviewKeyLearningPoints
-              keyLearningPoints={keyLearningPoints}
-            />
-          </Box>
-        )}
-        {commonMisconceptions && (
-          <Box>
-            <LessonOverviewCommonMisconceptions
-              commonMisconceptions={commonMisconceptions}
-            />
-          </Box>
-        )}
-        {keyWords && (
-          <Box>
-            <LessonOverviewKeywords keyWords={keyWords} />
-          </Box>
-        )}
+    <MathJaxWrap>
+      <Flex
+        $flexDirection={"row"}
+        $flexWrap={["wrap", "nowrap"]}
+        $justifyContent={["center", "normal"]}
+        $alignItems={"flex-start"}
+      >
+        <Flex
+          $flexDirection={"column"}
+          $flexGrow={1}
+          $mr={16}
+          $gap={48}
+          $mb={24}
+        >
+          {keyLearningPoints && (
+            <Box>
+              <LessonOverviewKeyLearningPoints
+                keyLearningPoints={keyLearningPoints}
+              />
+            </Box>
+          )}
+          {commonMisconceptions && (
+            <Box>
+              <LessonOverviewCommonMisconceptions
+                commonMisconceptions={commonMisconceptions}
+              />
+            </Box>
+          )}
+          {keyWords && (
+            <Box>
+              <LessonOverviewKeywords keyWords={keyWords} />
+            </Box>
+          )}
+        </Flex>
+        <Flex $flexDirection={"column"} $mt={[48, 0]} $gap={48} $mb={24}>
+          {teacherTips && (
+            <Box>
+              <LessonOverviewTeacherTips teacherTips={teacherTips} />
+            </Box>
+          )}
+          {(equipmentAndResources && equipmentAndResources.length > 0) ||
+          (contentGuidance && contentGuidance.length > 0) ||
+          supervisionLevel ||
+          isLegacyLicense !== undefined ? (
+            <Box>
+              <LessonOverviewHelper
+                equipment={equipmentAndResources}
+                contentGuidance={contentGuidance}
+                supervisionLevel={supervisionLevel}
+                isLegacyLicense={isLegacyLicense}
+              />
+            </Box>
+          ) : null}
+        </Flex>
       </Flex>
-      <Flex $flexDirection={"column"} $mt={[48, 0]} $gap={48} $mb={24}>
-        {teacherTips && (
-          <Box>
-            <LessonOverviewTeacherTips teacherTips={teacherTips} />
-          </Box>
-        )}
-        {(equipmentAndResources && equipmentAndResources.length > 0) ||
-        (contentGuidance && contentGuidance.length > 0) ||
-        supervisionLevel ||
-        isLegacyLicense !== undefined ? (
-          <Box>
-            <LessonOverviewHelper
-              equipment={equipmentAndResources}
-              contentGuidance={contentGuidance}
-              supervisionLevel={supervisionLevel}
-              isLegacyLicense={isLegacyLicense}
-            />
-          </Box>
-        ) : null}
-      </Flex>
-    </Flex>
+    </MathJaxWrap>
   );
 };
 

--- a/src/components/TeacherViews/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview.view.tsx
@@ -137,7 +137,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
   const exitQuizImageAttribution = createAttributionObject(exitQuiz);
 
   return (
-    <>
+    <MathJaxProvider>
       <HeaderLesson
         {...lesson}
         {...commonPathway}
@@ -218,7 +218,6 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                     />
                   </LessonItemContainer>
                 )}
-
                 <LessonItemContainer
                   ref={lessonDetailsSectionRef}
                   title={"Lesson details"}
@@ -285,62 +284,58 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                     />
                   </LessonItemContainer>
                 )}
-                <MathJaxProvider>
-                  {pageLinks.find((p) => p.label === "Starter quiz") && (
-                    <LessonItemContainer
-                      ref={starterQuizSectionRef}
-                      title={"Starter quiz"}
-                      shareable={isLegacyLicense}
-                      anchorId="starter-quiz"
-                      downloadable={true}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "starter quiz",
-                        });
-                      }}
-                      slugs={slugs}
-                      isFinalElement={
-                        pageLinks.findIndex(
-                          (p) => p.label === "Starter quiz",
-                        ) ===
-                        pageLinks.length - 1
-                      }
-                    >
-                      {starterQuiz && (
-                        <QuizContainerNew
-                          questions={starterQuiz}
-                          imageAttribution={starterQuizImageAttribution}
-                        />
-                      )}
-                    </LessonItemContainer>
-                  )}
-                  {pageLinks.find((p) => p.label === "Exit quiz") && (
-                    <LessonItemContainer
-                      ref={exitQuizSectionRef}
-                      title={"Exit quiz"}
-                      anchorId="exit-quiz"
-                      downloadable={true}
-                      shareable={isLegacyLicense}
-                      onDownloadButtonClick={() => {
-                        trackDownloadResourceButtonClicked({
-                          downloadResourceButtonName: "exit quiz",
-                        });
-                      }}
-                      slugs={slugs}
-                      isFinalElement={
-                        pageLinks.findIndex((p) => p.label === "Exit quiz") ===
-                        pageLinks.length - 1
-                      }
-                    >
-                      {exitQuiz && (
-                        <QuizContainerNew
-                          questions={exitQuiz}
-                          imageAttribution={exitQuizImageAttribution}
-                        />
-                      )}
-                    </LessonItemContainer>
-                  )}
-                </MathJaxProvider>
+                {pageLinks.find((p) => p.label === "Starter quiz") && (
+                  <LessonItemContainer
+                    ref={starterQuizSectionRef}
+                    title={"Starter quiz"}
+                    shareable={isLegacyLicense}
+                    anchorId="starter-quiz"
+                    downloadable={true}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "starter quiz",
+                      });
+                    }}
+                    slugs={slugs}
+                    isFinalElement={
+                      pageLinks.findIndex((p) => p.label === "Starter quiz") ===
+                      pageLinks.length - 1
+                    }
+                  >
+                    {starterQuiz && (
+                      <QuizContainerNew
+                        questions={starterQuiz}
+                        imageAttribution={starterQuizImageAttribution}
+                      />
+                    )}
+                  </LessonItemContainer>
+                )}
+                {pageLinks.find((p) => p.label === "Exit quiz") && (
+                  <LessonItemContainer
+                    ref={exitQuizSectionRef}
+                    title={"Exit quiz"}
+                    anchorId="exit-quiz"
+                    downloadable={true}
+                    shareable={isLegacyLicense}
+                    onDownloadButtonClick={() => {
+                      trackDownloadResourceButtonClicked({
+                        downloadResourceButtonName: "exit quiz",
+                      });
+                    }}
+                    slugs={slugs}
+                    isFinalElement={
+                      pageLinks.findIndex((p) => p.label === "Exit quiz") ===
+                      pageLinks.length - 1
+                    }
+                  >
+                    {exitQuiz && (
+                      <QuizContainerNew
+                        questions={exitQuiz}
+                        imageAttribution={exitQuizImageAttribution}
+                      />
+                    )}
+                  </LessonItemContainer>
+                )}
                 {pageLinks.find((p) => p.label === "Additional material") && (
                   <LessonItemContainer
                     ref={additionalMaterialSectionRef}
@@ -368,12 +363,12 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                     {/* 
                     Temporary fix for additional material due to unexpected poor rendering of google docs
                     <OverviewPresentation
-                      asset={additionalMaterialUrl}
-                      isAdditionalMaterial={true}
-                      title={lessonTitle}
-                      isWorksheetLandscape={isWorksheetLandscape}
-                      isWorksheet={true}
-                    /> */}
+                    asset={additionalMaterialUrl}
+                    isAdditionalMaterial={true}
+                    title={lessonTitle}
+                    isWorksheetLandscape={isWorksheetLandscape}
+                    isWorksheet={true}
+                  /> */}
                   </LessonItemContainer>
                 )}
               </Flex>
@@ -381,6 +376,6 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
           </Grid>
         )}
       </MaxWidth>
-    </>
+    </MathJaxProvider>
   );
 }


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Mathsjax in lesson details
- fixes copy error 'misconceptions'

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2208--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-foundation/units/surds/lessons/accuracy-of-final-answers

Mathjax should render correctly in quizes,
No Mathjax in lesson details yet
Misconceptions changed to misconception

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
