### PR TITLE
chore: update mv for downloads and overview - LESQ-674

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -14116,6 +14116,206 @@ export type Published_Mv_Downloads_3_0_8_Stream_Cursor_Value_Input = {
   unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9 = {
+  __typename?: 'published_mv_downloads_3_0_9';
+  downloads?: Maybe<Scalars['jsonb']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9DownloadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9_Aggregate = {
+  __typename?: 'published_mv_downloads_3_0_9_aggregate';
+  aggregate?: Maybe<Published_Mv_Downloads_3_0_9_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Downloads_3_0_9>;
+};
+
+/** aggregate fields of "published.mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9_Aggregate_Fields = {
+  __typename?: 'published_mv_downloads_3_0_9_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Downloads_3_0_9_Max_Fields>;
+  min?: Maybe<Published_Mv_Downloads_3_0_9_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_downloads_3_0_9". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Downloads_3_0_9_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Bool_Exp>>;
+  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonCohort?: InputMaybe<String_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Downloads_3_0_9_Max_Fields = {
+  __typename?: 'published_mv_downloads_3_0_9_max_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Downloads_3_0_9_Min_Fields = {
+  __typename?: 'published_mv_downloads_3_0_9_min_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_downloads_3_0_9". */
+export type Published_Mv_Downloads_3_0_9_Order_By = {
+  downloads?: InputMaybe<Order_By>;
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  hasDownloadableResources?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonCohort?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_downloads_3_0_9" */
+export enum Published_Mv_Downloads_3_0_9_Select_Column {
+  /** column name */
+  Downloads = 'downloads',
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasDownloadableResources = 'hasDownloadableResources',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonCohort = 'lessonCohort',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle'
+}
+
+/** Streaming cursor of the table "published_mv_downloads_3_0_9" */
+export type Published_Mv_Downloads_3_0_9_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Downloads_3_0_9_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Downloads_3_0_9_Stream_Cursor_Value_Input = {
+  downloads?: InputMaybe<Scalars['jsonb']['input']>;
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  expired?: InputMaybe<Scalars['Boolean']['input']>;
+  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonCohort?: InputMaybe<Scalars['String']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_homepage_3_0_1" */
 export type Published_Mv_Homepage_3_0_1 = {
   __typename?: 'published_mv_homepage_3_0_1';
@@ -19004,6 +19204,530 @@ export type Published_Mv_Lesson_Overview_3_0_8_Variance_Fields = {
   unitVariantId?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9 = {
+  __typename?: 'published_mv_lesson_overview_3_0_9';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
+  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
+  isLegacy?: Maybe<Scalars['Boolean']['output']>;
+  isWorksheetLandscape?: Maybe<Scalars['Boolean']['output']>;
+  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  teacherTips?: Maybe<Scalars['jsonb']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9ContentGuidanceArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9CopyrightContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9ExitQuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9KeyLearningPointsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9LessonEquipmentAndResourcesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9LessonKeywordsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9MisconceptionsAndCommonMistakesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9StarterQuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9TeacherTipsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9_Aggregate = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_aggregate';
+  aggregate?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Lesson_Overview_3_0_9>;
+};
+
+/** aggregate fields of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9_Aggregate_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_aggregate_fields';
+  avg?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Max_Fields>;
+  min?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Lesson_Overview_3_0_9_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Avg_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_avg_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_lesson_overview_3_0_9". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Lesson_Overview_3_0_9_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>>;
+  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
+  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
+  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
+  isWorksheetLandscape?: InputMaybe<Boolean_Comparison_Exp>;
+  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonCohort?: InputMaybe<String_Comparison_Exp>;
+  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonId?: InputMaybe<Int_Comparison_Exp>;
+  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
+  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
+  presentationUrl?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
+  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
+  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
+  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
+  videoTitle?: InputMaybe<String_Comparison_Exp>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
+  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
+  yearSlug?: InputMaybe<String_Comparison_Exp>;
+  yearTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Max_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_max_fields';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Min_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_min_fields';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_lesson_overview_3_0_9". */
+export type Published_Mv_Lesson_Overview_3_0_9_Order_By = {
+  additionalMaterialUrl?: InputMaybe<Order_By>;
+  contentGuidance?: InputMaybe<Order_By>;
+  copyrightContent?: InputMaybe<Order_By>;
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  exitQuiz?: InputMaybe<Order_By>;
+  exitQuizId?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  hasDownloadableResources?: InputMaybe<Order_By>;
+  isLegacy?: InputMaybe<Order_By>;
+  isWorksheetLandscape?: InputMaybe<Order_By>;
+  keyLearningPoints?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonCohort?: InputMaybe<Order_By>;
+  lessonEquipmentAndResources?: InputMaybe<Order_By>;
+  lessonId?: InputMaybe<Order_By>;
+  lessonKeywords?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
+  nullUnitVariantId?: InputMaybe<Order_By>;
+  presentationUrl?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  pupilLessonOutcome?: InputMaybe<Order_By>;
+  starterQuiz?: InputMaybe<Order_By>;
+  starterQuizId?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  supervisionLevel?: InputMaybe<Order_By>;
+  teacherTips?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  transcriptSentences?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+  unitVariantId?: InputMaybe<Order_By>;
+  videoMuxPlaybackId?: InputMaybe<Order_By>;
+  videoTitle?: InputMaybe<Order_By>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
+  worksheetUrl?: InputMaybe<Order_By>;
+  yearSlug?: InputMaybe<Order_By>;
+  yearTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_lesson_overview_3_0_9" */
+export enum Published_Mv_Lesson_Overview_3_0_9_Select_Column {
+  /** column name */
+  AdditionalMaterialUrl = 'additionalMaterialUrl',
+  /** column name */
+  ContentGuidance = 'contentGuidance',
+  /** column name */
+  CopyrightContent = 'copyrightContent',
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  ExitQuiz = 'exitQuiz',
+  /** column name */
+  ExitQuizId = 'exitQuizId',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasDownloadableResources = 'hasDownloadableResources',
+  /** column name */
+  IsLegacy = 'isLegacy',
+  /** column name */
+  IsWorksheetLandscape = 'isWorksheetLandscape',
+  /** column name */
+  KeyLearningPoints = 'keyLearningPoints',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonCohort = 'lessonCohort',
+  /** column name */
+  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
+  /** column name */
+  LessonId = 'lessonId',
+  /** column name */
+  LessonKeywords = 'lessonKeywords',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
+  /** column name */
+  NullUnitVariantId = 'nullUnitVariantId',
+  /** column name */
+  PresentationUrl = 'presentationUrl',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  PupilLessonOutcome = 'pupilLessonOutcome',
+  /** column name */
+  StarterQuiz = 'starterQuiz',
+  /** column name */
+  StarterQuizId = 'starterQuizId',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  SupervisionLevel = 'supervisionLevel',
+  /** column name */
+  TeacherTips = 'teacherTips',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  TranscriptSentences = 'transcriptSentences',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle',
+  /** column name */
+  UnitVariantId = 'unitVariantId',
+  /** column name */
+  VideoMuxPlaybackId = 'videoMuxPlaybackId',
+  /** column name */
+  VideoTitle = 'videoTitle',
+  /** column name */
+  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
+  /** column name */
+  WorksheetUrl = 'worksheetUrl',
+  /** column name */
+  YearSlug = 'yearSlug',
+  /** column name */
+  YearTitle = 'yearTitle'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Stddev_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_stddev_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_stddev_pop_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_stddev_samp_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_lesson_overview_3_0_9" */
+export type Published_Mv_Lesson_Overview_3_0_9_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Lesson_Overview_3_0_9_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Lesson_Overview_3_0_9_Stream_Cursor_Value_Input = {
+  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
+  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
+  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
+  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
+  expired?: InputMaybe<Scalars['Boolean']['input']>;
+  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
+  isWorksheetLandscape?: InputMaybe<Scalars['Boolean']['input']>;
+  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonCohort?: InputMaybe<Scalars['String']['input']>;
+  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonId?: InputMaybe<Scalars['Int']['input']>;
+  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
+  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
+  presentationUrl?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
+  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
+  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
+  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
+  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
+  videoTitle?: InputMaybe<Scalars['String']['input']>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
+  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
+  yearSlug?: InputMaybe<Scalars['String']['input']>;
+  yearTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Sum_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_sum_fields';
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Var_Pop_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_var_pop_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Var_Samp_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_var_samp_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Lesson_Overview_3_0_9_Variance_Fields = {
+  __typename?: 'published_mv_lesson_overview_3_0_9_variance_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_programme_listing_3_0_0" */
 export type Published_Mv_Programme_Listing_3_0_0 = {
   __typename?: 'published_mv_programme_listing_3_0_0';
@@ -21812,6 +22536,102 @@ export type Published_View_Synthetic_Programmes_3_Stream_Cursor_Value_Input = {
   synthetic_programme_slug?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
+/** columns and relationships of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4 = {
+  __typename?: 'published_view_synthetic_programmes_4';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['jsonb']['output']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4Synthetic_Programme_SlugArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4_Aggregate = {
+  __typename?: 'published_view_synthetic_programmes_4_aggregate';
+  aggregate?: Maybe<Published_View_Synthetic_Programmes_4_Aggregate_Fields>;
+  nodes: Array<Published_View_Synthetic_Programmes_4>;
+};
+
+/** aggregate fields of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4_Aggregate_Fields = {
+  __typename?: 'published_view_synthetic_programmes_4_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Synthetic_Programmes_4_Max_Fields>;
+  min?: Maybe<Published_View_Synthetic_Programmes_4_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_synthetic_programmes_4". All fields are combined with a logical 'AND'. */
+export type Published_View_Synthetic_Programmes_4_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Bool_Exp>>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  synthetic_programme_slug?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Synthetic_Programmes_4_Max_Fields = {
+  __typename?: 'published_view_synthetic_programmes_4_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Synthetic_Programmes_4_Min_Fields = {
+  __typename?: 'published_view_synthetic_programmes_4_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_synthetic_programmes_4". */
+export type Published_View_Synthetic_Programmes_4_Order_By = {
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  synthetic_programme_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_synthetic_programmes_4" */
+export enum Published_View_Synthetic_Programmes_4_Select_Column {
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  SyntheticProgrammeSlug = 'synthetic_programme_slug'
+}
+
+/** Streaming cursor of the table "published_view_synthetic_programmes_4" */
+export type Published_View_Synthetic_Programmes_4_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Synthetic_Programmes_4_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Synthetic_Programmes_4_Stream_Cursor_Value_Input = {
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  synthetic_programme_slug?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
 /** aggregated selection of "published.view_synthetic_programmes" */
 export type Published_View_Synthetic_Programmes_Aggregate = {
   __typename?: 'published_view_synthetic_programmes_aggregate';
@@ -23756,6 +24576,260 @@ export type Published_View_Unit_Unitvariant_Programmes_3_Variance_Fields = {
   unitvariant_id?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4 = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  programme_fields_p?: Maybe<Scalars['jsonb']['output']>;
+  programme_fields_uv?: Maybe<Scalars['jsonb']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_overrides?: Maybe<Scalars['jsonb']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Programme_Fields_PArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Programme_Fields_UvArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4Unit_OverridesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4_Aggregate = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_aggregate';
+  aggregate?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Aggregate_Fields>;
+  nodes: Array<Published_View_Unit_Unitvariant_Programmes_4>;
+};
+
+/** aggregate fields of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4_Aggregate_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_aggregate_fields';
+  avg?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Max_Fields>;
+  min?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Min_Fields>;
+  stddev?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Unit_Unitvariant_Programmes_4_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Avg_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_avg_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_unit_unitvariant_programmes_4". All fields are combined with a logical 'AND'. */
+export type Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>>;
+  _state_uv?: InputMaybe<String_Comparison_Exp>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  programme_fields_p?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_fields_uv?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_id?: InputMaybe<Int_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_overrides?: InputMaybe<Jsonb_Comparison_Exp>;
+  unitvariant_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Max_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_max_fields';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Min_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_min_fields';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_unit_unitvariant_programmes_4". */
+export type Published_View_Unit_Unitvariant_Programmes_4_Order_By = {
+  _state_uv?: InputMaybe<Order_By>;
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  is_legacy?: InputMaybe<Order_By>;
+  programme_fields_p?: InputMaybe<Order_By>;
+  programme_fields_uv?: InputMaybe<Order_By>;
+  programme_id?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_overrides?: InputMaybe<Order_By>;
+  unitvariant_id?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_unit_unitvariant_programmes_4" */
+export enum Published_View_Unit_Unitvariant_Programmes_4_Select_Column {
+  /** column name */
+  StateUv = '_state_uv',
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  ProgrammeFieldsP = 'programme_fields_p',
+  /** column name */
+  ProgrammeFieldsUv = 'programme_fields_uv',
+  /** column name */
+  ProgrammeId = 'programme_id',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOverrides = 'unit_overrides',
+  /** column name */
+  UnitvariantId = 'unitvariant_id'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Stddev_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_stddev_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Stddev_Pop_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_stddev_pop_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Stddev_Samp_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_stddev_samp_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_unit_unitvariant_programmes_4" */
+export type Published_View_Unit_Unitvariant_Programmes_4_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Unit_Unitvariant_Programmes_4_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Unit_Unitvariant_Programmes_4_Stream_Cursor_Value_Input = {
+  _state_uv?: InputMaybe<Scalars['String']['input']>;
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  programme_fields_p?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields_uv?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_id?: InputMaybe<Scalars['Int']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_overrides?: InputMaybe<Scalars['jsonb']['input']>;
+  unitvariant_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Sum_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_sum_fields';
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Var_Pop_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_var_pop_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Var_Samp_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_var_samp_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Unit_Unitvariant_Programmes_4_Variance_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_4_variance_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.viewmanager" */
 export type Published_Viewmanager = {
   __typename?: 'published_viewmanager';
@@ -24500,6 +25574,10 @@ export type Query_Root = {
   published_mv_downloads_3_0_8: Array<Published_Mv_Downloads_3_0_8>;
   /** fetch aggregated fields from the table: "published.mv_downloads_3_0_8" */
   published_mv_downloads_3_0_8_aggregate: Published_Mv_Downloads_3_0_8_Aggregate;
+  /** fetch data from the table: "published.mv_downloads_3_0_9" */
+  published_mv_downloads_3_0_9: Array<Published_Mv_Downloads_3_0_9>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_9" */
+  published_mv_downloads_3_0_9_aggregate: Published_Mv_Downloads_3_0_9_Aggregate;
   /** fetch data from the table: "published.mv_homepage_3_0_1" */
   published_mv_homepage_3_0_1: Array<Published_Mv_Homepage_3_0_1>;
   /** fetch aggregated fields from the table: "published.mv_homepage_3_0_1" */
@@ -24548,6 +25626,10 @@ export type Query_Root = {
   published_mv_lesson_overview_3_0_8: Array<Published_Mv_Lesson_Overview_3_0_8>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_3_0_8" */
   published_mv_lesson_overview_3_0_8_aggregate: Published_Mv_Lesson_Overview_3_0_8_Aggregate;
+  /** fetch data from the table: "published.mv_lesson_overview_3_0_9" */
+  published_mv_lesson_overview_3_0_9: Array<Published_Mv_Lesson_Overview_3_0_9>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_overview_3_0_9" */
+  published_mv_lesson_overview_3_0_9_aggregate: Published_Mv_Lesson_Overview_3_0_9_Aggregate;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
@@ -24618,6 +25700,10 @@ export type Query_Root = {
   published_view_synthetic_programmes_3: Array<Published_View_Synthetic_Programmes_3>;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes_3" */
   published_view_synthetic_programmes_3_aggregate: Published_View_Synthetic_Programmes_3_Aggregate;
+  /** fetch data from the table: "published.view_synthetic_programmes_4" */
+  published_view_synthetic_programmes_4: Array<Published_View_Synthetic_Programmes_4>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_programmes_4" */
+  published_view_synthetic_programmes_4_aggregate: Published_View_Synthetic_Programmes_4_Aggregate;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes" */
   published_view_synthetic_programmes_aggregate: Published_View_Synthetic_Programmes_Aggregate;
   /** fetch data from the table: "published.view_synthetic_unitvariant_lessons_2" */
@@ -24652,6 +25738,10 @@ export type Query_Root = {
   published_view_unit_unitvariant_programmes_3: Array<Published_View_Unit_Unitvariant_Programmes_3>;
   /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_3" */
   published_view_unit_unitvariant_programmes_3_aggregate: Published_View_Unit_Unitvariant_Programmes_3_Aggregate;
+  /** fetch data from the table: "published.view_unit_unitvariant_programmes_4" */
+  published_view_unit_unitvariant_programmes_4: Array<Published_View_Unit_Unitvariant_Programmes_4>;
+  /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_4" */
+  published_view_unit_unitvariant_programmes_4_aggregate: Published_View_Unit_Unitvariant_Programmes_4_Aggregate;
   /** fetch data from the table: "published.viewmanager" */
   published_viewmanager: Array<Published_Viewmanager>;
   /** fetch aggregated fields from the table: "published.viewmanager" */
@@ -25359,6 +26449,24 @@ export type Query_RootPublished_Mv_Downloads_3_0_8_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Downloads_3_0_9Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Downloads_3_0_9_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Homepage_3_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Homepage_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -25572,6 +26680,24 @@ export type Query_RootPublished_Mv_Lesson_Overview_3_0_8_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_8_Order_By>>;
   where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_8_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Overview_3_0_9Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Overview_3_0_9_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
 };
 
 
@@ -25890,6 +27016,24 @@ export type Query_RootPublished_View_Synthetic_Programmes_3_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_View_Synthetic_Programmes_4Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Programmes_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_View_Synthetic_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -26040,6 +27184,24 @@ export type Query_RootPublished_View_Unit_Unitvariant_Programmes_3_AggregateArgs
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_3_Order_By>>;
   where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_3_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Unit_Unitvariant_Programmes_4Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Unit_Unitvariant_Programmes_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
 };
 
 
@@ -28375,6 +29537,12 @@ export type Subscription_Root = {
   published_mv_downloads_3_0_8_aggregate: Published_Mv_Downloads_3_0_8_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_8" */
   published_mv_downloads_3_0_8_stream: Array<Published_Mv_Downloads_3_0_8>;
+  /** fetch data from the table: "published.mv_downloads_3_0_9" */
+  published_mv_downloads_3_0_9: Array<Published_Mv_Downloads_3_0_9>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_3_0_9" */
+  published_mv_downloads_3_0_9_aggregate: Published_Mv_Downloads_3_0_9_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_downloads_3_0_9" */
+  published_mv_downloads_3_0_9_stream: Array<Published_Mv_Downloads_3_0_9>;
   /** fetch data from the table: "published.mv_homepage_3_0_1" */
   published_mv_homepage_3_0_1: Array<Published_Mv_Homepage_3_0_1>;
   /** fetch aggregated fields from the table: "published.mv_homepage_3_0_1" */
@@ -28447,6 +29615,12 @@ export type Subscription_Root = {
   published_mv_lesson_overview_3_0_8_aggregate: Published_Mv_Lesson_Overview_3_0_8_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_3_0_8" */
   published_mv_lesson_overview_3_0_8_stream: Array<Published_Mv_Lesson_Overview_3_0_8>;
+  /** fetch data from the table: "published.mv_lesson_overview_3_0_9" */
+  published_mv_lesson_overview_3_0_9: Array<Published_Mv_Lesson_Overview_3_0_9>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_overview_3_0_9" */
+  published_mv_lesson_overview_3_0_9_aggregate: Published_Mv_Lesson_Overview_3_0_9_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_3_0_9" */
+  published_mv_lesson_overview_3_0_9_stream: Array<Published_Mv_Lesson_Overview_3_0_9>;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
@@ -28551,6 +29725,12 @@ export type Subscription_Root = {
   published_view_synthetic_programmes_3_aggregate: Published_View_Synthetic_Programmes_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes_3" */
   published_view_synthetic_programmes_3_stream: Array<Published_View_Synthetic_Programmes_3>;
+  /** fetch data from the table: "published.view_synthetic_programmes_4" */
+  published_view_synthetic_programmes_4: Array<Published_View_Synthetic_Programmes_4>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_programmes_4" */
+  published_view_synthetic_programmes_4_aggregate: Published_View_Synthetic_Programmes_4_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes_4" */
+  published_view_synthetic_programmes_4_stream: Array<Published_View_Synthetic_Programmes_4>;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes" */
   published_view_synthetic_programmes_aggregate: Published_View_Synthetic_Programmes_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes" */
@@ -28603,6 +29783,12 @@ export type Subscription_Root = {
   published_view_unit_unitvariant_programmes_3_aggregate: Published_View_Unit_Unitvariant_Programmes_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_unit_unitvariant_programmes_3" */
   published_view_unit_unitvariant_programmes_3_stream: Array<Published_View_Unit_Unitvariant_Programmes_3>;
+  /** fetch data from the table: "published.view_unit_unitvariant_programmes_4" */
+  published_view_unit_unitvariant_programmes_4: Array<Published_View_Unit_Unitvariant_Programmes_4>;
+  /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_4" */
+  published_view_unit_unitvariant_programmes_4_aggregate: Published_View_Unit_Unitvariant_Programmes_4_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_unit_unitvariant_programmes_4" */
+  published_view_unit_unitvariant_programmes_4_stream: Array<Published_View_Unit_Unitvariant_Programmes_4>;
   /** fetch data from the table: "published.viewmanager" */
   published_viewmanager: Array<Published_Viewmanager>;
   /** fetch aggregated fields from the table: "published.viewmanager" */
@@ -29532,6 +30718,31 @@ export type Subscription_RootPublished_Mv_Downloads_3_0_8_StreamArgs = {
 };
 
 
+export type Subscription_RootPublished_Mv_Downloads_3_0_9Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_3_0_9_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_3_0_9_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Downloads_3_0_9_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Downloads_3_0_9_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Homepage_3_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Homepage_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -29829,6 +31040,31 @@ export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_8_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_3_0_8_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_8_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_9Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_9_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_3_0_9_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Overview_3_0_9_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_3_0_9_Bool_Exp>;
 };
 
 
@@ -30266,6 +31502,31 @@ export type Subscription_RootPublished_View_Synthetic_Programmes_3_StreamArgs = 
 };
 
 
+export type Subscription_RootPublished_View_Synthetic_Programmes_4Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Programmes_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Programmes_4_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Synthetic_Programmes_4_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_4_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_View_Synthetic_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30479,6 +31740,31 @@ export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_3_Stream
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_View_Unit_Unitvariant_Programmes_3_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_4Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_4_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
 };
 
 
@@ -36595,7 +37881,7 @@ export type LessonDownloadsQueryVariables = Exact<{
 }>;
 
 
-export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_8', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, lessonCohort?: string | null, hasDownloadableResources?: boolean | null, expired?: boolean | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_1', lessons?: any | null }> };
+export type LessonDownloadsQuery = { __typename?: 'query_root', downloads: Array<{ __typename?: 'published_mv_downloads_3_0_9', downloads?: any | null, programmeSlug?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonSlug?: string | null, lessonTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, lessonCohort?: string | null, hasDownloadableResources?: boolean | null, expired?: boolean | null }>, unit: Array<{ __typename?: 'published_mv_lesson_listing_3_0_1', lessons?: any | null }> };
 
 export type LessonDownloadsCanonicalQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -36619,7 +37905,7 @@ export type LessonOverviewQueryVariables = Exact<{
 }>;
 
 
-export type LessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_8', lessonSlug?: string | null, lessonTitle?: string | null, programmeSlug?: string | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, examBoardTitle?: string | null, tierTitle?: string | null, misconceptionsAndCommonMistakes?: any | null, lessonEquipmentAndResources?: any | null, teacherTips?: any | null, keyLearningPoints?: any | null, pupilLessonOutcome?: string | null, lessonKeywords?: any | null, copyrightContent?: any | null, contentGuidance?: any | null, additionalMaterialUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, presentationUrl?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, yearTitle?: string | null, hasDownloadableResources?: boolean | null, videoTitle?: string | null, lessonCohort?: string | null, isWorksheetLandscape?: boolean | null, expired?: boolean | null }> };
+export type LessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_9', lessonSlug?: string | null, lessonTitle?: string | null, programmeSlug?: string | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, examBoardTitle?: string | null, tierTitle?: string | null, misconceptionsAndCommonMistakes?: any | null, lessonEquipmentAndResources?: any | null, teacherTips?: any | null, keyLearningPoints?: any | null, pupilLessonOutcome?: string | null, lessonKeywords?: any | null, copyrightContent?: any | null, contentGuidance?: any | null, additionalMaterialUrl?: string | null, supervisionLevel?: string | null, worksheetUrl?: string | null, presentationUrl?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, yearTitle?: string | null, hasDownloadableResources?: boolean | null, videoTitle?: string | null, lessonCohort?: string | null, isWorksheetLandscape?: boolean | null, expired?: boolean | null }> };
 
 export type LessonOverviewCanonicalQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -36738,7 +38024,7 @@ export const CurriculumUnitsDocument = gql`
     `;
 export const LessonDownloadsDocument = gql`
     query lessonDownloads($lessonSlug: String!, $programmeSlug: String!, $unitSlug: String!) {
-  downloads: published_mv_downloads_3_0_8(
+  downloads: published_mv_downloads_3_0_9(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
     downloads
@@ -36805,7 +38091,7 @@ export const LessonListingDocument = gql`
     `;
 export const LessonOverviewDocument = gql`
     query lessonOverview($programmeSlug: String!, $lessonSlug: String!, $unitSlug: String!) {
-  lesson: published_mv_lesson_overview_3_0_8(
+  lesson: published_mv_lesson_overview_3_0_9(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
     lessonSlug

--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.gql
@@ -3,7 +3,7 @@ query lessonDownloads(
   $programmeSlug: String!
   $unitSlug: String!
 ) {
-  downloads: published_mv_downloads_3_0_8(
+  downloads: published_mv_downloads_3_0_9(
     where: {
       lessonSlug: { _eq: $lessonSlug }
       programmeSlug: { _eq: $programmeSlug }

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.gql
@@ -3,7 +3,7 @@ query lessonOverview(
   $lessonSlug: String!
   $unitSlug: String!
 ) {
-  lesson: published_mv_lesson_overview_3_0_8(
+  lesson: published_mv_lesson_overview_3_0_9(
     where: {
       lessonSlug: { _eq: $lessonSlug }
       programmeSlug: { _eq: $programmeSlug }


### PR DESCRIPTION
## Description

Music year: 1967

- Connects the MV's that use 
```
  {
            "copyright_info": "Attributions in slides where needed."
  }
```
For both legacy and new content to determine if a lesson has downloads
More detail here - https://www.notion.so/oaknationalacademy/Spring-Sprint-1-fe3f5ac1bb0147668eb40dc32334d684?p=aa1063242dc847a2b0cb5eb96788b104&pm=s

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2293--oak-web-application.netlify.thenational.academy
teachers/programmes/science-primary-ks2/units/simple-forces-including-magnets/lessons/different-magnets-and-their-parts
 You should see downloads are available 

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
