### PR TITLE
fix: 404 on some lesson listing pages [LESQ-709]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonDownload/specialistLessonDownload.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonDownload/specialistLessonDownload.query.ts
@@ -50,18 +50,18 @@ export const constructDownloadsArray = (
     forbidden: false,
   };
   const worksheetPdf = {
-    exists: lesson.worksheet_asset_object?.google_drive_downloadable_version
-      ? true
-      : false,
+    exists:
+      typeof lesson.worksheet_asset_object
+        ?.google_drive_downloadable_version === "string",
     type: "worksheet-pdf" as const,
     label: "Worksheet",
     ext: "pdf",
     forbidden: false,
   };
   const worksheetPptx = {
-    exists: lesson.worksheet_asset_object?.google_drive_downloadable_version
-      ? true
-      : false,
+    exists:
+      typeof lesson.worksheet_asset_object
+        ?.google_drive_downloadable_version === "string",
     type: "worksheet-pptx" as const,
     label: "Worksheet",
     ext: "pptx",

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -248,7 +248,7 @@ export const legacyAssetObjectSchema = z
     google_drive_downloadable_version: z
       .object({
         id: z.string(),
-        url: z.string(),
+        url: z.string().nullish(),
       })
       .nullish(),
   })


### PR DESCRIPTION
## Description

Music year: 2017

- there was a schema validation error due to null values on some asset worksheet urls, so updated the schema
- this means we face the bug where the download button is available on individual resources but not on the downloads page, we have a ticket for that for next sprint

## How to test

1. Go to https://deploy-preview-2333--oak-web-application.netlify.thenational.academy
2. should be the same

## Screenshots

How it used to look (delete if n/a):
<img width=500 src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/2d653009-79d1-401c-a83a-d8702daf9c5a">

How it should now look:
<img width="500" alt="Screenshot 2024-03-26 at 13 55 34" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/900b17a6-23c8-44bc-94b7-2e785488c73d">
