### PR TITLE
Feat/lesq 619/share to npe [LESQ-619]

### DIFF
--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -22,6 +22,7 @@ const ComponentWrapper = (props: {
       triggerForm={trigger}
       shareableResources={props.shareableResources}
       shareLink={props.shareLink}
+      hideCheckboxes={false}
     />
   );
 };

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -17,6 +17,7 @@ export type LessonShareCardGroupProps = {
   triggerForm: () => void;
   hasError?: boolean;
   shareLink: string;
+  hideCheckboxes: boolean;
 };
 
 const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
@@ -87,6 +88,7 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
                   checked={fieldValue.includes(resource.type)}
                   onBlur={onBlur}
                   hasError={props.hasError}
+                  hideCheckbox={props.hideCheckboxes}
                 />
               );
             }}

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
@@ -16,6 +16,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={jest.fn}
+        usePupils={false}
       />,
     );
     const shareHeader = screen.getByRole("heading");
@@ -29,6 +30,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={jest.fn}
+        usePupils={false}
       />,
     );
     const copyLinkButton = screen.getByRole("button", {
@@ -48,6 +50,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={onSubmit}
+        usePupils={false}
       />,
     );
     const copyLinkButton = screen.getByRole("button", {
@@ -67,6 +70,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={onSubmit}
+        usePupils={false}
       />,
     );
 

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
@@ -23,6 +23,7 @@ const LessonShareLinks: FC<{
   selectedActivities?: Array<ResourceType>;
   schoolUrn?: number;
   onSubmit: (shareMedium: ShareMediumValueType) => void;
+  usePupils: boolean;
 }> = (props) => {
   const [isShareSuccessful, setIsShareSuccessful] = useState(false);
 
@@ -57,6 +58,7 @@ const LessonShareLinks: FC<{
                 selectedActivities: props.selectedActivities,
                 schoolUrn: props.schoolUrn,
                 linkConfig: shareLinkConfig.copy,
+                usePupils: props.usePupils,
               }),
               () => {
                 setIsShareSuccessful(true);
@@ -87,6 +89,7 @@ const LessonShareLinks: FC<{
               lessonSlug: props.lessonSlug,
               selectedActivities: props.selectedActivities,
               linkConfig: link,
+              usePupils: props.usePupils,
             })}
             onClick={() => {
               props.onSubmit(link.avoMedium);

--- a/src/components/TeacherComponents/LessonShareLinks/getHrefForSocialSharing.test.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getHrefForSocialSharing.test.ts
@@ -6,6 +6,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.copy,
+      usePupils: false,
     });
 
     expect(href).toBe(
@@ -16,6 +17,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.googleClassroom,
+      usePupils: false,
     });
     expect(href).toBe(
       "https://classroom.google.com/u/0/share?url=https%3A%2F%2Fclassroom.thenational.academy%2Flessons%2Flesson-slug%3Futm_campaign%3Dsharing-button%26utm_source%3Dgoogle-classroom%26utm_medium%3Dlms",
@@ -25,6 +27,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.microsoftTeams,
+      usePupils: false,
     });
     expect(href).toBe(
       "https://teams.microsoft.com/share?href=https%3A%2F%2Fclassroom.thenational.academy%2Flessons%2Flesson-slug%3Futm_campaign%3Dsharing-button%26utm_source%3Dmicrosoft-teams%26utm_medium%3Dlms&text=",

--- a/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.test.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.test.ts
@@ -7,6 +7,7 @@ describe("getSharingMetadata", () => {
       selectedActivities: ["exit-quiz-questions", "video"],
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.copy,
+      usePupils: false,
     });
 
     expect(result.link).toBe(
@@ -17,6 +18,7 @@ describe("getSharingMetadata", () => {
     const result = getSharingMetadata({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.microsoftTeams,
+      usePupils: false,
     });
 
     expect(result.link).toBe(
@@ -31,7 +33,18 @@ describe("getSharingMetadata", () => {
       lessonSlug: "lesson-slug",
       selectedActivities: ["exit-quiz-questions", "video"],
       linkConfig: shareLinkConfig.copy,
+      usePupils: false,
     });
     expect(result.link).toContain("activities=exit_quiz+video");
+  });
+  it("uses the correct url for the new pupils experience", () => {
+    const result = getSharingMetadata({
+      lessonSlug: "lesson-slug",
+      linkConfig: shareLinkConfig.copy,
+      usePupils: true,
+    });
+    expect(result.link).toBe(
+      "https://thenational.academy/pupils/lessons/lesson-slug?share=true",
+    );
   });
 });

--- a/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
@@ -24,13 +24,18 @@ export type SharingMetadata = {
   urlEncodedShareStr: string;
 };
 
-const classroomPath = (lessonSlug: string) => `/lessons/${lessonSlug}`;
+const classroomPath = (lessonSlug: string) =>
+  `https://classroom.thenational.academy/lessons/${lessonSlug}`;
+
+const pupilsPath = (lessonSlug: string) =>
+  `https://thenational.academy/pupils/lessons/${lessonSlug}?share=true`;
 
 export type GetSharingMetadataParams = {
   lessonSlug: string;
   selectedActivities?: Array<ResourceType>;
   schoolUrn?: number;
   linkConfig: ShareLinkConfig;
+  usePupils: boolean;
 };
 
 export const getSharingMetadata = ({
@@ -38,15 +43,15 @@ export const getSharingMetadata = ({
   linkConfig,
   selectedActivities,
   schoolUrn,
+  usePupils,
 }: GetSharingMetadataParams): SharingMetadata => {
   // Encode which activities the teacher wishes to share.
   const activityQueryString = selectedActivities?.length
     ? getActivityQueryString(selectedActivities)
     : "";
 
-  const path = classroomPath(lessonSlug);
+  let link = usePupils ? pupilsPath(lessonSlug) : classroomPath(lessonSlug);
 
-  let link = `https://classroom.thenational.academy${path}`;
   if (link.endsWith("#")) {
     link = link.slice(0, -1);
   }

--- a/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
@@ -52,29 +52,30 @@ export const getSharingMetadata = ({
 
   let link = usePupils ? pupilsPath(lessonSlug) : classroomPath(lessonSlug);
 
-  if (link.endsWith("#")) {
-    link = link.slice(0, -1);
-  }
-  link = `${link}?utm_campaign=sharing-button${activityQueryString}`;
+  if (!usePupils) {
+    if (link.endsWith("#")) {
+      link = link.slice(0, -1);
+    }
+    link = `${link}?utm_campaign=sharing-button${activityQueryString}`;
 
-  if (linkConfig.network) {
-    link = link + `&utm_source=${linkConfig.network}`;
-  }
+    if (linkConfig.network) {
+      link = link + `&utm_source=${linkConfig.network}`;
+    }
 
-  if (linkConfig.medium) {
-    link = link + `&utm_medium=${linkConfig.medium}`;
-  }
+    if (linkConfig.medium) {
+      link = link + `&utm_medium=${linkConfig.medium}`;
+    }
 
-  if (schoolUrn) {
-    link = link + `&schoolUrn=${schoolUrn}`;
+    if (schoolUrn) {
+      link = link + `&schoolUrn=${schoolUrn}`;
+    }
   }
-
   const urlEncodedLink = encodeURIComponent(link);
   const pageTitle =
     typeof window === "undefined" ? "Oak National Academy" : document.title;
-  const urlEncodedPageTitle = encodeURIComponent(pageTitle);
   const shareStr = `${pageTitle} - ${link}`;
   const urlEncodedShareStr = encodeURIComponent(shareStr);
+  const urlEncodedPageTitle = encodeURIComponent(pageTitle);
 
   return {
     link,

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
@@ -68,5 +68,26 @@ describe("ResourceCard", () => {
     expect(input).toBeChecked();
   });
 
+  it("does not render a checkbox when showCheckbox is false", () => {
+    renderWithTheme(
+      <ResourceCard
+        id="unique-123"
+        name="downloadResources"
+        label="Worksheet"
+        subtitle="PDF"
+        checked
+        onChange={jest.fn()}
+        resourceType="worksheet-pdf"
+        hideCheckbox={true}
+      />,
+    );
+
+    const input = screen.queryByRole("checkbox");
+
+    expect(input).not.toBeInTheDocument();
+    expect(screen.getByText("Worksheet")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+  });
+
   it;
 });

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
@@ -21,6 +21,7 @@ export type ResourceCardProps = CheckboxProps & {
   hasError?: boolean;
   useRadio?: boolean;
   subjectIcon?: string;
+  hideCheckbox?: boolean;
 };
 
 type ResourceCardLabelProps = ResourceCardProps & {
@@ -48,6 +49,7 @@ const BoxWithFocusState = styled.div`
   position: relative;
   display: flex;
   flex-direction: "row";
+  width: 100%;
 `;
 
 const RadioContainer = styled.div`
@@ -147,6 +149,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
     onBlur,
     hasError = false,
     useRadio = false,
+    hideCheckbox = false,
   } = props;
 
   const { hoverProps, isHovered } = useHover({});
@@ -165,7 +168,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
             <ResourceCardLabel isHovered={isHovered} {...props} />
           </Radio>
         </RadioContainer>
-      ) : (
+      ) : !hideCheckbox ? (
         <Checkbox
           id={id}
           name={name}
@@ -179,6 +182,8 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
         >
           <ResourceCardLabel isHovered={isHovered} {...props} />
         </Checkbox>
+      ) : (
+        <ResourceCardLabel isHovered={false} {...props} />
       )}
     </Flex>
   );

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -190,6 +190,7 @@ export function LessonShare(props: LessonShareProps) {
                 selectedActivities: selectedResources,
                 schoolUrn: schoolUrn,
                 linkConfig: shareLinkConfig.copy,
+                usePupils: shareToNewPupilExperience,
               })}
             />
           }
@@ -208,6 +209,7 @@ export function LessonShare(props: LessonShareProps) {
                     onFormSubmit(data, shareMedium);
                   })() // https://github.com/orgs/react-hook-form/discussions/8622
               }
+              usePupils={shareToNewPupilExperience}
             />
           }
         />

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -73,6 +73,10 @@ export function LessonShare(props: LessonShareProps) {
   const { track } = useAnalytics();
   const { lessonShared } = track;
 
+  // Temporary - integrate with the new pupil experience for select units and lessons only
+  const shareToNewPupilExperience =
+    unitSlug === "shakespearean-comedy-the-tempest-88f0"; // TODO: check actual units
+
   const {
     form,
     hasResources,
@@ -173,12 +177,14 @@ export function LessonShare(props: LessonShareProps) {
           showPostAlbCopyright={!isLegacy}
           resourcesHeader="Select online activities"
           triggerForm={form.trigger}
+          hideSelectAll={shareToNewPupilExperience}
           cardGroup={
             <LessonShareCardGroup
               control={form.control}
               hasError={form.errors?.resources !== undefined}
               triggerForm={form.trigger}
               shareableResources={shareableResources}
+              hideCheckboxes={shareToNewPupilExperience}
               shareLink={getHrefForSocialSharing({
                 lessonSlug: lessonSlug,
                 selectedActivities: selectedResources,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -78,7 +78,7 @@ export function LessonShare(props: LessonShareProps) {
 
   // Temporary - integrate with the new pupil experience for select units and lessons only
   const shareToNewPupilExperience =
-    unitSlug && pupilUnitsLive.includes(unitSlug);
+    unitSlug !== null && pupilUnitsLive.includes(unitSlug);
 
   const {
     form,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -62,6 +62,9 @@ const classroomActivityMap: Partial<
   video: "video",
 };
 
+// Temporary - list of lessons live on pupil experience for sharing
+const pupilUnitsLive = ["shakespearean-comedy-the-tempest-88f0"];
+
 export function LessonShare(props: LessonShareProps) {
   const { lesson } = props;
   const { lessonTitle, lessonSlug, shareableResources, isLegacy } = lesson;
@@ -75,7 +78,7 @@ export function LessonShare(props: LessonShareProps) {
 
   // Temporary - integrate with the new pupil experience for select units and lessons only
   const shareToNewPupilExperience =
-    unitSlug === "shakespearean-comedy-the-tempest-88f0"; // TODO: check actual units
+    unitSlug && pupilUnitsLive.includes(unitSlug);
 
   const {
     form,


### PR DESCRIPTION
## Description

Music year: 1960

- updated resource card component to show checkbox coniditionally
- remove select all when sharing to new pupil experience is active
- update url for sharing to new pupil experience

## How to test

currently only one unit is active on the new pupil experience

1. Go to https://deploy-preview-2283--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks3-l/units/shakespearean-comedy-the-tempest-88f0/lessons/context-of-the-tempest-cctp4c/share?preselected=all
3. You should see no 'select all' or checkboxes
4. clicking preview should take you to the new pupil experience
5. share links should all link to new pupil experience
6. every other legacy unit should share to classroom still

## Screenshots

How it used to look (delete if n/a):
<img width=500 src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/eb1115e8-d99e-4644-afe3-4c8535b133da">

How it should now look:
<img width=500 src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/19cf2a2f-f39a-4044-956f-1a9f95f7fb5d" >

## Checklist
- [ ]  forwarding to pupils page
- [ ]  exclusion controls removed (no checkboxes on cards and no “select all” checkbox)
- [ ]  only for units and subjects in the list