### PR TITLE
Fix/restrict eyfs paragraph

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
@@ -52,7 +52,7 @@ describe("Component - Curriculum Header", () => {
     });
   });
 
-  test("submits form when correct information is entered", async () => {
+  test.skip("submits form when correct information is entered", async () => {
     const { getAllByTestId, getByTestId } = renderComponent();
     const resourceCard = getAllByTestId("resourceCard")[0];
     if (resourceCard === undefined) {

--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
@@ -52,7 +52,7 @@ describe("Component - Curriculum Header", () => {
     });
   });
 
-  test.skip("submits form when correct information is entered", async () => {
+  test("submits form when correct information is entered", async () => {
     const { getAllByTestId, getByTestId } = renderComponent();
     const resourceCard = getAllByTestId("resourceCard")[0];
     if (resourceCard === undefined) {
@@ -62,9 +62,12 @@ describe("Component - Curriculum Header", () => {
     await userEvent.click(getByTestId("checkbox-download"));
     await userEvent.click(getByTestId("termsCheckbox").querySelector("label")!);
     await userEvent.click(getByTestId("loadingButton"));
-    await waitFor(() => {
-      expect(getByTestId("downloadSuccess")).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(getByTestId("downloadSuccess")).toBeInTheDocument();
+      },
+      { interval: 1000, timeout: 10000 },
+    );
   });
 
   afterEach(() => {

--- a/src/components/TeacherViews/SubjectListing.view.tsx
+++ b/src/components/TeacherViews/SubjectListing.view.tsx
@@ -23,7 +23,12 @@ const SubjectListingPage: FC<SubjectListingPageProps> = (props) => {
   return (
     <OakFlex $flexDirection={"column"}>
       <MaxWidth $maxWidth={[480, 840, 1280]} $ph={[12]}>
-        <Flex $flexDirection="column" $gap={16} $mb={isEyfs ? 26 : 40}>
+        <Flex
+          $flexDirection="column"
+          $gap={16}
+          $mb={isEyfs ? 26 : 40}
+          $maxWidth={960}
+        >
           <OakHeading
             $font={"heading-3"}
             tag={"h1"}


### PR DESCRIPTION
## Description

Music year: 2003

- Amends maxWidth of Flex container
- Fixes Curriculum test by extending timeout

## Issue(s)

Fixes #LESQ-640

## How to test

1. Go to https://deploy-preview-2265--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it should now look:

![Screenshot 2024-02-19 at 12 34 09](https://github.com/oaknational/Oak-Web-Application/assets/91190841/44fb3055-cc49-40e0-aa7d-1d9fdb8bb104)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
