### PR TITLE
Feat/lesq 668/specialist share page [LESQ-688]

### DIFF
--- a/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
+++ b/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
@@ -1,0 +1,76 @@
+import { screen } from "@testing-library/dom";
+
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import curriculumApi from "@/node-lib/curriculum-api-2023";
+import SpecialistLessonSharePage, {
+  getStaticProps,
+} from "@/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share";
+import { SpecialistLessonShareFixture } from "@/node-lib/curriculum-api-2023/fixtures/specialistLessonShare.fixture";
+
+const render = renderWithProviders();
+
+describe("pages/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share", () => {
+  it("renders shareable resource", () => {
+    render(
+      <SpecialistLessonSharePage
+        curriculumData={SpecialistLessonShareFixture()}
+      />,
+    );
+
+    const videoCard = screen.getByText("Video");
+    expect(videoCard).toBeInTheDocument();
+  });
+});
+
+jest.mock("@/node-lib/curriculum-api-2023", () => ({
+  specialistLessonShare: jest.fn(),
+}));
+
+describe("getStaticProps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+  it("should return  404 page when there are no downloads", async () => {
+    const result = await getStaticProps({
+      params: { programmeSlug: "fake", unitSlug: "news", lessonSlug: "blah" },
+    });
+    expect(result).toEqual({ notFound: true });
+  });
+  it("Should call the api", async () => {
+    await getStaticProps({
+      params: {
+        programmeSlug: "numeracy",
+        unitSlug: "numeracy 1",
+        lessonSlug: "first lesson",
+      },
+    });
+
+    expect(curriculumApi.specialistLessonShare).toHaveBeenCalledTimes(1);
+    expect(curriculumApi.specialistLessonShare).toHaveBeenCalledWith({
+      programmeSlug: "numeracy",
+      unitSlug: "numeracy 1",
+      lessonSlug: "first lesson",
+    });
+  });
+  it("should fetch the data and return the props", async () => {
+    const curriculumData = SpecialistLessonShareFixture();
+    (curriculumApi.specialistLessonShare as jest.Mock).mockResolvedValue(
+      curriculumData,
+    );
+
+    const result = await getStaticProps({
+      params: {
+        programmeSlug: "numeracy",
+        unitSlug: "numeracy 1",
+        lessonSlug: "first lesson",
+      },
+    });
+
+    expect(result).toEqual({
+      props: {
+        curriculumData,
+      },
+    });
+  });
+});

--- a/src/node-lib/curriculum-api-2023/fixtures/specialistLessonShare.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/specialistLessonShare.fixture.ts
@@ -1,0 +1,42 @@
+import { SpecialistLessonShareData } from "../queries/specialistLessonShare/specialistLessonShare.schema";
+
+export const SpecialistLessonShareFixture = (
+  partial?: SpecialistLessonShareData,
+): SpecialistLessonShareData => ({
+  programmeSlug: "independent-living-applying-learning",
+  lessonSlug: "online-safety-c5gk8r",
+  lessonTitle: "Online Safety",
+  unitSlug: "staying-safe-al-5556",
+  unitTitle: "Staying Safe",
+  subjectSlug: "independent-living",
+  subjectTitle: "Independent Living",
+  shareableResources: [
+    {
+      exists: true,
+      type: "video",
+      label: "Video",
+      metadata: "",
+    },
+    {
+      exists: true,
+      type: "intro-quiz-questions",
+      label: "Intro Quiz",
+      metadata: "",
+    },
+    {
+      exists: true,
+      type: "exit-quiz-questions",
+      label: "Exit Quiz",
+      metadata: "",
+    },
+    {
+      exists: true,
+      type: "worksheet-pdf",
+      label: "Worksheet",
+      metadata: "pdf",
+    },
+  ],
+  isLegacy: false,
+  expired: false,
+  ...partial,
+});

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -44097,7 +44097,7 @@ export type SpecialistLessonShareQueryVariables = Exact<{
 }>;
 
 
-export type SpecialistLessonShareQuery = { __typename?: 'query_root', specialistLessonShare: Array<{ __typename?: 'published_mv_specialist_1_0_1', lesson_title?: string | null, combined_programme_fields?: any | null, unit_title?: string | null, expired?: boolean | null, contains_copyright_content?: boolean | null, exit_quiz?: any | null, starter_quiz?: any | null, pupil_lesson_outcome?: string | null, worksheet_asset_object?: any | null, worksheet_url?: string | null, video_mux_playback_id?: string | null, video_title?: string | null, exit_quiz_asset_object?: any | null, presentation_url?: string | null, slidedeck_asset_object?: any | null, starter_quiz_asset_object?: any | null }> };
+export type SpecialistLessonShareQuery = { __typename?: 'query_root', specialistLessonShare: Array<{ __typename?: 'published_mv_specialist_1_0_1', lesson_title?: string | null, combined_programme_fields?: any | null, unit_title?: string | null, expired?: boolean | null, contains_copyright_content?: boolean | null, exit_quiz?: any | null, starter_quiz?: any | null, pupil_lesson_outcome?: string | null, worksheet_url?: string | null, video_mux_playback_id?: string | null, presentation_url?: string | null, synthetic_programme_slug?: string | null }> };
 
 export type SpecialistProgrammeListingQueryVariables = Exact<{
   _contains?: InputMaybe<Scalars['jsonb']['input']>;
@@ -44517,14 +44517,10 @@ export const SpecialistLessonShareDocument = gql`
     exit_quiz
     starter_quiz
     pupil_lesson_outcome
-    worksheet_asset_object
     worksheet_url
     video_mux_playback_id
-    video_title
-    exit_quiz_asset_object
     presentation_url
-    slidedeck_asset_object
-    starter_quiz_asset_object
+    synthetic_programme_slug
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -44090,6 +44090,15 @@ export type SpecialistLessonListingQueryVariables = Exact<{
 
 export type SpecialistLessonListingQuery = { __typename?: 'query_root', specialistLessonListing: Array<{ __typename?: 'published_mv_specialist_1_0_1', lesson_slug?: string | null, lesson_title?: string | null, combined_programme_fields?: any | null, unit_slug?: string | null, unit_title?: string | null, expired?: boolean | null, contains_copyright_content?: boolean | null, exit_quiz?: any | null, starter_quiz?: any | null, pupil_lesson_outcome?: string | null, worksheet_asset_object?: any | null, worksheet_url?: string | null, video_mux_playback_id?: string | null, video_title?: string | null }> };
 
+export type SpecialistLessonShareQueryVariables = Exact<{
+  programmeSlug?: InputMaybe<Scalars['String']['input']>;
+  unitSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type SpecialistLessonShareQuery = { __typename?: 'query_root', specialistLessonShare: Array<{ __typename?: 'published_mv_specialist_1_0_1', lesson_title?: string | null, combined_programme_fields?: any | null, unit_title?: string | null, expired?: boolean | null, contains_copyright_content?: boolean | null, exit_quiz?: any | null, starter_quiz?: any | null, pupil_lesson_outcome?: string | null, worksheet_asset_object?: any | null, worksheet_url?: string | null, video_mux_playback_id?: string | null, video_title?: string | null, exit_quiz_asset_object?: any | null, presentation_url?: string | null, slidedeck_asset_object?: any | null, starter_quiz_asset_object?: any | null }> };
+
 export type SpecialistProgrammeListingQueryVariables = Exact<{
   _contains?: InputMaybe<Scalars['jsonb']['input']>;
 }>;
@@ -44495,6 +44504,30 @@ export const SpecialistLessonListingDocument = gql`
   }
 }
     `;
+export const SpecialistLessonShareDocument = gql`
+    query specialistLessonShare($programmeSlug: String, $unitSlug: String, $lessonSlug: String) {
+  specialistLessonShare: published_mv_specialist_1_0_1(
+    where: {unit_slug: {_eq: $unitSlug}, synthetic_programme_slug: {_eq: $programmeSlug}, lesson_slug: {_eq: $lessonSlug}}
+  ) {
+    lesson_title
+    combined_programme_fields
+    unit_title
+    expired
+    contains_copyright_content
+    exit_quiz
+    starter_quiz
+    pupil_lesson_outcome
+    worksheet_asset_object
+    worksheet_url
+    video_mux_playback_id
+    video_title
+    exit_quiz_asset_object
+    presentation_url
+    slidedeck_asset_object
+    starter_quiz_asset_object
+  }
+}
+    `;
 export const SpecialistProgrammeListingDocument = gql`
     query specialistProgrammeListing($_contains: jsonb = "") {
   specialistProgrammeListing: published_mv_specialist_1_0_1(
@@ -44664,6 +44697,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     specialistLessonListing(variables?: SpecialistLessonListingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SpecialistLessonListingQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SpecialistLessonListingQuery>(SpecialistLessonListingDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'specialistLessonListing', 'query');
+    },
+    specialistLessonShare(variables?: SpecialistLessonShareQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SpecialistLessonShareQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SpecialistLessonShareQuery>(SpecialistLessonShareDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'specialistLessonShare', 'query');
     },
     specialistProgrammeListing(variables?: SpecialistProgrammeListingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SpecialistProgrammeListingQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SpecialistProgrammeListingQuery>(SpecialistProgrammeListingDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'specialistProgrammeListing', 'query');

--- a/src/node-lib/curriculum-api-2023/index.ts
+++ b/src/node-lib/curriculum-api-2023/index.ts
@@ -24,6 +24,7 @@ import { pupilLessonOverviewCanonicalQuery } from "./queries/pupilLessonOverview
 import specialistProgrammeListingQuery from "./queries/specialistProgrammeListing/specialistProgrammeListing.query";
 import specialistLessonListingQuery from "./queries/specialistLessonListing/specialistLessonListing.query";
 import { specialistLessonDownloadQuery } from "./queries/specialistLessonDownload/specialistLessonDownload.query";
+import { specialistLessonShareQuery } from "./queries/specialistLessonShare/specialistLessonShare.query";
 
 export const keyStageSchema = z.object({
   slug: z.string(),
@@ -140,6 +141,7 @@ const curriculumApi2023 = {
   specialistProgrammeListing: specialistProgrammeListingQuery(sdk),
   specialistLessonListing: specialistLessonListingQuery(sdk),
   specialistLessonDownloads: specialistLessonDownloadQuery(sdk),
+  specialistLessonShare: specialistLessonShareQuery(sdk),
 };
 
 export type CurriculumApi = typeof curriculumApi2023;

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
@@ -1,16 +1,6 @@
 import { z } from "zod";
 
-const lessonShareResourceSchema = z.object({
-  exists: z.boolean().nullable(),
-  type: z.enum([
-    "intro-quiz-questions",
-    "exit-quiz-questions",
-    "worksheet-pdf",
-    "video",
-  ]),
-  label: z.string(),
-  metadata: z.string().nullable(),
-});
+import { lessonShareResourceSchema } from "../../shared.schema";
 
 export const lessonShareSchema = z.object({
   programmeSlug: z.string(),

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.gql
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.gql
@@ -18,13 +18,9 @@ query specialistLessonShare(
     exit_quiz
     starter_quiz
     pupil_lesson_outcome
-    worksheet_asset_object
     worksheet_url
     video_mux_playback_id
-    video_title
-    exit_quiz_asset_object
     presentation_url
-    slidedeck_asset_object
-    starter_quiz_asset_object
+    synthetic_programme_slug
   }
 }

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.gql
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.gql
@@ -1,0 +1,30 @@
+query specialistLessonShare(
+  $programmeSlug: String
+  $unitSlug: String
+  $lessonSlug: String
+) {
+  specialistLessonShare: published_mv_specialist_1_0_1(
+    where: {
+      unit_slug: { _eq: $unitSlug }
+      synthetic_programme_slug: { _eq: $programmeSlug }
+      lesson_slug: { _eq: $lessonSlug }
+    }
+  ) {
+    lesson_title
+    combined_programme_fields
+    unit_title
+    expired
+    contains_copyright_content
+    exit_quiz
+    starter_quiz
+    pupil_lesson_outcome
+    worksheet_asset_object
+    worksheet_url
+    video_mux_playback_id
+    video_title
+    exit_quiz_asset_object
+    presentation_url
+    slidedeck_asset_object
+    starter_quiz_asset_object
+  }
+}

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.test.ts
@@ -1,0 +1,33 @@
+import sdk from "../../sdk";
+
+import { specialistLessonShareQuery } from "./specialistLessonShare.query";
+
+describe("specialistLessonShare.query", () => {
+  it("runs", async () => {
+    const res = await specialistLessonShareQuery(sdk)({
+      lessonSlug: "online-safety-c5gk8r",
+      unitSlug: "staying-safe-al-5556",
+      programmeSlug: "independent-living-applying-learning",
+    });
+
+    expect(res).toBeDefined();
+  });
+  it("throws an error if no lesson is found", async () => {
+    await expect(
+      async () =>
+        await specialistLessonShareQuery({
+          ...sdk,
+          specialistLessonShare: jest.fn(() =>
+            Promise.resolve({
+              specialistLessonShare: [],
+            }),
+          ),
+        })({
+          lessonSlug: "blah",
+          unitSlug: "blah",
+          programmeSlug: "fake-programme",
+        }),
+    ).rejects.toThrow("curriculum-api/not-found");
+  });
+  it.todo("returns data in the shape of the specialist lesson share schema");
+});

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.test.ts
@@ -1,6 +1,33 @@
 import sdk from "../../sdk";
 
 import { specialistLessonShareQuery } from "./specialistLessonShare.query";
+import { specialistLessonShareSchema } from "./specialistLessonShare.schema";
+
+jest.mock("../../sdk", () => ({
+  specialistLessonShare: jest.fn(() =>
+    Promise.resolve({
+      specialistLessonShare: [
+        {
+          lesson_slug: "online-safety-c5gk8r",
+          lesson_title: "Online Safety",
+          unit_title: "Staying Safe",
+          unit_slug: "staying-safe-al-5556",
+          expired: false,
+          worksheet_url: "https://www.example.com",
+          starter_quiz: "https://www.example.com",
+          exit_quiz: "https://www.example.com",
+          video_mux_playback_id: "123",
+          presentation_url: "https://www.example.com",
+          synthetic_programme_slug: "independent-living-applying-learning",
+          combined_programme_fields: {
+            subject_slug: "independent-living",
+            subject: "Independent Living",
+          },
+        },
+      ],
+    }),
+  ),
+}));
 
 describe("specialistLessonShare.query", () => {
   it("runs", async () => {
@@ -29,5 +56,13 @@ describe("specialistLessonShare.query", () => {
         }),
     ).rejects.toThrow("curriculum-api/not-found");
   });
-  it.todo("returns data in the shape of the specialist lesson share schema");
+  it("returns data in the shape of the specialist lesson share schema", async () => {
+    const res = await specialistLessonShareQuery(sdk)({
+      lessonSlug: "online-safety-c5gk8r",
+      unitSlug: "staying-safe-al-5556",
+      programmeSlug: "independent-living-applying-learning",
+    });
+
+    expect(specialistLessonShareSchema.parse(res)).toEqual(res);
+  });
 });

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
@@ -26,7 +26,7 @@ export const constructShareableResources = (
     exists: lesson.video_mux_playback_id !== null,
     type: "video" as const,
     label: "Video",
-    metadata: "", // TODO: get video duration
+    metadata: "mp4", // TODO: get video duration
   };
   const worksheet = {
     exists: lesson.worksheet_url !== null,

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
@@ -1,0 +1,24 @@
+import { Sdk } from "../../sdk";
+
+import { specialistLessonShareQueryResponseSchema } from "./specialistLessonShare.schema";
+
+export const specialistLessonShareQuery =
+  (sdk: Sdk) =>
+  async (args: {
+    lessonSlug: string;
+    unitSlug: string;
+    programmeSlug: string;
+  }) => {
+    const { specialistLessonShare } = await sdk.specialistLessonShare(args);
+
+    const parsedSpecialistLessonShare =
+      specialistLessonShareQueryResponseSchema.safeParse(
+        specialistLessonShare[0],
+      );
+
+    if (!parsedSpecialistLessonShare || !parsedSpecialistLessonShare.success) {
+      throw new Error("curriculum-api/not-found");
+    }
+
+    return specialistLessonShare;
+  };

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
@@ -1,6 +1,42 @@
+import { z } from "zod";
+
 import { Sdk } from "../../sdk";
 
-import { specialistLessonShareQueryResponseSchema } from "./specialistLessonShare.schema";
+import {
+  SpecialistLessonShareData,
+  specialistLessonShareQueryResponseSchema,
+} from "./specialistLessonShare.schema";
+
+export const constructShareableResources = (
+  lesson: z.infer<typeof specialistLessonShareQueryResponseSchema>,
+) => {
+  const introQuiz = {
+    exists: lesson.starter_quiz !== null,
+    type: "intro-quiz-questions" as const,
+    label: "Starter Quiz",
+    metadata: "", // TODO: get quiz questions
+  };
+  const exitQuiz = {
+    exists: lesson.exit_quiz !== null,
+    type: "exit-quiz-questions" as const,
+    label: "Exit Quiz",
+    metadata: "", // TODO: get quiz questions
+  };
+  const video = {
+    exists: lesson.video_mux_playback_id !== null,
+    type: "video" as const,
+    label: "Video",
+    metadata: "", // TODO: get video duration
+  };
+  const worksheet = {
+    exists: lesson.worksheet_url !== null,
+    type: "worksheet-pdf" as const,
+    label: "Worksheet",
+    metadata: "pdf",
+  };
+
+  return [video, introQuiz, exitQuiz, worksheet];
+};
 
 export const specialistLessonShareQuery =
   (sdk: Sdk) =>
@@ -8,7 +44,7 @@ export const specialistLessonShareQuery =
     lessonSlug: string;
     unitSlug: string;
     programmeSlug: string;
-  }) => {
+  }): Promise<SpecialistLessonShareData> => {
     const { specialistLessonShare } = await sdk.specialistLessonShare(args);
 
     const parsedSpecialistLessonShare =
@@ -20,5 +56,20 @@ export const specialistLessonShareQuery =
       throw new Error("curriculum-api/not-found");
     }
 
-    return specialistLessonShare;
+    const lesson = parsedSpecialistLessonShare.data;
+
+    const shareableResources = constructShareableResources(lesson);
+
+    return {
+      programmeSlug: lesson.synthetic_programme_slug,
+      lessonSlug: args.lessonSlug,
+      lessonTitle: lesson.lesson_title,
+      unitSlug: args.unitSlug,
+      unitTitle: lesson.unit_title,
+      subjectSlug: lesson.combined_programme_fields.subject_slug,
+      subjectTitle: lesson.combined_programme_fields.subject,
+      expired: lesson.expired,
+      isLegacy: true,
+      shareableResources,
+    };
   };

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 
-import { legacyAssetObjectSchema } from "../../shared.schema";
-
-import { lessonShareSchema } from "@/node-lib/curriculum-api";
+import { lessonShareResourceSchema } from "../../shared.schema";
 
 export const specialistLessonShareQueryResponseSchema = z.object({
   lesson_title: z.string(),
@@ -10,13 +8,14 @@ export const specialistLessonShareQueryResponseSchema = z.object({
   expired: z.boolean().nullable(),
   worksheet_url: z.string().nullable(),
   starter_quiz: z.string().nullable(),
-  worksheet_asset_object: legacyAssetObjectSchema,
+  exit_quiz: z.string().nullable(),
   video_mux_playback_id: z.string().nullish(),
-  video_title: z.string().nullish(),
-  exit_quiz_asset_object: legacyAssetObjectSchema,
   presentation_url: z.string().nullish(),
-  starter_quiz_asset_object: legacyAssetObjectSchema,
-  slidedeck_asset_object: legacyAssetObjectSchema,
+  synthetic_programme_slug: z.string(),
+  combined_programme_fields: z.object({
+    subject_slug: z.string(),
+    subject: z.string(),
+  }),
 });
 
 export const specialistLessonShareSchema = z.object({
@@ -27,14 +26,11 @@ export const specialistLessonShareSchema = z.object({
   unitTitle: z.string(),
   subjectSlug: z.string(),
   subjectTitle: z.string(),
-  shareableResources: z.array(lessonShareSchema),
+  shareableResources: z.array(lessonShareResourceSchema),
   isLegacy: z.boolean(),
   expired: z.boolean().nullable(),
 });
 
 export type SpecialistLessonShareData = z.infer<
-  typeof specialistLessonShareSchema
->;
-export type SpecialistLessonShareResourceData = z.infer<
   typeof specialistLessonShareSchema
 >;

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { legacyAssetObjectSchema } from "../../shared.schema";
+
+import { lessonShareSchema } from "@/node-lib/curriculum-api";
+
+export const specialistLessonShareQueryResponseSchema = z.object({
+  lesson_title: z.string(),
+  unit_title: z.string(),
+  expired: z.boolean().nullable(),
+  worksheet_url: z.string().nullable(),
+  starter_quiz: z.string().nullable(),
+  worksheet_asset_object: legacyAssetObjectSchema,
+  video_mux_playback_id: z.string().nullish(),
+  video_title: z.string().nullish(),
+  exit_quiz_asset_object: legacyAssetObjectSchema,
+  presentation_url: z.string().nullish(),
+  starter_quiz_asset_object: legacyAssetObjectSchema,
+  slidedeck_asset_object: legacyAssetObjectSchema,
+});
+
+export const specialistLessonShareSchema = z.object({
+  programmeSlug: z.string(),
+  lessonSlug: z.string(),
+  lessonTitle: z.string(),
+  unitSlug: z.string(),
+  unitTitle: z.string(),
+  subjectSlug: z.string(),
+  subjectTitle: z.string(),
+  shareableResources: z.array(lessonShareSchema),
+  isLegacy: z.boolean(),
+  expired: z.boolean().nullable(),
+});
+
+export type SpecialistLessonShareData = z.infer<
+  typeof specialistLessonShareSchema
+>;
+export type SpecialistLessonShareResourceData = z.infer<
+  typeof specialistLessonShareSchema
+>;

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -252,3 +252,15 @@ export const legacyAssetObjectSchema = z
       .nullish(),
   })
   .nullish();
+
+export const lessonShareResourceSchema = z.object({
+  exists: z.boolean().nullable(),
+  type: z.enum([
+    "intro-quiz-questions",
+    "exit-quiz-questions",
+    "worksheet-pdf",
+    "video",
+  ]),
+  label: z.string(),
+  metadata: z.string().nullable(),
+});

--- a/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
@@ -1,0 +1,96 @@
+import {
+  NextPage,
+  GetStaticProps,
+  GetStaticPathsResult,
+  GetStaticPropsResult,
+} from "next";
+
+import AppLayout from "@/components/SharedComponents/AppLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import {
+  getFallbackBlockingConfig,
+  shouldSkipInitialBuild,
+} from "@/node-lib/isr";
+import getPageProps from "@/node-lib/getPageProps";
+import { LessonShare } from "@/components/TeacherViews/LessonShare/LessonShare.view";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { SpecialistLessonShareData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema";
+
+export type SpecialistLessonSharePageProps = {
+  curriculumData: SpecialistLessonShareData;
+};
+
+const SpecialistLessonSharePage: NextPage<SpecialistLessonSharePageProps> = ({
+  curriculumData,
+}) => {
+  const { lessonTitle, subjectTitle } = curriculumData;
+
+  return (
+    <AppLayout
+      seoProps={{
+        ...getSeoProps({
+          title: `Lesson Share: ${lessonTitle} | ${subjectTitle}`,
+          description: "Lesson share",
+        }),
+        ...{ noFollow: true, noIndex: true },
+      }}
+    >
+      <LessonShare isCanonical={false} lesson={curriculumData} />
+    </AppLayout>
+  );
+};
+
+export type URLParams = {
+  lessonSlug: string;
+  programmeSlug: string;
+  unitSlug: string;
+};
+
+export const getStaticPaths = async () => {
+  if (shouldSkipInitialBuild) {
+    return getFallbackBlockingConfig();
+  }
+
+  const config: GetStaticPathsResult<URLParams> = {
+    fallback: "blocking",
+    paths: [],
+  };
+  return config;
+};
+
+export const getStaticProps: GetStaticProps<
+  SpecialistLessonSharePageProps,
+  URLParams
+> = async (context) => {
+  return getPageProps({
+    page: "downloads::getStaticProps",
+    context,
+    getProps: async () => {
+      if (!context.params) {
+        throw new Error("No context.params");
+      }
+      const { lessonSlug, programmeSlug, unitSlug } = context.params;
+
+      const curriculumData = await curriculumApi2023.specialistLessonShare({
+        programmeSlug,
+        unitSlug,
+        lessonSlug,
+      });
+
+      if (!curriculumData) {
+        return {
+          notFound: true,
+        };
+      }
+
+      const results: GetStaticPropsResult<SpecialistLessonSharePageProps> = {
+        props: {
+          curriculumData,
+        },
+      };
+      return results;
+    },
+  });
+};
+
+export default SpecialistLessonSharePage;

--- a/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
@@ -29,8 +29,8 @@ const SpecialistLessonSharePage: NextPage<SpecialistLessonSharePageProps> = ({
     <AppLayout
       seoProps={{
         ...getSeoProps({
-          title: `Lesson Share: ${lessonTitle} | ${subjectTitle}`,
-          description: "Lesson share",
+          title: `Specialist Lesson Share: ${lessonTitle} | ${subjectTitle}`,
+          description: "Specialist Lesson share",
         }),
         ...{ noFollow: true, noIndex: true },
       }}
@@ -40,7 +40,7 @@ const SpecialistLessonSharePage: NextPage<SpecialistLessonSharePageProps> = ({
   );
 };
 
-export type URLParams = {
+export type SpecialistShareURLParams = {
   lessonSlug: string;
   programmeSlug: string;
   unitSlug: string;
@@ -51,7 +51,7 @@ export const getStaticPaths = async () => {
     return getFallbackBlockingConfig();
   }
 
-  const config: GetStaticPathsResult<URLParams> = {
+  const config: GetStaticPathsResult<SpecialistShareURLParams> = {
     fallback: "blocking",
     paths: [],
   };
@@ -60,10 +60,10 @@ export const getStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps<
   SpecialistLessonSharePageProps,
-  URLParams
+  SpecialistShareURLParams
 > = async (context) => {
   return getPageProps({
-    page: "downloads::getStaticProps",
+    page: "specialist-share::getStaticProps",
     context,
     getProps: async () => {
       if (!context.params) {
@@ -71,24 +71,30 @@ export const getStaticProps: GetStaticProps<
       }
       const { lessonSlug, programmeSlug, unitSlug } = context.params;
 
-      const curriculumData = await curriculumApi2023.specialistLessonShare({
-        programmeSlug,
-        unitSlug,
-        lessonSlug,
-      });
+      try {
+        const curriculumData = await curriculumApi2023.specialistLessonShare({
+          programmeSlug,
+          unitSlug,
+          lessonSlug,
+        });
 
-      if (!curriculumData) {
+        if (!curriculumData) {
+          return {
+            notFound: true,
+          };
+        }
+
+        const results: GetStaticPropsResult<SpecialistLessonSharePageProps> = {
+          props: {
+            curriculumData,
+          },
+        };
+        return results;
+      } catch {
         return {
           notFound: true,
         };
       }
-
-      const results: GetStaticPropsResult<SpecialistLessonSharePageProps> = {
-        props: {
-          curriculumData,
-        },
-      };
-      return results;
     },
   });
 };


### PR DESCRIPTION
## Description

Music year: 2007

- Adds specialist share page, query and schema
- Note: we are mising information in the MV required to give video duration, so have added a placeholder text 'mp4' and added an issue in the specialist issues tracker
- We also don't have information on quiz questions but I don't think specialist has any quizzes

## How to test

1. Go to https://deploy-preview-2307--oak-web-application.netlify.thenational.academy/teachers/specialist/programmes/numeracy-building-understanding/units/number-c7b4/lessons/counting-individual-objects-one-to-one-correspondence-6nh32d/share
3. You should see internal server error (404)
4. the rest of the site should work the same :') 

## Screenshots

How it should now look:
<img width="1510" alt="Screenshot 2024-03-12 at 08 07 57" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/d7a3ffb8-3905-4fcb-a323-84d38c7e8e7c">