### PR TITLE
fix: lesson page blowing up when a download existence check fails

### DIFF
--- a/src/__tests__/pages/pupils/index.test.tsx
+++ b/src/__tests__/pages/pupils/index.test.tsx
@@ -160,5 +160,20 @@ describe("pages/pupils/programmes/[programmeSlug]/units/[unitSlug]/lessons/[less
       assert("props" in res);
       expect(res.props.hasWorksheet).toBe(false);
     });
+
+    it("does not blow up if the `getDownloadResourcesExistence` check fails", async () => {
+      getDownloadResourcesExistenceSpy.mockRejectedValue(new Error("oh no!"));
+
+      const res = await getStaticProps({
+        params: {
+          programmeSlug: "ks123",
+          unitSlug: "unitSlug",
+          lessonSlug: "lessonSlug",
+        },
+      });
+
+      assert("props" in res);
+      expect(res.props.hasWorksheet).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Music year: [2022](https://www.youtube.com/watch?v=pzVYSfzNQ5Y)

Fixes the lesson page blowing up when a the download existence check throws.

If the download existence check fails, we should not block the page from rendering. There appear to be two ways the `getDownloadResourcesExistence` will report a missing resource. Either by returning an object in the form `{ resources: ["worksheet-pdf", { exists: false }] }` or by throwing. Catching and reporting the error matches the behaviour of the teachers downloads page and allows the lesson page to render

## How to test

1. Go to the migrated legacy lesson https://deploy-preview-2253--oak-web-application.netlify.thenational.academy/pupils/programmes/english-secondary-ks3/units/the-oral-tradition-7424/lessons/the-origins-of-storytelling-cmrk0r — this lesson does not have a worksheet
2. You should see the overview page
3. Click "Intro"
4. You should see the intro page with no worksheet

