### PR TITLE
PUPIL-351: Pupil lesson copy changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^7.3.3",
         "@mux/mux-player-react": "^2.3.1",
-        "@oaknational/oak-components": "^0.0.34",
+        "@oaknational/oak-components": "^0.0.35",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
         "@sanity/asset-utils": "^1.3.0",
@@ -7769,9 +7769,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.34.tgz",
-      "integrity": "sha512-U16L83Z+4/alBTcRCmFus9VBf+eu0RcZU0jjgrhm6oI/g2vm0Q7sdKjskrIVvU4xD4Qxsk6OsmrU7uGcDaEDdg==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.35.tgz",
+      "integrity": "sha512-I0DNfyttLKmSlD8l7HRqF2m8ilSMVG6AXaUSVuZqrpthno+0pvrbQDriHPiKSHqG/ZGQ59PlSKlAuVdix6RJQA==",
       "peerDependencies": {
         "next": "13.4.4 - 14",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^7.3.3",
     "@mux/mux-player-react": "^2.3.1",
-    "@oaknational/oak-components": "^0.0.34",
+    "@oaknational/oak-components": "^0.0.35",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",
     "@sanity/asset-utils": "^1.3.0",

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -34,7 +34,7 @@ describe(PupilViewsLessonOverview, () => {
     [/Intro/, "intro"],
     [/Starter quiz/, "starter-quiz"],
     [/Exit quiz/, "exit-quiz"],
-    [/Watch video/, "video"],
+    [/Lesson video/, "video"],
   ].forEach(([name, section]) => {
     it(`allows navigation to the "${section}" section of the quiz`, () => {
       const updateCurrentSection = jest.fn();
@@ -77,7 +77,7 @@ describe(PupilViewsLessonOverview, () => {
     );
 
     expect(getByTestId("starter-quiz")).toHaveTextContent("4 Questions");
-    expect(getByTestId("exit-quiz")).toHaveTextContent("Practice 5 questions");
+    expect(getByTestId("exit-quiz")).toHaveTextContent("5 questions");
   });
 
   it.each([

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -3,7 +3,10 @@ import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 import { PupilViewsLessonOverview } from "./PupilLessonOverview.view";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import {
+  LessonEngineContext,
+  LessonEngineContextType,
+} from "@/components/PupilComponents/LessonEngineProvider";
 import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
 describe(PupilViewsLessonOverview, () => {
@@ -75,5 +78,60 @@ describe(PupilViewsLessonOverview, () => {
 
     expect(getByTestId("starter-quiz")).toHaveTextContent("4 Questions");
     expect(getByTestId("exit-quiz")).toHaveTextContent("Practice 5 questions");
+  });
+
+  (
+    [
+      {
+        context: {},
+        label: "Let's get ready",
+      },
+      {
+        context: {
+          sectionResults: { intro: { isComplete: true } },
+        },
+        label: "Start lesson",
+      },
+      {
+        context: {
+          sectionResults: { "starter-quiz": { isComplete: true } },
+        },
+        label: "Continue lesson",
+      },
+      {
+        context: {
+          sectionResults: { "exit-quiz": { isComplete: true } },
+        },
+        label: "Continue lesson",
+      },
+      {
+        context: {
+          isLessonComplete: true,
+        },
+        label: "Lesson review",
+      },
+    ] satisfies { context: Partial<LessonEngineContextType>; label: string }[]
+  ).forEach((example) => {
+    it(`displays '${example.label}' for the proceed to next section button`, () => {
+      const { getByTestId } = renderWithTheme(
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <LessonEngineContext.Provider
+            value={createLessonEngineContext(example.context)}
+          >
+            <PupilViewsLessonOverview
+              lessonTitle="Introduction to The Canterbury Tales"
+              subjectTitle="English"
+              subjectSlug="english"
+              starterQuizNumQuestions={4}
+              exitQuizNumQuestions={5}
+            />
+          </LessonEngineContext.Provider>
+        </OakThemeProvider>,
+      );
+
+      expect(getByTestId("proceed-to-next-section")).toHaveTextContent(
+        example.label,
+      );
+    });
   });
 });

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -80,43 +80,45 @@ describe(PupilViewsLessonOverview, () => {
     expect(getByTestId("exit-quiz")).toHaveTextContent("Practice 5 questions");
   });
 
-  (
-    [
-      {
-        context: {},
-        label: "Let's get ready",
+  it.each([
+    {
+      context: {},
+      label: "Let's get ready",
+    },
+    {
+      context: {
+        sectionResults: { intro: { isComplete: true } },
       },
-      {
-        context: {
-          sectionResults: { intro: { isComplete: true } },
-        },
-        label: "Start lesson",
+      label: "Start lesson",
+    },
+    {
+      context: {
+        sectionResults: { "starter-quiz": { isComplete: true } },
       },
-      {
-        context: {
-          sectionResults: { "starter-quiz": { isComplete: true } },
-        },
-        label: "Continue lesson",
+      label: "Continue lesson",
+    },
+    {
+      context: {
+        sectionResults: { "exit-quiz": { isComplete: true } },
       },
-      {
-        context: {
-          sectionResults: { "exit-quiz": { isComplete: true } },
-        },
-        label: "Continue lesson",
+      label: "Continue lesson",
+    },
+    {
+      context: {
+        isLessonComplete: true,
       },
-      {
-        context: {
-          isLessonComplete: true,
-        },
-        label: "Lesson review",
-      },
-    ] satisfies { context: Partial<LessonEngineContextType>; label: string }[]
-  ).forEach((example) => {
-    it(`displays '${example.label}' for the proceed to next section button`, () => {
+      label: "Lesson review",
+    },
+  ] satisfies Array<{
+    context: Partial<LessonEngineContextType>;
+    label: string;
+  }>)(
+    'renders "$label" for the proceed to next section button',
+    ({ label, context }) => {
       const { getByTestId } = renderWithTheme(
         <OakThemeProvider theme={oakDefaultTheme}>
           <LessonEngineContext.Provider
-            value={createLessonEngineContext(example.context)}
+            value={createLessonEngineContext(context)}
           >
             <PupilViewsLessonOverview
               lessonTitle="Introduction to The Canterbury Tales"
@@ -129,9 +131,7 @@ describe(PupilViewsLessonOverview, () => {
         </OakThemeProvider>,
       );
 
-      expect(getByTestId("proceed-to-next-section")).toHaveTextContent(
-        example.label,
-      );
-    });
-  });
+      expect(getByTestId("proceed-to-next-section")).toHaveTextContent(label);
+    },
+  );
 });

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -190,7 +190,6 @@ export const PupilViewsLessonOverview = ({
                   lessonSectionName="video"
                   onClick={() => updateCurrentSection("video")}
                   progress={pickProgressForSection("video")}
-                  videoLength={0}
                 />
               )}
               {lessonReviewSections.includes("exit-quiz") && (

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -45,6 +45,7 @@ export const PupilViewsLessonOverview = ({
     updateCurrentSection,
     proceedToNextSection,
     lessonReviewSections,
+    isLessonComplete,
   } = useLessonEngineContext();
   const subjectIconName: `subject-${string}` = `subject-${subjectSlug}`;
 
@@ -71,8 +72,9 @@ export const PupilViewsLessonOverview = ({
             width={["100%", "auto", "auto"]}
             iconName="arrow-right"
             isTrailingIcon
+            data-testid="proceed-to-next-section"
           >
-            Let's get ready
+            {pickProceedToNextSectionLabel(isLessonComplete, sectionResults)}
           </OakPrimaryButton>
         </OakLessonBottomNav>
       }
@@ -209,3 +211,22 @@ export const PupilViewsLessonOverview = ({
     </OakLessonLayout>
   );
 };
+
+function pickProceedToNextSectionLabel(
+  isLessonComplete: boolean,
+  results: ReturnType<typeof useLessonEngineContext>["sectionResults"],
+) {
+  if (isLessonComplete) {
+    return "Lesson review";
+  }
+
+  if (results["starter-quiz"]?.isComplete || results["exit-quiz"]?.isComplete) {
+    return "Continue lesson";
+  }
+
+  if (results["intro"]?.isComplete) {
+    return "Start lesson";
+  }
+
+  return "Let's get ready";
+}

--- a/src/components/PupilViews/PupilQuiz/PupilQuiz.view.test.tsx
+++ b/src/components/PupilViews/PupilQuiz/PupilQuiz.view.test.tsx
@@ -11,14 +11,12 @@ import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizEleme
 import { LessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 import { createLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test";
 
-const questionsArrayFixture = quizQuestions || [];
-
 describe("PupilQuizView", () => {
   it("renders heading, mode and answer when there is currentQuestionData", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider value={createLessonEngineContext()}>
-          <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
+          <PupilViewsQuiz questionsArray={quizQuestions} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
     );
@@ -30,18 +28,18 @@ describe("PupilQuizView", () => {
     const { getByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider value={createLessonEngineContext()}>
-          <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
+          <PupilViewsQuiz questionsArray={quizQuestions} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
     );
-    expect(getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(getByRole("button", { name: /Check/ })).toBeDisabled();
   });
 
   it("renders Next button when questionState.mode is feedback", () => {
-    const { getByLabelText, getByRole } = renderWithTheme(
+    const { getByLabelText, getByRole, container } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider value={createLessonEngineContext()}>
-          <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
+          <PupilViewsQuiz questionsArray={quizQuestions} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
     );
@@ -49,19 +47,40 @@ describe("PupilQuizView", () => {
 
     act(() => {
       fireEvent.click(getByLabelText(/a group of letters/));
-      fireEvent.click(getByRole("button", { name: "Submit" }));
+      console.log(container.innerHTML);
+      fireEvent.click(getByRole("button", { name: /Check/ }));
     });
-    expect(getByRole("button", { name: "Next question" })).toBeInTheDocument();
+    expect(getByRole("button", { name: /Next question/ })).toBeInTheDocument();
   });
 
   it("does not render Next button when questionState.mode is not feedback", () => {
     const { queryByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider value={createLessonEngineContext()}>
-          <PupilViewsQuiz questionsArray={questionsArrayFixture ?? []} />
+          <PupilViewsQuiz questionsArray={quizQuestions} />
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
     );
-    expect(queryByText("Next Question")).not.toBeInTheDocument();
+    expect(queryByText(/Next Question/)).not.toBeInTheDocument();
+  });
+
+  it("displays the 'Continue lesson' button when on the last question in the exit-quiz", () => {
+    const { getByLabelText, getByRole } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider
+          value={createLessonEngineContext({ currentSection: "exit-quiz" })}
+        >
+          <PupilViewsQuiz questionsArray={quizQuestions.slice(0, 1)} />
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+    expect(getByLabelText(/a group of letters/)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByLabelText(/a group of letters/));
+      fireEvent.click(getByRole("button", { name: /Check/ }));
+    });
+
+    expect(getByRole("button", { name: /Lesson review/ })).toBeInTheDocument();
   });
 });

--- a/src/components/PupilViews/PupilQuiz/PupilQuiz.view.tsx
+++ b/src/components/PupilViews/PupilQuiz/PupilQuiz.view.tsx
@@ -94,16 +94,30 @@ const QuizInner = () => {
           form={formId}
           disabled={questionState[currentQuestionIndex]?.mode === "init"}
           type="submit"
+          isTrailingIcon
+          iconName="arrow-right"
           width={["100%", "auto"]}
         >
-          Submit
+          Check
         </OakPrimaryButton>
       )}
       {isFeedbackMode && (
-        <OakPrimaryButton width={["100%", "auto"]} onClick={handleNextQuestion}>
-          {currentQuestionIndex + 1 === numQuestions
-            ? "Continue lesson"
-            : "Next question"}
+        <OakPrimaryButton
+          width={["100%", "auto"]}
+          onClick={handleNextQuestion}
+          isTrailingIcon
+          iconName="arrow-right"
+        >
+          {(() => {
+            if (currentQuestionIndex + 1 !== numQuestions) {
+              return "Next question";
+            }
+
+            // This is the last question in the quiz, show the appropriate button label
+            return currentSection === "exit-quiz"
+              ? "Lesson review"
+              : "Continue lesson";
+          })()}
         </OakPrimaryButton>
       )}
     </OakLessonBottomNav>

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -57,6 +57,6 @@ describe("PupilReview", () => {
       </OakThemeProvider>,
     );
 
-    expect(queryByText("Fantastic learning - well done!")).toBeInTheDocument();
+    expect(queryByText("Fantastic job, well done!")).toBeInTheDocument();
   });
 });

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -28,7 +28,7 @@ describe("PupilReview", () => {
         </LessonEngineContext.Provider>
       </OakThemeProvider>,
     );
-    expect(getByText("Intro")).toBeInTheDocument();
+    expect(getByText("Introduction")).toBeInTheDocument();
     expect(getByText("Starter quiz")).toBeInTheDocument();
     expect(getByText("Watch video")).toBeInTheDocument();
     expect(getByText("Exit quiz")).toBeInTheDocument();

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -90,6 +90,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
           {lessonReviewSections.map((lessonSection) => {
             return (
               <OakLessonReviewItem
+                key={lessonSection}
                 lessonSectionName={lessonSection}
                 completed={!!sectionResults[lessonSection]?.isComplete}
                 grade={sectionResults[lessonSection]?.grade ?? 0}
@@ -110,7 +111,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
           >
             <OakFlex $font="heading-5" $textAlign={["center", "left", "left"]}>
               {isLessonComplete
-                ? "Fantastic learning - well done!"
+                ? "Fantastic job, well done!"
                 : "Well done, you're Oaking it!"}
             </OakFlex>
           </OakHandDrawnCard>


### PR DESCRIPTION
Music year: [2006](https://www.youtube.com/watch?v=x1peC9_QOiE)

## Description

A bunch of copy changes and tweaks to match the [latest designs](https://www.figma.com/file/G7z5ufo2T0CHk14CkadeuB/Pupils-high-fidelity-designs?type=design&node-id=2980-64457&mode=design)

# Caveats
1. The "Lesson review" button label will appear at the end of the exit quiz even if the lesson is incomplete (I.e. the lesson has been completed out of order). I feel like this ok, but I can spend a little more time covering this case if it would be confusing. In the case that the lesson is completed out of order this label should be applied to any section that happens to be the last one completed.
2. I missed changing the "Watch video"  -> "Lesson video" on the lesson review page. This will trickle through in the next publish of the components library with this PR https://github.com/oaknational/oak-components/pull/107

## How to test

1. Go to https://deploy-preview-2255--oak-web-application.netlify.thenational.academy/pupils/programmes/maths-secondary-ks3/units/graphical-representations-of-data/lessons/constructing-bar-charts-by-utilising-technology
3. Take the lesson
4. The copy should match the latest designs

## Screenshots
<img width="1468" alt="Screenshot 2024-02-15 at 13 15 22" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/b011742e-30eb-4197-835e-59eb6b7afaf6">
<img width="1466" alt="Screenshot 2024-02-15 at 13 15 04" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/8e2b7e59-b3f6-4d59-951a-e7e54be8b69b">
<img width="1428" alt="Screenshot 2024-02-15 at 13 14 58" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/ee1eb276-ba92-4fc2-b2d5-cc7b51ddfdaa">
<img width="1425" alt="Screenshot 2024-02-15 at 13 14 47" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/9ee2e13d-54e5-44ea-b5e8-9472ca431af0">
<img width="1420" alt="Screenshot 2024-02-15 at 13 14 31" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/1ceecdcb-7a15-4287-90cb-3dd0b1bdba9c">
<img width="1432" alt="Screenshot 2024-02-15 at 13 14 07" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/a945db2e-95b3-4f26-95c2-fe8b9f439576">
<img width="1402" alt="Screenshot 2024-02-15 at 14 03 38" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/9380b482-bd8d-4754-a114-dcd74f6a2883">

