### PR TITLE
Footer button colour LESQ-495

### DIFF
--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
@@ -68,10 +68,9 @@ const FooterLink: FC<LayoutFooterLinkProps> = (props) => {
         $font={"body-2"}
         label={props.text}
         onClick={showConsentManager}
+        labelColor={"black"}
         $hoverStyles={["underline-link-text"]}
-      >
-        {props.text}
-      </Button>
+      />
     );
   }
 

--- a/src/components/SharedComponents/Button/Button.tsx
+++ b/src/components/SharedComponents/Button/Button.tsx
@@ -17,6 +17,7 @@ import typography, { FontVariant } from "@/styles/utils/typography";
 import UnstyledButton, {
   UnstyledButtonProps,
 } from "@/components/SharedComponents/UnstyledButton";
+import { OakColorName } from "@/styles/theme";
 
 const StyledButton = styled(UnstyledButton)<
   ButtonStylesProps & UnstyledButtonProps
@@ -34,6 +35,7 @@ export type ButtonProps = CommonButtonProps & {
   isCurrent?: boolean;
   currentStyles?: ButtonCurrentStyles;
   role?: string;
+  labelColor?: OakColorName;
 };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
@@ -90,6 +92,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
         disabled={disabled}
         isCurrent={isCurrent}
         currentStyles={currentStyles}
+        labelColor={props.labelColor}
       />
     </StyledButton>
   );

--- a/src/components/SharedComponents/Button/ButtonInner.tsx
+++ b/src/components/SharedComponents/Button/ButtonInner.tsx
@@ -140,7 +140,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
           $alignItems="center"
           $mr={$iconPosition === "leading" ? 8 : 0}
           $ml={$iconPosition === "trailing" ? 8 : 0}
-          $color={color}
+          $color={color ?? labelColor}
         >
           <Icon
             variant="brush"

--- a/src/components/SharedComponents/Button/ButtonInner.tsx
+++ b/src/components/SharedComponents/Button/ButtonInner.tsx
@@ -75,6 +75,7 @@ export type ButtonInnerProps = {
    */
   currentStyles?: ButtonCurrentStyles;
   $font?: ResponsiveValues<FontVariant> | undefined;
+  labelColor?: OakColorName;
 };
 const ButtonInner: FC<ButtonInnerProps> = (props) => {
   let { icon } = props;
@@ -91,6 +92,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
     isCurrent,
     currentStyles,
     $font,
+    labelColor,
   } = props;
   const iconSize = buttonIconSizeMap[buttonSize];
 
@@ -180,7 +182,7 @@ const ButtonInner: FC<ButtonInnerProps> = (props) => {
               : undefined
           }
         >
-          <ButtonLabel $font={$font}>
+          <ButtonLabel $font={$font} $color={labelColor}>
             {label}
             {labelSuffixA11y && (
               <ScreenReaderOnly> {labelSuffixA11y}</ScreenReaderOnly>


### PR DESCRIPTION
## Description

Music year: 2014

- Adds labelColor prop to button to change the colour of button labels when passed in 

## Issue(s)

Fixes #LESQ-495

## How to test

1. Go to https://deploy-preview-2209--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
