### PR TITLE
Feat hide content on expired share and overview

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -96,7 +96,7 @@ describe("pages/teachers/lessons", () => {
       <LessonOverviewPage
         curriculumData={lessonOverviewFixture({
           hasDownloadableResources: false,
-          expired: true,
+          expired: false,
           lessonCohort: null,
         })}
       />,
@@ -117,7 +117,7 @@ describe("pages/teachers/lessons", () => {
       <LessonOverviewPage
         curriculumData={lessonOverviewFixture({
           hasDownloadableResources: false,
-          expired: true,
+          expired: false,
           lessonCohort: LEGACY_COHORT,
         })}
       />,

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -33,6 +33,7 @@ import { useHubspotSubmit } from "@/components/TeacherComponents/hooks/downloadA
 import { LEGACY_COHORT } from "@/config/cohort";
 
 type BaseLessonDownload = {
+  expired: boolean | null;
   isLegacy: boolean;
   lessonTitle: string;
   lessonSlug: string;
@@ -62,8 +63,13 @@ type LessonDownloadsProps =
 
 export function LessonDownloads(props: LessonDownloadsProps) {
   const { lesson } = props;
-  const { lessonTitle, lessonSlug, downloads, hasDownloadableResources } =
-    lesson;
+  const {
+    lessonTitle,
+    lessonSlug,
+    downloads,
+    hasDownloadableResources,
+    expired,
+  } = lesson;
   const commonPathway = getCommonPathway(
     props.isCanonical ? props.lesson.pathways : [props.lesson],
   );
@@ -231,7 +237,9 @@ export function LessonDownloads(props: LessonDownloadsProps) {
             handleToggleSelectAll={handleToggleSelectAll}
             selectAllChecked={selectAllChecked}
             header="Download"
-            showNoResources={!hasResources || !hasDownloadableResources}
+            showNoResources={
+              !hasResources || !hasDownloadableResources || Boolean(expired)
+            }
             showLoading={isLocalStorageLoading}
             email={emailFromLocalStorage}
             school={schoolNameFromLocalStorage}
@@ -245,8 +253,10 @@ export function LessonDownloads(props: LessonDownloadsProps) {
             resourcesHeader="Lesson resources"
             triggerForm={form.trigger}
             apiError={apiError}
+            hideSelectAll={Boolean(expired)}
             cardGroup={
-              hasDownloadableResources && (
+              hasDownloadableResources &&
+              !expired && (
                 <DownloadCardGroup
                   control={form.control}
                   downloads={downloads}
@@ -266,6 +276,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
                 isLoading={isAttemptingDownload}
                 disabled={
                   hasFormErrors ||
+                  expired ||
                   !hasDownloadableResources ||
                   (!form.formState.isValid && !localStorageDetails)
                 }

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -181,7 +181,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
         track={track}
         analyticsUseCase={analyticsUseCase}
         isNew={isNew}
-        isShareable={isLegacyLicense}
+        isShareable={isLegacyLicense && !expired}
         onClickDownloadAll={() => {
           trackDownloadResourceButtonClicked({
             downloadResourceButtonName: "all",

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -183,13 +183,13 @@ export function LessonShare(props: LessonShareProps) {
           showPostAlbCopyright={!isLegacy}
           resourcesHeader="Select online activities"
           triggerForm={form.trigger}
-          hideSelectAll={shareToNewPupilExperience}
+          hideSelectAll={shareToNewPupilExperience || Boolean(expired)}
           cardGroup={
             <LessonShareCardGroup
               control={form.control}
               hasError={form.errors?.resources !== undefined}
               triggerForm={form.trigger}
-              shareableResources={shareableResources}
+              shareableResources={expired ? [] : shareableResources}
               hideCheckboxes={shareToNewPupilExperience}
               shareLink={getHrefForSocialSharing({
                 lessonSlug: lessonSlug,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -204,6 +204,7 @@ export function LessonShare(props: LessonShareProps) {
             <LessonShareLinks
               disabled={
                 hasFormErrors ||
+                expired ||
                 (!form.formState.isValid && !localStorageDetails)
               }
               lessonSlug={lessonSlug}

--- a/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.fixture.ts
+++ b/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.fixture.ts
@@ -43,6 +43,7 @@ const specialistLessonDownloadsFixtures = (
 ): SpecialistLessonDownloadsProps => {
   return {
     lesson: {
+      expired: false,
       isLegacy: true,
       lessonSlug: "test-lesson-1",
       lessonTitle: "Test lesson",

--- a/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.stories.tsx
+++ b/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.stories.tsx
@@ -18,6 +18,7 @@ export const SpecialistLessonDownloadsPage: Story = {
   args: {
     curriculumData: {
       lesson: {
+        expired: false,
         isLegacy: true,
         lessonSlug: "healthy-hugs-1",
         lessonTitle: "Healthy hugs",

--- a/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.view.tsx
@@ -17,6 +17,7 @@ export type SpecialistLessonDownloadsProps = {
     downloads: LessonDownloadsData["downloads"];
     nextLessons: NextLesson[];
     hasDownloadableResources: boolean;
+    expired: boolean | null;
   };
 };
 


### PR DESCRIPTION
## Description

Music year: 1990

- Disable buttons and hide content on the share and downloads pages that are expired. This pages are not linked to but could be found.

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2290--oak-web-application.netlify.thenational.academy
Nothing here to see everything works the same. On migration should see images below for expired lessons

for expired eyfs: /teachers/programmes/understanding-the-world-foundation-early-years-foundation-stage/units/transport-0359/lessons/to-explain-features-of-different-modes-of-transport-chjk0c/downloads

## Screenshots

How it used to look (delete if n/a):
<img width="1491" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/7987787/45759454-46ba-46de-bb5f-71d473f23203">

<img width="1491" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/7987787/0e2ef620-a91b-42fb-823c-897dbea5ec69">


How it should now look:
<img width="1491" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/7987787/af62cff9-1e29-4ffe-821e-c2be331abad5">

<img width="1491" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/7987787/103637af-6391-4c5e-935c-514f8b6fde98">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
