### PR TITLE
fix: specialist lesson schema [LESQ-704]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonOverview/specialistLessonOverview.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonOverview/specialistLessonOverview.schema.ts
@@ -57,8 +57,8 @@ type Threads = z.infer<typeof threads>;
 const combined_programme_fields = z.object({
   subject: z.string(),
   subject_slug: z.string(),
-  developmentstage: z.string().nullable(),
-  developmentstage_slug: z.string().nullable(),
+  developmentstage: z.string().nullish(),
+  developmentstage_slug: z.string().nullish(),
   phase_description: z.string().nullable().optional(),
   phase_slug: z.string().nullable().optional(),
 });


### PR DESCRIPTION
## Description

Music year: 2011

- make developmentstage optional in the schema

## Issue(s)

Fixes #
Therapy lessons not loading

## How to test

1. Go to https://deploy-preview-2319--oak-web-application.netlify.thenational.academy
2. should be the same

## Screenshots

How it used to look (delete if n/a):
<img width=500 src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/a2982349-9eeb-4c8a-9342-3fdddcd2860c">

How it should now look:
<img width="748" alt="Screenshot 2024-03-19 at 13 34 51" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/c7e57537-d1c8-416a-9d7e-ba401954e2e4">

