### PR TITLE
Fix/back to lesson button

### DIFF
--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.test.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.test.tsx
@@ -49,6 +49,27 @@ describe("DownloadConfirmation component", () => {
       "/teachers/programmes/test-programme/units/test-unit/lessons/test-lesson",
     );
   });
+  it("Back to lesson link specialist", () => {
+    const { getByTestId } = renderWithTheme(
+      <DownloadConfirmation
+        lessonSlug="test-lesson"
+        lessonTitle="Test lesson"
+        programmeSlug="test-programme"
+        unitTitle="Test unit"
+        unitSlug="test-unit"
+        isCanonical={false}
+        onwardContentSelected={onwardContentSelected}
+        isSpecialist={true}
+      />,
+    );
+
+    const link = getByTestId("back-to-lesson-link");
+
+    expect(link).toHaveAttribute(
+      "href",
+      "/teachers/specialist/programmes/test-programme/units/test-unit/lessons/test-lesson",
+    );
+  });
 
   it("when unitSlug or programmeSlug is null renders link to cannonical lesson", () => {
     const { getByTestId } = renderWithTheme(

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -17,7 +17,7 @@ type DownloadConfirmationProps = {
   unitTitle?: string | null;
   nextLessons?: NextLesson[];
   onwardContentSelected: TrackFns["onwardContentSelected"];
-  isSpecialist: boolean;
+  isSpecialist?: boolean;
 };
 
 const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
@@ -29,7 +29,7 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
   unitTitle,
   nextLessons,
   onwardContentSelected,
-  isSpecialist,
+  isSpecialist = false,
 }) => {
   const displayNextLessonContainer =
     !isCanonical && unitSlug && programmeSlug && unitTitle;

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -17,6 +17,7 @@ type DownloadConfirmationProps = {
   unitTitle?: string | null;
   nextLessons?: NextLesson[];
   onwardContentSelected: TrackFns["onwardContentSelected"];
+  isSpecialist: boolean;
 };
 
 const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
@@ -28,6 +29,7 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
   unitTitle,
   nextLessons,
   onwardContentSelected,
+  isSpecialist,
 }) => {
   const displayNextLessonContainer =
     !isCanonical && unitSlug && programmeSlug && unitTitle;
@@ -59,7 +61,9 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
         >
           {unitSlug && unitTitle && programmeSlug ? (
             <ButtonAsLink
-              page={"lesson-overview"}
+              page={
+                isSpecialist ? "specialist-lesson-overview" : "lesson-overview"
+              }
               lessonSlug={lessonSlug}
               programmeSlug={programmeSlug}
               unitSlug={unitSlug}

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -271,6 +271,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
             isCanonical={props.isCanonical}
             nextLessons={lesson.nextLessons}
             onwardContentSelected={onwardContentSelected}
+            isSpecialist={isSpecialist}
           />
         </Box>
         {!isDownloadSuccessful && (


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- fixes back to lesson button for specialist pages

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
