### PR TITLE
PUPIL-317: Support lessons with missing sections

### DIFF
--- a/src/__tests__/pages/pupils/index.test.tsx
+++ b/src/__tests__/pages/pupils/index.test.tsx
@@ -1,12 +1,52 @@
 import {
   getStaticPaths,
   getStaticProps,
+  pickAvailableSectionsForLesson,
 } from "@/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]";
 import * as curriculumApi2023 from "@/node-lib/curriculum-api-2023/__mocks__/index";
+import { allLessonReviewSections } from "@/components/PupilComponents/LessonEngineProvider";
+import pupilLessonOverviewFixture from "@/node-lib/curriculum-api/fixtures/pupilLessonOverview.fixture";
+import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.fixture";
 
 jest.mock("@/utils/handleTranscript");
 
 describe("pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index", () => {
+  describe("pickAvailableSectionsForLesson", () => {
+    it("returns all sections if all are available", () => {
+      const sections = pickAvailableSectionsForLesson(
+        pupilLessonOverviewFixture({
+          starterQuiz: quizQuestions,
+          exitQuiz: quizQuestions,
+          videoMuxPlaybackId: "123",
+        }),
+      );
+
+      expect(sections).toEqual(allLessonReviewSections);
+    });
+
+    it("should not include a section if it has no content", () => {
+      const withoutStarterQuiz = pickAvailableSectionsForLesson(
+        pupilLessonOverviewFixture({
+          starterQuiz: [],
+        }),
+      );
+      const withoutExitQuiz = pickAvailableSectionsForLesson(
+        pupilLessonOverviewFixture({
+          exitQuiz: [],
+        }),
+      );
+      const withoutVideo = pickAvailableSectionsForLesson(
+        pupilLessonOverviewFixture({
+          videoMuxPlaybackId: null,
+        }),
+      );
+
+      expect(withoutStarterQuiz).not.toContain("starter-quiz");
+      expect(withoutExitQuiz).not.toContain("exit-quiz");
+      expect(withoutVideo).not.toContain("video");
+    });
+  });
+
   describe("getStaticPaths", () => {
     it("Should not generate pages at build time", async () => {
       const res = await getStaticPaths();

--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
@@ -37,7 +37,7 @@ describe("Component - Curriculum Header", () => {
   test("generates school error", async () => {
     const { getByTestId } = renderComponent();
     const schoolInput = getByTestId("search-combobox-input");
-    userEvent.type(schoolInput, "notavalidschool!?{enter}");
+    await userEvent.type(schoolInput, "notavalidschool!?{enter}");
     await waitFor(() => {
       expect(getByTestId("errorList")).toBeInTheDocument();
     });
@@ -45,8 +45,8 @@ describe("Component - Curriculum Header", () => {
 
   test("generates download error", async () => {
     const { getByTestId } = renderComponent();
-    userEvent.click(getByTestId("checkbox-download"));
-    userEvent.click(getByTestId("loadingButton"));
+    await userEvent.click(getByTestId("checkbox-download"));
+    await userEvent.click(getByTestId("loadingButton"));
     await waitFor(() => {
       expect(getByTestId("errorList")).toBeInTheDocument();
     });
@@ -58,10 +58,10 @@ describe("Component - Curriculum Header", () => {
     if (resourceCard === undefined) {
       throw new Error("Resource card not found");
     }
-    userEvent.click(resourceCard.querySelector("label")!);
-    userEvent.click(getByTestId("checkbox-download"));
-    userEvent.click(getByTestId("termsCheckbox").querySelector("label")!);
-    userEvent.click(getByTestId("loadingButton"));
+    await userEvent.click(resourceCard.querySelector("label")!);
+    await userEvent.click(getByTestId("checkbox-download"));
+    await userEvent.click(getByTestId("termsCheckbox").querySelector("label")!);
+    await userEvent.click(getByTestId("loadingButton"));
     await waitFor(() => {
       expect(getByTestId("downloadSuccess")).toBeInTheDocument();
     });

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -67,7 +67,7 @@ describe("LessonEngineProvider", () => {
     expect(result.current.currentSection).toEqual("starter-quiz");
   });
 
-  it("returns to the first section when proceedToNextSection is called when all sections are complete", () => {
+  it("returns to the review when proceedToNextSection is called and all sections are complete", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
       wrapper: ProviderWrapper,
     });
@@ -83,7 +83,7 @@ describe("LessonEngineProvider", () => {
       result.current.proceedToNextSection();
     });
 
-    expect(result.current.currentSection).toEqual(allLessonReviewSections[0]);
+    expect(result.current.currentSection).toEqual("review");
   });
 
   it("returns to overview on completeSection when not all sections are complete", () => {
@@ -154,6 +154,23 @@ describe("LessonEngineProvider", () => {
     expect(result.current.sectionResults).toEqual({
       overview: expect.objectContaining({ grade: 0, numQuestions: 0 }),
     });
+  });
+
+  it('marks the section as incomplete when "updateQuizResult" is called', () => {
+    const { result } = renderHook(() => useLessonEngineContext(), {
+      wrapper: ProviderWrapper,
+    });
+
+    act(() => {
+      result.current.updateCurrentSection("starter-quiz");
+      result.current.updateQuizResult({ grade: 2, numQuestions: 4 });
+    });
+
+    // This ensures that when a pupil starts to retake a quiz the lesson
+    // returns to the incomplete state so that partial results are not displayed
+    expect(result.current.sectionResults["starter-quiz"]?.isComplete).toEqual(
+      false,
+    );
   });
 });
 

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -5,17 +5,25 @@ import { OakSpan } from "@oaknational/oak-components";
 import {
   LessonEngineContextType,
   LessonEngineProvider,
-  lessonReviewSections,
+  allLessonReviewSections,
   useLessonEngineContext,
 } from "./LessonEngineProvider";
 
 describe("LessonEngineProvider", () => {
-  const providerWrapper = ({ children }: { children: ReactNode }) => {
-    return <LessonEngineProvider>{children}</LessonEngineProvider>;
+  const ProviderWrapper = ({ children }: { children: ReactNode }) => {
+    return (
+      <LessonEngineProvider
+        initialLessonReviewSections={allLessonReviewSections}
+      >
+        {children}
+      </LessonEngineProvider>
+    );
   };
   it("renders children correctly", () => {
     const { getByText } = render(
-      <LessonEngineProvider>
+      <LessonEngineProvider
+        initialLessonReviewSections={allLessonReviewSections}
+      >
         <OakSpan>Hello World</OakSpan>
       </LessonEngineProvider>,
     );
@@ -25,10 +33,7 @@ describe("LessonEngineProvider", () => {
 
   it("tracks the current section", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
+      wrapper: ProviderWrapper,
     });
 
     if (result.current === null) {
@@ -48,10 +53,7 @@ describe("LessonEngineProvider", () => {
 
   it("progresses to the next uncompleted section in order with proceedToNextQuestion", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
+      wrapper: ProviderWrapper,
     });
 
     if (result.current === null) {
@@ -67,17 +69,14 @@ describe("LessonEngineProvider", () => {
 
   it("returns to overview on completeSection when not all sections are complete", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
+      wrapper: ProviderWrapper,
     });
 
     if (result.current === null) {
       throw new Error("result.current is null");
     }
 
-    lessonReviewSections.forEach((s) => {
+    allLessonReviewSections.forEach((s) => {
       expect(result.current.currentSection).toEqual("overview");
 
       act(() => {
@@ -90,13 +89,10 @@ describe("LessonEngineProvider", () => {
 
   it("sets `isComplete` for the section when it is completed", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
+      wrapper: ProviderWrapper,
     });
 
-    lessonReviewSections.forEach((section) => {
+    allLessonReviewSections.forEach((section) => {
       expect(result.current.sectionResults[section]?.isComplete).toBeFalsy();
       act(() => {
         result.current.completeSection("intro");
@@ -107,10 +103,10 @@ describe("LessonEngineProvider", () => {
 
   it("sets `isLessonComplete` to true when all review sections are complete", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: providerWrapper,
+      wrapper: ProviderWrapper,
     });
 
-    lessonReviewSections.forEach((section) => {
+    allLessonReviewSections.forEach((section) => {
       expect(result.current.isLessonComplete).toEqual(false);
 
       act(() => {
@@ -123,10 +119,7 @@ describe("LessonEngineProvider", () => {
 
   it("tracks section results", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
+      wrapper: ProviderWrapper,
     });
 
     if (result.current === null) {
@@ -152,6 +145,7 @@ export function createLessonEngineContext(
     isLessonComplete: false,
     currentSection: "starter-quiz",
     sectionResults: {},
+    lessonReviewSections: allLessonReviewSections,
     completeSection: jest.fn(),
     updateCurrentSection: jest.fn(),
     proceedToNextSection: jest.fn(),

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -51,7 +51,7 @@ describe("LessonEngineProvider", () => {
     expect(result.current.currentSection).toEqual("intro");
   });
 
-  it("progresses to the next uncompleted section in order with proceedToNextQuestion", () => {
+  it("progresses to the next uncompleted section in order with proceedToNextSection", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
       wrapper: ProviderWrapper,
     });
@@ -65,6 +65,25 @@ describe("LessonEngineProvider", () => {
       result.current.proceedToNextSection();
     });
     expect(result.current.currentSection).toEqual("starter-quiz");
+  });
+
+  it("returns to the first section when proceedToNextSection is called when all sections are complete", () => {
+    const { result } = renderHook(() => useLessonEngineContext(), {
+      wrapper: ProviderWrapper,
+    });
+
+    if (result.current === null) {
+      throw new Error("result.current is null");
+    }
+
+    act(() => {
+      allLessonReviewSections.forEach((section) => {
+        result.current.completeSection(section);
+      });
+      result.current.proceedToNextSection();
+    });
+
+    expect(result.current.currentSection).toEqual(allLessonReviewSections[0]);
   });
 
   it("returns to overview on completeSection when not all sections are complete", () => {

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -3,6 +3,7 @@ import { act, render, renderHook } from "@testing-library/react";
 import { OakSpan } from "@oaknational/oak-components";
 
 import {
+  LessonEngineContextType,
   LessonEngineProvider,
   lessonReviewSections,
   useLessonEngineContext,
@@ -59,40 +60,9 @@ describe("LessonEngineProvider", () => {
 
     act(() => {
       result.current.completeSection("intro");
-    });
-    expect(result.current.completedSections).toEqual(["intro"]);
-
-    act(() => {
       result.current.proceedToNextSection();
     });
     expect(result.current.currentSection).toEqual("starter-quiz");
-  });
-
-  it("tracks completed sections", () => {
-    const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
-    });
-
-    if (result.current === null) {
-      throw new Error("result.current is null");
-    }
-
-    expect(result.current.completedSections).toEqual([]);
-
-    const { completeSection } = result.current;
-
-    lessonReviewSections.forEach((s, i) => {
-      act(() => {
-        completeSection(s);
-      });
-
-      expect(result.current.completedSections).toEqual(
-        lessonReviewSections.slice(0, i + 1),
-      );
-    });
   });
 
   it("returns to overview on completeSection when not all sections are complete", () => {
@@ -108,21 +78,17 @@ describe("LessonEngineProvider", () => {
     }
 
     lessonReviewSections.forEach((s) => {
+      expect(result.current.currentSection).toEqual("overview");
+
       act(() => {
         result.current.completeSection(s);
       });
-
-      expect(result.current.currentSection).toEqual("overview");
-    });
-
-    act(() => {
-      result.current.completeSection("exit-quiz");
     });
 
     expect(result.current.currentSection).toEqual("review");
   });
 
-  it("doesn't duplicate completed sections", () => {
+  it("sets `isComplete` for the section when it is completed", () => {
     const { result } = renderHook(() => useLessonEngineContext(), {
       wrapper: (props) =>
         providerWrapper({
@@ -130,52 +96,29 @@ describe("LessonEngineProvider", () => {
         }),
     });
 
-    if (result.current === null) {
-      throw new Error("result.current is null");
-    }
-
-    expect(result.current.completedSections).toEqual([]);
-
-    const { completeSection } = result.current;
-
-    lessonReviewSections.forEach((s, i) => {
-      act(() => {
-        completeSection(s);
-      });
-
-      expect(result.current.completedSections).toEqual(
-        lessonReviewSections.slice(0, i + 1),
-      );
-    });
-
-    act(() => {
-      completeSection("intro");
-    });
-
-    expect(result.current.completedSections).toEqual(lessonReviewSections);
-  });
-
-  it("gets the correct isComplete value", () => {
-    const { result } = renderHook(() => useLessonEngineContext(), {
-      wrapper: (props) =>
-        providerWrapper({
-          ...props,
-        }),
-    });
-
-    if (result.current === null) {
-      throw new Error("result.current is null");
-    }
-
-    expect(result.current.completedSections).toEqual([]);
-
-    lessonReviewSections.forEach((s) => {
-      expect(result.current.getIsComplete(s)).toEqual(false);
+    lessonReviewSections.forEach((section) => {
+      expect(result.current.sectionResults[section]?.isComplete).toBeFalsy();
       act(() => {
         result.current.completeSection("intro");
       });
-      expect(result.current.getIsComplete("intro")).toEqual(true);
+      expect(result.current.sectionResults.intro?.isComplete).toEqual(true);
     });
+  });
+
+  it("sets `isLessonComplete` to true when all review sections are complete", () => {
+    const { result } = renderHook(() => useLessonEngineContext(), {
+      wrapper: providerWrapper,
+    });
+
+    lessonReviewSections.forEach((section) => {
+      expect(result.current.isLessonComplete).toEqual(false);
+
+      act(() => {
+        result.current.completeSection(section);
+      });
+    });
+
+    expect(result.current.isLessonComplete).toEqual(true);
   });
 
   it("tracks section results", () => {
@@ -197,7 +140,22 @@ describe("LessonEngineProvider", () => {
     });
 
     expect(result.current.sectionResults).toEqual({
-      overview: { grade: 0, numQuestions: 0 },
+      overview: expect.objectContaining({ grade: 0, numQuestions: 0 }),
     });
   });
 });
+
+export function createLessonEngineContext(
+  overrides?: Partial<LessonEngineContextType>,
+): NonNullable<LessonEngineContextType> {
+  return {
+    isLessonComplete: false,
+    currentSection: "starter-quiz",
+    sectionResults: {},
+    completeSection: jest.fn(),
+    updateCurrentSection: jest.fn(),
+    proceedToNextSection: jest.fn(),
+    updateQuizResult: jest.fn(),
+    ...overrides,
+  };
+}

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -4,8 +4,7 @@ import { OakSpan } from "@oaknational/oak-components";
 
 import {
   LessonEngineProvider,
-  LessonSection,
-  lessonSections,
+  lessonReviewSections,
   useLessonEngineContext,
 } from "./LessonEngineProvider";
 
@@ -85,13 +84,13 @@ describe("LessonEngineProvider", () => {
 
     const { completeSection } = result.current;
 
-    lessonSections.forEach((s, i) => {
+    lessonReviewSections.forEach((s, i) => {
       act(() => {
         completeSection(s);
       });
 
       expect(result.current.completedSections).toEqual(
-        lessonSections.slice(0, i + 1),
+        lessonReviewSections.slice(0, i + 1),
       );
     });
   });
@@ -108,9 +107,9 @@ describe("LessonEngineProvider", () => {
       throw new Error("result.current is null");
     }
 
-    ["intro", "starter-quiz", "video"].forEach((s) => {
+    lessonReviewSections.forEach((s) => {
       act(() => {
-        result.current.completeSection(s as LessonSection);
+        result.current.completeSection(s);
       });
 
       expect(result.current.currentSection).toEqual("overview");
@@ -139,21 +138,21 @@ describe("LessonEngineProvider", () => {
 
     const { completeSection } = result.current;
 
-    lessonSections.forEach((s, i) => {
+    lessonReviewSections.forEach((s, i) => {
       act(() => {
         completeSection(s);
       });
 
       expect(result.current.completedSections).toEqual(
-        lessonSections.slice(0, i + 1),
+        lessonReviewSections.slice(0, i + 1),
       );
     });
 
     act(() => {
-      completeSection("overview");
+      completeSection("intro");
     });
 
-    expect(result.current.completedSections).toEqual(lessonSections);
+    expect(result.current.completedSections).toEqual(lessonReviewSections);
   });
 
   it("gets the correct isComplete value", () => {
@@ -170,12 +169,12 @@ describe("LessonEngineProvider", () => {
 
     expect(result.current.completedSections).toEqual([]);
 
-    lessonSections.forEach((s) => {
+    lessonReviewSections.forEach((s) => {
       expect(result.current.getIsComplete(s)).toEqual(false);
       act(() => {
-        result.current.completeSection("overview");
+        result.current.completeSection("intro");
       });
-      expect(result.current.getIsComplete("overview")).toEqual(true);
+      expect(result.current.getIsComplete("intro")).toEqual(true);
     });
   });
 

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
@@ -94,14 +94,11 @@ const lessonEngineReducer: Reducer<LessonEngineState, LessonEngineAction> = (
       return newState;
     }
     case "proceedToNextSection": {
+      // Go to the lesson review when the lesson is complete
       const nextSection =
         currentState.lessonReviewSections.find(
           (section) => !currentState.sections[section]?.isComplete,
-        ) ?? currentState.lessonReviewSections[0];
-
-      if (!nextSection) {
-        throw new Error("Lesson contains no sections to proceed to");
-      }
+        ) ?? "review";
 
       return { ...currentState, currentSection: nextSection };
     }
@@ -119,6 +116,7 @@ const lessonEngineReducer: Reducer<LessonEngineState, LessonEngineAction> = (
           [currentState.currentSection]: {
             ...currentState.sections[currentState.currentSection],
             ...action.result,
+            isComplete: false,
           },
         },
       };

--- a/src/components/PupilComponents/QuizEngineProvider/QuizEngineProvider.test.tsx
+++ b/src/components/PupilComponents/QuizEngineProvider/QuizEngineProvider.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 
+import { createLessonEngineContext } from "../LessonEngineProvider/LessonEngineProvider.test";
+
 import {
   QuizEngineProps,
   QuizEngineProvider,
@@ -12,17 +14,6 @@ import {
   LessonEngineContextType,
 } from "@/components/PupilComponents/LessonEngineProvider";
 
-const getLessonEngineContext = (): NonNullable<LessonEngineContextType> => ({
-  currentSection: "starter-quiz",
-  completedSections: [],
-  sectionResults: {},
-  getIsComplete: jest.fn(),
-  completeSection: jest.fn(),
-  updateCurrentSection: jest.fn(),
-  proceedToNextSection: jest.fn(),
-  updateQuizResult: jest.fn(),
-});
-
 describe("QuizEngineContext", () => {
   const wrapper = (
     { children, questionsArray }: QuizEngineProps,
@@ -31,7 +22,9 @@ describe("QuizEngineContext", () => {
     return (
       <LessonEngineContext.Provider
         value={
-          lessonEngineContext ? lessonEngineContext : getLessonEngineContext()
+          lessonEngineContext
+            ? lessonEngineContext
+            : createLessonEngineContext()
         }
       >
         <QuizEngineProvider questionsArray={questionsArray}>
@@ -174,7 +167,7 @@ describe("QuizEngineContext", () => {
   });
 
   it("should update the section as complete when currentQuestionIndex is > numQuestions", () => {
-    const lessonEngineContext = getLessonEngineContext();
+    const lessonEngineContext = createLessonEngineContext();
 
     const { result } = renderHook(() => useQuizEngineContext(), {
       wrapper: (props) =>

--- a/src/components/PupilComponents/QuizEngineProvider/QuizEngineProvider.tsx
+++ b/src/components/PupilComponents/QuizEngineProvider/QuizEngineProvider.tsx
@@ -12,7 +12,10 @@ import {
   LessonOverviewQuizData,
   MCAnswer,
 } from "@/node-lib/curriculum-api-2023/shared.schema";
-import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import {
+  isLessonReviewSection,
+  useLessonEngineContext,
+} from "@/components/PupilComponents/LessonEngineProvider";
 
 export type QuestionsArray = NonNullable<LessonOverviewQuizData>;
 
@@ -208,7 +211,10 @@ export const QuizEngineProvider = memo((props: QuizEngineProps) => {
   const handleNextQuestion = useCallback(() => {
     setCurrentQuestionIndex((prev) => {
       const _currentQuestionIndex = Math.min(prev + 1, numQuestions);
-      if (_currentQuestionIndex === numQuestions) {
+      if (
+        _currentQuestionIndex === numQuestions &&
+        isLessonReviewSection(currentSection)
+      ) {
         completeSection(currentSection);
       }
       return _currentQuestionIndex;

--- a/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.stories.tsx
+++ b/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.stories.tsx
@@ -5,7 +5,10 @@ import {
   oakDefaultTheme,
 } from "@oaknational/oak-components";
 
-import { LessonEngineProvider } from "../LessonEngineProvider";
+import {
+  LessonEngineProvider,
+  allLessonReviewSections,
+} from "../LessonEngineProvider";
 
 import { QuizMCQMultiAnswer } from "./QuizMCQMultiAnswer";
 
@@ -25,7 +28,9 @@ const meta = {
   decorators: [
     (Story) => (
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineProvider>
+        <LessonEngineProvider
+          initialLessonReviewSections={allLessonReviewSections}
+        >
           <Story />
         </LessonEngineProvider>
       </OakThemeProvider>

--- a/src/components/PupilComponents/QuizRenderer/QuizRenderer.test.tsx
+++ b/src/components/PupilComponents/QuizRenderer/QuizRenderer.test.tsx
@@ -8,6 +8,8 @@ import {
 } from "@oaknational/oak-components";
 import { act, fireEvent } from "@testing-library/react";
 
+import { createLessonEngineContext } from "../LessonEngineProvider/LessonEngineProvider.test";
+
 import {
   QuizEngineContextType,
   QuizEngineContext,
@@ -15,10 +17,7 @@ import {
 import { QuizRenderer } from "@/components/PupilComponents/QuizRenderer";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.fixture";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 
 const questionsArrayFixture = quizQuestions || [];
 
@@ -40,17 +39,6 @@ const getQuizEngineContext = (): NonNullable<QuizEngineContextType> => ({
   numQuestions: 1,
 });
 
-const getLessonEngineContext = (): NonNullable<LessonEngineContextType> => ({
-  currentSection: "starter-quiz",
-  completedSections: [],
-  sectionResults: {},
-  getIsComplete: jest.fn(),
-  completeSection: jest.fn(),
-  updateCurrentSection: jest.fn(),
-  proceedToNextSection: jest.fn(),
-  updateQuizResult: jest.fn(),
-});
-
 describe("QuizRenderer", () => {
   it("throws an error when there is no context", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -63,7 +51,7 @@ describe("QuizRenderer", () => {
 
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <QuizEngineContext.Provider value={context}>
             <QuizRenderer formId="formId" />
           </QuizEngineContext.Provider>
@@ -79,7 +67,7 @@ describe("QuizRenderer", () => {
 
     const { getByLabelText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <QuizEngineContext.Provider value={context}>
             <QuizRenderer formId="formId" />
           </QuizEngineContext.Provider>
@@ -99,7 +87,7 @@ describe("QuizRenderer", () => {
 
       const { getByRole } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
-          <LessonEngineContext.Provider value={getLessonEngineContext()}>
+          <LessonEngineContext.Provider value={createLessonEngineContext()}>
             <QuizEngineContext.Provider value={context}>
               <QuizRenderer formId="formId" />
               <OakPrimaryButton form={"formId"} type="submit">
@@ -124,7 +112,7 @@ describe("QuizRenderer", () => {
 
       const { getByRole } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
-          <LessonEngineContext.Provider value={getLessonEngineContext()}>
+          <LessonEngineContext.Provider value={createLessonEngineContext()}>
             <QuizEngineContext.Provider value={context}>
               <QuizRenderer formId="formId" />
               <OakPrimaryButton onClick={handleNextQuestion}>
@@ -149,7 +137,7 @@ describe("QuizRenderer", () => {
 
       const { getByLabelText, getByRole } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
-          <LessonEngineContext.Provider value={getLessonEngineContext()}>
+          <LessonEngineContext.Provider value={createLessonEngineContext()}>
             <QuizEngineContext.Provider value={context}>
               <QuizRenderer formId="form-id" />
               <OakPrimaryButton form="form-id" type="submit">
@@ -189,7 +177,7 @@ describe("QuizRenderer", () => {
 
       const { getByLabelText, getByRole } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
-          <LessonEngineContext.Provider value={getLessonEngineContext()}>
+          <LessonEngineContext.Provider value={createLessonEngineContext()}>
             <QuizEngineContext.Provider value={context}>
               <QuizRenderer formId="form-id" />
               <OakPrimaryButton form="form-id" type="submit">
@@ -226,7 +214,7 @@ describe("QuizRenderer", () => {
     if (context?.currentQuestionData) {
       const { getByRole } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
-          <LessonEngineContext.Provider value={getLessonEngineContext()}>
+          <LessonEngineContext.Provider value={createLessonEngineContext()}>
             <QuizEngineContext.Provider value={context}>
               <QuizRenderer formId="form-id" />
             </QuizEngineContext.Provider>
@@ -253,7 +241,7 @@ describe("QuizRenderer", () => {
 
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <QuizEngineContext.Provider value={context}>
             <QuizRenderer formId="form-id" />
             <OakPrimaryButton form="form-id" type="submit">

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
@@ -8,10 +8,8 @@ import { PupilViewsIntro } from "./PupilIntro.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import pupilLessonOverviewFixture from "@/node-lib/curriculum-api/fixtures/pupilLessonOverview.fixture";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 const curriculumData = {
   ...pupilLessonOverviewFixture(),
@@ -27,22 +25,11 @@ const contentGuidance = [
 ];
 const supervisionLevel = "supervision level";
 
-const getLessonEngineContext = (): NonNullable<LessonEngineContextType> => ({
-  currentSection: "starter-quiz",
-  completedSections: [],
-  sectionResults: {},
-  getIsComplete: jest.fn(),
-  completeSection: jest.fn(),
-  updateCurrentSection: jest.fn(),
-  proceedToNextSection: jest.fn(),
-  updateQuizResult: jest.fn(),
-});
-
 describe("PupilIntro", () => {
   it("displays the section title: what will you need for this lesson?", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumData} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -54,7 +41,7 @@ describe("PupilIntro", () => {
   it("displays the question card: are you ready to learn?", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumData} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -68,7 +55,7 @@ describe("PupilIntro", () => {
     };
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumDataWithEquipment} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -83,7 +70,7 @@ describe("PupilIntro", () => {
     };
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumDataWithContentGuidance} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -97,7 +84,7 @@ describe("PupilIntro", () => {
     };
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumDataWithSupervision} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -112,7 +99,7 @@ describe("PupilIntro", () => {
     };
     const { getByText, getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumDataWithWorksheet} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -126,7 +113,7 @@ describe("PupilIntro", () => {
   it("displays I'm ready button which completed section", () => {
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsIntro {...curriculumData} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -134,7 +121,7 @@ describe("PupilIntro", () => {
     expect(getByRole("button", { name: /I'm ready/i })).toBeInTheDocument();
   });
   it("completes the section when I'm ready button is clicked", () => {
-    const context = getLessonEngineContext();
+    const context = createLessonEngineContext();
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider value={context}>

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -3,10 +3,8 @@ import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 import { PupilViewsLessonOverview } from "./PupilLessonOverview.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 describe(PupilViewsLessonOverview, () => {
   it("displays the lesson title", () => {
@@ -60,19 +58,3 @@ describe(PupilViewsLessonOverview, () => {
     });
   });
 });
-
-function createLessonEngineContext(
-  overrides?: Partial<LessonEngineContextType>,
-): NonNullable<LessonEngineContextType> {
-  return {
-    currentSection: "starter-quiz",
-    completedSections: [],
-    sectionResults: {},
-    getIsComplete: jest.fn(),
-    completeSection: jest.fn(),
-    updateCurrentSection: jest.fn(),
-    proceedToNextSection: jest.fn(),
-    updateQuizResult: jest.fn(),
-    ...overrides,
-  };
-}

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -57,4 +57,23 @@ describe(PupilViewsLessonOverview, () => {
       expect(updateCurrentSection).toHaveBeenCalledWith(section);
     });
   });
+
+  it("displays the number of questions for each quiz", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
+          <PupilViewsLessonOverview
+            lessonTitle="Introduction to The Canterbury Tales"
+            subjectTitle="English"
+            subjectSlug="english"
+            starterQuizNumQuestions={4}
+            exitQuizNumQuestions={5}
+          />
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    expect(getByTestId("starter-quiz")).toHaveTextContent("4 Questions");
+    expect(getByTestId("exit-quiz")).toHaveTextContent("Practice 5 questions");
+  });
 });

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -177,8 +177,9 @@ export const PupilViewsLessonOverview = ({
                   lessonSectionName="starter-quiz"
                   onClick={() => updateCurrentSection("starter-quiz")}
                   progress={pickProgressForSection("starter-quiz")}
-                  numQuestions={exitQuizNumQuestions}
+                  numQuestions={starterQuizNumQuestions}
                   grade={sectionResults["starter-quiz"]?.grade ?? 0}
+                  data-testid="starter-quiz"
                 />
               )}
               {lessonReviewSections.includes("video") && (
@@ -196,8 +197,9 @@ export const PupilViewsLessonOverview = ({
                   lessonSectionName="exit-quiz"
                   onClick={() => updateCurrentSection("exit-quiz")}
                   progress={pickProgressForSection("exit-quiz")}
-                  numQuestions={starterQuizNumQuestions}
+                  numQuestions={exitQuizNumQuestions}
                   grade={sectionResults["exit-quiz"]?.grade ?? 0}
+                  data-testid="exit-quiz"
                 />
               )}
             </OakFlex>

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -40,8 +40,12 @@ export const PupilViewsLessonOverview = ({
   exitQuizNumQuestions,
   starterQuizNumQuestions,
 }: PupilViewsLessonOverviewProps) => {
-  const { sectionResults, updateCurrentSection, proceedToNextSection } =
-    useLessonEngineContext();
+  const {
+    sectionResults,
+    updateCurrentSection,
+    proceedToNextSection,
+    lessonReviewSections,
+  } = useLessonEngineContext();
   const subjectIconName: `subject-${string}` = `subject-${subjectSlug}`;
 
   function pickProgressForSection(section: LessonReviewSection) {
@@ -159,35 +163,43 @@ export const PupilViewsLessonOverview = ({
             $ph={["inner-padding-m", "inner-padding-none"]}
           >
             <OakFlex $gap="space-between-s" $flexDirection="column">
-              <OakLessonNavItem
-                as="button"
-                lessonSectionName="intro"
-                onClick={() => updateCurrentSection("intro")}
-                progress={pickProgressForSection("intro")}
-              />
-              <OakLessonNavItem
-                as="button"
-                lessonSectionName="starter-quiz"
-                onClick={() => updateCurrentSection("starter-quiz")}
-                progress={pickProgressForSection("starter-quiz")}
-                numQuestions={exitQuizNumQuestions}
-                grade={sectionResults["starter-quiz"]?.grade ?? 0}
-              />
-              <OakLessonNavItem
-                as="button"
-                lessonSectionName="video"
-                onClick={() => updateCurrentSection("video")}
-                progress={pickProgressForSection("video")}
-                videoLength={0}
-              />
-              <OakLessonNavItem
-                as="button"
-                lessonSectionName="exit-quiz"
-                onClick={() => updateCurrentSection("exit-quiz")}
-                progress={pickProgressForSection("exit-quiz")}
-                numQuestions={starterQuizNumQuestions}
-                grade={sectionResults["exit-quiz"]?.grade ?? 0}
-              />
+              {lessonReviewSections.includes("intro") && (
+                <OakLessonNavItem
+                  as="button"
+                  lessonSectionName="intro"
+                  onClick={() => updateCurrentSection("intro")}
+                  progress={pickProgressForSection("intro")}
+                />
+              )}
+              {lessonReviewSections.includes("starter-quiz") && (
+                <OakLessonNavItem
+                  as="button"
+                  lessonSectionName="starter-quiz"
+                  onClick={() => updateCurrentSection("starter-quiz")}
+                  progress={pickProgressForSection("starter-quiz")}
+                  numQuestions={exitQuizNumQuestions}
+                  grade={sectionResults["starter-quiz"]?.grade ?? 0}
+                />
+              )}
+              {lessonReviewSections.includes("video") && (
+                <OakLessonNavItem
+                  as="button"
+                  lessonSectionName="video"
+                  onClick={() => updateCurrentSection("video")}
+                  progress={pickProgressForSection("video")}
+                  videoLength={0}
+                />
+              )}
+              {lessonReviewSections.includes("exit-quiz") && (
+                <OakLessonNavItem
+                  as="button"
+                  lessonSectionName="exit-quiz"
+                  onClick={() => updateCurrentSection("exit-quiz")}
+                  progress={pickProgressForSection("exit-quiz")}
+                  numQuestions={starterQuizNumQuestions}
+                  grade={sectionResults["exit-quiz"]?.grade ?? 0}
+                />
+              )}
             </OakFlex>
           </OakGridArea>
         </OakGrid>

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -17,7 +17,7 @@ import {
 } from "@oaknational/oak-components";
 
 import {
-  LessonSection,
+  LessonReviewSection,
   useLessonEngineContext,
 } from "@/components/PupilComponents/LessonEngineProvider";
 
@@ -40,16 +40,12 @@ export const PupilViewsLessonOverview = ({
   exitQuizNumQuestions,
   starterQuizNumQuestions,
 }: PupilViewsLessonOverviewProps) => {
-  const {
-    completedSections,
-    sectionResults,
-    updateCurrentSection,
-    proceedToNextSection,
-  } = useLessonEngineContext();
+  const { sectionResults, updateCurrentSection, proceedToNextSection } =
+    useLessonEngineContext();
   const subjectIconName: `subject-${string}` = `subject-${subjectSlug}`;
 
-  function pickProgressForSection(section: LessonSection) {
-    if (completedSections.includes(section)) {
+  function pickProgressForSection(section: LessonReviewSection) {
+    if (sectionResults[section]?.isComplete) {
       return "complete";
     }
 

--- a/src/components/PupilViews/PupilQuiz/PupilQuiz.view.test.tsx
+++ b/src/components/PupilViews/PupilQuiz/PupilQuiz.view.test.tsx
@@ -8,29 +8,16 @@ import { PupilViewsQuiz } from "./PupilQuiz.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.fixture";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 const questionsArrayFixture = quizQuestions || [];
-
-const getLessonEngineContext = (): NonNullable<LessonEngineContextType> => ({
-  currentSection: "starter-quiz",
-  completedSections: [],
-  sectionResults: {},
-  getIsComplete: jest.fn(),
-  completeSection: jest.fn(),
-  updateCurrentSection: jest.fn(),
-  proceedToNextSection: jest.fn(),
-  updateQuizResult: jest.fn(),
-});
 
 describe("PupilQuizView", () => {
   it("renders heading, mode and answer when there is currentQuestionData", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -42,7 +29,7 @@ describe("PupilQuizView", () => {
   it("disables submit button when mode is init", () => {
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -53,7 +40,7 @@ describe("PupilQuizView", () => {
   it("renders Next button when questionState.mode is feedback", () => {
     const { getByLabelText, getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -70,7 +57,7 @@ describe("PupilQuizView", () => {
   it("does not render Next button when questionState.mode is not feedback", () => {
     const { queryByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -6,27 +6,14 @@ import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 import { PupilViewsReview } from "./PupilReview.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
-
-const getLessonEngineContext = (): NonNullable<LessonEngineContextType> => ({
-  currentSection: "starter-quiz",
-  completedSections: [],
-  sectionResults: {},
-  getIsComplete: jest.fn(),
-  completeSection: jest.fn(),
-  updateCurrentSection: jest.fn(),
-  proceedToNextSection: jest.fn(),
-  updateQuizResult: jest.fn(),
-});
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 describe("PupilReview", () => {
   it("displays the lesson title", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsReview lessonTitle="Lesson title" />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -36,7 +23,7 @@ describe("PupilReview", () => {
   it("displays the review item cards for intro, starter quiz, video, exit quiz", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsReview lessonTitle="Lesson title" />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
@@ -49,7 +36,7 @@ describe("PupilReview", () => {
   it("displays the lesson overview button", () => {
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={getLessonEngineContext()}>
+        <LessonEngineContext.Provider value={createLessonEngineContext()}>
           <PupilViewsReview lessonTitle="Lesson title" />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -45,4 +45,18 @@ describe("PupilReview", () => {
       getByRole("button", { name: /Lesson overview/i }),
     ).toBeInTheDocument();
   });
+
+  it("displays a special message when the lesson is complete", () => {
+    const { queryByText } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider
+          value={createLessonEngineContext({ isLessonComplete: true })}
+        >
+          <PupilViewsReview lessonTitle="Lesson title" />
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    expect(queryByText("Fantastic learning - well done!")).toBeInTheDocument();
+  });
 });

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -21,10 +21,9 @@ type PupilViewsReviewProps = {
 
 export const PupilViewsReview = (props: PupilViewsReviewProps) => {
   const { lessonTitle } = props;
-  const { updateCurrentSection, sectionResults, completedSections } =
+  const { updateCurrentSection, sectionResults, isLessonComplete } =
     useLessonEngineContext();
 
-  const completed = completedSections.length === lessonReviewSections.length;
   const bottomNavSlot = (
     <OakLessonBottomNav>
       <OakPrimaryButton
@@ -91,7 +90,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
             return (
               <OakLessonReviewItem
                 lessonSectionName={lessonSection}
-                completed={completedSections.includes(lessonSection)}
+                completed={!!sectionResults[lessonSection]?.isComplete}
                 grade={sectionResults[lessonSection]?.grade ?? 0}
                 numQuestions={sectionResults[lessonSection]?.numQuestions ?? 0}
               />
@@ -109,7 +108,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
             $alignItems={"center"}
           >
             <OakFlex $font="heading-5" $textAlign={["center", "left", "left"]}>
-              {completed
+              {isLessonComplete
                 ? "Fantastic learning - well done!"
                 : "Well done, you're Oaking it!"}
             </OakFlex>

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -10,10 +10,7 @@ import {
   OakTertiaryButton,
 } from "@oaknational/oak-components";
 
-import {
-  lessonReviewSections,
-  useLessonEngineContext,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 
 type PupilViewsReviewProps = {
   lessonTitle: string;
@@ -21,8 +18,12 @@ type PupilViewsReviewProps = {
 
 export const PupilViewsReview = (props: PupilViewsReviewProps) => {
   const { lessonTitle } = props;
-  const { updateCurrentSection, sectionResults, isLessonComplete } =
-    useLessonEngineContext();
+  const {
+    updateCurrentSection,
+    sectionResults,
+    isLessonComplete,
+    lessonReviewSections,
+  } = useLessonEngineContext();
 
   const bottomNavSlot = (
     <OakLessonBottomNav>

--- a/src/components/PupilViews/PupilVideo/PupilVideo.test.tsx
+++ b/src/components/PupilViews/PupilVideo/PupilVideo.test.tsx
@@ -4,10 +4,8 @@ import userEvent from "@testing-library/user-event";
 import { PupilViewsVideo } from "./PupilVideo.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import {
-  LessonEngineContext,
-  LessonEngineContextType,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 jest.mock("@/components/SharedComponents/VideoPlayer/VideoPlayer", () => {
   return () => <span data-testid="video-player" />;
@@ -142,19 +140,3 @@ describe(PupilViewsVideo, () => {
     expect(queryByText("Hide sign language")).toBeInTheDocument();
   });
 });
-
-function createLessonEngineContext(
-  overrides?: Partial<LessonEngineContextType>,
-): NonNullable<LessonEngineContextType> {
-  return {
-    currentSection: "video",
-    completedSections: [],
-    sectionResults: {},
-    getIsComplete: jest.fn(),
-    completeSection: jest.fn(),
-    updateCurrentSection: jest.fn(),
-    proceedToNextSection: jest.fn(),
-    updateQuizResult: jest.fn(),
-    ...overrides,
-  };
-}

--- a/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
@@ -22,6 +22,7 @@ import {
 import {
   LessonEngineProvider,
   isLessonSection,
+  allLessonReviewSections,
   useLessonEngineContext,
 } from "@/components/PupilComponents/LessonEngineProvider";
 import { PupilViewsQuiz } from "@/components/PupilViews/PupilQuiz";
@@ -106,7 +107,9 @@ const PupilsPage: NextPage<PupilLessonOverviewPageProps> = ({
 }) => {
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
-      <LessonEngineProvider>
+      <LessonEngineProvider
+        initialLessonReviewSections={allLessonReviewSections}
+      >
         <OakBox $height={"100vh"}>
           <PupilPageContent curriculumData={curriculumData} />
         </OakBox>

--- a/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
@@ -105,18 +105,7 @@ const PupilPageContent = ({
 const PupilsPage: NextPage<PupilLessonOverviewPageProps> = ({
   curriculumData,
 }) => {
-  const availableSections = allLessonReviewSections.filter((section) => {
-    switch (section) {
-      case "starter-quiz":
-        return !!curriculumData?.starterQuiz?.length;
-      case "exit-quiz":
-        return !!curriculumData?.exitQuiz?.length;
-      case "video":
-        return !!curriculumData.videoMuxPlaybackId;
-      default:
-        return true;
-    }
-  });
+  const availableSections = pickAvailableSectionsForLesson(curriculumData);
 
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
@@ -134,6 +123,22 @@ export type PupilPageURLParams = {
   unitSlug: string;
   programmeSlug: string;
 };
+
+export const pickAvailableSectionsForLesson = (
+  curriculumData: PupilLessonOverviewData,
+) =>
+  allLessonReviewSections.filter((section) => {
+    switch (section) {
+      case "starter-quiz":
+        return !!curriculumData?.starterQuiz?.length;
+      case "exit-quiz":
+        return !!curriculumData?.exitQuiz?.length;
+      case "video":
+        return !!curriculumData.videoMuxPlaybackId;
+      default:
+        return true;
+    }
+  });
 
 export const getStaticPaths = async () => {
   if (shouldSkipInitialBuild) {

--- a/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/index.tsx
@@ -105,11 +105,22 @@ const PupilPageContent = ({
 const PupilsPage: NextPage<PupilLessonOverviewPageProps> = ({
   curriculumData,
 }) => {
+  const availableSections = allLessonReviewSections.filter((section) => {
+    switch (section) {
+      case "starter-quiz":
+        return !!curriculumData?.starterQuiz?.length;
+      case "exit-quiz":
+        return !!curriculumData?.exitQuiz?.length;
+      case "video":
+        return !!curriculumData.videoMuxPlaybackId;
+      default:
+        return true;
+    }
+  });
+
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
-      <LessonEngineProvider
-        initialLessonReviewSections={allLessonReviewSections}
-      >
+      <LessonEngineProvider initialLessonReviewSections={availableSections}>
         <OakBox $height={"100vh"}>
           <PupilPageContent curriculumData={curriculumData} />
         </OakBox>


### PR DESCRIPTION
Music year: [1997](https://www.youtube.com/watch?v=2H5uWRjFsGc)

## Description
Supports lessons with one or more missing sections (starter quiz, exit quiz and video).

🤦‍♂️ Includes a fix for a mistake I made when building the overview page — somehow I managed to get the count of exit and starter quiz questions the wrong way round.

## How to test

1. Go to https://deploy-preview-2234--oak-web-application.netlify.thenational.academy/pupils/programmes/english-primary-ks1/units/writing-lower-case-letters-in-print/lessons/formation-of-v-w-x-and-z
2. You should see a lesson with an intro, starter quiz and video
3. You should be able to take the lesson and complete the 3 sections
4. After completing the 3 sections you should see the lesson review.

NB: There aren't any lessons available currently with a missing starter-quiz or video. So i've had to simulate these in the API. If the API contracts can be relied upon when the data is available then we should be good 🤞🏼 

## Screenshots

https://github.com/oaknational/Oak-Web-Application/assets/122096/0c8e4fcd-da2f-4783-8f47-e2c962dae132


👇🏼 I cheated and simulated no quizzes in my local environment to create this demo 

https://github.com/oaknational/Oak-Web-Application/assets/122096/0219109b-25fa-456a-a336-e8f424c8cdc9

Theoretically according to the API we could have a lesson with no sections and only an intro. This is supported but I feel like it would be unlikely. 

<img width="1656" alt="Screenshot 2024-02-07 at 17 18 45" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/62ade426-7070-438c-9626-f2c180284475">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
