### PR TITLE
PUPIL-338: disable Gleap for pupils

### DIFF
--- a/src/components/AppComponents/App/AppHooks.tsx
+++ b/src/components/AppComponents/App/AppHooks.tsx
@@ -1,4 +1,5 @@
 import { watchModals } from "@react-aria/aria-modal-polyfill";
+import { useRouter } from "next/router";
 
 import useAxe from "@/browser-lib/axe/useAxe";
 import useBugsnag from "@/browser-lib/bugsnag/useBugsnag";
@@ -24,11 +25,16 @@ if (isBrowser) {
 const useAppHooks = () => {
   const { hasConsentedTo } = useCookieConsent();
   const { posthogDistinctId } = useAnalytics();
+  const router = useRouter();
   useBugsnag({
     enabled: hasConsentedTo("bugsnag") === "enabled",
     userId: posthogDistinctId,
   });
-  useGleap({ enabled: hasConsentedTo("gleap") === "enabled" });
+  useGleap({
+    enabled:
+      hasConsentedTo("gleap") === "enabled" &&
+      !router.pathname.startsWith("/pupils"), // Disable Gleap for pupils
+  });
   useAxe({ enabled: getBrowserConfig("axeA11yLogging") === "on" });
 };
 


### PR DESCRIPTION
## Description

It is not needed for pupils, and it is appearing on top of the submit button in quizzes. We'll use other methods to gather feedback from pupils

Music year: [1969](https://www.youtube.com/watch?v=zUQiUFZ5RDw)

## How to test

1. Go to https://deploy-preview-2259--oak-web-application.netlify.thenational.academy/pupils/programmes/science-secondary-ks3/units/moving-by-force/lessons/reading-distance-time-graphs
3. You **should not** see the Gleap
4. Go to https://deploy-preview-2259--oak-web-application.netlify.thenational.academy/
5. You **should** see the Gleap

## Screenshots

How it used to look 

<img width="1469" alt="Screenshot 2024-02-15 at 17 15 41" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/46fd2c55-ebc4-4d67-a517-a9409972da0b">

![localhost_3000_pupils_programmes_science-secondary-ks3_units_moving-by-force_lessons_reading-distance-time-graphs(iPhone 14 Pro Max)](https://github.com/oaknational/Oak-Web-Application/assets/122096/66ee3b80-cbff-4ceb-b3f7-ec5b43257bf4)


How it should now look:

<img width="1469" alt="Screenshot 2024-02-15 at 17 15 25" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/7e62184f-bcca-4f43-b0af-39642be2aede">

![localhost_3000_pupils_programmes_science-secondary-ks3_units_moving-by-force_lessons_reading-distance-time-graphs(iPhone 14 Pro Max) (1)](https://github.com/oaknational/Oak-Web-Application/assets/122096/9044bfcd-defb-447b-adba-67a6703f2479)
