### PR TITLE
PUPIL-457 Fix/start lesson label bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41744,15 +41744,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "7.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,

--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.tsx
@@ -161,6 +161,7 @@ export type LessonEngineContextType = {
   proceedToNextSection: () => void;
   updateSectionResult: (vals: QuizResult | VideoResult | IntroResult) => void;
   lessonReviewSections: Readonly<LessonReviewSection[]>;
+  lessonStarted: boolean;
 } | null;
 
 export const LessonEngineContext = createContext<LessonEngineContextType>(null);
@@ -279,6 +280,7 @@ export const LessonEngineProvider = memo(
           proceedToNextSection,
           updateSectionResult,
           lessonReviewSections: state.lessonReviewSections,
+          lessonStarted: state.lessonStarted,
         }}
       >
         {children}

--- a/src/components/PupilComponents/pupilTestHelpers/createLessonEngineContext.ts
+++ b/src/components/PupilComponents/pupilTestHelpers/createLessonEngineContext.ts
@@ -7,6 +7,7 @@ export function createLessonEngineContext(
   overrides?: Partial<LessonEngineContextType>,
 ): NonNullable<LessonEngineContextType> {
   return {
+    lessonStarted: false,
     isLessonComplete: false,
     currentSection: "starter-quiz",
     sectionResults: {},

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.test.tsx
@@ -105,30 +105,34 @@ describe(PupilViewsLessonOverview, () => {
 
   it.each([
     {
-      context: {},
+      context: { lessonStarted: false },
       label: "Let's get ready",
     },
     {
       context: {
         sectionResults: { intro: { isComplete: true } },
+        lessonStarted: false,
       },
       label: "Start lesson",
     },
     {
       context: {
         sectionResults: { "starter-quiz": { isComplete: true } },
+        lessonStarted: true,
       },
       label: "Continue lesson",
     },
     {
       context: {
         sectionResults: { "exit-quiz": { isComplete: true } },
+        lessonStarted: true,
       },
       label: "Continue lesson",
     },
     {
       context: {
         isLessonComplete: true,
+        lessonStarted: true,
       },
       label: "Lesson review",
     },

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -49,6 +49,7 @@ export const PupilViewsLessonOverview = ({
     proceedToNextSection,
     lessonReviewSections,
     isLessonComplete,
+    lessonStarted,
   } = useLessonEngineContext();
 
   const subjectIconName: `subject-${string}` = `subject-${subjectSlug}`;
@@ -83,7 +84,11 @@ export const PupilViewsLessonOverview = ({
             data-testid="proceed-to-next-section"
             disabled={!isMounted}
           >
-            {pickProceedToNextSectionLabel(isLessonComplete, sectionResults)}
+            {pickProceedToNextSectionLabel(
+              lessonStarted,
+              isLessonComplete,
+              sectionResults,
+            )}
           </OakPrimaryButton>
         </OakLessonBottomNav>
       }
@@ -223,6 +228,7 @@ export const PupilViewsLessonOverview = ({
 };
 
 function pickProceedToNextSectionLabel(
+  lessonStarted: boolean,
   isLessonComplete: boolean,
   results: ReturnType<typeof useLessonEngineContext>["sectionResults"],
 ) {
@@ -230,7 +236,7 @@ function pickProceedToNextSectionLabel(
     return "Lesson review";
   }
 
-  if (results["starter-quiz"]?.isComplete || results["exit-quiz"]?.isComplete) {
+  if (lessonStarted) {
     return "Continue lesson";
   }
 


### PR DESCRIPTION
## Description

Music year: 1951

overview next section label wasnt being driven by lesson state.lessonStarted

now using lesson sate to dictate label

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2289--oak-web-application.netlify.thenational.academy/pupils/l/shakespearean-comedy-the-tempest-88f0/lessons/context-of-the-tempest-cctp4c
2. Click through lesson
3. You should see once intro is complete the label should say continue lesson untilo the lesson is finished


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
