### PR TITLE
Feat/lesq 637/legacy remove duplicate description [LESQ-637]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41086,6 +41086,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/glob/node_modules/minipass": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.test.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.test.tsx
@@ -1,31 +1,29 @@
-import { isPupilLessonOutcomeInKeyLearningPoints } from "./LessonOverview.view";
+import { getDedupedPupilLessonOutcome } from "./LessonOverview.view";
 
 describe("isPupilLessonOutcomeInKeyLearningPoints", () => {
-  it("should return false if the pupil lesson outcome is not in the key learning points", () => {
-    const result = isPupilLessonOutcomeInKeyLearningPoints(
-      "pupil lesson outcome",
-      [{ keyLearningPoint: "key learning point" }],
-    );
-    expect(result).toBe(false);
-  });
-  it("should return false if pupilLessonOutcome is undefined", () => {
-    const result = isPupilLessonOutcomeInKeyLearningPoints(undefined, [
+  it("should return plo if the pupil lesson outcome is not in the key learning points", () => {
+    const result = getDedupedPupilLessonOutcome("pupil lesson outcome", [
       { keyLearningPoint: "key learning point" },
     ]);
-    expect(result).toBe(false);
+    expect(result).toBe("pupil lesson outcome");
   });
-  it("should return false is the key learning points are undefined", () => {
-    const result = isPupilLessonOutcomeInKeyLearningPoints(
+  it("should return undefined if pupilLessonOutcome is undefined", () => {
+    const result = getDedupedPupilLessonOutcome(undefined, [
+      { keyLearningPoint: "key learning point" },
+    ]);
+    expect(result).toBe(undefined);
+  });
+  it("should return plo if the key learning points are undefined", () => {
+    const result = getDedupedPupilLessonOutcome(
       "pupil lesson outcome",
       undefined,
     );
-    expect(result).toBe(false);
+    expect(result).toBe("pupil lesson outcome");
   });
-  it("should return true if the pupil lesson outcome is in the key learning points", () => {
-    const result = isPupilLessonOutcomeInKeyLearningPoints(
-      "pupil lesson outcome",
-      [{ keyLearningPoint: "pupil lesson outcome" }],
-    );
-    expect(result).toBe(true);
+  it("should return null if the pupil lesson outcome is in the key learning points", () => {
+    const result = getDedupedPupilLessonOutcome("pupil lesson outcome", [
+      { keyLearningPoint: "pupil lesson outcome" },
+    ]);
+    expect(result).toBe(null);
   });
 });

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.test.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.test.tsx
@@ -1,0 +1,31 @@
+import { isPupilLessonOutcomeInKeyLearningPoints } from "./LessonOverview.view";
+
+describe("isPupilLessonOutcomeInKeyLearningPoints", () => {
+  it("should return false if the pupil lesson outcome is not in the key learning points", () => {
+    const result = isPupilLessonOutcomeInKeyLearningPoints(
+      "pupil lesson outcome",
+      [{ keyLearningPoint: "key learning point" }],
+    );
+    expect(result).toBe(false);
+  });
+  it("should return false if pupilLessonOutcome is undefined", () => {
+    const result = isPupilLessonOutcomeInKeyLearningPoints(undefined, [
+      { keyLearningPoint: "key learning point" },
+    ]);
+    expect(result).toBe(false);
+  });
+  it("should return false is the key learning points are undefined", () => {
+    const result = isPupilLessonOutcomeInKeyLearningPoints(
+      "pupil lesson outcome",
+      undefined,
+    );
+    expect(result).toBe(false);
+  });
+  it("should return true if the pupil lesson outcome is in the key learning points", () => {
+    const result = isPupilLessonOutcomeInKeyLearningPoints(
+      "pupil lesson outcome",
+      [{ keyLearningPoint: "pupil lesson outcome" }],
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -38,12 +38,24 @@ import LessonOverviewAnchorLinks from "@/components/TeacherComponents/LessonOver
 import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
 import { GridArea } from "@/components/SharedComponents/Grid.deprecated/GridArea.deprecated.stories";
 import { LEGACY_COHORT, NEW_COHORT } from "@/config/cohort";
+import { keyLearningPoint } from "@/node-lib/curriculum-api-2023/shared.schema";
 
 export type LessonOverviewProps = {
   lesson:
     | LessonOverviewCanonical
     | LessonOverviewInPathway
     | SpecialistLessonOverview;
+};
+
+// helper function to dedupe key learning points from the header in legacy lessons
+export const isPupilLessonOutcomeInKeyLearningPoints = (
+  plo: string | null | undefined,
+  klp: keyLearningPoint[] | null | undefined,
+) => {
+  if (klp && plo) {
+    return klp.some((klpItem) => klpItem.keyLearningPoint === plo);
+  }
+  return false;
 };
 
 export function LessonOverview({ lesson }: LessonOverviewProps) {
@@ -66,6 +78,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
     exitQuiz,
     expired,
     keyLearningPoints,
+    pupilLessonOutcome,
     lessonCohort,
   } = lesson;
 
@@ -174,6 +187,14 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
           });
         }}
         onClickShareAll={trackShareAll}
+        pupilLessonOutcome={
+          isPupilLessonOutcomeInKeyLearningPoints(
+            pupilLessonOutcome,
+            keyLearningPoints,
+          )
+            ? undefined
+            : pupilLessonOutcome
+        }
       />
       <MaxWidth $ph={16} $pb={80}>
         {expired ? (

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -47,15 +47,15 @@ export type LessonOverviewProps = {
     | SpecialistLessonOverview;
 };
 
-// helper function to dedupe key learning points from the header in legacy lessons
-export const isPupilLessonOutcomeInKeyLearningPoints = (
+// helper function to remove key learning points from the header in legacy lessons
+export const getDedupedPupilLessonOutcome = (
   plo: string | null | undefined,
   klp: keyLearningPoint[] | null | undefined,
 ) => {
   if (klp && plo) {
-    return klp.some((klpItem) => klpItem.keyLearningPoint === plo);
+    return klp.some((klpItem) => klpItem.keyLearningPoint === plo) ? null : plo;
   }
-  return false;
+  return plo;
 };
 
 export function LessonOverview({ lesson }: LessonOverviewProps) {
@@ -187,14 +187,10 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
           });
         }}
         onClickShareAll={trackShareAll}
-        pupilLessonOutcome={
-          isPupilLessonOutcomeInKeyLearningPoints(
-            pupilLessonOutcome,
-            keyLearningPoints,
-          )
-            ? undefined
-            : pupilLessonOutcome
-        }
+        pupilLessonOutcome={getDedupedPupilLessonOutcome(
+          pupilLessonOutcome,
+          keyLearningPoints,
+        )}
       />
       <MaxWidth $ph={16} $pb={80}>
         {expired ? (

--- a/src/components/TeacherViews/SpecialistLesson/SpecialistLesson.view.tsx
+++ b/src/components/TeacherViews/SpecialistLesson/SpecialistLesson.view.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 
-import { LessonOverview } from "@/components/TeacherViews/LessonOverview.view";
+import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import { LessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
 
 type SpecialistLessonProps = {

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -23,6 +23,8 @@ const keyLearningPointsSchema = z.object({
   keyLearningPoint: z.string().nullable(),
 });
 
+export type keyLearningPoint = z.infer<typeof keyLearningPointsSchema>;
+
 const copyrightContentSchema = z.object({
   copyrightInfo: z.string(),
 });

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -17,7 +17,7 @@ import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import MaxWidth from "@/components/SharedComponents/MaxWidth";
 import { LessonAppearsIn } from "@/components/TeacherComponents/LessonAppearsIn";
 import { groupLessonPathways } from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
-import { LessonOverview } from "@/components/TeacherViews/LessonOverview.view";
+import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import curriculumApi from "@/node-lib/curriculum-api";
 import OakError from "@/errors/OakError";
 

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -16,7 +16,7 @@ import curriculumApi, { LessonOverviewData } from "@/node-lib/curriculum-api";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
-import { LessonOverview } from "@/components/TeacherViews/LessonOverview.view";
+import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import { getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export type LessonOverviewPageProps = {


### PR DESCRIPTION
## Description

Music year: 1976

- remove the pupil lesson outcome from the lesson header when it is included in key learning points
- only applies to EYFS currently, but will apply to legacy when migrated

## How to test
1. Go to https://deploy-preview-2247--oak-web-application.netlify.thenational.academy/teachers/programmes/citizenship-secondary-ks4-l/units/how-well-does-the-media-hold-those-in-power-to-account-63c4/lessons/what-is-the-role-of-the-media-in-a-democracy-cmw32c
3. You should see no pupil lesosn outcome in the header (same as prod)
4. Go to https://deploy-preview-2247--oak-web-application.netlify.thenational.academy/teachers/programmes/combined-science-secondary-ks4-higher-aqa/units/measuring-waves/lessons/transverse-waves
5. You should see the pupil lesson outcome in the header (same as prod)

## Screenshots

How it used to look (delete if n/a):
<img src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/50bc261a-b12b-476f-ad90-e6a535d60019" width=500>

How it should now look:
<img src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/d6135ae7-629b-4876-8706-efa13708b869" width=500>
