### PR TITLE
LESQ-708: Removes expired lesson coming soon 

### DIFF
--- a/src/components/TeacherComponents/UnitListItemLessonCount/UnitListItemLessonCount.tsx
+++ b/src/components/TeacherComponents/UnitListItemLessonCount/UnitListItemLessonCount.tsx
@@ -26,7 +26,6 @@ export const UnitListItemLessonCount = ({
           <OakSpan $font={["body-3", "heading-light-7"]} $color={textColor}>
             {!!lessonCount &&
               `${lessonCount} ${lessonCount > 1 ? "lessons" : "lesson"}`}
-            {expired && ` Coming soon`}
           </OakSpan>
         )}
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Removes coming soon from unit cards

## Issue(s)

Fixes #LESQ-708

## How to test

## Screenshots

How it used to look (delete if n/a):
<img width="963" alt="Screenshot 2024-03-22 at 13 30 07" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/d98746f8-91af-4f70-9638-adf14c554e60">

How it should now look:
![Uploading Screenshot 2024-03-22 at 13.30.38.png…]()

