### PR TITLE
feat: update curriculum links on unit listing pages

### DIFF
--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -243,6 +243,10 @@ type CurriculumDownloadsLinkProps = {
 };
 type CurriculumPreviousDownloadsLinkProps = {
   page: "curriculum-previous-downloads";
+  query?: {
+    subject: string;
+    keystage: string;
+  };
 };
 
 export type OakLinkProps =

--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.test.tsx
@@ -3,16 +3,20 @@ import { waitFor } from "@testing-library/dom";
 
 import CurriculumDownloads from "./CurriculumDownloads";
 
+import createAndClickHiddenDownloadLink from "@/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+
+jest.mock(
+  "@/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink",
+  () => ({
+    __esModule: true,
+    default: jest.fn(),
+  }),
+);
 
 const render = renderWithProviders();
 
 describe("Component - Curriculum Header", () => {
-  beforeEach(() => {
-    jest.resetModules();
-    jest.clearAllMocks();
-  });
-
   const renderComponent = () => {
     const defaultProps = {
       category: "test-category",
@@ -64,14 +68,16 @@ describe("Component - Curriculum Header", () => {
     await userEvent.click(getByTestId("loadingButton"));
     await waitFor(
       () => {
+        expect(createAndClickHiddenDownloadLink).toHaveBeenCalledWith(
+          "https://test-url.com",
+        );
         expect(getByTestId("downloadSuccess")).toBeInTheDocument();
       },
-      { interval: 1000, timeout: 10000 },
+      { interval: 100, timeout: 1000 },
     );
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    jest.useRealTimers();
   });
 });

--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, forwardRef, useImperativeHandle, useState } from "react";
+import {
+  ChangeEvent,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+import { useRouter } from "next/router";
 import { Controller } from "react-hook-form";
 import styled from "styled-components";
 import {
@@ -66,6 +73,7 @@ function CurriculumDownloads(
   props: CurriculumDownloadsProps,
   ref: React.ForwardedRef<CurriculumDownloadsRef>,
 ) {
+  const router = useRouter();
   const { category, downloads } = props;
   const { track } = useAnalytics();
   const { analyticsUseCase } = useAnalyticsPageProps();
@@ -117,10 +125,12 @@ function CurriculumDownloads(
     useState<boolean>(false);
   const [hasSuccessfullyDownloaded, setHasSuccessfullyDownloaded] =
     useState<boolean>(false);
-
-  const { onHubspotSubmit } = useHubspotSubmit();
+  const [hasSetPreselectedDownload, setHasSetPreselectedDownload] =
+    useState<boolean>(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [selectedUrl, setSelectedUrl] = useState<string>("");
+
+  const { onHubspotSubmit } = useHubspotSubmit();
 
   const clearSelection = () => {
     setSelectedUrl("");
@@ -132,7 +142,7 @@ function CurriculumDownloads(
   }));
 
   const handleDownload = (url: string) => {
-    if (!url) return false; // Early return if no URL
+    if (!url) return false;
     createAndClickHiddenDownloadLink(url);
     return true;
   };
@@ -209,6 +219,19 @@ function CurriculumDownloads(
     );
     return errorMessage;
   };
+
+  useEffect(() => {
+    const subject = router.query.subject as string;
+    if (subject) {
+      const selectedDownload = downloads.find(
+        (download) => download.label.toLowerCase() === subject,
+      );
+      if (selectedDownload && !hasSetPreselectedDownload) {
+        setHasSetPreselectedDownload(true);
+        setSelectedUrl(selectedDownload.url);
+      }
+    }
+  }, [router.query.subject, downloads, hasSetPreselectedDownload]);
 
   return (
     <Box

--- a/src/components/TeacherComponents/HeaderListing/HeaderListing.test.tsx
+++ b/src/components/TeacherComponents/HeaderListing/HeaderListing.test.tsx
@@ -24,10 +24,29 @@ describe("HeaderListing", () => {
     expect(subjectHeading[0]).toHaveTextContent("English");
   });
 
-  it("renders the curriculum download button", () => {
-    const { queryAllByText } = renderWithTheme(<HeaderListing {...props} />);
-    const downloadLink = queryAllByText("Curriculum download (PDF)");
+  it("renders the curriculum download buttons by default", () => {
+    const { queryAllByTestId } = renderWithTheme(<HeaderListing {...props} />);
+    const downloadLinks = queryAllByTestId("curriculum-download-link");
+    expect(downloadLinks).toHaveLength(2);
+  });
 
-    expect(downloadLink[0]).toBeInTheDocument();
+  it("does not renders the curriculum download button when no download is available", () => {
+    const { queryAllByTestId } = renderWithTheme(
+      <HeaderListing hasCurriculumDownload={false} {...props} />,
+    );
+    const downloadLinks = queryAllByTestId("curriculum-download-link");
+    expect(downloadLinks).toHaveLength(0);
+  });
+
+  it("renders the curriculum download button when key stages are available", () => {
+    const { queryAllByTestId } = renderWithTheme(
+      <HeaderListing
+        keyStageSlug={"ks1"}
+        keyStageTitle={"Key Stage 1"}
+        {...props}
+      />,
+    );
+    const downloadLinks = queryAllByTestId("curriculum-download-link");
+    expect(downloadLinks).toHaveLength(2);
   });
 });

--- a/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
+++ b/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
@@ -42,13 +42,11 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
     title,
     keyStageSlug,
     keyStageTitle,
-    subjectTitle,
     isNew,
     programmeFactor,
     subjectIconBackgroundColor,
     breadcrumbs,
     background,
-    tierSlug,
     hasCurriculumDownload = true,
     examBoardTitle,
     tierTitle,
@@ -56,7 +54,7 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
   } = props;
 
   const isKeyStagesAvailable = keyStageSlug && keyStageTitle;
-  const specialistDownloadLink = `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=${subjectSlug}&extension=pdf`;
+  const specialistDownloadLink = `/teachers/curriculum/previous-downloads#Specialist`;
 
   return (
     <LessonHeaderWrapper breadcrumbs={breadcrumbs} background={background}>
@@ -100,22 +98,20 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
               {hasCurriculumDownload && isKeyStagesAvailable && (
                 <HeaderListingCurriculumDownloadButton
                   keyStageSlug={keyStageSlug}
-                  keyStageTitle={keyStageTitle}
                   subjectSlug={subjectSlug}
-                  subjectTitle={subjectTitle}
-                  tier={tierSlug}
                 />
               )}
               {hasCurriculumDownload && !isKeyStagesAvailable && (
                 <ButtonAsLink
                   icon={"download"}
                   iconBackground="black"
-                  label={"Curriculum download (PDF)"}
+                  label={"Curriculum download"}
                   href={specialistDownloadLink}
                   page={null}
                   size="large"
                   variant="minimal"
                   $iconPosition={"trailing"}
+                  data-testid="curriculum-download-link"
                 />
               )}
             </Flex>
@@ -126,22 +122,20 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
         {hasCurriculumDownload && isKeyStagesAvailable && (
           <HeaderListingCurriculumDownloadButton
             keyStageSlug={keyStageSlug}
-            keyStageTitle={keyStageTitle}
             subjectSlug={subjectSlug}
-            subjectTitle={subjectTitle}
-            tier={tierSlug}
           />
         )}
         {hasCurriculumDownload && !isKeyStagesAvailable && (
           <ButtonAsLink
             icon={"download"}
             iconBackground="black"
-            label={"Curriculum download (PDF)"}
+            label={"Curriculum download"}
             href={specialistDownloadLink}
             page={null}
             size="large"
             variant="minimal"
             $iconPosition={"trailing"}
+            data-testid="curriculum-download-link"
           />
         )}
       </Flex>

--- a/src/components/TeacherComponents/HeaderListingCurriculumDownloadButton/HeaderListingCurriculumDownloadButton.test.tsx
+++ b/src/components/TeacherComponents/HeaderListingCurriculumDownloadButton/HeaderListingCurriculumDownloadButton.test.tsx
@@ -1,170 +1,21 @@
-import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-
 import HeaderListingCurriculumDownloadButton from "./HeaderListingCurriculumDownloadButton";
-import downloadZip from "./helpers/downloadZip";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
-
-jest.mock("./helpers/downloadZip");
-
-const curriculumMapDownloaded = jest.fn();
-jest.mock("@/context/Analytics/useAnalytics", () => ({
-  __esModule: true,
-  default: () => ({
-    track: {
-      curriculumMapDownloaded: (...args: unknown[]) =>
-        curriculumMapDownloaded(...args),
-    },
-  }),
-}));
 
 const render = renderWithProviders();
 
 describe("HeaderListingCurriculumDownloadButton", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   test("renders a download button link with href corresponding to passed in props", () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <HeaderListingCurriculumDownloadButton
-        keyStageSlug={"ks4"}
-        keyStageTitle={"Key stage 4"}
-        subjectSlug={"english"}
-        subjectTitle="English"
-      />,
-    );
-
-    const downloadLink = getByRole("link", {
-      name: "Curriculum download (PDF)",
-    });
-
-    expect(downloadLink).toHaveAttribute(
-      "href",
-      `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=key-stage-4-english&extension=pdf`,
-    );
-  });
-
-  test("calls tracking with correct parameters when a download zip link is clicked on a non tierred lesson page", async () => {
-    render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageTitle={"Key stage 4"}
-        subjectTitle={"English"}
         keyStageSlug={"ks4"}
         subjectSlug={"english"}
       />,
     );
-
-    const linkTitle = screen.getByText("Curriculum download (PDF)");
-
-    const user = userEvent.setup();
-    await user.click(linkTitle);
-
-    expect(curriculumMapDownloaded).toHaveBeenCalledTimes(1);
-    expect(curriculumMapDownloaded).toHaveBeenCalledWith({
-      analyticsUseCase: null,
-      keyStageSlug: "ks4",
-      keyStageTitle: "Key stage 4",
-      pageName: null,
-      subjectSlug: "english",
-      subjectTitle: "English",
-    });
-  });
-
-  test("renders a tiered download button link from unit page with tiers", () => {
-    const { getByRole } = render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageSlug={"ks4"}
-        keyStageTitle={"Key stage 4"}
-        subjectSlug={"maths"}
-        subjectTitle={"Maths"}
-        tier={"core"}
-      />,
-    );
-
-    const downloadLink = getByRole("link", {
-      name: "Core curriculum download (PDF)",
-    });
-
+    const downloadLink = getByTestId("curriculum-download-link");
     expect(downloadLink).toHaveAttribute(
       "href",
-      `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=key-stage-4-maths-core&extension=pdf`,
+      "/teachers/curriculum/previous-downloads?subject=english&keystage=ks4",
     );
-  });
-
-  test("renders a button to download a zip file when on a tiered lesson page", () => {
-    render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageTitle={"Key stage 4"}
-        subjectTitle={"Maths"}
-        keyStageSlug={"ks4"}
-        subjectSlug={"maths"}
-      />,
-    );
-
-    const buttonTitle = screen.getByText("Curriculum download (.zip)");
-    expect(buttonTitle).toBeInTheDocument();
-  });
-  test("it downloads a zip when there are no tiers, ks4 and maths", async () => {
-    render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageTitle={"Key stage 4"}
-        subjectTitle={"Maths"}
-        keyStageSlug={"ks4"}
-        subjectSlug={"maths"}
-      />,
-    );
-
-    const buttonTitle = screen.getByText("Curriculum download (.zip)");
-
-    const user = userEvent.setup();
-    await user.click(buttonTitle);
-
-    expect(downloadZip).toHaveBeenCalledTimes(1);
-    expect(downloadZip).toHaveBeenCalledWith("4", "maths");
-  });
-  test("it downloads a pdf when there are tiers, ks4 and maths", async () => {
-    render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageTitle={"Key stage 4"}
-        subjectTitle={"Maths"}
-        keyStageSlug={"ks4"}
-        subjectSlug={"maths"}
-        tier={"core"}
-      />,
-    );
-
-    const linkTitle = screen.getByText("Core curriculum download (PDF)");
-
-    expect(linkTitle).toBeInTheDocument();
-    expect(downloadZip).toHaveBeenCalledTimes(0);
-  });
-  test("calls tracking with correct parameters when a download zip button is clicked on a tierred lesson page", async () => {
-    render(
-      <HeaderListingCurriculumDownloadButton
-        keyStageTitle={"Key stage 4"}
-        subjectTitle={"Maths"}
-        keyStageSlug={"ks4"}
-        subjectSlug={"maths"}
-      />,
-    );
-
-    const buttonTitle = screen.getByText("Curriculum download (.zip)");
-
-    const user = userEvent.setup();
-    await user.click(buttonTitle);
-
-    expect(downloadZip).toHaveBeenCalledTimes(1);
-    expect(downloadZip).toHaveBeenCalledWith("4", "maths");
-    expect(curriculumMapDownloaded).toHaveBeenCalledTimes(1);
-    expect(curriculumMapDownloaded).toHaveBeenCalledWith({
-      analyticsUseCase: null,
-      keyStageSlug: "ks4",
-      keyStageTitle: "Key stage 4",
-      pageName: null,
-      subjectSlug: "maths",
-      subjectTitle: "Maths",
-    });
   });
 });

--- a/src/components/TeacherComponents/HeaderListingCurriculumDownloadButton/HeaderListingCurriculumDownloadButton.tsx
+++ b/src/components/TeacherComponents/HeaderListingCurriculumDownloadButton/HeaderListingCurriculumDownloadButton.tsx
@@ -1,108 +1,34 @@
-import React, { FC, useState } from "react";
-import { capitalize } from "lodash";
+import React, { FC } from "react";
 import { OakFlex } from "@oaknational/oak-components";
 
-import FieldError from "@/components/SharedComponents/FieldError";
-import downloadZip from "@/components/TeacherComponents/HeaderListingCurriculumDownloadButton/helpers/downloadZip";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
-import Button from "@/components/SharedComponents/Button";
-import Box from "@/components/SharedComponents/Box";
-import useAnalytics from "@/context/Analytics/useAnalytics";
-import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
-import type { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
 
 type HeaderListingCurriculumDownloadButtonProps = {
   keyStageSlug: string;
-  keyStageTitle: string;
   subjectSlug: string;
-  subjectTitle: string;
-  tier?: string | null;
 };
 
 const HeaderListingCurriculumDownloadButton: FC<
   HeaderListingCurriculumDownloadButtonProps
-> = ({ keyStageSlug, keyStageTitle, subjectSlug, subjectTitle, tier }) => {
-  const [downloadResourceError, setDownloadResourceError] =
-    useState<boolean>(false);
-
-  const isMathsKs4ProgrammesPage =
-    !tier && keyStageSlug === "ks4" && subjectSlug === "maths";
-
-  const keyStageNum = keyStageSlug.slice(-1);
-  let downloadLink = `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=key-stage-${keyStageNum}-${subjectSlug}&extension=pdf`;
-  let downloadLabel = `Curriculum download (PDF)`;
-
-  if (tier) {
-    //change download link to access only tiered curriculum
-    downloadLink = `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=key-stage-${keyStageNum}-${subjectSlug}-${tier}&extension=pdf`;
-    downloadLabel = capitalize(tier) + ` curriculum download (PDF)`;
-  }
-
-  if (isMathsKs4ProgrammesPage) {
-    downloadLink = `${process.env.NEXT_PUBLIC_VERCEL_API_URL}/api/download-asset?type=curriculum-map&id=key-stage-${keyStageNum}-${subjectSlug}&tiers=core,higher,foundation`;
-    downloadLabel = `Curriculum download (.zip)`;
-  }
-
-  const { track } = useAnalytics();
-  const { analyticsUseCase, pageName } = useAnalyticsPageProps();
-
-  const trackCurriculumMapDownloaded = () => {
-    track.curriculumMapDownloaded({
-      subjectTitle,
-      subjectSlug,
-      keyStageTitle: keyStageTitle as KeyStageTitleValueType,
-      keyStageSlug,
-      pageName,
-      analyticsUseCase,
-    });
-  };
-
-  const handleZipDownloadClick = async () => {
-    try {
-      await downloadZip(keyStageNum, subjectSlug);
-      setDownloadResourceError(false);
-      trackCurriculumMapDownloaded();
-    } catch (error) {
-      setDownloadResourceError(true);
-    }
-  };
-
+> = ({ keyStageSlug, subjectSlug }) => {
   return (
     <>
       <OakFlex>
-        {isMathsKs4ProgrammesPage ? ( // if on a maths programmes page, we want to download a zip of tier.pdf curriculum maps
-          <Button
-            icon={"download"}
-            size="large"
-            variant="minimal"
-            $iconPosition={"trailing"}
-            iconBackground="black"
-            label={downloadLabel}
-            onClick={handleZipDownloadClick}
-          />
-        ) : (
-          <>
-            <ButtonAsLink
-              icon={"download"}
-              iconBackground="black"
-              label={downloadLabel}
-              href={downloadLink}
-              onClick={() => trackCurriculumMapDownloaded()}
-              page={null}
-              size="large"
-              variant="minimal"
-              $iconPosition={"trailing"}
-            />
-          </>
-        )}
+        <ButtonAsLink
+          icon={"download"}
+          iconBackground="black"
+          label={"Curriculum download"}
+          page={"curriculum-previous-downloads"}
+          size="large"
+          variant="minimal"
+          $iconPosition={"trailing"}
+          query={{
+            subject: subjectSlug,
+            keystage: keyStageSlug,
+          }}
+          data-testid="curriculum-download-link"
+        />
       </OakFlex>
-      <Box>
-        {downloadResourceError && (
-          <FieldError id={"download-resource-error"}>
-            Sorry, we're having technical problems. Please try again later.
-          </FieldError>
-        )}
-      </Box>
     </>
   );
 };

--- a/src/components/TeacherComponents/UnitList/UnitList.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.tsx
@@ -71,6 +71,7 @@ const UnitList: FC<UnitListProps> = (props) => {
                       return (
                         <UnitListItem
                           {...unitOption}
+                          key={`UnitList-UnitListItem-UnitListOption-${unitOption.slug}`}
                           hideTopHeading
                           index={index + pageSize * (currentPage - 1)}
                           firstItemRef={index === 0 ? firstItemRef : null}

--- a/src/pages/teachers/curriculum/previous-downloads.tsx
+++ b/src/pages/teachers/curriculum/previous-downloads.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from "next";
+import { useRouter } from "next/router";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { OakFlex, OakHeading, OakP } from "@oaknational/oak-components";
 
@@ -19,6 +20,7 @@ import CurriculumDownloads, {
 import DropdownSelect from "@/components/GenericPagesComponents/DropdownSelect";
 
 const CurriculumPreviousDownloadsPage: NextPage = () => {
+  const router = useRouter();
   const data = curriculumPreviousDownloadsFixture();
   const [activeTab, setActiveTab] = useState<string>("EYFS");
   const downloadsRef = useRef<CurriculumDownloadsRef>(null);
@@ -34,24 +36,16 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
     return documents;
   }, [data.documents]);
 
-  useEffect(() => {
-    const hashTab = window.location.hash.slice(1);
-    if (hashTab && categoryDocuments[hashTab]) {
-      setActiveTab(hashTab);
-    }
-  }, [categoryDocuments]);
-
   const updateTab = (category: string) => {
     setActiveTab(category);
-    const newUrl = `#${category}`;
+    const newUrl = `${window.location.pathname}#${category}`;
     window.history.replaceState(
       { ...window.history.state, as: newUrl, url: newUrl },
       "",
       newUrl,
     );
-    if (downloadsRef.current) {
-      downloadsRef.current.clearSelection();
-    }
+    delete router.query.keystage;
+    downloadsRef.current?.clearSelection();
   };
 
   const downloads: CurriculumDownload[] = [];
@@ -78,6 +72,14 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
       },
     });
   }
+
+  useEffect(() => {
+    const keystage = router.query.keystage as string;
+    const hashTab = keystage?.toUpperCase() || window.location.hash.slice(1);
+    if (hashTab && categoryDocuments[hashTab]) {
+      setActiveTab(hashTab);
+    }
+  }, [categoryDocuments, router.query.keystage]);
 
   return (
     <AppLayout


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Updated "Curriculum download" link on unit listing pages
- Updated Curriculum Previous Downloads page to accept subject and key stage in URL params
- Fixed timer issues in tests
- Refactored Header Listing Curriculum Download Button component for simplicity

## How to test

1. Go to {owa_deployment_url}/teachers/programmes/citizenship-secondary-ks3-l/units
2. Click on `Curriculum Download`
3. You should navigate to the "Previously released curricula" page
4. The tab "KS3" should be active
5. The option for "Citizenship" should be selected for download

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
