### PR TITLE
Feat/lesq 559/specialist lesson listing [LESQ-559]

### DIFF
--- a/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons.test.tsx
+++ b/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from "@testing-library/dom";
+
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import specialistLessonListingFixture from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.fixture";
+import SpecialistLessonListing from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
+import { getStaticProps } from "@/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons";
+import curriculumApi from "@/node-lib/curriculum-api-2023";
+
+const render = renderWithProviders();
+
+describe("pages/specialist/programmes/[programmeSlug]/units/[unitSlug]", () => {
+  it("renders lessons", () => {
+    render(
+      <SpecialistLessonListing
+        curriculumData={specialistLessonListingFixture()}
+      />,
+    );
+
+    const lessonCard = screen.getByText("Super juice");
+    expect(lessonCard).toBeInTheDocument();
+  });
+});
+
+jest.mock("@/node-lib/curriculum-api-2023", () => ({
+  specialistLessonListing: jest.fn(),
+}));
+
+describe("getStaticProps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+  it("should return  404 page when there are no lessons", async () => {
+    const result = await getStaticProps({
+      params: { programmeSlug: "fake", unitSlug: "news" },
+    });
+    expect(result).toEqual({ notFound: true });
+  });
+  it("Should call the api", async () => {
+    await getStaticProps({
+      params: { programmeSlug: "numeracy", unitSlug: "numeracy 1" },
+    });
+
+    expect(curriculumApi.specialistLessonListing).toHaveBeenCalledTimes(1);
+    expect(curriculumApi.specialistLessonListing).toHaveBeenCalledWith({
+      programmeSlug: "numeracy",
+      unitSlug: "numeracy 1",
+    });
+  });
+  it("should fetch the data and return the props", async () => {
+    const curriculumData = specialistLessonListingFixture();
+    (curriculumApi.specialistLessonListing as jest.Mock).mockResolvedValue(
+      curriculumData,
+    );
+
+    const result = await getStaticProps({
+      params: { programmeSlug: "numeracy", unitSlug: "numeracy 1" },
+    });
+
+    expect(result).toEqual({
+      props: {
+        curriculumData,
+      },
+    });
+  });
+});

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -15,8 +15,8 @@ import Pagination, {
   PaginationProps,
 } from "@/components/SharedComponents/Pagination";
 import { UsePaginationProps } from "@/components/SharedComponents/Pagination/usePagination";
-import { SpecialistLesson } from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
 import { SpecialistLessonListItemProps } from "@/components/TeacherComponents/LessonListItem/LessonListItem";
+import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 export type LessonListProps = {
   lessonCount: number;

--- a/src/components/TeacherComponents/LessonListItem/LessonListItem.tsx
+++ b/src/components/TeacherComponents/LessonListItem/LessonListItem.tsx
@@ -11,7 +11,7 @@ import ListItemIndexMobile from "@/components/TeacherComponents/ListItemIndexMob
 import ListItemIndexDesktop from "@/components/TeacherComponents/ListItemIndexDesktop";
 import Box from "@/components/SharedComponents/Box";
 import { OakColorName } from "@/styles/theme";
-import { SpecialistLesson } from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
+import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 export type LessonListItemProps = LessonListingPageData["lessons"][number] & {
   programmeSlug: string;

--- a/src/components/TeacherComponents/ListItemHeader/ListItemHeader.tsx
+++ b/src/components/TeacherComponents/ListItemHeader/ListItemHeader.tsx
@@ -11,7 +11,7 @@ import {
   LessonOverviewLinkProps,
 } from "@/common-lib/urls";
 import { IndividualSpecialistUnit } from "@/components/TeacherViews/SpecialistUnitListing/SpecialistUnitListing.view";
-import { SpecialistLesson } from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
+import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 type PrimaryTargetProps = {
   ref: MutableRefObject<HTMLAnchorElement | null>;

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.fixture.ts
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.fixture.ts
@@ -1,4 +1,4 @@
-import { SpecialistLessonListingData } from "./SpecialistLessonListing.view";
+import { SpecialistLessonListingData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 const specialistLessonListingFixture = (
   partial?: Partial<SpecialistLessonListingData>,

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
@@ -23,7 +23,7 @@ function getHydratedLessonsFromUnit(unit: SpecialistLessonListingData) {
 const SpecialistLessonListing: FC<SpecialistLessonListingProps> = ({
   curriculumData,
 }) => {
-  const { subjectSlug, subjectTitle, unitTitle, unitSlug, programmeTitle } =
+  const { subjectSlug, subjectTitle, unitTitle, programmeTitle } =
     curriculumData;
 
   const lessons = getHydratedLessonsFromUnit(curriculumData);
@@ -46,25 +46,24 @@ const SpecialistLessonListing: FC<SpecialistLessonListingProps> = ({
           },
           {
             oakLinkProps: {
-              page: "specialist-programme-index",
-              subjectSlug,
+              page: "specialist-subject-index",
             },
-            label: "Specialist programmes",
+            label: "Specialist and therapies",
           },
           {
             oakLinkProps: {
-              page: "specialist-unit-index",
-              programmeSlug: unitSlug,
+              page: "specialist-programme-index",
+              subjectSlug,
             },
-            label: unitTitle,
+            label: subjectTitle,
           },
         ]}
         background={"pink30"}
         subjectIconBackgroundColor={"pink"}
         subjectSlug={subjectSlug}
-        subjectTitle={unitTitle}
+        subjectTitle={subjectTitle}
         programmeFactor={programmeTitle}
-        title={subjectTitle}
+        title={unitTitle}
         isNew={false}
       />
       <MaxWidth $ph={16}>

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
@@ -61,7 +61,7 @@ const SpecialistLessonListing: FC<SpecialistLessonListingProps> = ({
         ]}
         background={"pink30"}
         subjectIconBackgroundColor={"pink"}
-        subjectSlug={unitSlug}
+        subjectSlug={subjectSlug}
         subjectTitle={unitTitle}
         programmeFactor={programmeTitle}
         title={subjectTitle}

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
@@ -6,39 +6,10 @@ import LessonList from "@/components/TeacherComponents/LessonList";
 import usePagination from "@/components/SharedComponents/Pagination/usePagination";
 import HeaderListing from "@/components/TeacherComponents/HeaderListing";
 import { RESULTS_PER_PAGE } from "@/utils/resultsPerPage";
+import { SpecialistLessonListingData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 type SpecialistLessonListingProps = {
   curriculumData: SpecialistLessonListingData;
-};
-
-export type SpecialistLessonListingData = {
-  lessons: SpecialistLesson[];
-  programmeSlug: string;
-  programmeTitle: string;
-  subjectSlug: string;
-  subjectTitle: string;
-  unitSlug: string;
-  unitTitle: string;
-};
-
-export type SpecialistLesson = {
-  lessonSlug: string;
-  lessonTitle: string;
-  subjectSlug: string;
-  subjectTitle: string;
-  unitSlug: string;
-  programmeSlug: string;
-  programmeTitle: string;
-  description: string;
-  expired: boolean;
-  pupilLessonOutcome?: string | null;
-  quizCount?: number | null;
-  videoCount?: number | null;
-  presentationCount?: number | null;
-  worksheetCount?: number | null;
-  hasCurriculumDownload?: boolean | null;
-  orderInUnit?: number | null;
-  hasCopyrightMaterial?: boolean | null;
 };
 
 function getHydratedLessonsFromUnit(unit: SpecialistLessonListingData) {

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
@@ -46,10 +46,16 @@ const SpecialistLessonListing: FC<SpecialistLessonListingProps> = ({
           },
           {
             oakLinkProps: {
+              page: "specialist-subject-index",
+            },
+            label: "Specialist and therapies",
+          },
+          {
+            oakLinkProps: {
               page: "specialist-programme-index",
               subjectSlug,
             },
-            label: "Specialist programmes",
+            label: programmeTitle,
           },
           {
             oakLinkProps: {

--- a/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
+++ b/src/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view.tsx
@@ -46,16 +46,10 @@ const SpecialistLessonListing: FC<SpecialistLessonListingProps> = ({
           },
           {
             oakLinkProps: {
-              page: "specialist-subject-index",
-            },
-            label: "Specialist and therapies",
-          },
-          {
-            oakLinkProps: {
               page: "specialist-programme-index",
               subjectSlug,
             },
-            label: programmeTitle,
+            label: "Specialist programmes",
           },
           {
             oakLinkProps: {

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -45020,6 +45020,14 @@ export type SearchPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type SearchPageQuery = { __typename?: 'query_root', searchPage: Array<{ __typename?: 'published_mv_search_page_3', subjects?: any | null, contentTypes?: any | null, keyStages?: any | null, examBoards?: any | null }> };
 
+export type SpecialistLessonListingQueryVariables = Exact<{
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type SpecialistLessonListingQuery = { __typename?: 'query_root', specialistLessonListing: Array<{ __typename?: 'published_mv_specialist_1_0_1', lesson_slug?: string | null, lesson_title?: string | null, combined_programme_fields?: any | null, unit_slug?: string | null, unit_title?: string | null, expired?: boolean | null, contains_copyright_content?: boolean | null, exit_quiz?: any | null, starter_quiz?: any | null, pupil_lesson_outcome?: string | null, worksheet_asset_object?: any | null, worksheet_url?: string | null, video_mux_playback_id?: string | null, video_title?: string | null }> };
+
 export type SpecialistProgrammeListingQueryVariables = Exact<{
   _contains?: InputMaybe<Scalars['jsonb']['input']>;
 }>;
@@ -45377,6 +45385,28 @@ export const SearchPageDocument = gql`
   }
 }
     `;
+export const SpecialistLessonListingDocument = gql`
+    query specialistLessonListing($programmeSlug: String, $unitSlug: String) {
+  specialistLessonListing: published_mv_specialist_1_0_1(
+    where: {unit_slug: {_eq: $unitSlug}, synthetic_programme_slug: {_eq: $programmeSlug}}
+  ) {
+    lesson_slug
+    lesson_title
+    combined_programme_fields
+    unit_slug
+    unit_title
+    expired
+    contains_copyright_content
+    exit_quiz
+    starter_quiz
+    pupil_lesson_outcome
+    worksheet_asset_object
+    worksheet_url
+    video_mux_playback_id
+    video_title
+  }
+}
+    `;
 export const SpecialistProgrammeListingDocument = gql`
     query specialistProgrammeListing($_contains: jsonb = "") {
   specialistProgrammeListing: published_mv_specialist_1_0_1(
@@ -45540,6 +45570,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     searchPage(variables?: SearchPageQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchPageQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SearchPageQuery>(SearchPageDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchPage', 'query');
+    },
+    specialistLessonListing(variables?: SpecialistLessonListingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SpecialistLessonListingQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SpecialistLessonListingQuery>(SpecialistLessonListingDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'specialistLessonListing', 'query');
     },
     specialistProgrammeListing(variables?: SpecialistProgrammeListingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SpecialistProgrammeListingQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SpecialistProgrammeListingQuery>(SpecialistProgrammeListingDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'specialistProgrammeListing', 'query');

--- a/src/node-lib/curriculum-api-2023/index.ts
+++ b/src/node-lib/curriculum-api-2023/index.ts
@@ -22,6 +22,7 @@ import lessonShareQuery from "./queries/lessonShare/lessonShare.query";
 import specialistSubjectListingQuery from "./queries/specialistSubjectListing/specialistSubjectListing.query";
 import { pupilLessonOverviewCanonicalQuery } from "./queries/pupilLessonOverviewCanonical/pupilLessonOverviewCanonical.query";
 import specialistProgrammeListingQuery from "./queries/specialistProgrammeListing/specialistProgrammeListing.query";
+import specialistLessonListingQuery from "./queries/specialistLessonListing/specialistLessonListing.query";
 
 export const keyStageSchema = z.object({
   slug: z.string(),
@@ -136,6 +137,7 @@ const curriculumApi2023 = {
   unitListing: unitListingQuery(sdk),
   specialistSubjectListing: specialistSubjectListingQuery(sdk),
   specialistProgrammeListing: specialistProgrammeListingQuery(sdk),
+  specialistLessonListing: specialistLessonListingQuery(sdk),
 };
 
 export type CurriculumApi = typeof curriculumApi2023;

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.gql
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.gql
@@ -1,0 +1,23 @@
+query specialistLessonListing($programmeSlug: String, $unitSlug: String) {
+  specialistLessonListing: published_mv_specialist_1_0_1(
+    where: {
+      unit_slug: { _eq: $unitSlug }
+      synthetic_programme_slug: { _eq: $programmeSlug }
+    }
+  ) {
+    lesson_slug
+    lesson_title
+    combined_programme_fields
+    unit_slug
+    unit_title
+    expired
+    contains_copyright_content
+    exit_quiz
+    starter_quiz
+    pupil_lesson_outcome
+    worksheet_asset_object
+    worksheet_url
+    video_mux_playback_id
+    video_title
+  }
+}

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
@@ -3,6 +3,39 @@ import sdk from "../../sdk";
 import specialistLessonListingQuery from "./specialistLessonListing.query";
 import { SpecialistLessonListingDataSchema } from "./specialistLessonListing.schema";
 
+jest.mock("../../sdk", () => {
+  return {
+    specialistLessonListing: jest.fn(() =>
+      Promise.resolve({
+        specialistLessonListing: [
+          {
+            unit_slug: "staying-safe-al-5556",
+            programme_slug: "independent-living-applying-learning",
+            combined_programme_fields: {
+              subject: "Staying safe",
+              subject_slug: "staying-safe",
+              developmentstage: "Applying learning",
+              developmentstage_slug: "applying-learning",
+              developmentstage_display_order: 3,
+            },
+            lesson_slug: "staying-safe-al-5556",
+            lesson_title: "Staying safe",
+            expired: false,
+            pupil_lesson_outcome: "Pupils will be able to stay safe",
+            worksheet_url: "https://www.example.com",
+            video_mux_playback_id: "123",
+            video_title: "Staying safe",
+            starter_quiz: 1,
+            exit_quiz: 1,
+            contains_copyright_content: false,
+            unit_title: "Staying safe",
+          },
+        ],
+      }),
+    ),
+  };
+});
+
 describe("specialist programme listing", () => {
   test("it runs", async () => {
     const res = await specialistLessonListingQuery(sdk)({
@@ -15,7 +48,14 @@ describe("specialist programme listing", () => {
   test("it throws an error if no lessons are found", async () => {
     await expect(
       async () =>
-        await specialistLessonListingQuery(sdk)({
+        await specialistLessonListingQuery({
+          ...sdk,
+          specialistLessonListing: jest.fn(() =>
+            Promise.resolve({
+              specialistLessonListing: [],
+            }),
+          ),
+        })({
           unitSlug: "blah",
           programmeSlug: "fake-programme",
         }),
@@ -26,9 +66,6 @@ describe("specialist programme listing", () => {
       unitSlug: "staying-safe-al-5556",
       programmeSlug: "independent-living-applying-learning",
     });
-
-    console.log("diego res", res);
-
     expect(SpecialistLessonListingDataSchema.parse(res)).toEqual(res);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
@@ -1,0 +1,23 @@
+import sdk from "../../sdk";
+
+import specialistLessonListingQuery from "./specialistLessonListing.query";
+
+describe("specialist programme listing", () => {
+  test("it runs", async () => {
+    const res = await specialistLessonListingQuery(sdk)({
+      unitSlug: "staying-safe-al-5556",
+      programmeSlug: "independent-living-applying-learning",
+    });
+
+    expect(res).toBeDefined();
+  });
+  test("it throws an error if no lessons are found", async () => {
+    await expect(
+      async () =>
+        await specialistLessonListingQuery(sdk)({
+          unitSlug: "blah",
+          programmeSlug: "fake-programme",
+        }),
+    ).rejects.toThrow("curriculum-api/not-found");
+  });
+});

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.test.ts
@@ -1,6 +1,7 @@
 import sdk from "../../sdk";
 
 import specialistLessonListingQuery from "./specialistLessonListing.query";
+import { SpecialistLessonListingDataSchema } from "./specialistLessonListing.schema";
 
 describe("specialist programme listing", () => {
   test("it runs", async () => {
@@ -19,5 +20,15 @@ describe("specialist programme listing", () => {
           programmeSlug: "fake-programme",
         }),
     ).rejects.toThrow("curriculum-api/not-found");
+  });
+  test("it returns data in the shape of the specialist lesson listing schema", async () => {
+    const res = await specialistLessonListingQuery(sdk)({
+      unitSlug: "staying-safe-al-5556",
+      programmeSlug: "independent-living-applying-learning",
+    });
+
+    console.log("diego res", res);
+
+    expect(SpecialistLessonListingDataSchema.parse(res)).toEqual(res);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
@@ -1,17 +1,75 @@
 import { Sdk } from "../../sdk";
 
+import {
+  SpecialistLessonListingData,
+  specialistLessonQueryResponseSchema,
+} from "./specialistLessonListing.schema";
+
 const specialistLessonListingQuery =
   (sdk: Sdk) => async (args: { unitSlug: string; programmeSlug: string }) => {
+    const { programmeSlug, unitSlug } = args;
     const { specialistLessonListing } = await sdk.specialistLessonListing({
-      unitSlug: args.unitSlug,
-      programmeSlug: args.programmeSlug,
+      unitSlug: unitSlug,
+      programmeSlug: programmeSlug,
     });
 
-    if (!specialistLessonListing || specialistLessonListing.length === 0) {
+    const parsedLessonListing = specialistLessonQueryResponseSchema.parse(
+      specialistLessonListing,
+    );
+
+    if (!parsedLessonListing || parsedLessonListing.length === 0) {
       throw new Error("curriculum-api/not-found");
     }
 
-    return specialistLessonListing;
+    const transformedLessonLising: SpecialistLessonListingData =
+      parsedLessonListing.reduce(
+        (acc, lesson) => {
+          if (!acc.programmeTitle) {
+            acc.programmeTitle = `${lesson.combined_programme_fields.subject} - ${lesson.combined_programme_fields.developmentstage}`;
+          }
+          if (!acc.subjectSlug) {
+            acc.subjectSlug = lesson.combined_programme_fields.subject_slug;
+          }
+          if (!acc.subjectTitle) {
+            acc.subjectTitle = lesson.combined_programme_fields.subject;
+          }
+          if (!acc.unitTitle) {
+            acc.unitTitle = lesson.unit_title;
+          }
+          if (!acc.lessons) {
+            acc.lessons = [];
+          }
+
+          const quizCount =
+            (lesson.exit_quiz ? 1 : 0) + (lesson.starter_quiz ? 1 : 0);
+
+          const lessonDetails = {
+            lessonSlug: lesson.lesson_slug,
+            lessonTitle: lesson.lesson_title,
+            subjectSlug: lesson.combined_programme_fields.subject_slug,
+            subjectTitle: lesson.combined_programme_fields.subject,
+            unitSlug: lesson.unit_slug,
+            programmeSlug: programmeSlug,
+            programmeTitle: acc.programmeTitle,
+            description: "", // TODO: description
+            expired: lesson.expired ? true : false,
+            pupilLessonOutcome: lesson.pupil_lesson_outcome,
+            quizCount: quizCount,
+            videoCount: lesson.video_mux_playback_id ? 1 : 0,
+            presentationCount: lesson.video_mux_playback_id ? 1 : 0,
+            worksheetCount: lesson.worksheet_url ? 1 : 0,
+            hasCurriculumDownload: false, // TODO: curriculum download
+            orderInUnit: 1, // TODO: order in unit
+          };
+
+          acc.lessons.push(lessonDetails);
+
+          return acc;
+        },
+        { programmeSlug, unitSlug } as SpecialistLessonListingData,
+      );
+
+    return transformedLessonLising;
   };
 
 export default specialistLessonListingQuery;

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
@@ -1,0 +1,17 @@
+import { Sdk } from "../../sdk";
+
+const specialistLessonListingQuery =
+  (sdk: Sdk) => async (args: { unitSlug: string; programmeSlug: string }) => {
+    const { specialistLessonListing } = await sdk.specialistLessonListing({
+      unitSlug: args.unitSlug,
+      programmeSlug: args.programmeSlug,
+    });
+
+    if (!specialistLessonListing || specialistLessonListing.length === 0) {
+      throw new Error("curriculum-api/not-found");
+    }
+
+    return specialistLessonListing;
+  };
+
+export default specialistLessonListingQuery;

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+const assetObjectSchema = z
+  .object({
+    google_drive: z.object({
+      id: z.string(),
+      url: z.string(),
+    }),
+    google_drive_downloadable_version: z.object({
+      id: z.string(),
+      url: z.string(),
+    }),
+  })
+  .nullish();
+
+export const specialistLessonQueryResponseSchema = z.array(
+  z.object({
+    lesson_slug: z.string(),
+    lesson_title: z.string(),
+    combined_programme_fields: z.object({
+      subject: z.string(),
+      subject_slug: z.string(),
+      developmentstage: z.string().nullish(),
+      developmentstage_slug: z.string().nullish(),
+    }),
+    unit_slug: z.string(),
+    unit_title: z.string(),
+    expired: z.boolean(),
+    contains_copyright_content: z.boolean(),
+    exit_quiz: z.number().nullable(),
+    starter_quiz: z.number().nullable(),
+    pupil_lesson_outcome: z.string().nullish(),
+    worksheet_asset_object: assetObjectSchema,
+    worksheet_url: z.string().nullish(),
+    video_mux_playback_id: z.string().nullish(),
+    video_title: z.string().nullish(),
+  }),
+);
+
+export const SpecialistLessonSchema = z.object({
+  lessonSlug: z.string(),
+  lessonTitle: z.string(),
+  subjectSlug: z.string(),
+  subjectTitle: z.string(),
+  unitSlug: z.string(),
+  programmeSlug: z.string(),
+  programmeTitle: z.string(),
+  description: z.string(),
+  expired: z.boolean(),
+  pupilLessonOutcome: z.string().nullish(),
+  quizCount: z.number().nullable(),
+  videoCount: z.number().nullable(),
+  presentationCount: z.number().nullable(),
+  worksheetCount: z.number().nullable(),
+  hasCurriculumDownload: z.boolean().nullish(),
+  orderInUnit: z.number().nullish(),
+  hasCopyrightMaterial: z.boolean().nullish(),
+});
+
+export type SpecialistLesson = z.infer<typeof SpecialistLessonSchema>;
+
+export const SpecialistLessonListingDataSchema = z.object({
+  lessons: z.array(SpecialistLessonSchema),
+  programmeSlug: z.string(),
+  programmeTitle: z.string(),
+  subjectSlug: z.string(),
+  subjectTitle: z.string(),
+  unitSlug: z.string(),
+  unitTitle: z.string(),
+});
+
+export type SpecialistLessonListingData = z.infer<
+  typeof SpecialistLessonListingDataSchema
+>;

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema.ts
@@ -25,7 +25,7 @@ export const specialistLessonQueryResponseSchema = z.array(
     }),
     unit_slug: z.string(),
     unit_title: z.string(),
-    expired: z.boolean(),
+    expired: z.boolean().nullish(),
     contains_copyright_content: z.boolean(),
     exit_quiz: z.number().nullable(),
     starter_quiz: z.number().nullable(),

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -30,8 +30,8 @@ import { LessonListItemProps } from "@/components/TeacherComponents/LessonListIt
 import { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
-import { SpecialistLesson } from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
 import { NEW_COHORT } from "@/config/cohort";
+import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 
 export type LessonListingPageProps = {
   curriculumData: LessonListingPageData;

--- a/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import {
+  GetStaticPathsResult,
+  GetStaticProps,
+  GetStaticPropsResult,
+  NextPage,
+} from "next";
+
+import AppLayout from "@/components/SharedComponents/AppLayout";
+import getPageProps from "@/node-lib/getPageProps";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import {
+  getFallbackBlockingConfig,
+  shouldSkipInitialBuild,
+} from "@/node-lib/isr";
+import { SpecialistLessonListingData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
+import SpecialistLessonListing from "@/components/TeacherViews/SpecialistLessonListing/SpecialistLessonListing.view";
+
+export type SpecialistLessonListingPageProps = {
+  curriculumData: SpecialistLessonListingData;
+};
+
+const SEO = {
+  ...getSeoProps({
+    title: `Free Specialist Teaching Resources for Lesson Planning`,
+    description: "Specialist lessons",
+  }),
+  ...{ noFollow: true, noIndex: true },
+};
+
+const SpecialistLessonListingPage: NextPage<
+  SpecialistLessonListingPageProps
+> = ({ curriculumData }) => {
+  return (
+    <AppLayout seoProps={SEO}>
+      <SpecialistLessonListing curriculumData={curriculumData} />
+    </AppLayout>
+  );
+};
+
+export type URLParams = {
+  programmeSlug: string;
+  unitSlug: string;
+};
+
+export const getStaticPaths = async () => {
+  if (shouldSkipInitialBuild) {
+    return getFallbackBlockingConfig();
+  }
+
+  const config: GetStaticPathsResult<URLParams> = {
+    fallback: "blocking",
+    paths: [],
+  };
+  return config;
+};
+
+export const getStaticProps: GetStaticProps<
+  SpecialistLessonListingPageProps,
+  URLParams
+> = async (context) => {
+  return getPageProps({
+    page: "teachers-specialist-lesson-index::getStaticProps",
+    context,
+    getProps: async () => {
+      if (!context.params) {
+        throw new Error("No context.params");
+      }
+      const { programmeSlug, unitSlug } = context.params;
+      try {
+        const curriculumData = await curriculumApi2023.specialistLessonListing({
+          unitSlug,
+          programmeSlug,
+        });
+
+        if (!curriculumData) {
+          return {
+            notFound: true,
+          };
+        }
+
+        const results: GetStaticPropsResult<SpecialistLessonListingPageProps> =
+          {
+            props: {
+              curriculumData,
+            },
+          };
+
+        return results;
+      } catch {
+        return {
+          notFound: true,
+        };
+      }
+    },
+  });
+};
+
+export default SpecialistLessonListingPage;


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- add query for specialist lesson listing
- add specialist lesson listing page
- update schema and types


## How to test

Once again this should 404 until published, so nothing to see here. 

1. Go to https://deploy-preview-2303--oak-web-application.netlify.thenational.academy/teachers/specialist/programmes/numeracy-building-understanding/units/number-c7b4/lessons
2. Observe the internal server error (404)
  
  
## Screenshots

How it should now look:
![Screenshot 2024-03-07 at 14 31 07](https://github.com/oaknational/Oak-Web-Application/assets/45038878/bc47f1d1-eb18-4da4-8e29-c1025af6a353)


The 'curriculum download' buttons seems to _just work_, which is a nice surprise 
![Screenshot 2024-03-07 at 14 22 22](https://github.com/oaknational/Oak-Web-Application/assets/45038878/452b469a-92d9-42cb-ba75-6bef00771023)
