### PR TITLE
feat(PUPIL-413): bump oak-components@0.0.37 to apply Next13 image placeholders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^7.3.3",
         "@mux/mux-player-react": "^2.3.1",
-        "@oaknational/oak-components": "^0.0.36",
+        "@oaknational/oak-components": "^0.0.37",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
         "@sanity/asset-utils": "^1.3.0",
@@ -7769,9 +7769,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.36.tgz",
-      "integrity": "sha512-ofZEcAlCxSo9Ib0lb6Vek7p5hM+jPIJXoswwNSw58dFk+9a2rj2l9PnxGfSLGQzMgl7eDFoJZz3aQGXTFCHNzg==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.0.37.tgz",
+      "integrity": "sha512-hBP/l+c7cVHbtDhBSxSz2ju7ebAABKhNI1XyS55LJJCukVgp8YOfl7QdBTNESFySheTXIU3UKQyuw1yypK6EaQ==",
       "peerDependencies": {
         "next": "13.4.4 - 14",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^7.3.3",
     "@mux/mux-player-react": "^2.3.1",
-    "@oaknational/oak-components": "^0.0.36",
+    "@oaknational/oak-components": "^0.0.37",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",
     "@sanity/asset-utils": "^1.3.0",


### PR DESCRIPTION
## Description

Music year: [1993](https://www.youtube.com/watch?v=7kmEEkECFQw)

Fixes loading placeholders not being displayed in OWA owing to it running an older version of Next

## How to test

✋🏼 you might need to disable cache in dev tools if it is already primed 

1. Go to https://deploy-preview-2271--oak-web-application.netlify.thenational.academy/pupils/programmes/science-secondary-ks3/units/moving-by-force/lessons/reading-distance-time-graphs
2. Click on "Starter quiz"
3. You should see loading placeholders for each answer while the image loads
4. Go to https://deploy-preview-2271--oak-web-application.netlify.thenational.academy/pupils/programmes/english-primary-ks2/units/developing-reading-preferences-in-year-5/lessons/developing-reading-preferences-in-year-5-through-appreciation-of-characters
5. Click on "Starter quiz"
6. You should see loading placeholders for the questions with images

## Screenshots

https://github.com/oaknational/Oak-Web-Application/assets/122096/80a10b4f-0318-482f-b829-db1f878c1c30

https://github.com/oaknational/Oak-Web-Application/assets/122096/0c96fa2d-81ea-463a-a609-465513326161
