### PR TITLE
Split string into array LESQ-661

### DIFF
--- a/src/components/TeacherComponents/LessonOverviewVideo/LessonOverviewVideo.tsx
+++ b/src/components/TeacherComponents/LessonOverviewVideo/LessonOverviewVideo.tsx
@@ -9,7 +9,7 @@ export interface LessonOverviewVideoProps {
   video: string | null;
   signLanguageVideo: string | null;
   title: string;
-  transcriptSentences?: string[] | string | null;
+  transcriptSentences?: string[] | null;
   isLegacy: boolean;
 }
 

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -3,6 +3,7 @@ import lessonOverviewSchema from "./lessonOverview.schema";
 import errorReporter from "@/common-lib/error-reporter";
 import OakError from "@/errors/OakError";
 import { Sdk } from "@/node-lib/curriculum-api-2023/sdk";
+import { formatSentences } from "@/utils/handleTranscript";
 
 const lessonOverviewQuery =
   (sdk: Sdk) =>
@@ -28,9 +29,20 @@ const lessonOverviewQuery =
         res,
       });
     }
+    let transformedTranscript;
+    if (
+      lesson.transcriptSentences &&
+      !Array.isArray(lesson.transcriptSentences)
+    ) {
+      const splitTranscript = lesson.transcriptSentences.split(/\r?\n/);
+      const formattedTranscript = formatSentences(splitTranscript);
+
+      transformedTranscript = formattedTranscript;
+    }
 
     return lessonOverviewSchema.parse({
       ...lesson,
+      transcriptSentences: transformedTranscript,
       isLegacy: false,
       hasCopyrightMaterial: false,
       expired: false,

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -29,7 +29,7 @@ const lessonOverviewQuery =
         res,
       });
     }
-    let transformedTranscript;
+    let transformedTranscript = null;
     if (
       lesson.transcriptSentences &&
       !Array.isArray(lesson.transcriptSentences)

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -176,7 +176,7 @@ export const baseLessonOverviewSchema = z.object({
   presentationUrl: z.string().nullable(),
   videoMuxPlaybackId: z.string().nullable(),
   videoWithSignLanguageMuxPlaybackId: z.string().nullable(),
-  transcriptSentences: z.union([z.array(z.string()), z.string()]).nullable(),
+  transcriptSentences: z.array(z.string()).nullable(),
   isWorksheetLandscape: z.boolean().optional().nullable(),
   hasDownloadableResources: z.boolean(),
   hasCopyrightMaterial: z.boolean().optional().nullable(),

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -91,7 +91,7 @@ export const getStaticProps: GetStaticProps<
         };
       }
 
-      const { videoTitle } = curriculumData;
+      const { videoTitle, transcriptSentences } = curriculumData;
       if (videoTitle && !isSlugLegacy(programmeSlug)) {
         // For new content we need to fetch the captions file from gCloud and parse the result to generate
         // the transcript sentences.
@@ -100,6 +100,10 @@ export const getStaticProps: GetStaticProps<
         if (transcript) {
           curriculumData.transcriptSentences = transcript;
         }
+      } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
+        const splitTranscript = transcriptSentences.split(/\r?\n/);
+
+        curriculumData.transcriptSentences = splitTranscript;
       }
 
       const results: GetStaticPropsResult<LessonOverviewPageProps> = {

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -17,7 +17,7 @@ import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
-import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
+import { getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewData;
@@ -99,11 +99,6 @@ export const getStaticProps: GetStaticProps<
         if (transcript) {
           curriculumData.transcriptSentences = transcript;
         }
-      } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
-        const splitTranscript = transcriptSentences.split(/\r?\n/);
-        const formattedTranscript = formatSentences(splitTranscript);
-
-        curriculumData.transcriptSentences = formattedTranscript;
       }
 
       const results: GetStaticPropsResult<LessonOverviewPageProps> = {

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -17,7 +17,7 @@ import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
-import { getCaptionsFromFile } from "@/utils/handleTranscript";
+import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewData;
@@ -101,7 +101,9 @@ export const getStaticProps: GetStaticProps<
         }
       } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
         const splitTranscript = transcriptSentences.split(/\r?\n/);
-        curriculumData.transcriptSentences = splitTranscript;
+        const formattedTranscript = formatSentences(splitTranscript);
+
+        curriculumData.transcriptSentences = formattedTranscript;
       }
 
       const results: GetStaticPropsResult<LessonOverviewPageProps> = {

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -90,9 +90,8 @@ export const getStaticProps: GetStaticProps<
           notFound: true,
         };
       }
-
       const { videoTitle, transcriptSentences } = curriculumData;
-      if (videoTitle && !isSlugLegacy(programmeSlug)) {
+      if (videoTitle && !isSlugLegacy(programmeSlug) && !transcriptSentences) {
         // For new content we need to fetch the captions file from gCloud and parse the result to generate
         // the transcript sentences.
         const fileName = `${videoTitle}.vtt`;
@@ -102,7 +101,6 @@ export const getStaticProps: GetStaticProps<
         }
       } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
         const splitTranscript = transcriptSentences.split(/\r?\n/);
-
         curriculumData.transcriptSentences = splitTranscript;
       }
 


### PR DESCRIPTION
## Description

Music year: 1985

- Splits transcripts which are returned as strings into an array by line breaks / new lines
(Some subject transcripts are returned with no line breaks)

## Issue(s)

Fixes #LESQ-661

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="959" alt="Screenshot 2024-02-22 at 12 34 33" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/b449fcc1-6a13-40f9-a765-005395e1e2a1">


How it should now look:
<img width="956" alt="Screenshot 2024-02-22 at 12 05 57" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/8e2433b3-7a55-4fbc-87df-f7d83a507b46">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
