### PR TITLE
fix: icon color to white on home page - LESQ-624

### DIFF
--- a/src/components/GenericPagesComponents/TeachersTabResourceSelectorCard/TeachersTabResourceSelectorCard.tsx
+++ b/src/components/GenericPagesComponents/TeachersTabResourceSelectorCard/TeachersTabResourceSelectorCard.tsx
@@ -35,7 +35,13 @@ const TeachersTabResourceSelectorCard: FC<
           $pa="inner-padding-xs"
         >
           {" "}
-          <Icon name={icon} $objectPosition={"center"} size={50} $pa={3} />
+          <Icon
+            $color={"white"}
+            name={icon}
+            $objectPosition={"center"}
+            size={50}
+            $pa={3}
+          />
         </OakFlex>
         <OakFlex $height={"100%"} $alignItems={"center"}>
           <OakTypography $font={"heading-light-7"} $color={"black"}>


### PR DESCRIPTION
## Description

Music year: 2004

- Fix icons so they are all white


## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2238--oak-web-application.netlify.thenational.academy


## Screenshots

How it used to look (delete if n/a):
![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/121e35f7-8042-424f-a953-f50b03733efa)

How it should now look:
![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/5944eff1-ba9c-42ed-acc8-5a203dfd62f0)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
