### PR TITLE
PUPIL-398: correct spacing around "View all lessons" button

### DIFF
--- a/src/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton.test.tsx
+++ b/src/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton.test.tsx
@@ -1,0 +1,30 @@
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import { render } from "@testing-library/react";
+
+import { ViewAllLessonsButton } from "./ViewAllLessonsButton";
+
+describe(ViewAllLessonsButton, () => {
+  describe("when href is provided", () => {
+    it("renders a link", () => {
+      const { getByRole } = render(
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <ViewAllLessonsButton href="/back" />,
+        </OakThemeProvider>,
+      );
+
+      expect(getByRole("link")).toHaveAttribute("href", "/back");
+    });
+  });
+
+  describe("when href is not provided", () => {
+    it("renders a disabled button", () => {
+      const { getByRole } = render(
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <ViewAllLessonsButton />
+        </OakThemeProvider>,
+      );
+
+      expect(getByRole("button")).toHaveAttribute("disabled");
+    });
+  });
+});

--- a/src/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton.tsx
+++ b/src/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton.tsx
@@ -1,0 +1,24 @@
+import { OakTertiaryButton } from "@oaknational/oak-components";
+
+type ViewAllLessonsButtonProps = {
+  href?: string | null;
+};
+
+/**
+ * A tertiary button to link back to the directory of lessons
+ */
+export const ViewAllLessonsButton = ({ href }: ViewAllLessonsButtonProps) => {
+  if (href) {
+    return (
+      <OakTertiaryButton iconName="arrow-left" href={href} element="a">
+        View all lessons
+      </OakTertiaryButton>
+    );
+  }
+
+  return (
+    <OakTertiaryButton disabled iconName="arrow-left">
+      View all lessons
+    </OakTertiaryButton>
+  );
+};

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -45,8 +45,6 @@ export const PupilPageContent = ({
 }: PupilExperienceViewProps) => {
   const { currentSection } = useLessonEngineContext();
 
-  console.log("currentSection", currentSection);
-
   const {
     starterQuiz,
     exitQuiz,
@@ -95,7 +93,7 @@ export const PupilPageContent = ({
     case "exit-quiz":
       return <PupilViewsQuiz questionsArray={exitQuiz ?? []} />;
     case "review":
-      return <PupilViewsReview lessonTitle={lessonTitle} />;
+      return <PupilViewsReview lessonTitle={lessonTitle} backUrl={backUrl} />;
     default:
       return null;
   }

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -12,7 +12,6 @@ import {
   OakPrimaryButton,
   OakSpan,
   OakSubjectIcon,
-  OakTertiaryButton,
   isValidIconName,
 } from "@oaknational/oak-components";
 import { useEffect, useState } from "react";
@@ -21,6 +20,7 @@ import {
   LessonReviewSection,
   useLessonEngineContext,
 } from "@/components/PupilComponents/LessonEngineProvider";
+import { ViewAllLessonsButton } from "@/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton";
 
 type PupilViewsLessonOverviewProps = {
   lessonTitle: string;
@@ -96,15 +96,7 @@ export const PupilViewsLessonOverview = ({
         $ph={["inner-padding-m", "inner-padding-xl", "inner-padding-none"]}
       >
         <OakGridArea $colStart={[1, 1, 2]} $colSpan={[12, 12, 10]}>
-          {backUrl ? (
-            <OakTertiaryButton iconName="arrow-left" href={backUrl} element="a">
-              View all lessons
-            </OakTertiaryButton>
-          ) : (
-            <OakTertiaryButton disabled iconName="arrow-left">
-              View all lessons
-            </OakTertiaryButton>
-          )}
+          <ViewAllLessonsButton href={backUrl} />
         </OakGridArea>
       </OakGrid>
       <OakFlex

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -9,10 +9,10 @@ import {
   OakLessonLayout,
   OakLessonReviewItem,
   OakPrimaryButton,
-  OakTertiaryButton,
 } from "@oaknational/oak-components";
 
 import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import { ViewAllLessonsButton } from "@/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton";
 
 type PupilViewsReviewProps = {
   lessonTitle: string;
@@ -58,15 +58,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
         $ph={["inner-padding-m", "inner-padding-xl", "inner-padding-none"]}
       >
         <OakGridArea $colStart={[1, 1, 2]} $colSpan={[12, 12, 10]}>
-          {backUrl ? (
-            <OakTertiaryButton iconName="arrow-left" href={backUrl} element="a">
-              View all lessons
-            </OakTertiaryButton>
-          ) : (
-            <OakTertiaryButton disabled iconName="arrow-left">
-              View all lessons
-            </OakTertiaryButton>
-          )}
+          <ViewAllLessonsButton href={backUrl} />
 
           <OakFlex $mv="space-between-xl">
             <OakFlex

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -1,5 +1,7 @@
 import {
   OakFlex,
+  OakGrid,
+  OakGridArea,
   OakHandDrawnCard,
   OakHeading,
   OakImage,
@@ -14,10 +16,11 @@ import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngin
 
 type PupilViewsReviewProps = {
   lessonTitle: string;
+  backUrl?: string | null;
 };
 
 export const PupilViewsReview = (props: PupilViewsReviewProps) => {
-  const { lessonTitle } = props;
+  const { lessonTitle, backUrl } = props;
   const {
     updateCurrentSection,
     sectionResults,
@@ -47,76 +50,90 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
       lessonSectionName={"review"}
       topNavSlot={null}
     >
-      <OakFlex
-        $pt={["inner-padding-m", "inner-padding-none"]}
-        $flexDirection={"column"}
-        $alignItems={"stretch"}
-        $pa={["inner-padding-none", "inner-padding-xl"]}
-        $gap={"space-between-xl"}
-        $mh={["space-between-s", "space-between-l"]}
+      <OakGrid
+        $maxWidth={["100%", "all-spacing-23", "100%"]}
+        $mt="space-between-m"
+        $mb={["space-between-none", "space-between-s"]}
+        $mh="auto"
+        $ph={["inner-padding-m", "inner-padding-xl", "inner-padding-none"]}
       >
-        <OakTertiaryButton iconName="arrow-left" disabled>
-          View all lessons
-        </OakTertiaryButton>
-        <OakFlex>
+        <OakGridArea $colStart={[1, 1, 2]} $colSpan={[12, 12, 10]}>
+          {backUrl ? (
+            <OakTertiaryButton iconName="arrow-left" href={backUrl} element="a">
+              View all lessons
+            </OakTertiaryButton>
+          ) : (
+            <OakTertiaryButton disabled iconName="arrow-left">
+              View all lessons
+            </OakTertiaryButton>
+          )}
+
+          <OakFlex $mv="space-between-xl">
+            <OakFlex
+              $flexDirection={"column"}
+              $flexGrow={2}
+              $gap={"space-between-l"}
+              $justifyContent={"center"}
+            >
+              <OakHeading tag="h1" $font={["heading-4", "heading-3"]}>
+                Lesson review
+              </OakHeading>
+              <OakHeading tag="h2" $font={"heading-light-7"}>
+                {lessonTitle}
+              </OakHeading>
+            </OakFlex>
+
+            <OakFlex $flexGrow={1}>
+              <OakImage
+                $display={["none", "none", "block"]}
+                $height={"all-spacing-19"}
+                alt="a man standing in front of a blackboard with a bunch of objects on top of his head and hands in the air"
+                src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1699887218/svg-illustrations/xrazqgtjmbdf1clz8wic`}
+              />
+            </OakFlex>
+          </OakFlex>
           <OakFlex
             $flexDirection={"column"}
-            $flexGrow={2}
-            $gap={"space-between-l"}
-            $justifyContent={"center"}
+            $alignItems={"stretch"}
+            $gap={"space-between-s"}
+            $mb="space-between-xl"
           >
-            <OakHeading tag="h1" $font={["heading-4", "heading-3"]}>
-              Lesson review
-            </OakHeading>
-            <OakHeading tag="h2" $font={"heading-light-7"}>
-              {lessonTitle}
-            </OakHeading>
+            {lessonReviewSections.map((lessonSection) => {
+              return (
+                <OakLessonReviewItem
+                  key={lessonSection}
+                  lessonSectionName={lessonSection}
+                  completed={!!sectionResults[lessonSection]?.isComplete}
+                  grade={sectionResults[lessonSection]?.grade ?? 0}
+                  numQuestions={
+                    sectionResults[lessonSection]?.numQuestions ?? 0
+                  }
+                />
+              );
+            })}
           </OakFlex>
-
-          <OakFlex $flexGrow={1}>
-            <OakImage
-              $display={["none", "none", "block"]}
-              $height={"all-spacing-19"}
-              alt="a man standing in front of a blackboard with a bunch of objects on top of his head and hands in the air"
-              src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1699887218/svg-illustrations/xrazqgtjmbdf1clz8wic`}
-            />
-          </OakFlex>
-        </OakFlex>
-        <OakFlex
-          $flexDirection={"column"}
-          $alignItems={"stretch"}
-          $gap={"space-between-s"}
-        >
-          {lessonReviewSections.map((lessonSection) => {
-            return (
-              <OakLessonReviewItem
-                key={lessonSection}
-                lessonSectionName={lessonSection}
-                completed={!!sectionResults[lessonSection]?.isComplete}
-                grade={sectionResults[lessonSection]?.grade ?? 0}
-                numQuestions={sectionResults[lessonSection]?.numQuestions ?? 0}
-              />
-            );
-          })}
-        </OakFlex>
-        <OakFlex
-          $flexGrow={1}
-          $flexDirection={["row", "column"]}
-          $alignItems={["center", "flex-end"]}
-        >
-          <OakHandDrawnCard
-            $pv={"inner-padding-xl"}
-            $ph={"inner-padding-xl"}
-            $alignItems={"center"}
+          <OakFlex
+            $flexGrow={1}
+            $flexDirection={["row", "column"]}
+            $alignItems={["center", "flex-end"]}
           >
-            <OakFlex $font="heading-5" $textAlign={["center", "left", "left"]}>
-              {isLessonComplete
-                ? "Fantastic job, well done!"
-                : "Well done, you're Oaking it!"}
-            </OakFlex>
-          </OakHandDrawnCard>
-        </OakFlex>
-      </OakFlex>
+            <OakHandDrawnCard
+              $pv={"inner-padding-xl"}
+              $ph={"inner-padding-xl"}
+              $alignItems={"center"}
+            >
+              <OakFlex
+                $font="heading-5"
+                $textAlign={["center", "left", "left"]}
+              >
+                {isLessonComplete
+                  ? "Fantastic job, well done!"
+                  : "Well done, you're Oaking it!"}
+              </OakFlex>
+            </OakHandDrawnCard>
+          </OakFlex>
+        </OakGridArea>
+      </OakGrid>
     </OakLessonLayout>
   );
 };


### PR DESCRIPTION
## Description

Music year: [2000](https://www.youtube.com/watch?v=9Ht5RZpzPqw)

* Applies the same grid as the lesson overview so that the button and content align correctly at each breakpoint
* Adds the missing link back to "View all lessons" on lesson review
  * This should behave the same as the link on the overview page?

## How to test

1. Go to https://deploy-preview-2263--oak-web-application.netlify.thenational.academy/pupils/programmes/science-secondary-ks3/units/forces/lessons/what-forces-do
2. Take the lesson and stop at the lesson review
3. Observe the position and spacing of the "View all lessons" button
4. Click "Lesson overview" button
5. Observe that the position of the "View all lessons" buttons match on both pages

## Screenshots

https://github.com/oaknational/Oak-Web-Application/assets/122096/c78bbec7-e96b-4d93-b17a-813961b4eccd

