### PR TITLE
fix: schema for search highlight - LESQ-528

### DIFF
--- a/src/context/Search/search.schema.ts
+++ b/src/context/Search/search.schema.ts
@@ -56,7 +56,7 @@ const searchResultsSourceUnitSchema = searchResultsSourceCommon.extend({
 
 const searchResultsHighlightLessonSchema = z.object({
   lesson_description: z.coerce.string(),
-  pupil_lesson_outcomes: z.coerce.string(),
+  pupil_lesson_outcome: z.coerce.string(),
   topic_title: z.coerce.string(),
 });
 


### PR DESCRIPTION
## Description

- Typo in the search highlight schema was removing the lesson description highlight field.

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2240--oak-web-application.netlify.thenational.academy
Search for object - you should the it highlighted in the search results

There are still some issues - `objects` does not match, but `object` matches 'object' and 'objects', we should look into tweaking the analyser for highlighting when we work more on search.




## Checklist


