### PR TITLE
feat: console log errors on legacy canonical so that it appears in da…

### DIFF
--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -61,7 +61,7 @@ const LessonList: FC<LessonListProps> = (props) => {
         </OakHeading>
       </OakFlex>
 
-      {currentPageItems.length ? (
+      {currentPageItems?.length ? (
         <>
           <OakUL aria-label="A list of lessons" $reset>
             {currentPageItems.map((item, index) => (

--- a/src/pages/pupils/l/[redirectFrom]/lessons/[lessonSlug]/index.tsx
+++ b/src/pages/pupils/l/[redirectFrom]/lessons/[lessonSlug]/index.tsx
@@ -98,6 +98,8 @@ export const getStaticProps: GetStaticProps<
             redirectFrom,
           });
 
+          console.error("Error in getStaticProps", error);
+
           return null;
         });
 


### PR DESCRIPTION
Console logging any errors that come from the api when accessing the pupil legacy canonical page so that they are searchable on data dog. This gives us an easy way to cross check our posthog data.