### PR TITLE
PUPIL-274: Fix footer button wrapping in lesson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^7.3.3",
         "@mux/mux-player-react": "^2.3.1",
-        "@oaknational/oak-components": "^0.0.35",
+        "@oaknational/oak-components": "^0.0.36",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
         "@sanity/asset-utils": "^1.3.0",
@@ -7769,9 +7769,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.35.tgz",
-      "integrity": "sha512-I0DNfyttLKmSlD8l7HRqF2m8ilSMVG6AXaUSVuZqrpthno+0pvrbQDriHPiKSHqG/ZGQ59PlSKlAuVdix6RJQA==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.36.tgz",
+      "integrity": "sha512-ofZEcAlCxSo9Ib0lb6Vek7p5hM+jPIJXoswwNSw58dFk+9a2rj2l9PnxGfSLGQzMgl7eDFoJZz3aQGXTFCHNzg==",
       "peerDependencies": {
         "next": "13.4.4 - 14",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^7.3.3",
     "@mux/mux-player-react": "^2.3.1",
-    "@oaknational/oak-components": "^0.0.35",
+    "@oaknational/oak-components": "^0.0.36",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",
     "@sanity/asset-utils": "^1.3.0",

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
@@ -68,7 +68,7 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
     <OakLessonBottomNav>
       <OakPrimaryButton
         type="button"
-        width={["100%", "auto"]}
+        width={["100%", "max-content"]}
         isTrailingIcon
         iconName="arrow-right"
         onClick={() => {

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -77,7 +77,7 @@ export const PupilViewsLessonOverview = ({
         <OakLessonBottomNav>
           <OakPrimaryButton
             onClick={proceedToNextSection}
-            width={["100%", "auto", "auto"]}
+            width={["100%", "max-content"]}
             iconName="arrow-right"
             isTrailingIcon
             data-testid="proceed-to-next-section"

--- a/src/components/PupilViews/PupilQuiz/PupilQuiz.view.tsx
+++ b/src/components/PupilViews/PupilQuiz/PupilQuiz.view.tsx
@@ -96,14 +96,14 @@ const QuizInner = () => {
           type="submit"
           isTrailingIcon
           iconName="arrow-right"
-          width={["100%", "auto"]}
+          width={["100%", "max-content"]}
         >
           Check
         </OakPrimaryButton>
       )}
       {isFeedbackMode && (
         <OakPrimaryButton
-          width={["100%", "auto"]}
+          width={["100%", "max-content"]}
           onClick={handleNextQuestion}
           isTrailingIcon
           iconName="arrow-right"

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -30,7 +30,7 @@ describe("PupilReview", () => {
     );
     expect(getByText("Introduction")).toBeInTheDocument();
     expect(getByText("Starter quiz")).toBeInTheDocument();
-    expect(getByText("Watch video")).toBeInTheDocument();
+    expect(getByText("Lesson video")).toBeInTheDocument();
     expect(getByText("Exit quiz")).toBeInTheDocument();
   });
   it("displays the lesson overview button", () => {

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -31,7 +31,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
         iconName="arrow-right"
         isTrailingIcon
         type="button"
-        width={["100%", "auto"]}
+        width={["100%", "max-content"]}
         onClick={() => {
           updateCurrentSection("overview");
         }}

--- a/src/components/PupilViews/PupilVideo/PupilVideo.view.tsx
+++ b/src/components/PupilViews/PupilVideo/PupilVideo.view.tsx
@@ -61,7 +61,7 @@ export const PupilViewsVideo = ({
             onClick={() => {
               completeSection("video");
             }}
-            width={["100%", "auto"]}
+            width={["100%", "max-content"]}
             iconName="arrow-right"
             isTrailingIcon
           >


### PR DESCRIPTION
## Issue(s)

Fixes the button in the lesson footer wrapping when the answer is long

## How to test

1. Go to https://deploy-preview-2262--oak-web-application.netlify.thenational.academy/pupils/programmes/english-primary-ks2/units/developing-reading-preferences-in-year-5/lessons/developing-reading-preferences-in-year-5-through-appreciation-of-characters
2. Click on "Starter lesson"
3. Take the quiz and answer question 5
4. Resize the window until the answer text wraps
5. The button should not wrap.

## Screenshots

How it used to look

<img width="890" alt="Screenshot 2024-02-16 at 16 39 24" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/04b623e3-798f-471b-8e47-f460c8a5837e">


How it should now look:
<img width="890" alt="Screenshot 2024-02-16 at 16 39 03" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/a406d74f-6401-47e3-818e-1ff1f670f95c">
