### PR TITLE
chore(Storybook): disable Storybook autodocs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -75,6 +75,6 @@ export default {
   },
 
   docs: {
-    autodocs: true,
+    autodocs: false,
   },
 };

--- a/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.stories.tsx
+++ b/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.stories.tsx
@@ -24,7 +24,6 @@ import {
 
 const meta = {
   component: QuizMCQMultiAnswer,
-  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <OakThemeProvider theme={oakDefaultTheme}>

--- a/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.stories.tsx
+++ b/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.stories.tsx
@@ -19,7 +19,6 @@ import {
 
 const meta = {
   component: QuizMCQSingleAnswer,
-  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <OakThemeProvider theme={oakDefaultTheme}>

--- a/src/components/PupilComponents/QuizShortAnswer/QuizShortAnswer.stories.tsx
+++ b/src/components/PupilComponents/QuizShortAnswer/QuizShortAnswer.stories.tsx
@@ -17,7 +17,6 @@ import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizEleme
 
 const meta = {
   component: QuizShortAnswer,
-  tags: ["autodocs"],
   decorators: [
     (Story) => (
       <OakThemeProvider theme={oakDefaultTheme}>


### PR DESCRIPTION
Because they are broken and will stay broken, the resolution is part of the new open source components library.

How to test: the Storybook deployment should no longer contain autodocs.