### PR TITLE
Feat/pupil 435/pupil experience tracking

### DIFF
--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -9,15 +9,19 @@ import {
 } from "./LessonEngineProvider";
 
 describe("LessonEngineProvider", () => {
+  const sectionCompletedTrackingCB = jest.fn();
+
   const ProviderWrapper = ({ children }: { children: ReactNode }) => {
     return (
       <LessonEngineProvider
         initialLessonReviewSections={allLessonReviewSections}
+        sectionCompletedTrackingCB={sectionCompletedTrackingCB}
       >
         {children}
       </LessonEngineProvider>
     );
   };
+
   it("renders children correctly", () => {
     const { getByText } = render(
       <LessonEngineProvider
@@ -113,9 +117,23 @@ describe("LessonEngineProvider", () => {
     allLessonReviewSections.forEach((section) => {
       expect(result.current.sectionResults[section]?.isComplete).toBeFalsy();
       act(() => {
-        result.current.completeSection("intro");
+        result.current.completeSection(section);
       });
       expect(result.current.sectionResults.intro?.isComplete).toEqual(true);
+    });
+  });
+
+  it("calls the sectionCompleted tracking callback when the section is completed", () => {
+    const { result } = renderHook(() => useLessonEngineContext(), {
+      wrapper: ProviderWrapper,
+    });
+
+    allLessonReviewSections.forEach((section) => {
+      expect(result.current.sectionResults[section]?.isComplete).toBeFalsy();
+      act(() => {
+        result.current.completeSection("intro");
+      });
+      expect(sectionCompletedTrackingCB).toHaveBeenCalledWith(section);
     });
   });
 

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
@@ -150,16 +150,22 @@ export const useLessonEngineContext = () => {
 export type LessonEngineProviderProps = {
   children: ReactNode;
   initialLessonReviewSections: Readonly<LessonReviewSection[]>;
+  sectionCompletedTrackingCB?: (section: LessonReviewSection) => void;
 };
 
 export const LessonEngineProvider = memo(
-  ({ children, initialLessonReviewSections }: LessonEngineProviderProps) => {
+  ({
+    children,
+    initialLessonReviewSections,
+    sectionCompletedTrackingCB,
+  }: LessonEngineProviderProps) => {
     const [state, dispatch] = useReducer(lessonEngineReducer, {
       lessonReviewSections: initialLessonReviewSections,
       currentSection: "overview",
       sections: {},
     });
     const completeSection = (section: LessonReviewSection) => {
+      if (sectionCompletedTrackingCB) sectionCompletedTrackingCB(section);
       dispatch({ type: "completeSection", section });
     };
     const updateCurrentSection = (section: LessonSection) =>

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -7,6 +7,7 @@ import {
 import { PupilLessonOverviewData } from "@/node-lib/curriculum-api";
 import {
   LessonEngineProvider,
+  LessonReviewSection,
   allLessonReviewSections,
   useLessonEngineContext,
 } from "@/components/PupilComponents/LessonEngineProvider";
@@ -110,9 +111,17 @@ export const PupilExperienceView = ({
 }: PupilExperienceViewProps) => {
   const availableSections = pickAvailableSectionsForLesson(curriculumData);
 
+  const sectionCompletedTrackingCB = (section: LessonReviewSection) => {
+    console.log("Section completed: ", section);
+    // send tracking here
+  };
+
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
-      <LessonEngineProvider initialLessonReviewSections={availableSections}>
+      <LessonEngineProvider
+        initialLessonReviewSections={availableSections}
+        sectionCompletedTrackingCB={sectionCompletedTrackingCB}
+      >
         <OakBox $height={"100vh"}>
           <PupilPageContent
             curriculumData={curriculumData}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2275--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
