### PR TITLE
PUPIL-478: Confirmic blocking the bottom nav in pupil lessons

### DIFF
--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -1,3 +1,4 @@
+import { createGlobalStyle } from "styled-components";
 import {
   OakBox,
   OakThemeProvider,
@@ -104,6 +105,21 @@ export const PupilPageContent = ({
   }
 };
 
+// Moves Confirmic modal clear of the bottom navigation
+// This should be removed once confirmic is replaced (PUPIL-478)
+const CookieConsentStyles = createGlobalStyle`
+#mtm-frame-container {
+  bottom: 70px!important;
+  height: 510px;
+  overflow: clip;
+
+  // Hides the corner shadow
+  > div {
+    display: none;  
+  }
+}
+`;
+
 export const PupilExperienceView = ({
   curriculumData,
   hasWorksheet,
@@ -113,6 +129,7 @@ export const PupilExperienceView = ({
 
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
+      <CookieConsentStyles />
       <LessonEngineProvider initialLessonReviewSections={availableSections}>
         <OakBox $height={"100vh"}>
           {curriculumData.expired ? (


### PR DESCRIPTION
## Description

Music year: 1977

Moves the Confirmic widget above the footer nav in pupil lessons so that it no longer obscures and blocks interaction with the button beneath

## How to test

1. Open an incognito browser window or clear your cookies + localStorage for `thenational.academy`
2. Go to https://deploy-preview-2311--oak-web-application.netlify.thenational.academy/pupils/lessons/prologue-grime-mix-ccuk0d
3. Observe the appearance of the Confirmic consent widget
4. You should be able to click on "Let's get ready"
5. The confirmic widget should work as before
6. The confirmic widget should not be affected in any other section of OWA

## Screenshots

How it used to look (delete if n/a):


https://github.com/oaknational/Oak-Web-Application/assets/122096/1af63711-856c-4bca-8313-f4fe8f5898c2



How it should now look:

<img width="1459" alt="Screenshot 2024-03-14 at 11 39 17" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/dad34f27-6b29-4e13-a89e-51c6766885de">

![localhost_3000_pupils_lessons_prologue-grime-mix-ccuk0d(iPad Air)](https://github.com/oaknational/Oak-Web-Application/assets/122096/0eb31767-6d06-46d2-a8be-3863e7486b43)

![localhost_3000_pupils_lessons_prologue-grime-mix-ccuk0d(iPhone 14 Pro Max)](https://github.com/oaknational/Oak-Web-Application/assets/122096/9587ab67-fa78-4b62-b6f0-e95c0f94e753)

