### PR TITLE
fix: convert empty keywords array to undefined [LESQ-626]

### DIFF
--- a/src/components/TeacherViews/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview.view.tsx
@@ -238,7 +238,9 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                   <LessonDetails
                     keyLearningPoints={keyLearningPoints}
                     commonMisconceptions={misconceptionsAndCommonMistakes}
-                    keyWords={lessonKeywords}
+                    keyWords={
+                      lessonKeywords?.length ? lessonKeywords : undefined
+                    }
                     teacherTips={teacherTips}
                     equipmentAndResources={lessonEquipmentAndResources}
                     contentGuidance={contentGuidance}


### PR DESCRIPTION
## Description

Music year: 1950

- prevent lesson overview rendering empty keywords section
- 

## How to test

Everything should look the same, only EYFS is affected currently on the migration environment

1. Go to https://deploy-preview-2241--oak-web-application.netlify.thenational.academy

## Screenshots

How it used to look (delete if n/a):
<img src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/de730fde-7b8d-4180-a98d-005185cb97ac" width=500 >

How it should now look:
{screenshots}
<img src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/b66bbfd5-d161-4c43-855e-3cb0cbc70b71" width=500>

