### PR TITLE
Feat/pupil 560/seo meta data is correct

### DIFF
--- a/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
+++ b/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
@@ -1,0 +1,27 @@
+import Head from "next/head";
+import { FC } from "react";
+
+import Seo, { SeoProps } from "@/browser-lib/seo/Seo";
+
+export type PupilLayoutProps = {
+  children?: React.ReactNode;
+  seoProps: SeoProps;
+};
+
+/**
+ * Layout for pupil pages. Simplified in comparison to the AppLayout as we don't include headers and footers.
+ */
+
+export const PupilLayout: FC<PupilLayoutProps> = (props) => {
+  const { seoProps, children } = props;
+
+  return (
+    <>
+      <Head>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <Seo {...seoProps} />
+      {children}
+    </>
+  );
+};

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -134,7 +134,7 @@ export const PupilExperienceView = ({
       seoProps={{
         ...getSeoProps({
           title: curriculumData.lessonTitle,
-          description: "Lesson description",
+          description: curriculumData.pupilLessonOutcome,
         }),
       }}
     >

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -18,6 +18,8 @@ import { PupilViewsQuiz } from "@/components/PupilViews/PupilQuiz";
 import { PupilViewsVideo } from "@/components/PupilViews/PupilVideo";
 import { getInteractiveQuestions } from "@/components/PupilComponents/QuizUtils/questionUtils";
 import { PupilExpiredView } from "@/components/PupilViews/PupilExpired/PupilExpired.view";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 
 export const pickAvailableSectionsForLesson = (
   curriculumData: PupilLessonOverviewData,
@@ -128,21 +130,30 @@ export const PupilExperienceView = ({
   const availableSections = pickAvailableSectionsForLesson(curriculumData);
 
   return (
-    <OakThemeProvider theme={oakDefaultTheme}>
-      <CookieConsentStyles />
-      <LessonEngineProvider initialLessonReviewSections={availableSections}>
-        <OakBox $height={"100vh"}>
-          {curriculumData.expired ? (
-            <PupilExpiredView lessonTitle={curriculumData.lessonTitle} />
-          ) : (
-            <PupilPageContent
-              curriculumData={curriculumData}
-              hasWorksheet={hasWorksheet}
-              backUrl={backUrl}
-            />
-          )}
-        </OakBox>
-      </LessonEngineProvider>
-    </OakThemeProvider>
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: curriculumData.lessonTitle,
+          description: "Lesson description",
+        }),
+      }}
+    >
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <CookieConsentStyles />
+        <LessonEngineProvider initialLessonReviewSections={availableSections}>
+          <OakBox $height={"100vh"}>
+            {curriculumData.expired ? (
+              <PupilExpiredView lessonTitle={curriculumData.lessonTitle} />
+            ) : (
+              <PupilPageContent
+                curriculumData={curriculumData}
+                hasWorksheet={hasWorksheet}
+                backUrl={backUrl}
+              />
+            )}
+          </OakBox>
+        </LessonEngineProvider>
+      </OakThemeProvider>
+    </PupilLayout>
   );
 };


### PR DESCRIPTION
### Story

Add Seo to pupil pages

### Implementation

I have created a new PupilLayout component . Very similar to AppLayout but without Header and Footer.

### Testing

Check SEO tags are correct in `<head>` for lesson (and canonical) lessons pages.

### Acceptance Criteria

- [x]  Page title, eg.
    
    ```html
    <title>LESSON TITLE | Oak National Academy</title> 
    ```
    
- [x]  Robots meta, eg.
    
    ```html
    <meta name="robots" content="index,follow" />
    ```
    
- [x]  Meta description, eg.
    
    ```html
     <meta name="description" content="LESSON OVERVIEW/SUMMARY HERE" />
    ```
    
- [x]  open graph meta:
    
    ```html
    <meta property="og:title" content="LESSON TITLE HERE" />
    <meta property="og:description" content="LESSON OVERVIEW/SUMMARY HERE" />
    <meta property="og:url" content="NEW URL HERE" />
    <meta property="og:image" content="https://www.thenational.academy/images/sharing/default-social-sharing-2022.png?2024" />
    <meta property="og:image:alt" content="Oak National Academy" />
    <meta property="og:image:width" content="1200" />
    <meta property="og:image:height" content="630" />
    <meta property="og:site_name" content="Oak National Academy" />
    ```
    
- [x]  Canonical link, eg.