### PR TITLE
fix: white bg for quiz stem images to avoid contrast issues

### DIFF
--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
@@ -65,6 +65,7 @@ export const QuizQuestionStem = ({
                 $minWidth={"all-spacing-19"}
                 placeholder="oak"
                 sizes={getSizes(["100vw", 1200])}
+                $background={"white"}
               />
             </OakFlex>
           );


### PR DESCRIPTION
Quiz images (especially PNGs and SVGs) may have transparency. The lemon and mint page backgrounds of the quiz pages will show through and could cause contrast issues with the content of the image. To avoid this we can set a white background on all quiz images which will show through the transparency to provide a default backdrop.

### Before
![image](https://github.com/oaknational/Oak-Web-Application/assets/1030540/a0d13d8f-eba9-4b51-811e-3b24bbbc2214)


### After
![image](https://github.com/oaknational/Oak-Web-Application/assets/1030540/3accd081-69c9-48b9-bd3b-f6aeb6aac9e7)

### To test
https://deploy-preview-2225--oak-web-application.netlify.thenational.academy/pupils/programmes/combined-science-secondary-ks4-foundation-aqa/units/measuring-waves/lessons/representing-longitudinal-waves

exit quiz
question 4/6

### Acceptance criteria

- [ x]  Quiz images with transparency are filled with white