### PR TITLE
fix: point dowloads gql to correct mv

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -14190,6 +14190,192 @@ export type Published_Mv_Downloads_3_0_1_Stream_Cursor_Value_Input = {
   unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2 = {
+  __typename?: 'published_mv_downloads_3_0_2';
+  downloads?: Maybe<Scalars['jsonb']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2DownloadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2_Aggregate = {
+  __typename?: 'published_mv_downloads_3_0_2_aggregate';
+  aggregate?: Maybe<Published_Mv_Downloads_3_0_2_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Downloads_3_0_2>;
+};
+
+/** aggregate fields of "published.mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2_Aggregate_Fields = {
+  __typename?: 'published_mv_downloads_3_0_2_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Downloads_3_0_2_Max_Fields>;
+  min?: Maybe<Published_Mv_Downloads_3_0_2_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_downloads_3_0_2". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Downloads_3_0_2_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Bool_Exp>>;
+  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Downloads_3_0_2_Max_Fields = {
+  __typename?: 'published_mv_downloads_3_0_2_max_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Downloads_3_0_2_Min_Fields = {
+  __typename?: 'published_mv_downloads_3_0_2_min_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_downloads_3_0_2". */
+export type Published_Mv_Downloads_3_0_2_Order_By = {
+  downloads?: InputMaybe<Order_By>;
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  hasDownloadableResources?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_downloads_3_0_2" */
+export enum Published_Mv_Downloads_3_0_2_Select_Column {
+  /** column name */
+  Downloads = 'downloads',
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  HasDownloadableResources = 'hasDownloadableResources',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle'
+}
+
+/** Streaming cursor of the table "published_mv_downloads_3_0_2" */
+export type Published_Mv_Downloads_3_0_2_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Downloads_3_0_2_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Downloads_3_0_2_Stream_Cursor_Value_Input = {
+  downloads?: InputMaybe<Scalars['jsonb']['input']>;
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_homepage_2" */
 export type Published_Mv_Homepage_2 = {
   __typename?: 'published_mv_homepage_2';
@@ -19093,6 +19279,10 @@ export type Query_Root = {
   published_mv_downloads_3_0_1: Array<Published_Mv_Downloads_3_0_1>;
   /** fetch aggregated fields from the table: "published.mv_downloads_3_0_1" */
   published_mv_downloads_3_0_1_aggregate: Published_Mv_Downloads_3_0_1_Aggregate;
+  /** fetch data from the table: "published.mv_downloads_3_0_2" */
+  published_mv_downloads_3_0_2: Array<Published_Mv_Downloads_3_0_2>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_2" */
+  published_mv_downloads_3_0_2_aggregate: Published_Mv_Downloads_3_0_2_Aggregate;
   /** fetch data from the table: "published.mv_homepage_2" */
   published_mv_homepage_2: Array<Published_Mv_Homepage_2>;
   /** fetch aggregated fields from the table: "published.mv_homepage_2" */
@@ -19873,6 +20063,24 @@ export type Query_RootPublished_Mv_Downloads_3_0_1_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_1_Order_By>>;
   where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Downloads_3_0_2Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Downloads_3_0_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
 };
 
 
@@ -22629,6 +22837,12 @@ export type Subscription_Root = {
   published_mv_downloads_3_0_1_aggregate: Published_Mv_Downloads_3_0_1_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_1" */
   published_mv_downloads_3_0_1_stream: Array<Published_Mv_Downloads_3_0_1>;
+  /** fetch data from the table: "published.mv_downloads_3_0_2" */
+  published_mv_downloads_3_0_2: Array<Published_Mv_Downloads_3_0_2>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_2" */
+  published_mv_downloads_3_0_2_aggregate: Published_Mv_Downloads_3_0_2_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_2" */
+  published_mv_downloads_3_0_2_stream: Array<Published_Mv_Downloads_3_0_2>;
   /** fetch data from the table: "published.mv_homepage_2" */
   published_mv_homepage_2: Array<Published_Mv_Homepage_2>;
   /** fetch aggregated fields from the table: "published.mv_homepage_2" */
@@ -23672,6 +23886,31 @@ export type Subscription_RootPublished_Mv_Downloads_3_0_1_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Downloads_3_0_1_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Downloads_3_0_1_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_3_0_2Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_3_0_2_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_2_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_3_0_2_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Downloads_3_0_2_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_2_Bool_Exp>;
 };
 
 
@@ -30387,14 +30626,14 @@ export type LessonDownloadsQueryVariables = Exact<{
 }>;
 
 
-export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_1', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_0', lessons?: any | null }> };
+export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_2', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_0', lessons?: any | null }> };
 
 export type LessonDownloadsCanonicalQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
 }>;
 
 
-export type LessonDownloadsCanonicalQuery = { __typename?: 'query_root', lessonDownloadsCanonical: Array<{ __typename?: 'published_mv_downloads_3_0_0', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }> };
+export type LessonDownloadsCanonicalQuery = { __typename?: 'query_root', lessonDownloadsCanonical: Array<{ __typename?: 'published_mv_downloads_3_0_2', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null }> };
 
 export type LessonListingQueryVariables = Exact<{
   programmeSlug: Scalars['String']['input'];
@@ -30512,7 +30751,7 @@ export const CurriculumUnitsDocument = gql`
     `;
 export const LessonDownloadsDocument = gql`
     query lessonDownloads($lessonSlug: String!, $programmeSlug: String!, $unitSlug: String!) {
-  downloads: published_mv_downloads_3_0_1(
+  downloads: published_mv_downloads_3_0_2(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
     downloads
@@ -30535,7 +30774,7 @@ export const LessonDownloadsDocument = gql`
     `;
 export const LessonDownloadsCanonicalDocument = gql`
     query lessonDownloadsCanonical($lessonSlug: String!) {
-  lessonDownloadsCanonical: published_mv_downloads_3_0_0(
+  lessonDownloadsCanonical: published_mv_downloads_3_0_2(
     where: {lessonSlug: {_eq: $lessonSlug}}
   ) {
     downloads

--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
@@ -3,7 +3,7 @@ query lessonDownloads(
   $programmeSlug: String!
   $unitSlug: String!
 ) {
-  downloads: published_mv_downloads_3_0_1(
+  downloads: published_mv_downloads_3_0_2(
     where: {
       lessonSlug: { _eq: $lessonSlug }
       programmeSlug: { _eq: $programmeSlug }

--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloadsCanonical/lessonDownloadsCanonical.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloadsCanonical/lessonDownloadsCanonical.gql
@@ -1,5 +1,5 @@
 query lessonDownloadsCanonical($lessonSlug: String!) {
-  lessonDownloadsCanonical: published_mv_downloads_3_0_0(
+  lessonDownloadsCanonical: published_mv_downloads_3_0_2(
     where: { lessonSlug: { _eq: $lessonSlug } }
   ) {
     downloads


### PR DESCRIPTION
point src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql and src/node-lib/curriculum-api-2023/queries/lessonDownloadsCanonical/lessonDownloadsCanonical.gql to mv_downloads_3_0_2 which corrects and issue with duplicate lessons

### testing

Head to any lesson on the teacher journey and download some items