### PR TITLE
LESQ-715: Fix specialist heading icon sizes

### DIFF
--- a/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
+++ b/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
@@ -6,7 +6,6 @@ import { LessonHeaderWrapper } from "@/components/TeacherComponents/LessonHeader
 import SubjectIconBrushBorders from "@/components/TeacherComponents/SubjectIconBrushBorders";
 import HeaderListingCurriculumDownloadButton from "@/components/TeacherComponents/HeaderListingCurriculumDownloadButton";
 import LessonMetadata from "@/components/SharedComponents/LessonMetadata";
-import Box from "@/components/SharedComponents/Box";
 import Flex from "@/components/SharedComponents/Flex.deprecated";
 import { OakColorName } from "@/styles/theme";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
@@ -60,17 +59,15 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
     <LessonHeaderWrapper breadcrumbs={breadcrumbs} background={background}>
       <Flex $mb={[12, 0]} $flexDirection={"column"}>
         <Flex>
-          <Box $height={[80, 140]} $maxWidth={[80, 140]} $mr={[16, 32]}>
+          <Flex $mr={[16, 32]} $height={[80, 140]} $maxWidth={[80, 140]}>
             <SubjectIconBrushBorders
-              $pa={8}
+              $pa={16}
               subjectSlug={subjectSlug}
-              height={15}
-              width={20}
               $ma={"auto"}
               isNew={isNew}
               color={subjectIconBackgroundColor}
             />
-          </Box>
+          </Flex>
           <Flex $flexDirection={"column"}>
             <OakSpan
               $mb="space-between-ssx"

--- a/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
+++ b/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
@@ -50,7 +50,8 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
           <OakFlex $flexDirection={["column", "row", "row"]}>
             <OakFlex
               $gap={["all-spacing-4", "all-spacing-0"]}
-              $maxWidth="all-spacing-11"
+              // $maxWidth="all-spacing-18"
+              // $height={"all-spacing-18"}
               $mr={"space-between-s"}
             >
               <SubjectIconBrushBorders

--- a/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
+++ b/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
@@ -44,15 +44,21 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
     <LessonHeaderWrapper breadcrumbs={breadcrumbs} background={background}>
       <OakGrid>
         <OakGridArea $colSpan={[12, 6]}>
-          <OakFlex $flexDirection={["column", "row", "row"]}>
+          <OakFlex $flexDirection={["column", "column", "row"]}>
             <OakFlex
               $mr={["space-between-s", "space-between-l"]}
-              $maxWidth={["all-spacing-13", "all-spacing-16"]}
-              $alignItems={"center"}
+              $maxWidth={["all-spacing-13", "all-spacing-13", "all-spacing-16"]}
+              $alignItems={"flex-start"}
+              $mb={[
+                "space-between-m",
+                "space-between-m2",
+                "space-between-none",
+              ]}
             >
               <SubjectIconBrushBorders
                 $pa={16}
                 subjectSlug={subjectSlug}
+                containerMinWidth={[80, 80, 140]}
                 $ma={"auto"}
                 isNew={false}
                 color={subjectIconBackgroundColor}
@@ -69,11 +75,16 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
               <OakHeading tag={"h1"} $font={["heading-4", "heading-3"]}>
                 {subjectTitle}
               </OakHeading>
+              <OakP
+                $mb="space-between-s"
+                $mt="space-between-s"
+                $font={"body-1"}
+              >
+                {description}
+              </OakP>
             </OakFlex>
           </OakFlex>
-          <OakP $mb="space-between-s" $mt="space-between-s" $font={"body-1"}>
-            {description}
-          </OakP>
+
           {/* Commented out until - I want to be able to download specialist curriculum maps LESQ-586 */}
           {/* {hasCurriculumDownload && (
             <HeaderListingCurriculumDownloadButton

--- a/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
+++ b/src/components/TeacherComponents/SpecialistProgrammeHeaderListing/SpecialistProgrammeHeaderListing.tsx
@@ -34,9 +34,9 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
     subjectSlug,
     title,
     subjectTitle,
-    subjectIconBackgroundColor = "white",
+    subjectIconBackgroundColor = "aqua",
     breadcrumbs,
-    background = "aqua",
+    background = "aqua50",
     description,
   } = props;
 
@@ -44,19 +44,14 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
     <LessonHeaderWrapper breadcrumbs={breadcrumbs} background={background}>
       <OakGrid>
         <OakGridArea $colSpan={[12, 6]}>
-          <OakSpan $mb="space-between-s" $color={"grey60"} $font={"heading-7"}>
-            {title}
-          </OakSpan>
           <OakFlex $flexDirection={["column", "row", "row"]}>
             <OakFlex
-              $gap={["all-spacing-4", "all-spacing-0"]}
-              // $maxWidth="all-spacing-18"
-              // $height={"all-spacing-18"}
-              $mr={"space-between-s"}
+              $mr={["space-between-s", "space-between-l"]}
+              $maxWidth={["all-spacing-13", "all-spacing-16"]}
+              $alignItems={"center"}
             >
               <SubjectIconBrushBorders
-                $pa={4}
-                containerMinWidth={[40, 60]}
+                $pa={16}
                 subjectSlug={subjectSlug}
                 $ma={"auto"}
                 isNew={false}
@@ -64,6 +59,13 @@ const SpecialistHeaderListing: FC<SpecialistHeaderListingProps> = (props) => {
               />
             </OakFlex>
             <OakFlex $flexDirection={"column"}>
+              <OakSpan
+                $mb="space-between-s"
+                $color={"grey60"}
+                $font={"heading-7"}
+              >
+                {title}
+              </OakSpan>
               <OakHeading tag={"h1"} $font={["heading-4", "heading-3"]}>
                 {subjectTitle}
               </OakHeading>


### PR DESCRIPTION
## Description

Music year: 2014
https://www.youtube.com/watch?v=ZbZSe6N_BXs

- Amends heading Icon sizes on `SpecialistProgrammeHeadingListing` and `HeaderListing` components

## Issue(s)

Fixes #LESQ-715

## Screenshots

How it used to look (delete if n/a):
<img width="789" alt="Screenshot 2024-03-26 at 08 41 51" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/b8b16c12-4244-4a23-a51a-4f9debccdc4d">

<img width="779" alt="Screenshot 2024-03-20 at 10 38 02" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/16fd8c50-a966-491c-93f3-ebf931034119">


How it should now look:
<img width="1149" alt="Screenshot 2024-03-26 at 08 39 01" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/2589fa01-041e-4c35-a907-74ba8c441047">
<img width="333" alt="Screenshot 2024-03-26 at 08 40 16" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/8ae2dcd1-86b8-4647-ae9c-e795eeca32b1">
<img width="953" alt="Screenshot 2024-03-26 at 08 40 54" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/1ad09277-b1bb-436c-b321-39dbebb6c195">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
