### PR TITLE
fix(PUPIL-524): split `transcriptSentences` into an array of transcript sentences

### DIFF
--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
@@ -3,7 +3,12 @@ import { requestLessonResources } from "./requestLessonResources";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import { pupilLessonOverviewFixture } from "@/node-lib/curriculum-api-2023/fixtures/pupilLessonOverview.fixture";
 
-jest.mock("@/utils/handleTranscript");
+jest.mock("@/utils/handleTranscript", () => {
+  return {
+    ...jest.requireActual("@/utils/handleTranscript"),
+    getCaptionsFromFile: jest.fn().mockResolvedValue([]),
+  };
+});
 
 describe("requestLessonResources", () => {
   const lessonDownloadsCanonicalResponse = {
@@ -35,9 +40,7 @@ describe("requestLessonResources", () => {
     });
 
     const res = await requestLessonResources({
-      curriculumData: {
-        ...pupilLessonOverviewFixture(),
-      },
+      curriculumData: pupilLessonOverviewFixture(),
     });
 
     expect(res.hasWorksheet).toBe(true);
@@ -50,9 +53,7 @@ describe("requestLessonResources", () => {
     });
 
     const res = await requestLessonResources({
-      curriculumData: {
-        ...pupilLessonOverviewFixture(),
-      },
+      curriculumData: pupilLessonOverviewFixture(),
     });
 
     expect(res.hasWorksheet).toBe(false);
@@ -61,16 +62,32 @@ describe("requestLessonResources", () => {
   // refactored into helper file
   it("tests for the presence of a worksheet", async () => {
     await requestLessonResources({
-      curriculumData: {
-        ...pupilLessonOverviewFixture({
-          lessonSlug: "lessonSlug",
-          isLegacy: false,
-        }),
-      },
+      curriculumData: pupilLessonOverviewFixture({
+        lessonSlug: "lessonSlug",
+        isLegacy: false,
+      }),
     });
 
     expect(getDownloadResourcesExistenceSpy).toHaveBeenCalledWith({
       lessonSlug: "lessonSlug",
     });
+  });
+
+  it("for legacy lessons it splits the transcript into sentences", async () => {
+    const transcriptSentences = [
+      "This is a sentence. This is another sentence.",
+    ];
+
+    const res = await requestLessonResources({
+      curriculumData: pupilLessonOverviewFixture({
+        isLegacy: true,
+        transcriptSentences,
+      }),
+    });
+
+    expect(res.transcriptSentences).toEqual([
+      "This is a sentence.",
+      "This is another sentence.",
+    ]);
   });
 });

--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
@@ -1,6 +1,6 @@
 import { PupilLessonOverviewData } from "@/node-lib/curriculum-api";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { getCaptionsFromFile } from "@/utils/handleTranscript";
+import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export const requestLessonResources = async ({
   curriculumData,
@@ -16,7 +16,7 @@ export const requestLessonResources = async ({
       return getCaptionsFromFile(`${curriculumData.videoTitle}.vtt`);
     }
 
-    return curriculumData.transcriptSentences;
+    return formatSentences(curriculumData.transcriptSentences);
   })();
 
   // Resolve the requests for the transcript and worksheet existence in parallel


### PR DESCRIPTION
## Description

Music year: 1959

Legacy transcripts are stored as a big string which we have to split into sentences to properly format in the frontend.

## How to test

1. Go to https://deploy-preview-2330--oak-web-application.netlify.thenational.academy/pupils/lessons/introduction-to-the-canterbury-tales-cmrk4d
2. Click on "Lesson video"
3. Click on "Show transcript"
4. You should see a transcript with line breaks.

Line breaking should now match the same lesson in the teacher's section https://www.thenational.academy/teachers/programmes/english-secondary-ks3-l/units/the-canterbury-tales-general-prologue-7d62/lessons/introduction-to-the-canterbury-tales-cmrk4d

## Screenshots

How it used to look:
<img width="1780" alt="Screenshot 2024-03-22 at 15 34 40" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/bd658501-e0d3-4056-8fae-617994875610">

How it should now look:
<img width="1780" alt="Screenshot 2024-03-22 at 15 34 45" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/f0b738c2-b915-4bc3-89e0-04344ec22dbf">

Compared to the same lesson in the teacher section:
<img width="1192" alt="Screenshot 2024-03-22 at 16 51 41" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/62adbaad-70f3-4073-b9cb-89cd333b1e41">



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
