### PR TITLE
PUPIL-412: Disable buttons on the lesson overview until page hydration

### DIFF
--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -15,6 +15,7 @@ import {
   OakTertiaryButton,
   isValidIconName,
 } from "@oaknational/oak-components";
+import { useEffect, useState } from "react";
 
 import {
   LessonReviewSection,
@@ -51,6 +52,10 @@ export const PupilViewsLessonOverview = ({
   } = useLessonEngineContext();
 
   const subjectIconName: `subject-${string}` = `subject-${subjectSlug}`;
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   function pickProgressForSection(section: LessonReviewSection) {
     if (sectionResults[section]?.isComplete) {
@@ -76,6 +81,7 @@ export const PupilViewsLessonOverview = ({
             iconName="arrow-right"
             isTrailingIcon
             data-testid="proceed-to-next-section"
+            disabled={!isMounted}
           >
             {pickProceedToNextSectionLabel(isLessonComplete, sectionResults)}
           </OakPrimaryButton>
@@ -180,6 +186,7 @@ export const PupilViewsLessonOverview = ({
                   lessonSectionName="intro"
                   onClick={() => updateCurrentSection("intro")}
                   progress={pickProgressForSection("intro")}
+                  disabled={!isMounted}
                 />
               )}
               {lessonReviewSections.includes("starter-quiz") && (
@@ -191,6 +198,7 @@ export const PupilViewsLessonOverview = ({
                   numQuestions={starterQuizNumQuestions}
                   grade={sectionResults["starter-quiz"]?.grade ?? 0}
                   data-testid="starter-quiz"
+                  disabled={!isMounted}
                 />
               )}
               {lessonReviewSections.includes("video") && (
@@ -199,6 +207,7 @@ export const PupilViewsLessonOverview = ({
                   lessonSectionName="video"
                   onClick={() => updateCurrentSection("video")}
                   progress={pickProgressForSection("video")}
+                  disabled={!isMounted}
                 />
               )}
               {lessonReviewSections.includes("exit-quiz") && (
@@ -210,6 +219,7 @@ export const PupilViewsLessonOverview = ({
                   numQuestions={exitQuizNumQuestions}
                   grade={sectionResults["exit-quiz"]?.grade ?? 0}
                   data-testid="exit-quiz"
+                  disabled={!isMounted}
                 />
               )}
             </OakFlex>


### PR DESCRIPTION
## Description

Music year: [1957](https://www.youtube.com/watch?v=tE46zm4yjhA)

Disables the nav items and "Let's get ready" button (using their existing disabled states) on the lesson overview until the page has hydrated. This is a temporary measure until they are replaced with links. However until then the page will appear broken while the JS is loading. 

## How to test:
1. Visit https://deploy-preview-2260--oak-web-application.netlify.thenational.academy/pupils/programmes/english-secondary-ks4-aqa/units/modern-text-second-deep-dive-194/lessons/men-in-leave-taking#lesson-details on a slow or throttled connection (climb a remote hillside in North Wales, go to a music festival, or use the Network tab of DevTools).
2. Try to interact with the buttons on the overview screen while the page is still loading.

### Known limitations and reasoning
1. Deep linking with a #fragment to another section of the lesson will still appear broken while loading — this seems acceptable since we're not actively exposing the deep linking to pupils and we intend to use real links in future.
2. I didn't feel like a loading spinner would be appropriate since it's quite distracting and would defeat the purpose of SSR
3. I didn't think a skeleton loader would be appropriate since we already have the page content available through SSR

https://github.com/oaknational/Oak-Web-Application/assets/122096/333c46af-4fab-4a79-93db-cb7e776397a2

