### PR TITLE
LESQ-693 -  Refactor: share link to pupil experience by subject

### DIFF
--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -65,7 +65,7 @@ const classroomActivityMap: Partial<
 };
 
 // Temporary - list of lessons live on pupil experience for sharing
-const pupilUnitsLive = ["shakespearean-comedy-the-tempest-88f0"];
+const pupilSubjectsLive = ["english"];
 
 export function LessonShare(props: LessonShareProps) {
   const { lesson } = props;
@@ -74,14 +74,14 @@ export function LessonShare(props: LessonShareProps) {
   const commonPathway = getCommonPathway(
     props.isCanonical ? props.lesson.pathways : [props.lesson],
   );
-  const { programmeSlug, unitSlug } = commonPathway;
+  const { programmeSlug, unitSlug, subjectSlug } = commonPathway;
 
   const { track } = useAnalytics();
   const { lessonShared } = track;
 
   // Temporary - integrate with the new pupil experience for select units and lessons only
   const shareToNewPupilExperience =
-    unitSlug !== null && pupilUnitsLive.includes(unitSlug);
+    subjectSlug !== null && pupilSubjectsLive.includes(subjectSlug);
 
   const {
     form,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -65,7 +65,12 @@ const classroomActivityMap: Partial<
 };
 
 // Temporary - list of subjects live on pupil experience for sharing
-const pupilSubjectsLive = ["english"];
+const pupilSubjectsLive = [
+  "english",
+  "english-grammar",
+  "english-reading-for-pleasure",
+  "english-spelling",
+];
 
 export function LessonShare(props: LessonShareProps) {
   const { lesson } = props;

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -64,7 +64,7 @@ const classroomActivityMap: Partial<
   video: "video",
 };
 
-// Temporary - list of lessons live on pupil experience for sharing
+// Temporary - list of subjects live on pupil experience for sharing
 const pupilSubjectsLive = ["english"];
 
 export function LessonShare(props: LessonShareProps) {
@@ -79,7 +79,7 @@ export function LessonShare(props: LessonShareProps) {
   const { track } = useAnalytics();
   const { lessonShared } = track;
 
-  // Temporary - integrate with the new pupil experience for select units and lessons only
+  // Temporary - integrate with the new pupil experience for select subjects only
   const shareToNewPupilExperience =
     subjectSlug !== null && pupilSubjectsLive.includes(subjectSlug);
 


### PR DESCRIPTION
## Description

Music year: 2001

- Amends how links are generated to be by subject 

## Issue(s)

Fixes #LESQ-693

## How to test

1. Go to https://deploy-preview-2304--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
