### PR TITLE
Feat/pupil 479/handle expired lessons

### DIFF
--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.test.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.test.tsx
@@ -19,6 +19,10 @@ jest.mock("@/components/PupilComponents/LessonEngineProvider", () => ({
   useLessonEngineContext: jest.fn(),
 }));
 
+jest.mock("@/components/PupilViews/PupilExpired/PupilExpired.view", () => ({
+  PupilExpiredView: jest.fn(() => "PupilExpiredView"),
+}));
+
 const render = renderWithProviders();
 
 describe("PupilExperienceView", () => {
@@ -117,5 +121,27 @@ describe("PupilExperienceView", () => {
         expect(getByText(name as RegExp)).toBeInTheDocument();
       });
     });
+  });
+
+  it("should render the expired view if the lesson is expired", () => {
+    const lessonData = pupilLessonOverviewFixture({
+      expired: true,
+    });
+
+    const pupilPathwayData = getPupilPathwayData(lessonData);
+
+    jest.spyOn(LessonEngineProvider, "useLessonEngineContext").mockReturnValue(
+      createLessonEngineContext({
+        currentSection: "overview",
+      }),
+    );
+
+    const { getByText } = render(
+      <PupilAnalyticsProvider pupilPathwayData={pupilPathwayData}>
+        <PupilExperienceView curriculumData={lessonData} hasWorksheet={false} />
+      </PupilAnalyticsProvider>,
+    );
+
+    expect(getByText("PupilExpiredView", { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -16,6 +16,7 @@ import { PupilViewsReview } from "@/components/PupilViews/PupilReview";
 import { PupilViewsQuiz } from "@/components/PupilViews/PupilQuiz";
 import { PupilViewsVideo } from "@/components/PupilViews/PupilVideo";
 import { getInteractiveQuestions } from "@/components/PupilComponents/QuizUtils/questionUtils";
+import { PupilExpiredView } from "@/components/PupilViews/PupilExpired/PupilExpired.view";
 
 export const pickAvailableSectionsForLesson = (
   curriculumData: PupilLessonOverviewData,
@@ -114,11 +115,15 @@ export const PupilExperienceView = ({
     <OakThemeProvider theme={oakDefaultTheme}>
       <LessonEngineProvider initialLessonReviewSections={availableSections}>
         <OakBox $height={"100vh"}>
-          <PupilPageContent
-            curriculumData={curriculumData}
-            hasWorksheet={hasWorksheet}
-            backUrl={backUrl}
-          />
+          {curriculumData.expired ? (
+            <PupilExpiredView lessonTitle={curriculumData.lessonTitle} />
+          ) : (
+            <PupilPageContent
+              curriculumData={curriculumData}
+              hasWorksheet={hasWorksheet}
+              backUrl={backUrl}
+            />
+          )}
         </OakBox>
       </LessonEngineProvider>
     </OakThemeProvider>

--- a/src/components/PupilViews/PupilExpired/PupilExpired.view.stories.tsx
+++ b/src/components/PupilViews/PupilExpired/PupilExpired.view.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+
+import { PupilExpiredView } from "./PupilExpired.view";
+
+const meta = {
+  component: PupilExpiredView,
+  decorators: [
+    (Story) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <Story />
+      </OakThemeProvider>
+    ),
+  ],
+  parameters: {
+    controls: {
+      include: [],
+    },
+  },
+} satisfies Meta<typeof PupilExpiredView>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/*
+ * This is the view users will see on encountering an expired lesson
+ *
+ */
+
+export const Default: Story = {
+  render: (args) => {
+    return <PupilExpiredView lessonTitle={args.lessonTitle} />;
+  },
+  args: { lessonTitle: "The lesson title" },
+};

--- a/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
+++ b/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
@@ -1,0 +1,68 @@
+import {
+  OakBox,
+  OakFlex,
+  OakHeading,
+  OakPrimaryButton,
+} from "@oaknational/oak-components";
+
+export const PupilExpiredView = ({ lessonTitle }: { lessonTitle: string }) => {
+  return (
+    <OakFlex
+      $height={"100vh"}
+      $justifyContent={"center"}
+      $alignItems={"center"}
+      $background={"bg-decorative1-main"}
+      $flexDirection={"column"}
+    >
+      <OakFlex
+        $pa={["inner-padding-none", "inner-padding-xl"]}
+        $justifyContent={"center"}
+        $gap={["space-between-m"]}
+        $alignItems={["center", "flex-start"]}
+        $flexDirection={"column"}
+        $background={"bg-decorative1-very-subdued"}
+        $flexGrow={[1, 0]}
+        $width={["100%", "auto"]}
+        $borderRadius={[null, "border-radius-m"]}
+        $borderColor={[null, "border-decorative1-stronger"]}
+        $ba={["border-solid-none", "border-solid-m"]}
+      >
+        <OakFlex
+          $flexDirection={"column"}
+          $gap={["space-between-m"]}
+          $alignItems={["center", "flex-start"]}
+          $justifyContent={["center", "flex-start"]}
+          $flexGrow={[1, 0]}
+        >
+          <OakHeading
+            $textAlign={"center"}
+            tag="h1"
+            $font={["heading-5", "heading-4"]}
+          >
+            {lessonTitle}
+          </OakHeading>
+          <OakHeading
+            $textAlign={"center"}
+            tag="h2"
+            $font={["body-2", "body-1"]}
+          >
+            Sorry, this lesson is no longer available
+          </OakHeading>
+        </OakFlex>
+        <OakBox
+          $width={["100%", "max-content"]}
+          $pa={["inner-padding-l", "inner-padding-none"]}
+        >
+          <OakPrimaryButton
+            width={["100%", "max-content"]}
+            element="a"
+            href="https://support.thenational.academy/lesson-unavailable"
+            target="_blank"
+          >
+            Find out why
+          </OakPrimaryButton>
+        </OakBox>
+      </OakFlex>
+    </OakFlex>
+  );
+};

--- a/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
+++ b/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
@@ -2,6 +2,7 @@ import {
   OakBox,
   OakFlex,
   OakHeading,
+  OakLink,
   OakPrimaryButton,
 } from "@oaknational/oak-components";
 
@@ -46,7 +47,10 @@ export const PupilExpiredView = ({ lessonTitle }: { lessonTitle: string }) => {
             tag="h2"
             $font={["body-2", "body-1"]}
           >
-            Sorry, this lesson is no longer available
+            Sorry, this lesson is no longer available.{" "}
+            <OakLink href="https://support.thenational.academy/lesson-unavailable">
+              Find out why here
+            </OakLink>
           </OakHeading>
         </OakFlex>
         <OakBox
@@ -56,10 +60,10 @@ export const PupilExpiredView = ({ lessonTitle }: { lessonTitle: string }) => {
           <OakPrimaryButton
             width={["100%", "max-content"]}
             element="a"
-            href="https://support.thenational.academy/lesson-unavailable"
             target="_blank"
+            href="/"
           >
-            Find out why
+            Go to homepage
           </OakPrimaryButton>
         </OakBox>
       </OakFlex>

--- a/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
+++ b/src/components/PupilViews/PupilExpired/PupilExpired.view.tsx
@@ -60,7 +60,6 @@ export const PupilExpiredView = ({ lessonTitle }: { lessonTitle: string }) => {
           <OakPrimaryButton
             width={["100%", "max-content"]}
             element="a"
-            target="_blank"
             href="/"
           >
             Go to homepage

--- a/src/node-lib/curriculum-api-2023/fixtures/pupilLessonOverview.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/pupilLessonOverview.fixture.ts
@@ -28,6 +28,7 @@ export const pupilLessonOverviewFixture = (
     transcriptSentences: [],
     starterQuiz: quizQuestions,
     exitQuiz: quizQuestions,
+    expired: false,
     ...partial,
   };
 };

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -760,6 +760,8 @@ export type Cat_Contentguidance_Avg_Fields = {
   __typename?: 'cat_contentguidance_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -849,6 +851,8 @@ export type Cat_Contentguidance_Max_Fields = {
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_label?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
@@ -865,6 +869,8 @@ export type Cat_Contentguidance_Min_Fields = {
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_label?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
@@ -973,6 +979,8 @@ export type Cat_Contentguidance_Stddev_Fields = {
   __typename?: 'cat_contentguidance_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -981,6 +989,8 @@ export type Cat_Contentguidance_Stddev_Pop_Fields = {
   __typename?: 'cat_contentguidance_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -989,6 +999,8 @@ export type Cat_Contentguidance_Stddev_Samp_Fields = {
   __typename?: 'cat_contentguidance_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1023,6 +1035,8 @@ export type Cat_Contentguidance_Sum_Fields = {
   __typename?: 'cat_contentguidance_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -1082,6 +1096,8 @@ export type Cat_Contentguidance_Var_Pop_Fields = {
   __typename?: 'cat_contentguidance_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1090,6 +1106,8 @@ export type Cat_Contentguidance_Var_Samp_Fields = {
   __typename?: 'cat_contentguidance_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1098,6 +1116,8 @@ export type Cat_Contentguidance_Variance_Fields = {
   __typename?: 'cat_contentguidance_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
+  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1184,6 +1204,8 @@ export type Cat_Examboardspecs_Avg_Fields = {
   __typename?: 'cat_examboardspecs_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Boolean expression to filter rows from the table "cat_examboardspecs". All fields are combined with a logical 'AND'. */
@@ -1208,7 +1230,7 @@ export type Cat_Examboardspecs_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_examboardspecs" */
 export enum Cat_Examboardspecs_Constraint {
-  /** unique or primary key constraint on columns "_state", "examboardspecs_id" */
+  /** unique or primary key constraint on columns "examboardspecs_id", "_state" */
   CatExamboardspecsPkey = 'cat_examboardspecs_pkey'
 }
 
@@ -1261,6 +1283,8 @@ export type Cat_Examboardspecs_Max_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1274,6 +1298,8 @@ export type Cat_Examboardspecs_Min_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1368,6 +1394,8 @@ export type Cat_Examboardspecs_Stddev_Fields = {
   __typename?: 'cat_examboardspecs_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -1375,6 +1403,8 @@ export type Cat_Examboardspecs_Stddev_Pop_Fields = {
   __typename?: 'cat_examboardspecs_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -1382,6 +1412,8 @@ export type Cat_Examboardspecs_Stddev_Samp_Fields = {
   __typename?: 'cat_examboardspecs_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Streaming cursor of the table "cat_examboardspecs" */
@@ -1412,6 +1444,8 @@ export type Cat_Examboardspecs_Sum_Fields = {
   __typename?: 'cat_examboardspecs_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** update columns of table "cat_examboardspecs" */
@@ -1464,6 +1498,8 @@ export type Cat_Examboardspecs_Var_Pop_Fields = {
   __typename?: 'cat_examboardspecs_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate var_samp on columns */
@@ -1471,6 +1507,8 @@ export type Cat_Examboardspecs_Var_Samp_Fields = {
   __typename?: 'cat_examboardspecs_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate variance on columns */
@@ -1478,6 +1516,8 @@ export type Cat_Examboardspecs_Variance_Fields = {
   __typename?: 'cat_examboardspecs_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
+  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** columns and relationships of "cat_nationalcurriculum" */
@@ -1563,6 +1603,8 @@ export type Cat_Nationalcurriculum_Avg_Fields = {
   __typename?: 'cat_nationalcurriculum_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Boolean expression to filter rows from the table "cat_nationalcurriculum". All fields are combined with a logical 'AND'. */
@@ -1640,6 +1682,8 @@ export type Cat_Nationalcurriculum_Max_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1653,6 +1697,8 @@ export type Cat_Nationalcurriculum_Min_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1747,6 +1793,8 @@ export type Cat_Nationalcurriculum_Stddev_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -1754,6 +1802,8 @@ export type Cat_Nationalcurriculum_Stddev_Pop_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -1761,6 +1811,8 @@ export type Cat_Nationalcurriculum_Stddev_Samp_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Streaming cursor of the table "cat_nationalcurriculum" */
@@ -1791,6 +1843,8 @@ export type Cat_Nationalcurriculum_Sum_Fields = {
   __typename?: 'cat_nationalcurriculum_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** update columns of table "cat_nationalcurriculum" */
@@ -1843,6 +1897,8 @@ export type Cat_Nationalcurriculum_Var_Pop_Fields = {
   __typename?: 'cat_nationalcurriculum_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate var_samp on columns */
@@ -1850,6 +1906,8 @@ export type Cat_Nationalcurriculum_Var_Samp_Fields = {
   __typename?: 'cat_nationalcurriculum_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate variance on columns */
@@ -1857,6 +1915,8 @@ export type Cat_Nationalcurriculum_Variance_Fields = {
   __typename?: 'cat_nationalcurriculum_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
+  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** columns and relationships of "cat_supervisionlevels" */
@@ -2360,7 +2420,11 @@ export type Cat_Tags_Append_Input = {
 export type Cat_Tags_Avg_Fields = {
   __typename?: 'cat_tags_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by avg() on columns of table "cat_tags" */
@@ -2394,7 +2458,7 @@ export type Cat_Tags_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_tags" */
 export enum Cat_Tags_Constraint {
-  /** unique or primary key constraint on columns "tag_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "tag_id" */
   CatTagsPkey = 'cat_tags_pkey'
 }
 
@@ -2446,9 +2510,13 @@ export type Cat_Tags_Max_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_category?: Maybe<Scalars['String']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -2473,9 +2541,13 @@ export type Cat_Tags_Min_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_category?: Maybe<Scalars['String']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -2588,7 +2660,11 @@ export type Cat_Tags_Set_Input = {
 export type Cat_Tags_Stddev_Fields = {
   __typename?: 'cat_tags_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev() on columns of table "cat_tags" */
@@ -2601,7 +2677,11 @@ export type Cat_Tags_Stddev_Order_By = {
 export type Cat_Tags_Stddev_Pop_Fields = {
   __typename?: 'cat_tags_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev_pop() on columns of table "cat_tags" */
@@ -2614,7 +2694,11 @@ export type Cat_Tags_Stddev_Pop_Order_By = {
 export type Cat_Tags_Stddev_Samp_Fields = {
   __typename?: 'cat_tags_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev_samp() on columns of table "cat_tags" */
@@ -2651,7 +2735,11 @@ export type Cat_Tags_Stream_Cursor_Value_Input = {
 export type Cat_Tags_Sum_Fields = {
   __typename?: 'cat_tags_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by sum() on columns of table "cat_tags" */
@@ -2711,7 +2799,11 @@ export type Cat_Tags_Updates = {
 export type Cat_Tags_Var_Pop_Fields = {
   __typename?: 'cat_tags_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by var_pop() on columns of table "cat_tags" */
@@ -2724,7 +2816,11 @@ export type Cat_Tags_Var_Pop_Order_By = {
 export type Cat_Tags_Var_Samp_Fields = {
   __typename?: 'cat_tags_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by var_samp() on columns of table "cat_tags" */
@@ -2737,7 +2833,11 @@ export type Cat_Tags_Var_Samp_Order_By = {
 export type Cat_Tags_Variance_Fields = {
   __typename?: 'cat_tags_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__lessons__count" */
+  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__cat_tags__units__count" */
+  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by variance() on columns of table "cat_tags" */
@@ -3765,6 +3865,10 @@ export type Internal_Review_Lessons_Max_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__firstapproval" */
+  firstapproval?: Maybe<Scalars['timestamp']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__lastapproval" */
+  lastapproval?: Maybe<Scalars['timestamp']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
   release_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -3808,6 +3912,10 @@ export type Internal_Review_Lessons_Min_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__firstapproval" */
+  firstapproval?: Maybe<Scalars['timestamp']['output']>;
+  /** A computed field, executes function "internal.function__internal_review_lessons__lastapproval" */
+  lastapproval?: Maybe<Scalars['timestamp']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
   release_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -8126,7 +8234,7 @@ export type Pf_Developmentstages_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_developmentstages" */
 export enum Pf_Developmentstages_Constraint {
-  /** unique or primary key constraint on columns "developmentstage_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "developmentstage_id" */
   PfDevelopmentstagesPkey = 'pf_developmentstages_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfDevelopmentstagesSlugStateCohortKey = 'pf_developmentstages_slug__state__cohort_key'
@@ -9251,7 +9359,7 @@ export type Pf_Phases_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_phases" */
 export enum Pf_Phases_Constraint {
-  /** unique or primary key constraint on columns "phase_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "phase_id" */
   PfPhasesPkey = 'pf_phases_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfPhasesSlugStateCohortKey = 'pf_phases_slug__state__cohort_key'
@@ -9550,6 +9658,10 @@ export type Pf_Subjects = {
   deprecated_fields?: Maybe<Scalars['jsonb']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes" */
+  programmes?: Maybe<Array<Programmes>>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   subject?: Maybe<Scalars['String']['output']>;
   subject_id: Scalars['Int']['output'];
@@ -9561,6 +9673,16 @@ export type Pf_Subjects = {
 /** columns and relationships of "pf_subjects" */
 export type Pf_SubjectsDeprecated_FieldsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "pf_subjects" */
+export type Pf_SubjectsProgrammesArgs = {
+  distinct_on?: InputMaybe<Array<Programmes_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmes_Order_By>>;
+  where?: InputMaybe<Programmes_Bool_Exp>;
 };
 
 /** aggregated selection of "pf_subjects" */
@@ -9603,6 +9725,8 @@ export type Pf_Subjects_Avg_Fields = {
   __typename?: 'pf_subjects_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9620,6 +9744,8 @@ export type Pf_Subjects_Bool_Exp = {
   deprecated_fields?: InputMaybe<Jsonb_Comparison_Exp>;
   description?: InputMaybe<String_Comparison_Exp>;
   display_order?: InputMaybe<Int_Comparison_Exp>;
+  programmes?: InputMaybe<Programmes_Bool_Exp>;
+  programmes_count?: InputMaybe<Int_Comparison_Exp>;
   slug?: InputMaybe<String_Comparison_Exp>;
   subject?: InputMaybe<String_Comparison_Exp>;
   subject_id?: InputMaybe<Int_Comparison_Exp>;
@@ -9684,6 +9810,8 @@ export type Pf_Subjects_Max_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   subject?: Maybe<Scalars['String']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
@@ -9700,6 +9828,8 @@ export type Pf_Subjects_Min_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   subject?: Maybe<Scalars['String']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
@@ -9733,6 +9863,8 @@ export type Pf_Subjects_Order_By = {
   deprecated_fields?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
   display_order?: InputMaybe<Order_By>;
+  programmes_aggregate?: InputMaybe<Programmes_Aggregate_Order_By>;
+  programmes_count?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   subject?: InputMaybe<Order_By>;
   subject_id?: InputMaybe<Order_By>;
@@ -9803,6 +9935,8 @@ export type Pf_Subjects_Stddev_Fields = {
   __typename?: 'pf_subjects_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9812,6 +9946,8 @@ export type Pf_Subjects_Stddev_Pop_Fields = {
   __typename?: 'pf_subjects_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9821,6 +9957,8 @@ export type Pf_Subjects_Stddev_Samp_Fields = {
   __typename?: 'pf_subjects_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9855,6 +9993,8 @@ export type Pf_Subjects_Sum_Fields = {
   __typename?: 'pf_subjects_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
   subject_parent_id?: Maybe<Scalars['Int']['output']>;
 };
@@ -9913,6 +10053,8 @@ export type Pf_Subjects_Var_Pop_Fields = {
   __typename?: 'pf_subjects_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9922,6 +10064,8 @@ export type Pf_Subjects_Var_Samp_Fields = {
   __typename?: 'pf_subjects_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9931,6 +10075,8 @@ export type Pf_Subjects_Variance_Fields = {
   __typename?: 'pf_subjects_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
+  /** A computed field, executes function "function__pf_subjects__programmes__count" */
+  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10022,7 +10168,7 @@ export type Pf_Tiers_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_tiers" */
 export enum Pf_Tiers_Constraint {
-  /** unique or primary key constraint on columns "tier_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "tier_id" */
   PfTiersPkey = 'pf_tiers_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfTiersSlugStateCohortKey = 'pf_tiers_slug__state__cohort_key'
@@ -10893,7 +11039,7 @@ export type Programme_Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "programme_threads" */
 export enum Programme_Threads_Constraint {
-  /** unique or primary key constraint on columns "_state", "thread_id", "programme_id" */
+  /** unique or primary key constraint on columns "thread_id", "_state", "programme_id" */
   ProgrammeThreadsPkey = 'programme_threads_pkey'
 }
 
@@ -14516,6 +14662,206 @@ export type Published_Mv_Downloads_4_0_0_Stream_Cursor_Value_Input = {
   unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0 = {
+  __typename?: 'published_mv_downloads_5_0_0';
+  downloads?: Maybe<Scalars['jsonb']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0DownloadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0_Aggregate = {
+  __typename?: 'published_mv_downloads_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Downloads_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Downloads_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_downloads_5_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Downloads_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Downloads_5_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_downloads_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Downloads_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Bool_Exp>>;
+  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonCohort?: InputMaybe<String_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Downloads_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_downloads_5_0_0_max_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Downloads_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_downloads_5_0_0_min_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_downloads_5_0_0". */
+export type Published_Mv_Downloads_5_0_0_Order_By = {
+  downloads?: InputMaybe<Order_By>;
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  hasDownloadableResources?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonCohort?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_downloads_5_0_0" */
+export enum Published_Mv_Downloads_5_0_0_Select_Column {
+  /** column name */
+  Downloads = 'downloads',
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasDownloadableResources = 'hasDownloadableResources',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonCohort = 'lessonCohort',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle'
+}
+
+/** Streaming cursor of the table "published_mv_downloads_5_0_0" */
+export type Published_Mv_Downloads_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Downloads_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Downloads_5_0_0_Stream_Cursor_Value_Input = {
+  downloads?: InputMaybe<Scalars['jsonb']['input']>;
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  expired?: InputMaybe<Scalars['Boolean']['input']>;
+  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonCohort?: InputMaybe<Scalars['String']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_homepage_3_0_1" */
 export type Published_Mv_Homepage_3_0_1 = {
   __typename?: 'published_mv_homepage_3_0_1';
@@ -15521,6 +15867,526 @@ export type Published_Mv_Lesson_Listing_4_0_0_Var_Samp_Fields = {
 /** aggregate variance on columns */
 export type Published_Mv_Lesson_Listing_4_0_0_Variance_Fields = {
   __typename?: 'published_mv_lesson_listing_4_0_0_variance_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0 = {
+  __typename?: 'published_mv_lesson_listing_5_0_0';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0_Aggregate = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Lesson_Listing_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_aggregate_fields';
+  avg?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Avg_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_avg_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_lesson_listing_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Lesson_Listing_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>>;
+  examboardSlug?: InputMaybe<String_Comparison_Exp>;
+  examboardTitle?: InputMaybe<String_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonsCount?: InputMaybe<Bigint_Comparison_Exp>;
+  optionality?: InputMaybe<String_Comparison_Exp>;
+  phaseSlug?: InputMaybe<String_Comparison_Exp>;
+  phaseTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+  yearTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_max_fields';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_min_fields';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_lesson_listing_5_0_0". */
+export type Published_Mv_Lesson_Listing_5_0_0_Order_By = {
+  examboardSlug?: InputMaybe<Order_By>;
+  examboardTitle?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  lessonsCount?: InputMaybe<Order_By>;
+  optionality?: InputMaybe<Order_By>;
+  phaseSlug?: InputMaybe<Order_By>;
+  phaseTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+  yearTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_lesson_listing_5_0_0" */
+export enum Published_Mv_Lesson_Listing_5_0_0_Select_Column {
+  /** column name */
+  ExamboardSlug = 'examboardSlug',
+  /** column name */
+  ExamboardTitle = 'examboardTitle',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  LessonsCount = 'lessonsCount',
+  /** column name */
+  Optionality = 'optionality',
+  /** column name */
+  PhaseSlug = 'phaseSlug',
+  /** column name */
+  PhaseTitle = 'phaseTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle',
+  /** column name */
+  YearTitle = 'yearTitle'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_pop_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_samp_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_lesson_listing_5_0_0" */
+export type Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Value_Input = {
+  examboardSlug?: InputMaybe<Scalars['String']['input']>;
+  examboardTitle?: InputMaybe<Scalars['String']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonsCount?: InputMaybe<Scalars['bigint']['input']>;
+  optionality?: InputMaybe<Scalars['String']['input']>;
+  phaseSlug?: InputMaybe<Scalars['String']['input']>;
+  phaseTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+  yearTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Sum_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_sum_fields';
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Var_Pop_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_var_pop_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Var_Samp_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_var_samp_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Lesson_Listing_5_0_0_Variance_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_0_variance_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1 = {
+  __typename?: 'published_mv_lesson_listing_5_0_1';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1_Aggregate = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_aggregate';
+  aggregate?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Lesson_Listing_5_0_1>;
+};
+
+/** aggregate fields of "published.mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1_Aggregate_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_aggregate_fields';
+  avg?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Max_Fields>;
+  min?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Lesson_Listing_5_0_1_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Avg_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_avg_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_lesson_listing_5_0_1". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Lesson_Listing_5_0_1_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>>;
+  examboardSlug?: InputMaybe<String_Comparison_Exp>;
+  examboardTitle?: InputMaybe<String_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonsCount?: InputMaybe<Bigint_Comparison_Exp>;
+  optionality?: InputMaybe<String_Comparison_Exp>;
+  phaseSlug?: InputMaybe<String_Comparison_Exp>;
+  phaseTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+  yearTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Max_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_max_fields';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Min_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_min_fields';
+  examboardSlug?: Maybe<Scalars['String']['output']>;
+  examboardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+  optionality?: Maybe<Scalars['String']['output']>;
+  phaseSlug?: Maybe<Scalars['String']['output']>;
+  phaseTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_lesson_listing_5_0_1". */
+export type Published_Mv_Lesson_Listing_5_0_1_Order_By = {
+  examboardSlug?: InputMaybe<Order_By>;
+  examboardTitle?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  lessonsCount?: InputMaybe<Order_By>;
+  optionality?: InputMaybe<Order_By>;
+  phaseSlug?: InputMaybe<Order_By>;
+  phaseTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+  yearTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_lesson_listing_5_0_1" */
+export enum Published_Mv_Lesson_Listing_5_0_1_Select_Column {
+  /** column name */
+  ExamboardSlug = 'examboardSlug',
+  /** column name */
+  ExamboardTitle = 'examboardTitle',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  LessonsCount = 'lessonsCount',
+  /** column name */
+  Optionality = 'optionality',
+  /** column name */
+  PhaseSlug = 'phaseSlug',
+  /** column name */
+  PhaseTitle = 'phaseTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle',
+  /** column name */
+  YearTitle = 'yearTitle'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Stddev_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_stddev_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_stddev_pop_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_stddev_samp_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_lesson_listing_5_0_1" */
+export type Published_Mv_Lesson_Listing_5_0_1_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Lesson_Listing_5_0_1_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Lesson_Listing_5_0_1_Stream_Cursor_Value_Input = {
+  examboardSlug?: InputMaybe<Scalars['String']['input']>;
+  examboardTitle?: InputMaybe<Scalars['String']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonsCount?: InputMaybe<Scalars['bigint']['input']>;
+  optionality?: InputMaybe<Scalars['String']['input']>;
+  phaseSlug?: InputMaybe<Scalars['String']['input']>;
+  phaseTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+  yearTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Sum_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_sum_fields';
+  lessonsCount?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Var_Pop_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_var_pop_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Var_Samp_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_var_samp_fields';
+  lessonsCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Lesson_Listing_5_0_1_Variance_Fields = {
+  __typename?: 'published_mv_lesson_listing_5_0_1_variance_fields';
   lessonsCount?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -20712,6 +21578,530 @@ export type Published_Mv_Lesson_Overview_4_0_0_Variance_Fields = {
   unitVariantId?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0 = {
+  __typename?: 'published_mv_lesson_overview_5_0_0';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
+  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
+  isLegacy?: Maybe<Scalars['Boolean']['output']>;
+  isWorksheetLandscape?: Maybe<Scalars['Boolean']['output']>;
+  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  teacherTips?: Maybe<Scalars['jsonb']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0ContentGuidanceArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0CopyrightContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0ExitQuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0KeyLearningPointsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0LessonEquipmentAndResourcesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0LessonKeywordsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0MisconceptionsAndCommonMistakesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0StarterQuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0TeacherTipsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0_Aggregate = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Lesson_Overview_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_aggregate_fields';
+  avg?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Lesson_Overview_5_0_0_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Avg_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_avg_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_lesson_overview_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Lesson_Overview_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>>;
+  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
+  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
+  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
+  isWorksheetLandscape?: InputMaybe<Boolean_Comparison_Exp>;
+  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonCohort?: InputMaybe<String_Comparison_Exp>;
+  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonId?: InputMaybe<Int_Comparison_Exp>;
+  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
+  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
+  presentationUrl?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
+  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
+  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
+  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
+  videoTitle?: InputMaybe<String_Comparison_Exp>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
+  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
+  yearSlug?: InputMaybe<String_Comparison_Exp>;
+  yearTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_max_fields';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_min_fields';
+  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  presentationUrl?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  supervisionLevel?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  transcriptSentences?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  videoTitle?: Maybe<Scalars['String']['output']>;
+  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
+  worksheetUrl?: Maybe<Scalars['String']['output']>;
+  yearSlug?: Maybe<Scalars['String']['output']>;
+  yearTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_lesson_overview_5_0_0". */
+export type Published_Mv_Lesson_Overview_5_0_0_Order_By = {
+  additionalMaterialUrl?: InputMaybe<Order_By>;
+  contentGuidance?: InputMaybe<Order_By>;
+  copyrightContent?: InputMaybe<Order_By>;
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  exitQuiz?: InputMaybe<Order_By>;
+  exitQuizId?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  hasDownloadableResources?: InputMaybe<Order_By>;
+  isLegacy?: InputMaybe<Order_By>;
+  isWorksheetLandscape?: InputMaybe<Order_By>;
+  keyLearningPoints?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonCohort?: InputMaybe<Order_By>;
+  lessonEquipmentAndResources?: InputMaybe<Order_By>;
+  lessonId?: InputMaybe<Order_By>;
+  lessonKeywords?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
+  nullUnitVariantId?: InputMaybe<Order_By>;
+  presentationUrl?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  pupilLessonOutcome?: InputMaybe<Order_By>;
+  starterQuiz?: InputMaybe<Order_By>;
+  starterQuizId?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  supervisionLevel?: InputMaybe<Order_By>;
+  teacherTips?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  transcriptSentences?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+  unitVariantId?: InputMaybe<Order_By>;
+  videoMuxPlaybackId?: InputMaybe<Order_By>;
+  videoTitle?: InputMaybe<Order_By>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
+  worksheetUrl?: InputMaybe<Order_By>;
+  yearSlug?: InputMaybe<Order_By>;
+  yearTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_lesson_overview_5_0_0" */
+export enum Published_Mv_Lesson_Overview_5_0_0_Select_Column {
+  /** column name */
+  AdditionalMaterialUrl = 'additionalMaterialUrl',
+  /** column name */
+  ContentGuidance = 'contentGuidance',
+  /** column name */
+  CopyrightContent = 'copyrightContent',
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  ExitQuiz = 'exitQuiz',
+  /** column name */
+  ExitQuizId = 'exitQuizId',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasDownloadableResources = 'hasDownloadableResources',
+  /** column name */
+  IsLegacy = 'isLegacy',
+  /** column name */
+  IsWorksheetLandscape = 'isWorksheetLandscape',
+  /** column name */
+  KeyLearningPoints = 'keyLearningPoints',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonCohort = 'lessonCohort',
+  /** column name */
+  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
+  /** column name */
+  LessonId = 'lessonId',
+  /** column name */
+  LessonKeywords = 'lessonKeywords',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
+  /** column name */
+  NullUnitVariantId = 'nullUnitVariantId',
+  /** column name */
+  PresentationUrl = 'presentationUrl',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  PupilLessonOutcome = 'pupilLessonOutcome',
+  /** column name */
+  StarterQuiz = 'starterQuiz',
+  /** column name */
+  StarterQuizId = 'starterQuizId',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  SupervisionLevel = 'supervisionLevel',
+  /** column name */
+  TeacherTips = 'teacherTips',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  TranscriptSentences = 'transcriptSentences',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle',
+  /** column name */
+  UnitVariantId = 'unitVariantId',
+  /** column name */
+  VideoMuxPlaybackId = 'videoMuxPlaybackId',
+  /** column name */
+  VideoTitle = 'videoTitle',
+  /** column name */
+  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
+  /** column name */
+  WorksheetUrl = 'worksheetUrl',
+  /** column name */
+  YearSlug = 'yearSlug',
+  /** column name */
+  YearTitle = 'yearTitle'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Stddev_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_stddev_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_stddev_pop_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_stddev_samp_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_lesson_overview_5_0_0" */
+export type Published_Mv_Lesson_Overview_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Lesson_Overview_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Lesson_Overview_5_0_0_Stream_Cursor_Value_Input = {
+  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
+  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
+  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
+  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
+  expired?: InputMaybe<Scalars['Boolean']['input']>;
+  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
+  isWorksheetLandscape?: InputMaybe<Scalars['Boolean']['input']>;
+  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonCohort?: InputMaybe<Scalars['String']['input']>;
+  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonId?: InputMaybe<Scalars['Int']['input']>;
+  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
+  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
+  presentationUrl?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
+  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
+  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
+  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
+  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
+  videoTitle?: InputMaybe<Scalars['String']['input']>;
+  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
+  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
+  yearSlug?: InputMaybe<Scalars['String']['input']>;
+  yearTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Sum_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_sum_fields';
+  exitQuizId?: Maybe<Scalars['Int']['output']>;
+  lessonId?: Maybe<Scalars['Int']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
+  starterQuizId?: Maybe<Scalars['Int']['output']>;
+  unitVariantId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Var_Pop_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_var_pop_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Var_Samp_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_var_samp_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Lesson_Overview_5_0_0_Variance_Fields = {
+  __typename?: 'published_mv_lesson_overview_5_0_0_variance_fields';
+  exitQuizId?: Maybe<Scalars['Float']['output']>;
+  lessonId?: Maybe<Scalars['Float']['output']>;
+  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
+  starterQuizId?: Maybe<Scalars['Float']['output']>;
+  unitVariantId?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_programme_listing_3_0_0" */
 export type Published_Mv_Programme_Listing_3_0_0 = {
   __typename?: 'published_mv_programme_listing_3_0_0';
@@ -20933,6 +22323,128 @@ export type Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Value_Input = {
+  baseSlug?: InputMaybe<Scalars['String']['input']>;
+  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  programmes?: InputMaybe<Scalars['jsonb']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** columns and relationships of "published.mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0 = {
+  __typename?: 'published_mv_programme_listing_5_0_0';
+  baseSlug?: Maybe<Scalars['String']['output']>;
+  isLegacy?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  programmes?: Maybe<Scalars['jsonb']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0ProgrammesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0_Aggregate = {
+  __typename?: 'published_mv_programme_listing_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Programme_Listing_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Programme_Listing_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_programme_listing_5_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Programme_Listing_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Programme_Listing_5_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_programme_listing_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Programme_Listing_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>>;
+  baseSlug?: InputMaybe<String_Comparison_Exp>;
+  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  programmes?: InputMaybe<Jsonb_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Programme_Listing_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_programme_listing_5_0_0_max_fields';
+  baseSlug?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Programme_Listing_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_programme_listing_5_0_0_min_fields';
+  baseSlug?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_programme_listing_5_0_0". */
+export type Published_Mv_Programme_Listing_5_0_0_Order_By = {
+  baseSlug?: InputMaybe<Order_By>;
+  isLegacy?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  programmes?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_programme_listing_5_0_0" */
+export enum Published_Mv_Programme_Listing_5_0_0_Select_Column {
+  /** column name */
+  BaseSlug = 'baseSlug',
+  /** column name */
+  IsLegacy = 'isLegacy',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  Programmes = 'programmes',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle'
+}
+
+/** Streaming cursor of the table "published_mv_programme_listing_5_0_0" */
+export type Published_Mv_Programme_Listing_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Programme_Listing_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Programme_Listing_5_0_0_Stream_Cursor_Value_Input = {
   baseSlug?: InputMaybe<Scalars['String']['input']>;
   isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
   keyStageSlug?: InputMaybe<Scalars['String']['input']>;
@@ -22124,6 +23636,206 @@ export type Published_Mv_Share_4_0_0_Stream_Cursor_Value_Input = {
   unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0 = {
+  __typename?: 'published_mv_share_5_0_0';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  expired?: Maybe<Scalars['Boolean']['output']>;
+  hasShareableResources?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  shareableResources?: Maybe<Scalars['jsonb']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0ShareableResourcesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0_Aggregate = {
+  __typename?: 'published_mv_share_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Share_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Share_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_share_5_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Share_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Share_5_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Share_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_share_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Share_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Share_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Share_5_0_0_Bool_Exp>>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  expired?: InputMaybe<Boolean_Comparison_Exp>;
+  hasShareableResources?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  lessonCohort?: InputMaybe<String_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  shareableResources?: InputMaybe<Jsonb_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tierTitle?: InputMaybe<String_Comparison_Exp>;
+  unitSlug?: InputMaybe<String_Comparison_Exp>;
+  unitTitle?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Share_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_share_5_0_0_max_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Share_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_share_5_0_0_min_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  lessonCohort?: Maybe<Scalars['String']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tierTitle?: Maybe<Scalars['String']['output']>;
+  unitSlug?: Maybe<Scalars['String']['output']>;
+  unitTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_share_5_0_0". */
+export type Published_Mv_Share_5_0_0_Order_By = {
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  expired?: InputMaybe<Order_By>;
+  hasShareableResources?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  lessonCohort?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  shareableResources?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tierTitle?: InputMaybe<Order_By>;
+  unitSlug?: InputMaybe<Order_By>;
+  unitTitle?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_share_5_0_0" */
+export enum Published_Mv_Share_5_0_0_Select_Column {
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  Expired = 'expired',
+  /** column name */
+  HasShareableResources = 'hasShareableResources',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LessonCohort = 'lessonCohort',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  ShareableResources = 'shareableResources',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  TierTitle = 'tierTitle',
+  /** column name */
+  UnitSlug = 'unitSlug',
+  /** column name */
+  UnitTitle = 'unitTitle'
+}
+
+/** Streaming cursor of the table "published_mv_share_5_0_0" */
+export type Published_Mv_Share_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Share_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Share_5_0_0_Stream_Cursor_Value_Input = {
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  expired?: InputMaybe<Scalars['Boolean']['input']>;
+  hasShareableResources?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  lessonCohort?: InputMaybe<Scalars['String']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  shareableResources?: InputMaybe<Scalars['jsonb']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tierTitle?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  unitTitle?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_specialist_1_0_0" */
 export type Published_Mv_Specialist_1_0_0 = {
   __typename?: 'published_mv_specialist_1_0_0';
@@ -23024,6 +24736,124 @@ export type Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Value_Input = {
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  keyStages?: InputMaybe<Scalars['jsonb']['input']>;
+  subjects?: InputMaybe<Scalars['jsonb']['input']>;
+  subjectsUnavailable?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** columns and relationships of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0 = {
+  __typename?: 'published_mv_subject_listing_5_0_0';
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  keyStages?: Maybe<Scalars['jsonb']['output']>;
+  subjects?: Maybe<Scalars['jsonb']['output']>;
+  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0KeyStagesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0SubjectsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0_Aggregate = {
+  __typename?: 'published_mv_subject_listing_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Subject_Listing_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Subject_Listing_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_subject_listing_5_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Subject_Listing_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Subject_Listing_5_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_subject_listing_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Subject_Listing_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  keyStages?: InputMaybe<Jsonb_Comparison_Exp>;
+  subjects?: InputMaybe<Jsonb_Comparison_Exp>;
+  subjectsUnavailable?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Subject_Listing_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_subject_listing_5_0_0_max_fields';
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Subject_Listing_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_subject_listing_5_0_0_min_fields';
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_subject_listing_5_0_0". */
+export type Published_Mv_Subject_Listing_5_0_0_Order_By = {
+  is_legacy?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  keyStages?: InputMaybe<Order_By>;
+  subjects?: InputMaybe<Order_By>;
+  subjectsUnavailable?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_subject_listing_5_0_0" */
+export enum Published_Mv_Subject_Listing_5_0_0_Select_Column {
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  KeyStages = 'keyStages',
+  /** column name */
+  Subjects = 'subjects',
+  /** column name */
+  SubjectsUnavailable = 'subjectsUnavailable'
+}
+
+/** Streaming cursor of the table "published_mv_subject_listing_5_0_0" */
+export type Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Value_Input = {
   is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
   keyStageSlug?: InputMaybe<Scalars['String']['input']>;
   keyStageTitle?: InputMaybe<Scalars['String']['input']>;
@@ -24070,6 +25900,240 @@ export type Published_Mv_Unit_Listing_Page_4_0_0_Variance_Fields = {
   unitCount?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0 = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  isLegacy?: Maybe<Scalars['Boolean']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  learningThemes?: Maybe<Scalars['jsonb']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  tiers?: Maybe<Scalars['jsonb']['output']>;
+  unitCount?: Maybe<Scalars['bigint']['output']>;
+  units?: Maybe<Scalars['jsonb']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0LearningThemesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0TiersArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0UnitsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
+};
+
+/** aggregate fields of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_aggregate_fields';
+  avg?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Avg_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_avg_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_unit_listing_page_5_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>>;
+  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
+  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
+  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
+  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
+  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
+  learningThemes?: InputMaybe<Jsonb_Comparison_Exp>;
+  programmeSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectSlug?: InputMaybe<String_Comparison_Exp>;
+  subjectTitle?: InputMaybe<String_Comparison_Exp>;
+  tierSlug?: InputMaybe<String_Comparison_Exp>;
+  tiers?: InputMaybe<Jsonb_Comparison_Exp>;
+  unitCount?: InputMaybe<Bigint_Comparison_Exp>;
+  units?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Max_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_max_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  unitCount?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Min_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_min_fields';
+  examBoardSlug?: Maybe<Scalars['String']['output']>;
+  examBoardTitle?: Maybe<Scalars['String']['output']>;
+  keyStageSlug?: Maybe<Scalars['String']['output']>;
+  keyStageTitle?: Maybe<Scalars['String']['output']>;
+  programmeSlug?: Maybe<Scalars['String']['output']>;
+  subjectSlug?: Maybe<Scalars['String']['output']>;
+  subjectTitle?: Maybe<Scalars['String']['output']>;
+  tierSlug?: Maybe<Scalars['String']['output']>;
+  unitCount?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_unit_listing_page_5_0_0". */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Order_By = {
+  examBoardSlug?: InputMaybe<Order_By>;
+  examBoardTitle?: InputMaybe<Order_By>;
+  isLegacy?: InputMaybe<Order_By>;
+  keyStageSlug?: InputMaybe<Order_By>;
+  keyStageTitle?: InputMaybe<Order_By>;
+  learningThemes?: InputMaybe<Order_By>;
+  programmeSlug?: InputMaybe<Order_By>;
+  subjectSlug?: InputMaybe<Order_By>;
+  subjectTitle?: InputMaybe<Order_By>;
+  tierSlug?: InputMaybe<Order_By>;
+  tiers?: InputMaybe<Order_By>;
+  unitCount?: InputMaybe<Order_By>;
+  units?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_unit_listing_page_5_0_0" */
+export enum Published_Mv_Unit_Listing_Page_5_0_0_Select_Column {
+  /** column name */
+  ExamBoardSlug = 'examBoardSlug',
+  /** column name */
+  ExamBoardTitle = 'examBoardTitle',
+  /** column name */
+  IsLegacy = 'isLegacy',
+  /** column name */
+  KeyStageSlug = 'keyStageSlug',
+  /** column name */
+  KeyStageTitle = 'keyStageTitle',
+  /** column name */
+  LearningThemes = 'learningThemes',
+  /** column name */
+  ProgrammeSlug = 'programmeSlug',
+  /** column name */
+  SubjectSlug = 'subjectSlug',
+  /** column name */
+  SubjectTitle = 'subjectTitle',
+  /** column name */
+  TierSlug = 'tierSlug',
+  /** column name */
+  Tiers = 'tiers',
+  /** column name */
+  UnitCount = 'unitCount',
+  /** column name */
+  Units = 'units'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_pop_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_samp_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_unit_listing_page_5_0_0" */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Value_Input = {
+  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
+  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
+  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
+  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
+  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
+  learningThemes?: InputMaybe<Scalars['jsonb']['input']>;
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
+  tierSlug?: InputMaybe<Scalars['String']['input']>;
+  tiers?: InputMaybe<Scalars['jsonb']['input']>;
+  unitCount?: InputMaybe<Scalars['bigint']['input']>;
+  units?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Sum_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_sum_fields';
+  unitCount?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Var_Pop_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_var_pop_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Var_Samp_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_var_samp_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Unit_Listing_Page_5_0_0_Variance_Fields = {
+  __typename?: 'published_mv_unit_listing_page_5_0_0_variance_fields';
+  unitCount?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.view_keystages_1_0_0" */
 export type Published_View_Keystages_1_0_0 = {
   __typename?: 'published_view_keystages_1_0_0';
@@ -24621,6 +26685,102 @@ export type Published_View_Synthetic_Programmes_4_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_View_Synthetic_Programmes_4_Stream_Cursor_Value_Input = {
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  synthetic_programme_slug?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** columns and relationships of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5 = {
+  __typename?: 'published_view_synthetic_programmes_5';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['jsonb']['output']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5Synthetic_Programme_SlugArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5_Aggregate = {
+  __typename?: 'published_view_synthetic_programmes_5_aggregate';
+  aggregate?: Maybe<Published_View_Synthetic_Programmes_5_Aggregate_Fields>;
+  nodes: Array<Published_View_Synthetic_Programmes_5>;
+};
+
+/** aggregate fields of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5_Aggregate_Fields = {
+  __typename?: 'published_view_synthetic_programmes_5_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Synthetic_Programmes_5_Max_Fields>;
+  min?: Maybe<Published_View_Synthetic_Programmes_5_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_synthetic_programmes_5". All fields are combined with a logical 'AND'. */
+export type Published_View_Synthetic_Programmes_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Bool_Exp>>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  synthetic_programme_slug?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Synthetic_Programmes_5_Max_Fields = {
+  __typename?: 'published_view_synthetic_programmes_5_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Synthetic_Programmes_5_Min_Fields = {
+  __typename?: 'published_view_synthetic_programmes_5_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_synthetic_programmes_5". */
+export type Published_View_Synthetic_Programmes_5_Order_By = {
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  synthetic_programme_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_synthetic_programmes_5" */
+export enum Published_View_Synthetic_Programmes_5_Select_Column {
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  SyntheticProgrammeSlug = 'synthetic_programme_slug'
+}
+
+/** Streaming cursor of the table "published_view_synthetic_programmes_5" */
+export type Published_View_Synthetic_Programmes_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Synthetic_Programmes_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Synthetic_Programmes_5_Stream_Cursor_Value_Input = {
   base_slug?: InputMaybe<Scalars['String']['input']>;
   combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
   synthetic_programme_slug?: InputMaybe<Scalars['jsonb']['input']>;
@@ -25440,6 +27600,252 @@ export type Published_View_Synthetic_Unitvariant_Lessons_4_Variance_Fields = {
   uv_lessons_count?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5 = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  is_published?: Maybe<Scalars['Boolean']['output']>;
+  lesson_data?: Maybe<Scalars['jsonb']['output']>;
+  null_unitvariant?: Maybe<Scalars['jsonb']['output']>;
+  programme_ids?: Maybe<Scalars['jsonb']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+  uv_lessons_count?: Maybe<Scalars['bigint']['output']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Lesson_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Null_UnitvariantArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Programme_IdsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_aggregate';
+  aggregate?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate_Fields>;
+  nodes: Array<Published_View_Synthetic_Unitvariant_Lessons_5>;
+};
+
+/** aggregate fields of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_aggregate_fields';
+  avg?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Max_Fields>;
+  min?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Min_Fields>;
+  stddev?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Synthetic_Unitvariant_Lessons_5_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Avg_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_avg_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_synthetic_unitvariant_lessons_5". All fields are combined with a logical 'AND'. */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_published?: InputMaybe<Boolean_Comparison_Exp>;
+  lesson_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  null_unitvariant?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_ids?: InputMaybe<Jsonb_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  synthetic_programme_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unitvariant_id?: InputMaybe<Int_Comparison_Exp>;
+  uv_lessons_count?: InputMaybe<Bigint_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Max_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+  uv_lessons_count?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Min_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+  uv_lessons_count?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_synthetic_unitvariant_lessons_5". */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Order_By = {
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  is_published?: InputMaybe<Order_By>;
+  lesson_data?: InputMaybe<Order_By>;
+  null_unitvariant?: InputMaybe<Order_By>;
+  programme_ids?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  synthetic_programme_slug?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unitvariant_id?: InputMaybe<Order_By>;
+  uv_lessons_count?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_synthetic_unitvariant_lessons_5" */
+export enum Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column {
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  IsPublished = 'is_published',
+  /** column name */
+  LessonData = 'lesson_data',
+  /** column name */
+  NullUnitvariant = 'null_unitvariant',
+  /** column name */
+  ProgrammeIds = 'programme_ids',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  SyntheticProgrammeSlug = 'synthetic_programme_slug',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitvariantId = 'unitvariant_id',
+  /** column name */
+  UvLessonsCount = 'uv_lessons_count'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_stddev_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_stddev_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Stddev_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_stddev_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_synthetic_unitvariant_lessons_5" */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Synthetic_Unitvariant_Lessons_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Stream_Cursor_Value_Input = {
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  is_published?: InputMaybe<Scalars['Boolean']['input']>;
+  lesson_data?: InputMaybe<Scalars['jsonb']['input']>;
+  null_unitvariant?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  synthetic_programme_slug?: InputMaybe<Scalars['String']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_slug?: InputMaybe<Scalars['String']['input']>;
+  unitvariant_id?: InputMaybe<Scalars['Int']['input']>;
+  uv_lessons_count?: InputMaybe<Scalars['bigint']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Sum_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_sum_fields';
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+  uv_lessons_count?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Var_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_var_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Var_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_var_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Synthetic_Unitvariant_Lessons_5_Variance_Fields = {
+  __typename?: 'published_view_synthetic_unitvariant_lessons_5_variance_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+  uv_lessons_count?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.view_synthetic_unitvariants_2" */
 export type Published_View_Synthetic_Unitvariants_2 = {
   __typename?: 'published_view_synthetic_unitvariants_2';
@@ -26097,6 +28503,230 @@ export type Published_View_Synthetic_Unitvariants_4_Var_Samp_Fields = {
 /** aggregate variance on columns */
 export type Published_View_Synthetic_Unitvariants_4_Variance_Fields = {
   __typename?: 'published_view_synthetic_unitvariants_4_variance_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5 = {
+  __typename?: 'published_view_synthetic_unitvariants_5';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  is_published?: Maybe<Scalars['Boolean']['output']>;
+  null_unitvariant?: Maybe<Scalars['jsonb']['output']>;
+  programme_ids?: Maybe<Scalars['jsonb']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5Null_UnitvariantArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5Programme_IdsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5_Aggregate = {
+  __typename?: 'published_view_synthetic_unitvariants_5_aggregate';
+  aggregate?: Maybe<Published_View_Synthetic_Unitvariants_5_Aggregate_Fields>;
+  nodes: Array<Published_View_Synthetic_Unitvariants_5>;
+};
+
+/** aggregate fields of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5_Aggregate_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_aggregate_fields';
+  avg?: Maybe<Published_View_Synthetic_Unitvariants_5_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Synthetic_Unitvariants_5_Max_Fields>;
+  min?: Maybe<Published_View_Synthetic_Unitvariants_5_Min_Fields>;
+  stddev?: Maybe<Published_View_Synthetic_Unitvariants_5_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Synthetic_Unitvariants_5_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Synthetic_Unitvariants_5_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Synthetic_Unitvariants_5_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Synthetic_Unitvariants_5_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Synthetic_Unitvariants_5_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Synthetic_Unitvariants_5_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Synthetic_Unitvariants_5_Avg_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_avg_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_synthetic_unitvariants_5". All fields are combined with a logical 'AND'. */
+export type Published_View_Synthetic_Unitvariants_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Bool_Exp>>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  is_published?: InputMaybe<Boolean_Comparison_Exp>;
+  null_unitvariant?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_ids?: InputMaybe<Jsonb_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  synthetic_programme_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unitvariant_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Synthetic_Unitvariants_5_Max_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Synthetic_Unitvariants_5_Min_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_synthetic_unitvariants_5". */
+export type Published_View_Synthetic_Unitvariants_5_Order_By = {
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  is_legacy?: InputMaybe<Order_By>;
+  is_published?: InputMaybe<Order_By>;
+  null_unitvariant?: InputMaybe<Order_By>;
+  programme_ids?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  synthetic_programme_slug?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unitvariant_id?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_synthetic_unitvariants_5" */
+export enum Published_View_Synthetic_Unitvariants_5_Select_Column {
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  IsPublished = 'is_published',
+  /** column name */
+  NullUnitvariant = 'null_unitvariant',
+  /** column name */
+  ProgrammeIds = 'programme_ids',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  SyntheticProgrammeSlug = 'synthetic_programme_slug',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitvariantId = 'unitvariant_id'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Synthetic_Unitvariants_5_Stddev_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_stddev_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Synthetic_Unitvariants_5_Stddev_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_stddev_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Synthetic_Unitvariants_5_Stddev_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_stddev_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_synthetic_unitvariants_5" */
+export type Published_View_Synthetic_Unitvariants_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Synthetic_Unitvariants_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Synthetic_Unitvariants_5_Stream_Cursor_Value_Input = {
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  is_published?: InputMaybe<Scalars['Boolean']['input']>;
+  null_unitvariant?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  synthetic_programme_slug?: InputMaybe<Scalars['String']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_slug?: InputMaybe<Scalars['String']['input']>;
+  unitvariant_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Synthetic_Unitvariants_5_Sum_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_sum_fields';
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Synthetic_Unitvariants_5_Var_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_var_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Synthetic_Unitvariants_5_Var_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_var_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Synthetic_Unitvariants_5_Variance_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_5_variance_fields';
   unitvariant_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -26763,6 +29393,228 @@ export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4_Var_Samp_Fie
 /** aggregate variance on columns */
 export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4_Variance_Fields = {
   __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_4_variance_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5 = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5';
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  is_published?: Maybe<Scalars['Boolean']['output']>;
+  lesson_count?: Maybe<Scalars['bigint']['output']>;
+  lesson_ids?: Maybe<Scalars['jsonb']['output']>;
+  null_unitvariant?: Maybe<Scalars['jsonb']['output']>;
+  programme_ids?: Maybe<Scalars['jsonb']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Lesson_IdsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Null_UnitvariantArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Programme_IdsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_aggregate';
+  aggregate?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate_Fields>;
+  nodes: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5>;
+};
+
+/** aggregate fields of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_aggregate_fields';
+  avg?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Max_Fields>;
+  min?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Min_Fields>;
+  stddev?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Avg_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_avg_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_synthetic_unitvariants_with_lesson_ids_5". All fields are combined with a logical 'AND'. */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_published?: InputMaybe<Boolean_Comparison_Exp>;
+  lesson_count?: InputMaybe<Bigint_Comparison_Exp>;
+  lesson_ids?: InputMaybe<Jsonb_Comparison_Exp>;
+  null_unitvariant?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_ids?: InputMaybe<Jsonb_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  synthetic_programme_slug?: InputMaybe<String_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Max_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_max_fields';
+  lesson_count?: Maybe<Scalars['bigint']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Min_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_min_fields';
+  lesson_count?: Maybe<Scalars['bigint']['output']>;
+  synthetic_programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_synthetic_unitvariants_with_lesson_ids_5". */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Order_By = {
+  combined_programme_fields?: InputMaybe<Order_By>;
+  is_published?: InputMaybe<Order_By>;
+  lesson_count?: InputMaybe<Order_By>;
+  lesson_ids?: InputMaybe<Order_By>;
+  null_unitvariant?: InputMaybe<Order_By>;
+  programme_ids?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  synthetic_programme_slug?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+export enum Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column {
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  IsPublished = 'is_published',
+  /** column name */
+  LessonCount = 'lesson_count',
+  /** column name */
+  LessonIds = 'lesson_ids',
+  /** column name */
+  NullUnitvariant = 'null_unitvariant',
+  /** column name */
+  ProgrammeIds = 'programme_ids',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  SyntheticProgrammeSlug = 'synthetic_programme_slug',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitSlug = 'unit_slug'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_stddev_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_stddev_pop_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stddev_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_stddev_samp_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_synthetic_unitvariants_with_lesson_ids_5" */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stream_Cursor_Value_Input = {
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  is_published?: InputMaybe<Scalars['Boolean']['input']>;
+  lesson_count?: InputMaybe<Scalars['bigint']['input']>;
+  lesson_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  null_unitvariant?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  synthetic_programme_slug?: InputMaybe<Scalars['String']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Sum_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_sum_fields';
+  lesson_count?: Maybe<Scalars['bigint']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Var_Pop_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_var_pop_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Var_Samp_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_var_samp_fields';
+  lesson_count?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Variance_Fields = {
+  __typename?: 'published_view_synthetic_unitvariants_with_lesson_ids_5_variance_fields';
   lesson_count?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -27511,6 +30363,260 @@ export type Published_View_Unit_Unitvariant_Programmes_4_Var_Samp_Fields = {
 /** aggregate variance on columns */
 export type Published_View_Unit_Unitvariant_Programmes_4_Variance_Fields = {
   __typename?: 'published_view_unit_unitvariant_programmes_4_variance_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5 = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  combined_programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  programme_fields_p?: Maybe<Scalars['jsonb']['output']>;
+  programme_fields_uv?: Maybe<Scalars['jsonb']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_overrides?: Maybe<Scalars['jsonb']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Combined_Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Programme_Fields_PArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Programme_Fields_UvArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5Unit_OverridesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5_Aggregate = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_aggregate';
+  aggregate?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Aggregate_Fields>;
+  nodes: Array<Published_View_Unit_Unitvariant_Programmes_5>;
+};
+
+/** aggregate fields of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5_Aggregate_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_aggregate_fields';
+  avg?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Max_Fields>;
+  min?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Min_Fields>;
+  stddev?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Unit_Unitvariant_Programmes_5_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Avg_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_avg_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_unit_unitvariant_programmes_5". All fields are combined with a logical 'AND'. */
+export type Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>>;
+  _state_uv?: InputMaybe<String_Comparison_Exp>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  combined_programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  programme_fields_p?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_fields_uv?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_id?: InputMaybe<Int_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_overrides?: InputMaybe<Jsonb_Comparison_Exp>;
+  unitvariant_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Max_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_max_fields';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Min_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_min_fields';
+  _state_uv?: Maybe<Scalars['String']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_unit_unitvariant_programmes_5". */
+export type Published_View_Unit_Unitvariant_Programmes_5_Order_By = {
+  _state_uv?: InputMaybe<Order_By>;
+  base_slug?: InputMaybe<Order_By>;
+  combined_programme_fields?: InputMaybe<Order_By>;
+  is_legacy?: InputMaybe<Order_By>;
+  programme_fields_p?: InputMaybe<Order_By>;
+  programme_fields_uv?: InputMaybe<Order_By>;
+  programme_id?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_overrides?: InputMaybe<Order_By>;
+  unitvariant_id?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_unit_unitvariant_programmes_5" */
+export enum Published_View_Unit_Unitvariant_Programmes_5_Select_Column {
+  /** column name */
+  StateUv = '_state_uv',
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  CombinedProgrammeFields = 'combined_programme_fields',
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  ProgrammeFieldsP = 'programme_fields_p',
+  /** column name */
+  ProgrammeFieldsUv = 'programme_fields_uv',
+  /** column name */
+  ProgrammeId = 'programme_id',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOverrides = 'unit_overrides',
+  /** column name */
+  UnitvariantId = 'unitvariant_id'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Stddev_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_stddev_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Stddev_Pop_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_stddev_pop_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Stddev_Samp_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_stddev_samp_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_unit_unitvariant_programmes_5" */
+export type Published_View_Unit_Unitvariant_Programmes_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Unit_Unitvariant_Programmes_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Unit_Unitvariant_Programmes_5_Stream_Cursor_Value_Input = {
+  _state_uv?: InputMaybe<Scalars['String']['input']>;
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  combined_programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  programme_fields_p?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields_uv?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_id?: InputMaybe<Scalars['Int']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_overrides?: InputMaybe<Scalars['jsonb']['input']>;
+  unitvariant_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Sum_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_sum_fields';
+  programme_id?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Var_Pop_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_var_pop_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Var_Samp_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_var_samp_fields';
+  programme_id?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Unit_Unitvariant_Programmes_5_Variance_Fields = {
+  __typename?: 'published_view_unit_unitvariant_programmes_5_variance_fields';
   programme_id?: Maybe<Scalars['Float']['output']>;
   unit_id?: Maybe<Scalars['Float']['output']>;
   unitvariant_id?: Maybe<Scalars['Float']['output']>;
@@ -28268,6 +31374,10 @@ export type Query_Root = {
   published_mv_downloads_4_0_0: Array<Published_Mv_Downloads_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_downloads_4_0_0" */
   published_mv_downloads_4_0_0_aggregate: Published_Mv_Downloads_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_downloads_5_0_0" */
+  published_mv_downloads_5_0_0: Array<Published_Mv_Downloads_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_0" */
+  published_mv_downloads_5_0_0_aggregate: Published_Mv_Downloads_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_homepage_3_0_1" */
   published_mv_homepage_3_0_1: Array<Published_Mv_Homepage_3_0_1>;
   /** fetch aggregated fields from the table: "published.mv_homepage_3_0_1" */
@@ -28288,6 +31398,14 @@ export type Query_Root = {
   published_mv_lesson_listing_4_0_0: Array<Published_Mv_Lesson_Listing_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_listing_4_0_0" */
   published_mv_lesson_listing_4_0_0_aggregate: Published_Mv_Lesson_Listing_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_lesson_listing_5_0_0" */
+  published_mv_lesson_listing_5_0_0: Array<Published_Mv_Lesson_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_0" */
+  published_mv_lesson_listing_5_0_0_aggregate: Published_Mv_Lesson_Listing_5_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_lesson_listing_5_0_1" */
+  published_mv_lesson_listing_5_0_1: Array<Published_Mv_Lesson_Listing_5_0_1>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_1" */
+  published_mv_lesson_listing_5_0_1_aggregate: Published_Mv_Lesson_Listing_5_0_1_Aggregate;
   /** fetch data from the table: "published.mv_lesson_openapi_1_0_0" */
   published_mv_lesson_openapi_1_0_0: Array<Published_Mv_Lesson_Openapi_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_openapi_1_0_0" */
@@ -28328,6 +31446,10 @@ export type Query_Root = {
   published_mv_lesson_overview_4_0_0: Array<Published_Mv_Lesson_Overview_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_4_0_0" */
   published_mv_lesson_overview_4_0_0_aggregate: Published_Mv_Lesson_Overview_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_lesson_overview_5_0_0" */
+  published_mv_lesson_overview_5_0_0: Array<Published_Mv_Lesson_Overview_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_0" */
+  published_mv_lesson_overview_5_0_0_aggregate: Published_Mv_Lesson_Overview_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
@@ -28336,6 +31458,10 @@ export type Query_Root = {
   published_mv_programme_listing_4_0_0: Array<Published_Mv_Programme_Listing_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_4_0_0" */
   published_mv_programme_listing_4_0_0_aggregate: Published_Mv_Programme_Listing_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_programme_listing_5_0_0" */
+  published_mv_programme_listing_5_0_0: Array<Published_Mv_Programme_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_programme_listing_5_0_0" */
+  published_mv_programme_listing_5_0_0_aggregate: Published_Mv_Programme_Listing_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_search_page_3" */
   published_mv_search_page_3: Array<Published_Mv_Search_Page_3>;
   /** fetch data from the table: "published.mv_search_page_3_0_1" */
@@ -28364,6 +31490,10 @@ export type Query_Root = {
   published_mv_share_4_0_0: Array<Published_Mv_Share_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_share_4_0_0" */
   published_mv_share_4_0_0_aggregate: Published_Mv_Share_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_share_5_0_0" */
+  published_mv_share_5_0_0: Array<Published_Mv_Share_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_share_5_0_0" */
+  published_mv_share_5_0_0_aggregate: Published_Mv_Share_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_specialist_1_0_0" */
   published_mv_specialist_1_0_0: Array<Published_Mv_Specialist_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_specialist_1_0_0" */
@@ -28380,6 +31510,10 @@ export type Query_Root = {
   published_mv_subject_listing_4_0_0: Array<Published_Mv_Subject_Listing_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_subject_listing_4_0_0" */
   published_mv_subject_listing_4_0_0_aggregate: Published_Mv_Subject_Listing_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_subject_listing_5_0_0" */
+  published_mv_subject_listing_5_0_0: Array<Published_Mv_Subject_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_0" */
+  published_mv_subject_listing_5_0_0_aggregate: Published_Mv_Subject_Listing_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_subject_phase_options_0_1" */
   published_mv_subject_phase_options_0_1: Array<Published_Mv_Subject_Phase_Options_0_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_1" */
@@ -28400,6 +31534,10 @@ export type Query_Root = {
   published_mv_unit_listing_page_4_0_0: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
   /** fetch aggregated fields from the table: "published.mv_unit_listing_page_4_0_0" */
   published_mv_unit_listing_page_4_0_0_aggregate: Published_Mv_Unit_Listing_Page_4_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_unit_listing_page_5_0_0" */
+  published_mv_unit_listing_page_5_0_0: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_0" */
+  published_mv_unit_listing_page_5_0_0_aggregate: Published_Mv_Unit_Listing_Page_5_0_0_Aggregate;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -28422,6 +31560,10 @@ export type Query_Root = {
   published_view_synthetic_programmes_4: Array<Published_View_Synthetic_Programmes_4>;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes_4" */
   published_view_synthetic_programmes_4_aggregate: Published_View_Synthetic_Programmes_4_Aggregate;
+  /** fetch data from the table: "published.view_synthetic_programmes_5" */
+  published_view_synthetic_programmes_5: Array<Published_View_Synthetic_Programmes_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_programmes_5" */
+  published_view_synthetic_programmes_5_aggregate: Published_View_Synthetic_Programmes_5_Aggregate;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes" */
   published_view_synthetic_programmes_aggregate: Published_View_Synthetic_Programmes_Aggregate;
   /** fetch data from the table: "published.view_synthetic_unitvariant_lessons_2" */
@@ -28436,6 +31578,10 @@ export type Query_Root = {
   published_view_synthetic_unitvariant_lessons_4: Array<Published_View_Synthetic_Unitvariant_Lessons_4>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariant_lessons_4" */
   published_view_synthetic_unitvariant_lessons_4_aggregate: Published_View_Synthetic_Unitvariant_Lessons_4_Aggregate;
+  /** fetch data from the table: "published.view_synthetic_unitvariant_lessons_5" */
+  published_view_synthetic_unitvariant_lessons_5: Array<Published_View_Synthetic_Unitvariant_Lessons_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariant_lessons_5" */
+  published_view_synthetic_unitvariant_lessons_5_aggregate: Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate;
   /** fetch data from the table: "published.view_synthetic_unitvariants_2" */
   published_view_synthetic_unitvariants_2: Array<Published_View_Synthetic_Unitvariants_2>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_2" */
@@ -28448,6 +31594,10 @@ export type Query_Root = {
   published_view_synthetic_unitvariants_4: Array<Published_View_Synthetic_Unitvariants_4>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_4" */
   published_view_synthetic_unitvariants_4_aggregate: Published_View_Synthetic_Unitvariants_4_Aggregate;
+  /** fetch data from the table: "published.view_synthetic_unitvariants_5" */
+  published_view_synthetic_unitvariants_5: Array<Published_View_Synthetic_Unitvariants_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_5" */
+  published_view_synthetic_unitvariants_5_aggregate: Published_View_Synthetic_Unitvariants_5_Aggregate;
   /** fetch data from the table: "published.view_synthetic_unitvariants_with_lesson_ids_2" */
   published_view_synthetic_unitvariants_with_lesson_ids_2: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_2>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_with_lesson_ids_2" */
@@ -28460,6 +31610,10 @@ export type Query_Root = {
   published_view_synthetic_unitvariants_with_lesson_ids_4: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_with_lesson_ids_4" */
   published_view_synthetic_unitvariants_with_lesson_ids_4_aggregate: Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4_Aggregate;
+  /** fetch data from the table: "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+  published_view_synthetic_unitvariants_with_lesson_ids_5: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+  published_view_synthetic_unitvariants_with_lesson_ids_5_aggregate: Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate;
   /** fetch data from the table: "published.view_unit_unitvariant_programmes_1" */
   published_view_unit_unitvariant_programmes_1: Array<Published_View_Unit_Unitvariant_Programmes_1>;
   /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_1" */
@@ -28472,6 +31626,10 @@ export type Query_Root = {
   published_view_unit_unitvariant_programmes_4: Array<Published_View_Unit_Unitvariant_Programmes_4>;
   /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_4" */
   published_view_unit_unitvariant_programmes_4_aggregate: Published_View_Unit_Unitvariant_Programmes_4_Aggregate;
+  /** fetch data from the table: "published.view_unit_unitvariant_programmes_5" */
+  published_view_unit_unitvariant_programmes_5: Array<Published_View_Unit_Unitvariant_Programmes_5>;
+  /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_5" */
+  published_view_unit_unitvariant_programmes_5_aggregate: Published_View_Unit_Unitvariant_Programmes_5_Aggregate;
   /** fetch data from the table: "published.viewmanager" */
   published_viewmanager: Array<Published_Viewmanager>;
   /** fetch aggregated fields from the table: "published.viewmanager" */
@@ -29215,6 +32373,24 @@ export type Query_RootPublished_Mv_Downloads_4_0_0_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Downloads_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Downloads_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Homepage_3_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Homepage_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -29302,6 +32478,42 @@ export type Query_RootPublished_Mv_Lesson_Listing_4_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_4_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Lesson_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Listing_5_0_1Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Listing_5_0_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
 };
 
 
@@ -29485,6 +32697,24 @@ export type Query_RootPublished_Mv_Lesson_Overview_4_0_0_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Lesson_Overview_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Lesson_Overview_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Programme_Listing_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -29518,6 +32748,24 @@ export type Query_RootPublished_Mv_Programme_Listing_4_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Programme_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Programme_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -29647,6 +32895,24 @@ export type Query_RootPublished_Mv_Share_4_0_0_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Share_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Share_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Share_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Share_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Share_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Share_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Specialist_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Specialist_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -29716,6 +32982,24 @@ export type Query_RootPublished_Mv_Subject_Listing_4_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -29806,6 +33090,24 @@ export type Query_RootPublished_Mv_Unit_Listing_Page_4_0_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Unit_Listing_Page_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Unit_Listing_Page_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
 };
 
 
@@ -29908,6 +33210,24 @@ export type Query_RootPublished_View_Synthetic_Programmes_4_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_View_Synthetic_Programmes_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Programmes_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_View_Synthetic_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -29971,6 +33291,24 @@ export type Query_RootPublished_View_Synthetic_Unitvariant_Lessons_4_AggregateAr
 };
 
 
+export type Query_RootPublished_View_Synthetic_Unitvariant_Lessons_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Unitvariant_Lessons_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_View_Synthetic_Unitvariants_2Args = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_2_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30022,6 +33360,24 @@ export type Query_RootPublished_View_Synthetic_Unitvariants_4_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_4_Order_By>>;
   where?: InputMaybe<Published_View_Synthetic_Unitvariants_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Unitvariants_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Unitvariants_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
 };
 
 
@@ -30079,6 +33435,24 @@ export type Query_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_4_Ag
 };
 
 
+export type Query_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_View_Unit_Unitvariant_Programmes_1Args = {
   distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30130,6 +33504,24 @@ export type Query_RootPublished_View_Unit_Unitvariant_Programmes_4_AggregateArgs
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_4_Order_By>>;
   where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Unit_Unitvariant_Programmes_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Unit_Unitvariant_Programmes_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
 };
 
 
@@ -31283,7 +34675,7 @@ export type Quiz_Questions_Bool_Exp = {
 
 /** unique or primary key constraints on table "quiz_questions" */
 export enum Quiz_Questions_Constraint {
-  /** unique or primary key constraint on columns "question_id", "quiz_id", "_state" */
+  /** unique or primary key constraint on columns "quiz_id", "question_id", "_state" */
   QuizQuestionsPkey = 'quiz_questions_pkey'
 }
 
@@ -32477,6 +35869,12 @@ export type Subscription_Root = {
   published_mv_downloads_4_0_0_aggregate: Published_Mv_Downloads_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_downloads_4_0_0" */
   published_mv_downloads_4_0_0_stream: Array<Published_Mv_Downloads_4_0_0>;
+  /** fetch data from the table: "published.mv_downloads_5_0_0" */
+  published_mv_downloads_5_0_0: Array<Published_Mv_Downloads_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_0" */
+  published_mv_downloads_5_0_0_aggregate: Published_Mv_Downloads_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_downloads_5_0_0" */
+  published_mv_downloads_5_0_0_stream: Array<Published_Mv_Downloads_5_0_0>;
   /** fetch data from the table: "published.mv_homepage_3_0_1" */
   published_mv_homepage_3_0_1: Array<Published_Mv_Homepage_3_0_1>;
   /** fetch aggregated fields from the table: "published.mv_homepage_3_0_1" */
@@ -32507,6 +35905,18 @@ export type Subscription_Root = {
   published_mv_lesson_listing_4_0_0_aggregate: Published_Mv_Lesson_Listing_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_4_0_0" */
   published_mv_lesson_listing_4_0_0_stream: Array<Published_Mv_Lesson_Listing_4_0_0>;
+  /** fetch data from the table: "published.mv_lesson_listing_5_0_0" */
+  published_mv_lesson_listing_5_0_0: Array<Published_Mv_Lesson_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_0" */
+  published_mv_lesson_listing_5_0_0_aggregate: Published_Mv_Lesson_Listing_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_5_0_0" */
+  published_mv_lesson_listing_5_0_0_stream: Array<Published_Mv_Lesson_Listing_5_0_0>;
+  /** fetch data from the table: "published.mv_lesson_listing_5_0_1" */
+  published_mv_lesson_listing_5_0_1: Array<Published_Mv_Lesson_Listing_5_0_1>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_1" */
+  published_mv_lesson_listing_5_0_1_aggregate: Published_Mv_Lesson_Listing_5_0_1_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_5_0_1" */
+  published_mv_lesson_listing_5_0_1_stream: Array<Published_Mv_Lesson_Listing_5_0_1>;
   /** fetch data from the table: "published.mv_lesson_openapi_1_0_0" */
   published_mv_lesson_openapi_1_0_0: Array<Published_Mv_Lesson_Openapi_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_openapi_1_0_0" */
@@ -32567,6 +35977,12 @@ export type Subscription_Root = {
   published_mv_lesson_overview_4_0_0_aggregate: Published_Mv_Lesson_Overview_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_4_0_0" */
   published_mv_lesson_overview_4_0_0_stream: Array<Published_Mv_Lesson_Overview_4_0_0>;
+  /** fetch data from the table: "published.mv_lesson_overview_5_0_0" */
+  published_mv_lesson_overview_5_0_0: Array<Published_Mv_Lesson_Overview_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_0" */
+  published_mv_lesson_overview_5_0_0_aggregate: Published_Mv_Lesson_Overview_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_5_0_0" */
+  published_mv_lesson_overview_5_0_0_stream: Array<Published_Mv_Lesson_Overview_5_0_0>;
   /** fetch data from the table: "published.mv_programme_listing_3_0_0" */
   published_mv_programme_listing_3_0_0: Array<Published_Mv_Programme_Listing_3_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_3_0_0" */
@@ -32579,6 +35995,12 @@ export type Subscription_Root = {
   published_mv_programme_listing_4_0_0_aggregate: Published_Mv_Programme_Listing_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_programme_listing_4_0_0" */
   published_mv_programme_listing_4_0_0_stream: Array<Published_Mv_Programme_Listing_4_0_0>;
+  /** fetch data from the table: "published.mv_programme_listing_5_0_0" */
+  published_mv_programme_listing_5_0_0: Array<Published_Mv_Programme_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_programme_listing_5_0_0" */
+  published_mv_programme_listing_5_0_0_aggregate: Published_Mv_Programme_Listing_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_programme_listing_5_0_0" */
+  published_mv_programme_listing_5_0_0_stream: Array<Published_Mv_Programme_Listing_5_0_0>;
   /** fetch data from the table: "published.mv_search_page_3" */
   published_mv_search_page_3: Array<Published_Mv_Search_Page_3>;
   /** fetch data from the table: "published.mv_search_page_3_0_1" */
@@ -32621,6 +36043,12 @@ export type Subscription_Root = {
   published_mv_share_4_0_0_aggregate: Published_Mv_Share_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_share_4_0_0" */
   published_mv_share_4_0_0_stream: Array<Published_Mv_Share_4_0_0>;
+  /** fetch data from the table: "published.mv_share_5_0_0" */
+  published_mv_share_5_0_0: Array<Published_Mv_Share_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_share_5_0_0" */
+  published_mv_share_5_0_0_aggregate: Published_Mv_Share_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_share_5_0_0" */
+  published_mv_share_5_0_0_stream: Array<Published_Mv_Share_5_0_0>;
   /** fetch data from the table: "published.mv_specialist_1_0_0" */
   published_mv_specialist_1_0_0: Array<Published_Mv_Specialist_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_specialist_1_0_0" */
@@ -32645,6 +36073,12 @@ export type Subscription_Root = {
   published_mv_subject_listing_4_0_0_aggregate: Published_Mv_Subject_Listing_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_subject_listing_4_0_0" */
   published_mv_subject_listing_4_0_0_stream: Array<Published_Mv_Subject_Listing_4_0_0>;
+  /** fetch data from the table: "published.mv_subject_listing_5_0_0" */
+  published_mv_subject_listing_5_0_0: Array<Published_Mv_Subject_Listing_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_0" */
+  published_mv_subject_listing_5_0_0_aggregate: Published_Mv_Subject_Listing_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_subject_listing_5_0_0" */
+  published_mv_subject_listing_5_0_0_stream: Array<Published_Mv_Subject_Listing_5_0_0>;
   /** fetch data from the table: "published.mv_subject_phase_options_0_1" */
   published_mv_subject_phase_options_0_1: Array<Published_Mv_Subject_Phase_Options_0_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_1" */
@@ -32675,6 +36109,12 @@ export type Subscription_Root = {
   published_mv_unit_listing_page_4_0_0_aggregate: Published_Mv_Unit_Listing_Page_4_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_4_0_0" */
   published_mv_unit_listing_page_4_0_0_stream: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
+  /** fetch data from the table: "published.mv_unit_listing_page_5_0_0" */
+  published_mv_unit_listing_page_5_0_0: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_0" */
+  published_mv_unit_listing_page_5_0_0_aggregate: Published_Mv_Unit_Listing_Page_5_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_5_0_0" */
+  published_mv_unit_listing_page_5_0_0_stream: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -32707,6 +36147,12 @@ export type Subscription_Root = {
   published_view_synthetic_programmes_4_aggregate: Published_View_Synthetic_Programmes_4_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes_4" */
   published_view_synthetic_programmes_4_stream: Array<Published_View_Synthetic_Programmes_4>;
+  /** fetch data from the table: "published.view_synthetic_programmes_5" */
+  published_view_synthetic_programmes_5: Array<Published_View_Synthetic_Programmes_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_programmes_5" */
+  published_view_synthetic_programmes_5_aggregate: Published_View_Synthetic_Programmes_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes_5" */
+  published_view_synthetic_programmes_5_stream: Array<Published_View_Synthetic_Programmes_5>;
   /** fetch aggregated fields from the table: "published.view_synthetic_programmes" */
   published_view_synthetic_programmes_aggregate: Published_View_Synthetic_Programmes_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_programmes" */
@@ -32729,6 +36175,12 @@ export type Subscription_Root = {
   published_view_synthetic_unitvariant_lessons_4_aggregate: Published_View_Synthetic_Unitvariant_Lessons_4_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariant_lessons_4" */
   published_view_synthetic_unitvariant_lessons_4_stream: Array<Published_View_Synthetic_Unitvariant_Lessons_4>;
+  /** fetch data from the table: "published.view_synthetic_unitvariant_lessons_5" */
+  published_view_synthetic_unitvariant_lessons_5: Array<Published_View_Synthetic_Unitvariant_Lessons_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariant_lessons_5" */
+  published_view_synthetic_unitvariant_lessons_5_aggregate: Published_View_Synthetic_Unitvariant_Lessons_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariant_lessons_5" */
+  published_view_synthetic_unitvariant_lessons_5_stream: Array<Published_View_Synthetic_Unitvariant_Lessons_5>;
   /** fetch data from the table: "published.view_synthetic_unitvariants_2" */
   published_view_synthetic_unitvariants_2: Array<Published_View_Synthetic_Unitvariants_2>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_2" */
@@ -32747,6 +36199,12 @@ export type Subscription_Root = {
   published_view_synthetic_unitvariants_4_aggregate: Published_View_Synthetic_Unitvariants_4_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariants_4" */
   published_view_synthetic_unitvariants_4_stream: Array<Published_View_Synthetic_Unitvariants_4>;
+  /** fetch data from the table: "published.view_synthetic_unitvariants_5" */
+  published_view_synthetic_unitvariants_5: Array<Published_View_Synthetic_Unitvariants_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_5" */
+  published_view_synthetic_unitvariants_5_aggregate: Published_View_Synthetic_Unitvariants_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariants_5" */
+  published_view_synthetic_unitvariants_5_stream: Array<Published_View_Synthetic_Unitvariants_5>;
   /** fetch data from the table: "published.view_synthetic_unitvariants_with_lesson_ids_2" */
   published_view_synthetic_unitvariants_with_lesson_ids_2: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_2>;
   /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_with_lesson_ids_2" */
@@ -32765,6 +36223,12 @@ export type Subscription_Root = {
   published_view_synthetic_unitvariants_with_lesson_ids_4_aggregate: Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariants_with_lesson_ids_4" */
   published_view_synthetic_unitvariants_with_lesson_ids_4_stream: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_4>;
+  /** fetch data from the table: "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+  published_view_synthetic_unitvariants_with_lesson_ids_5: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5>;
+  /** fetch aggregated fields from the table: "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+  published_view_synthetic_unitvariants_with_lesson_ids_5_aggregate: Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_synthetic_unitvariants_with_lesson_ids_5" */
+  published_view_synthetic_unitvariants_with_lesson_ids_5_stream: Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5>;
   /** fetch data from the table: "published.view_unit_unitvariant_programmes_1" */
   published_view_unit_unitvariant_programmes_1: Array<Published_View_Unit_Unitvariant_Programmes_1>;
   /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_1" */
@@ -32783,6 +36247,12 @@ export type Subscription_Root = {
   published_view_unit_unitvariant_programmes_4_aggregate: Published_View_Unit_Unitvariant_Programmes_4_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_unit_unitvariant_programmes_4" */
   published_view_unit_unitvariant_programmes_4_stream: Array<Published_View_Unit_Unitvariant_Programmes_4>;
+  /** fetch data from the table: "published.view_unit_unitvariant_programmes_5" */
+  published_view_unit_unitvariant_programmes_5: Array<Published_View_Unit_Unitvariant_Programmes_5>;
+  /** fetch aggregated fields from the table: "published.view_unit_unitvariant_programmes_5" */
+  published_view_unit_unitvariant_programmes_5_aggregate: Published_View_Unit_Unitvariant_Programmes_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_unit_unitvariant_programmes_5" */
+  published_view_unit_unitvariant_programmes_5_stream: Array<Published_View_Unit_Unitvariant_Programmes_5>;
   /** fetch data from the table: "published.viewmanager" */
   published_viewmanager: Array<Published_Viewmanager>;
   /** fetch aggregated fields from the table: "published.viewmanager" */
@@ -33762,6 +37232,31 @@ export type Subscription_RootPublished_Mv_Downloads_4_0_0_StreamArgs = {
 };
 
 
+export type Subscription_RootPublished_Mv_Downloads_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Downloads_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Downloads_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Homepage_3_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Homepage_3_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -33884,6 +37379,56 @@ export type Subscription_RootPublished_Mv_Lesson_Listing_4_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Lesson_Listing_4_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Lesson_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_1Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_1_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_1_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_1_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_1_Bool_Exp>;
 };
 
 
@@ -34137,6 +37682,31 @@ export type Subscription_RootPublished_Mv_Lesson_Overview_4_0_0_StreamArgs = {
 };
 
 
+export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_0_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Programme_Listing_3_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_3_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34184,6 +37754,31 @@ export type Subscription_RootPublished_Mv_Programme_Listing_4_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Programme_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Programme_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Programme_Listing_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Programme_Listing_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Programme_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -34362,6 +37957,31 @@ export type Subscription_RootPublished_Mv_Share_4_0_0_StreamArgs = {
 };
 
 
+export type Subscription_RootPublished_Mv_Share_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Share_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Share_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Share_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Share_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Share_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Share_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Share_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Share_5_0_0_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Specialist_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Specialist_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34459,6 +38079,31 @@ export type Subscription_RootPublished_Mv_Subject_Listing_4_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -34584,6 +38229,31 @@ export type Subscription_RootPublished_Mv_Unit_Listing_Page_4_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
 };
 
 
@@ -34721,6 +38391,31 @@ export type Subscription_RootPublished_View_Synthetic_Programmes_4_StreamArgs = 
 };
 
 
+export type Subscription_RootPublished_View_Synthetic_Programmes_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Programmes_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Programmes_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Synthetic_Programmes_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Synthetic_Programmes_5_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_View_Synthetic_Programmes_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34812,6 +38507,31 @@ export type Subscription_RootPublished_View_Synthetic_Unitvariant_Lessons_4_Stre
 };
 
 
+export type Subscription_RootPublished_View_Synthetic_Unitvariant_Lessons_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariant_Lessons_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariant_Lessons_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariant_Lessons_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariant_Lessons_5_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_View_Synthetic_Unitvariants_2Args = {
   distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_2_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34884,6 +38604,31 @@ export type Subscription_RootPublished_View_Synthetic_Unitvariants_4_StreamArgs 
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_View_Synthetic_Unitvariants_4_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_View_Synthetic_Unitvariants_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Synthetic_Unitvariants_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_5_Bool_Exp>;
 };
 
 
@@ -34962,6 +38707,31 @@ export type Subscription_RootPublished_View_Synthetic_Unitvariants_With_Lesson_I
 };
 
 
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Order_By>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Synthetic_Unitvariants_With_Lesson_Ids_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Synthetic_Unitvariants_With_Lesson_Ids_5_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_1Args = {
   distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -35034,6 +38804,31 @@ export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_4_Stream
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_5Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Unit_Unitvariant_Programmes_5_Order_By>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Unit_Unitvariant_Programmes_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Unit_Unitvariant_Programmes_5_Bool_Exp>;
 };
 
 
@@ -35656,7 +39451,7 @@ export type Thirdpartycontent_Bool_Exp = {
 
 /** unique or primary key constraints on table "thirdpartycontent" */
 export enum Thirdpartycontent_Constraint {
-  /** unique or primary key constraint on columns "thirdpartycontent_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "thirdpartycontent_id" */
   ThirdpartycontentPkey = 'thirdpartycontent_pkey'
 }
 
@@ -36417,7 +40212,7 @@ export type Thread_Units_Bool_Exp = {
 
 /** unique or primary key constraints on table "thread_units" */
 export enum Thread_Units_Constraint {
-  /** unique or primary key constraint on columns "unit_id", "_state", "thread_id" */
+  /** unique or primary key constraint on columns "unit_id", "thread_id", "_state" */
   ThreadUnitsPkey = 'thread_units_pkey'
 }
 
@@ -37070,7 +40865,7 @@ export type Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "threads" */
 export enum Threads_Constraint {
-  /** unique or primary key constraint on columns "_state", "thread_id" */
+  /** unique or primary key constraint on columns "thread_id", "_state" */
   ThreadsPkey = 'threads_pkey'
 }
 
@@ -38063,6 +41858,8 @@ export type Units_Max_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   intro_video_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__units__last_updated_lesson_review_date" */
+  last_updated_lesson_review_date?: Maybe<Scalars['timestamptz']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -38106,6 +41903,8 @@ export type Units_Min_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   intro_video_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__units__last_updated_lesson_review_date" */
+  last_updated_lesson_review_date?: Maybe<Scalars['timestamptz']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -39430,7 +43229,7 @@ export type Unitvariants_Bool_Exp = {
 export enum Unitvariants_Constraint {
   /** unique or primary key constraint on columns "unitvariant_id", "_state" */
   UnitvariantsPkey = 'unitvariants_pkey',
-  /** unique or primary key constraint on columns "unit_id", "programme_fields", "_state" */
+  /** unique or primary key constraint on columns "programme_fields", "unit_id", "_state" */
   UnitvariantsUnitIdProgrammeFieldsStateKey = 'unitvariants_unit_id_programme_fields__state_key'
 }
 
@@ -40048,7 +43847,7 @@ export type Videocaptions_Bool_Exp = {
 
 /** unique or primary key constraints on table "videocaptions" */
 export enum Videocaptions_Constraint {
-  /** unique or primary key constraint on columns "caption_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "caption_id" */
   VideocaptionsPkey = 'videocaptions_pkey'
 }
 
@@ -40646,7 +44445,7 @@ export type Videos_Bool_Exp = {
 
 /** unique or primary key constraints on table "videos" */
 export enum Videos_Constraint {
-  /** unique or primary key constraint on columns "video_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "video_id" */
   VideosPkey = 'videos_pkey'
 }
 
@@ -41207,14 +45006,14 @@ export type PupilLessonOverviewQueryVariables = Exact<{
 }>;
 
 
-export type PupilLessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_2', lessonSlug?: string | null, lessonTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, programmeSlug?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, yearSlug?: string | null, yearTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonKeywords?: any | null, pupilLessonOutcome?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, supervisionLevel?: string | null, contentGuidance?: any | null, lessonEquipmentAndResources?: any | null, videoTitle?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, isLegacy?: boolean | null }> };
+export type PupilLessonOverviewQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_5_0_0', lessonSlug?: string | null, lessonTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, programmeSlug?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, yearSlug?: string | null, yearTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonKeywords?: any | null, pupilLessonOutcome?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, supervisionLevel?: string | null, contentGuidance?: any | null, lessonEquipmentAndResources?: any | null, videoTitle?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, isLegacy?: boolean | null, expired?: boolean | null }> };
 
 export type PupilLessonOverviewCanonicalQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
 }>;
 
 
-export type PupilLessonOverviewCanonicalQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_3_0_2', lessonSlug?: string | null, lessonTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, programmeSlug?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, yearSlug?: string | null, yearTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonKeywords?: any | null, pupilLessonOutcome?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, supervisionLevel?: string | null, contentGuidance?: any | null, lessonEquipmentAndResources?: any | null, videoTitle?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, isLegacy?: boolean | null }> };
+export type PupilLessonOverviewCanonicalQuery = { __typename?: 'query_root', lesson: Array<{ __typename?: 'published_mv_lesson_overview_5_0_0', lessonSlug?: string | null, lessonTitle?: string | null, unitSlug?: string | null, unitTitle?: string | null, programmeSlug?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, yearSlug?: string | null, yearTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, lessonKeywords?: any | null, pupilLessonOutcome?: string | null, starterQuiz?: any | null, exitQuiz?: any | null, supervisionLevel?: string | null, contentGuidance?: any | null, lessonEquipmentAndResources?: any | null, videoTitle?: string | null, videoMuxPlaybackId?: string | null, videoWithSignLanguageMuxPlaybackId?: string | null, transcriptSentences?: string | null, isLegacy?: boolean | null, expired?: boolean | null }> };
 
 export type SearchPageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -41494,7 +45293,7 @@ export const ProgrammeListingDocument = gql`
     `;
 export const PupilLessonOverviewDocument = gql`
     query pupilLessonOverview($programmeSlug: String!, $lessonSlug: String!, $unitSlug: String!) {
-  lesson: published_mv_lesson_overview_3_0_2(
+  lesson: published_mv_lesson_overview_5_0_0(
     where: {lessonSlug: {_eq: $lessonSlug}, programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
   ) {
     lessonSlug
@@ -41520,12 +45319,13 @@ export const PupilLessonOverviewDocument = gql`
     videoWithSignLanguageMuxPlaybackId
     transcriptSentences
     isLegacy
+    expired
   }
 }
     `;
 export const PupilLessonOverviewCanonicalDocument = gql`
     query pupilLessonOverviewCanonical($lessonSlug: String!) {
-  lesson: published_mv_lesson_overview_3_0_2(
+  lesson: published_mv_lesson_overview_5_0_0(
     where: {lessonSlug: {_eq: $lessonSlug}}
   ) {
     lessonSlug
@@ -41551,6 +45351,7 @@ export const PupilLessonOverviewCanonicalDocument = gql`
     videoWithSignLanguageMuxPlaybackId
     transcriptSentences
     isLegacy
+    expired
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/queries/pupilLessonOverview/pupilLessonOverview.gql
+++ b/src/node-lib/curriculum-api-2023/queries/pupilLessonOverview/pupilLessonOverview.gql
@@ -3,7 +3,7 @@ query pupilLessonOverview(
   $lessonSlug: String!
   $unitSlug: String!
 ) {
-  lesson: published_mv_lesson_overview_3_0_2(
+  lesson: published_mv_lesson_overview_5_0_0(
     where: {
       lessonSlug: { _eq: $lessonSlug }
       programmeSlug: { _eq: $programmeSlug }
@@ -33,5 +33,6 @@ query pupilLessonOverview(
     videoWithSignLanguageMuxPlaybackId
     transcriptSentences
     isLegacy
+    expired
   }
 }

--- a/src/node-lib/curriculum-api-2023/queries/pupilLessonOverview/pupilLessonOverview.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/pupilLessonOverview/pupilLessonOverview.schema.ts
@@ -20,6 +20,7 @@ export const pupilLessonOverviewSchema = baseLessonOverviewSchema
     videoTitle: true,
     transcriptSentences: true,
     pupilLessonOutcome: true,
+    expired: true,
   })
   .merge(
     lessonPathwaySchema.pick({

--- a/src/node-lib/curriculum-api-2023/queries/pupilLessonOverviewCanonical/pupilLessonOverviewCanonical.gql
+++ b/src/node-lib/curriculum-api-2023/queries/pupilLessonOverviewCanonical/pupilLessonOverviewCanonical.gql
@@ -1,5 +1,5 @@
 query pupilLessonOverviewCanonical($lessonSlug: String!) {
-  lesson: published_mv_lesson_overview_3_0_2(
+  lesson: published_mv_lesson_overview_5_0_0(
     where: { lessonSlug: { _eq: $lessonSlug } }
   ) {
     lessonSlug
@@ -25,5 +25,6 @@ query pupilLessonOverviewCanonical($lessonSlug: String!) {
     videoWithSignLanguageMuxPlaybackId
     transcriptSentences
     isLegacy
+    expired
   }
 }

--- a/src/node-lib/curriculum-api/fixtures/pupilLessonOverview.fixture.ts
+++ b/src/node-lib/curriculum-api/fixtures/pupilLessonOverview.fixture.ts
@@ -25,6 +25,7 @@ const pupilLessonOverviewFixture = (
     videoTitle: "Introduction to Islamic Geometry",
     isLegacy: false,
     pupilLessonOutcome: undefined,
+    expired: false,
     ...partial,
   };
 };


### PR DESCRIPTION
# Story 
As a rights holder of copyrighted content,
I want expired lessons not to be accessible in the pupil experience,
So that I do not have to take legal action against Oak National Academy

As a pupil who has somehow found their way to an expired lesson in the Pupil experience
I want to be shown a clear message when the lesson is no longer available
So that I receive better information than a generic error page

### How to test
See here:
https://deploy-preview-2301--owa-storybook.netlify.thenational.academy/?path=/story/components-pupilviews-pupilexpired--default

- NB. we haven't published expired lessons yet so there's no way of checking via OWA in prod.


### Implementation details

- Expose expired field in MV lesson overview
- OWA Redirect to a 'this content is no longer available page' when said field is shown

### Acceptance criteria

- [x]  A storybook for QA purposes
- [x]  expired field appears in mv_lesson_overview
- [x]  OWA redirects to / renders expired page