### PR TITLE
Fix/lesq 628/lesson share [LESQ-628]

### DIFF
--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -1,0 +1,104 @@
+import { screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import userEvent from "@testing-library/user-event";
+
+import { ResourceFormProps } from "../types/downloadAndShare.types";
+
+import LessonShareCardGroup from "./LessonShareCardGroup";
+
+import { LessonShareData } from "@/node-lib/curriculum-api";
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+const ComponentWrapper = (props: {
+  shareableResources: LessonShareData["shareableResources"];
+  shareLink: string;
+}) => {
+  const { control, trigger } = useForm<ResourceFormProps>();
+
+  return (
+    <LessonShareCardGroup
+      {...props}
+      control={control}
+      triggerForm={trigger}
+      shareableResources={props.shareableResources}
+      shareLink={props.shareLink}
+    />
+  );
+};
+
+describe("lesson share card group", () => {
+  it("should render", () => {
+    renderWithTheme(
+      <ComponentWrapper shareableResources={[]} shareLink="www.fake.com" />,
+    );
+
+    const previewButton = screen.getByText("Preview as a pupil");
+    expect(previewButton).toBeInTheDocument();
+  });
+  it("should render with resources", () => {
+    const shareableResources = [
+      {
+        exists: true,
+        type: "video" as const,
+        metadata: "5min",
+        label: "Video",
+      },
+    ];
+    renderWithTheme(
+      <ComponentWrapper
+        shareableResources={shareableResources}
+        shareLink="www.fake.com"
+      />,
+    );
+
+    const resourceCardLabel = screen.getByText("Video");
+    expect(resourceCardLabel).toBeInTheDocument();
+  });
+  it("should toggle the checkbox when clicked", async () => {
+    const shareableResources = [
+      {
+        exists: true,
+        type: "video" as const,
+        metadata: "5min",
+        label: "Video",
+      },
+    ];
+    renderWithTheme(
+      <ComponentWrapper
+        shareableResources={shareableResources}
+        shareLink="www.fake.com"
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+
+    const user = userEvent.setup();
+    const checkboxLabel = screen.getByText("Video");
+    await user.click(checkboxLabel);
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkboxLabel);
+    expect(checkbox).not.toBeChecked();
+  });
+  it("should render pdf label in uppercase", () => {
+    const shareableResources = [
+      {
+        exists: true,
+        type: "worksheet-pdf" as const,
+        metadata: "pdf",
+        label: "Worksheet",
+      },
+    ];
+    renderWithTheme(
+      <ComponentWrapper
+        shareableResources={shareableResources}
+        shareLink="www.fake.com"
+      />,
+    );
+
+    const resourceCardLabel = screen.getByText("PDF");
+    expect(resourceCardLabel).toBeInTheDocument();
+  });
+});

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -20,7 +20,9 @@ export type LessonShareCardGroupProps = {
 };
 
 const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
-  const sortedResources = sortShareResources(props.shareableResources);
+  const sortedResources = sortShareResources(props.shareableResources).filter(
+    (r) => r.exists && r.metadata !== null,
+  );
 
   return (
     <OakFlex
@@ -33,56 +35,50 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
         $flexDirection={["column", "row"]}
         $flexWrap={["nowrap", "wrap"]}
       >
-        {sortedResources.map(
-          (resource, i) =>
-            resource.exists &&
-            resource.metadata && (
-              <Controller
-                data-testid="lessonResourcesToShare"
-                control={props.control}
-                name="resources"
-                defaultValue={[]}
-                key={`${resource.type}-${i}`}
-                render={({
-                  field: { value: fieldValue, onChange, name, onBlur },
-                }) => {
-                  const onChangeHandler = (
-                    e: ChangeEvent<HTMLInputElement>,
-                  ) => {
-                    if (e.target.checked) {
-                      onChange([...fieldValue, resource.type]);
-                    } else {
-                      onChange(
-                        fieldValue.filter(
-                          (val: LessonShareResourceData["type"] | string) =>
-                            val !== resource.type,
-                        ),
-                      );
-                    }
-                    // Trigger the form to reevaluate errors
-                    props.triggerForm();
-                  };
-                  return (
-                    <ResourceCard
-                      id={resource.type}
-                      name={name}
-                      label={resource.label}
-                      subtitle={
-                        resource.metadata?.toLowerCase() === "pdf"
-                          ? "PDF"
-                          : resource.metadata! // this cannot be null here
-                      }
-                      resourceType={resource.type}
-                      onChange={onChangeHandler}
-                      checked={fieldValue.includes(resource.type)}
-                      onBlur={onBlur}
-                      hasError={props.hasError}
-                    />
+        {sortedResources.map((resource, i) => (
+          <Controller
+            data-testid="lessonResourcesToShare"
+            control={props.control}
+            name="resources"
+            defaultValue={[]}
+            key={`${resource.type}-${i}`}
+            render={({
+              field: { value: fieldValue, onChange, name, onBlur },
+            }) => {
+              const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+                if (e.target.checked) {
+                  onChange([...fieldValue, resource.type]);
+                } else {
+                  onChange(
+                    fieldValue.filter(
+                      (val: LessonShareResourceData["type"] | string) =>
+                        val !== resource.type,
+                    ),
                   );
-                }}
-              />
-            ),
-        )}
+                }
+                // Trigger the form to reevaluate errors
+                props.triggerForm();
+              };
+              return (
+                <ResourceCard
+                  id={resource.type}
+                  name={name}
+                  label={resource.label}
+                  subtitle={
+                    resource.metadata?.toLowerCase() === "pdf"
+                      ? "PDF"
+                      : resource.metadata! // this cannot be null here
+                  }
+                  resourceType={resource.type}
+                  onChange={onChangeHandler}
+                  checked={fieldValue.includes(resource.type)}
+                  onBlur={onBlur}
+                  hasError={props.hasError}
+                />
+              );
+            }}
+          />
+        ))}
       </OakFlex>
       <ButtonAsLink
         label="Preview as a pupil"

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -35,7 +35,8 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
       >
         {sortedResources.map(
           (resource, i) =>
-            resource.exists && (
+            resource.exists &&
+            resource.metadata && (
               <Controller
                 data-testid="lessonResourcesToShare"
                 control={props.control}
@@ -67,9 +68,9 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
                       name={name}
                       label={resource.label}
                       subtitle={
-                        resource.metadata.toLowerCase() === "pdf"
+                        resource.metadata?.toLowerCase() === "pdf"
                           ? "PDF"
-                          : resource.metadata
+                          : resource.metadata! // this cannot be null here
                       }
                       resourceType={resource.type}
                       onChange={onChangeHandler}

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -24,6 +24,26 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
     (r) => r.exists && r.metadata !== null,
   );
 
+  const removeFieldValue = (fieldValue: string[], resourceType: string) =>
+    fieldValue.filter(
+      (val: LessonShareResourceData["type"] | string) => val !== resourceType,
+    );
+
+  const checkboxOnChangeHandler = (
+    e: ChangeEvent<HTMLInputElement>,
+    onChange: (val: string[]) => void,
+    fieldValue: string[],
+    resourceType: string,
+  ) => {
+    if (e.target.checked) {
+      onChange([...fieldValue, resourceType]);
+    } else {
+      onChange(removeFieldValue(fieldValue, resourceType));
+    }
+    // Trigger the form to reevaluate errors
+    props.triggerForm();
+  };
+
   return (
     <OakFlex
       $flexDirection="column"
@@ -45,20 +65,6 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
             render={({
               field: { value: fieldValue, onChange, name, onBlur },
             }) => {
-              const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
-                if (e.target.checked) {
-                  onChange([...fieldValue, resource.type]);
-                } else {
-                  onChange(
-                    fieldValue.filter(
-                      (val: LessonShareResourceData["type"] | string) =>
-                        val !== resource.type,
-                    ),
-                  );
-                }
-                // Trigger the form to reevaluate errors
-                props.triggerForm();
-              };
               return (
                 <ResourceCard
                   id={resource.type}
@@ -70,7 +76,14 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
                       : resource.metadata! // this cannot be null here
                   }
                   resourceType={resource.type}
-                  onChange={onChangeHandler}
+                  onChange={(e) =>
+                    checkboxOnChangeHandler(
+                      e,
+                      onChange,
+                      fieldValue,
+                      resource.type,
+                    )
+                  }
                   checked={fieldValue.includes(resource.type)}
                   onBlur={onBlur}
                   hasError={props.hasError}

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
@@ -9,7 +9,7 @@ const lessonShareResourceSchema = z.object({
     "video",
   ]),
   label: z.string(),
-  metadata: z.string(),
+  metadata: z.string().nullable(),
 });
 
 export const lessonShareSchema = z.object({


### PR DESCRIPTION
## Description

Music year: 2014

- make shareable resource metadata nullable as it only exists when the resource exists 

## Issue(s)

Fixes # 
share page not loading for EYFS lessons

can't be tested until it is deployed to the migration instance
<img src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/bef524d7-cc6a-4804-9281-e33802fab2b5" width=500 >
