### PR TITLE
[ENG-675] fix(policy pages): make internal links work

### DIFF
--- a/src/pages/legal/[policyPageSlug].tsx
+++ b/src/pages/legal/[policyPageSlug].tsx
@@ -89,6 +89,24 @@ const customPolicyComponent: PortableTextComponents = {
         </OwaLink>
       );
     },
+    internalLink: ({ children, value }) => {
+      let ariaLabel = "";
+      console.log("value", value);
+      if (Array.isArray(children)) {
+        ariaLabel = children[0];
+      }
+      return (
+        <OwaLink
+          aria-label={ariaLabel}
+          legalSlug={value?.reference?.slug}
+          // It doesn't feel great that this is hard-coded to "legal".
+          page={"legal"}
+          $textDecoration={"underline"}
+        >
+          {children}
+        </OwaLink>
+      );
+    },
   },
 };
 

--- a/src/pages/legal/[policyPageSlug].tsx
+++ b/src/pages/legal/[policyPageSlug].tsx
@@ -91,7 +91,6 @@ const customPolicyComponent: PortableTextComponents = {
     },
     internalLink: ({ children, value }) => {
       let ariaLabel = "";
-      console.log("value", value);
       if (Array.isArray(children)) {
         ariaLabel = children[0];
       }


### PR DESCRIPTION
Internal links on policy pages weren't working, now they should.

To test, open the privacy policy page, and check that the first paragraph has a working, underlined link to the child-friendly version of the privacy policy.