### PR TITLE
Fix/hide copyright slide deck

### DIFF
--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
@@ -214,6 +214,7 @@ type GetPageLinksForLessonProps = Pick<
   | "starterQuiz"
   | "exitQuiz"
   | "hasCopyrightMaterial"
+  | "hasDownloadableResources"
 >;
 export type LessonPageLinkAnchorId =
   | "slide-deck"
@@ -238,7 +239,11 @@ export const getPageLinksForLesson = (
       label: "Slide deck",
       anchorId: "slide-deck",
       condition: (lesson) =>
-        Boolean(lesson.presentationUrl && !lesson.hasCopyrightMaterial),
+        Boolean(
+          lesson.presentationUrl &&
+            !lesson.hasCopyrightMaterial &&
+            lesson.hasDownloadableResources,
+        ),
     },
     {
       label: "Lesson details",

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -228,26 +228,27 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
             </GridArea>
             <OakGridArea $colSpan={[12, 9]}>
               <OakFlex $flexDirection={"column"} $position={"relative"}>
-                {pageLinks.find((p) => p.label === "Slide deck") && (
-                  <LessonItemContainer
-                    ref={slideDeckSectionRef}
-                    title={"Slide deck"}
-                    downloadable={hasDownloadableResources}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "slide deck",
-                      });
-                    }}
-                    slugs={slugs}
-                    anchorId="slide-deck"
-                  >
-                    <LessonOverviewPresentation
-                      asset={presentationUrl}
-                      title={lessonTitle}
-                      isWorksheet={false}
-                    />
-                  </LessonItemContainer>
-                )}
+                {pageLinks.find((p) => p.label === "Slide deck") &&
+                  hasDownloadableResources && (
+                    <LessonItemContainer
+                      ref={slideDeckSectionRef}
+                      title={"Slide deck"}
+                      downloadable={hasDownloadableResources}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "slide deck",
+                        });
+                      }}
+                      slugs={slugs}
+                      anchorId="slide-deck"
+                    >
+                      <LessonOverviewPresentation
+                        asset={presentationUrl}
+                        title={lessonTitle}
+                        isWorksheet={false}
+                      />
+                    </LessonItemContainer>
+                  )}
                 <LessonItemContainer
                   ref={lessonDetailsSectionRef}
                   title={"Lesson details"}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds additional check to only display slide decks if they're downloadable
- 

## Issue(s)

Fixes #LESQ-676

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
