### PR TITLE
fix: do not exclude copyright from counts - LESQ-719

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -41628,14 +41628,14 @@ export const DevelopmentStagesDocument = gql`
 export const SpecialistLessonCountDocument = gql`
     query specialistLessonCount($unit_slug: String!) {
   specialistUnitLessonCount: published_mv_specialist_1_0_2_aggregate(
-    where: {unit_slug: {_eq: $unit_slug}, contains_copyright_content: {_eq: false}, expired: {_is_null: true}}
+    where: {unit_slug: {_eq: $unit_slug}, expired: {_is_null: true}}
   ) {
     aggregate {
       count(distinct: true, columns: lesson_slug)
     }
   }
   specialistUnitExpiredLessonCount: published_mv_specialist_1_0_2_aggregate(
-    where: {unit_slug: {_eq: $unit_slug}, contains_copyright_content: {_eq: false}, expired: {_is_null: false}}
+    where: {unit_slug: {_eq: $unit_slug}, expired: {_is_null: false}}
   ) {
     aggregate {
       count(distinct: true, columns: lesson_slug)

--- a/src/node-lib/curriculum-api-2023/queries/specialistUnitListing/specialistLessonCount.query.gql
+++ b/src/node-lib/curriculum-api-2023/queries/specialistUnitListing/specialistLessonCount.query.gql
@@ -1,21 +1,13 @@
 query specialistLessonCount($unit_slug: String!) {
   specialistUnitLessonCount: published_mv_specialist_1_0_2_aggregate(
-    where: {
-      unit_slug: { _eq: $unit_slug }
-      contains_copyright_content: { _eq: false }
-      expired: { _is_null: true }
-    }
+    where: { unit_slug: { _eq: $unit_slug }, expired: { _is_null: true } }
   ) {
     aggregate {
       count(distinct: true, columns: lesson_slug)
     }
   }
   specialistUnitExpiredLessonCount: published_mv_specialist_1_0_2_aggregate(
-    where: {
-      unit_slug: { _eq: $unit_slug }
-      contains_copyright_content: { _eq: false }
-      expired: { _is_null: false }
-    }
+    where: { unit_slug: { _eq: $unit_slug }, expired: { _is_null: false } }
   ) {
     aggregate {
       count(distinct: true, columns: lesson_slug)


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Remove contains_copyright_content: { _eq: false } from gql query
- https://www.notion.so/oaknationalacademy/I-want-correct-lesson-counts-on-unit-cards-for-specialist-content-2eb71e0ef8bc46f68975c8465d7b4752

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2334--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

`Our world` has an incorrect count

How it used to look (delete if n/a):
{screenshots}

![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/ad6b4f3c-361b-41eb-b0c6-171e183145f7)



How it should now look:
{screenshots}

![image](https://github.com/oaknational/Oak-Web-Application/assets/7987787/d9f7910c-c060-4617-9c71-264256a03426)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
