### PR TITLE
fix(PUPIL-425): set a height for the `VideoPlayer` loading state

### DIFF
--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -20,7 +20,6 @@ import theme, { OakColorName } from "@/styles/theme";
 import errorReporter from "@/common-lib/error-reporter";
 import { VideoLocationValueType } from "@/browser-lib/avo/Avo";
 import OakError from "@/errors/OakError";
-import BoxBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BoxBorders/BoxBorders";
 
 const INITIAL_DEBUG = false;
 const INITIAL_ENV_KEY = process.env.MUX_ENVIRONMENT_KEY;
@@ -148,13 +147,16 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
   if (videoToken.loading || thumbnailToken.loading || storyboardToken.loading) {
     return (
       <OakFlex
-        $flexDirection={"column"}
-        $width={"100%"}
-        $height={["all-spacing-19"]}
         $alignItems={"center"}
         $justifyContent={"center"}
+        $ba={"border-solid-l"}
+        $minWidth={"100%"}
+        $borderColor={"black"}
+        style={{
+          aspectRatio: "16/9",
+          boxSizing: "content-box",
+        }}
       >
-        <BoxBorders />
         <OakP $textAlign="center">Loading...</OakP>
       </OakFlex>
     );
@@ -173,9 +175,12 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
   return (
     <OakFlex
       $flexDirection={"column"}
-      $width={"100%"}
-      $ba={["border-solid-l"]}
+      $ba={"border-solid-l"}
+      $minWidth={"100%"}
       $borderColor={"black"}
+      style={{
+        boxSizing: "content-box",
+      }}
     >
       <MuxPlayer
         preload="metadata"


### PR DESCRIPTION
## Description

Music year: [1989](https://www.youtube.com/watch?v=ks_qOI0lzho)

## Issue(s)

Fixes the height of the `VideoPlayer` loading state so that it perfectly matches the final dimensions of the player — thus avoiding a reflow. The issue was most noticeable in the pupil lesson video since the player is visible above the fold. 

This also impacted the teacher section and other pages with video content (E.g. https://deploy-preview-2270--oak-web-application.netlify.thenational.academy/blog/preparing-to-teach-for-september)

## How to test

1. Go to https://deploy-preview-2270--oak-web-application.netlify.thenational.academy/pupils/programmes/english-primary-ks2/units/developing-reading-preferences-in-year-5/lessons/developing-reading-preferences-in-year-5-through-appreciation-of-characters
2. Click on "Lesson video"
3. Observe the video loading and see that the page does not shift

## Screenshots

✋🏼 The loading times are exaggerated in these videos to demonstrate the sequence of video loading.

How it used to look:
<img width="1081" alt="Screenshot 2024-02-21 at 09 58 07" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/710d4dc2-c406-46a3-a934-b285f4e926d2">

https://github.com/oaknational/Oak-Web-Application/assets/122096/4a9c30bf-9f12-4d99-bb3f-2ba490d01560

<img width="1416" alt="Screenshot 2024-02-21 at 11 12 56" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/d1319a58-0a61-4615-857a-9d866c15ccc3">

https://github.com/oaknational/Oak-Web-Application/assets/122096/fe32d088-83ed-4496-95cb-16f7bf90c32b


How it should now look:

<img width="1248" alt="Screenshot 2024-02-21 at 09 57 36" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/bdc37275-73a4-4bc6-9e8c-c83f1a5dd603">

https://github.com/oaknational/Oak-Web-Application/assets/122096/73232685-d4f4-41d0-a0fb-a6f7926ce8c2

<img width="1256" alt="Screenshot 2024-02-21 at 09 53 55" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/fe61efde-0986-4d69-8e5c-ecb89975bb74">

https://github.com/oaknational/Oak-Web-Application/assets/122096/6a1ef393-9e32-4203-81a6-95587b53590f


