### PR TITLE
feat: use new api for all lesson overview pages [LESQ-727]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -424,9 +424,10 @@ describe("pages/teachers/lessons", () => {
     it("Should fetch the correct data", async () => {
       const propsResult = (await getStaticProps({
         params: {
-          lessonSlug: "macbeth-lesson-1",
-          programmeSlug: "english-primary-ks2-l",
-          unitSlug: "shakespeare",
+          lessonSlug:
+            "lesson-4-in-grammar-1-simple-compound-and-adverbial-complex-sentences",
+          programmeSlug: "english-primary-ks2",
+          unitSlug: "grammar-1-simple-compound-and-adverbial-complex-sentences",
         },
         query: {},
       } as GetStaticPropsContext<URLParams, PreviewData>)) as {
@@ -434,7 +435,7 @@ describe("pages/teachers/lessons", () => {
       };
 
       expect(propsResult.props.curriculumData.lessonSlug).toEqual(
-        "macbeth-lesson-1",
+        "lesson-4-in-grammar-1-simple-compound-and-adverbial-complex-sentences",
       );
     });
     it("should throw error", async () => {

--- a/src/node-lib/curriculum-api-2023/__mocks__/index.ts
+++ b/src/node-lib/curriculum-api-2023/__mocks__/index.ts
@@ -24,6 +24,7 @@ const curriculumApi: Pick<
   | "specialistSubjectListing"
   | "specialistUnitListing"
   | "specialistLessonOverviewCanonical"
+  | "lessonOverview"
 > = {
   subjectPhaseOptions: jest.fn(async () => {
     return subjectPhaseOptionsFixture();
@@ -42,6 +43,9 @@ const curriculumApi: Pick<
   }),
   pupilLessonOverviewCanonical: jest.fn(async () => {
     return pupilLessonOverviewFixture();
+  }),
+  lessonOverview: jest.fn(async () => {
+    return lessonOverviewFixture();
   }),
   lessonOverviewCanonical: jest.fn(async () => {
     return {

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -12,13 +12,12 @@ import {
 } from "@/node-lib/isr";
 import AppLayout from "@/components/SharedComponents/AppLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
-import curriculumApi, { LessonOverviewData } from "@/node-lib/curriculum-api";
+import { LessonOverviewData } from "@/node-lib/curriculum-api";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import { getCaptionsFromFile, formatSentences } from "@/utils/handleTranscript";
-import shouldUseLegacyApi from "@/utils/slugModifiers/shouldUseLegacyApi";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewData;
@@ -88,17 +87,12 @@ export const getStaticProps: GetStaticProps<
       }
       const { lessonSlug, unitSlug, programmeSlug } = context.params;
 
-      const curriculumData = shouldUseLegacyApi(programmeSlug)
-        ? await curriculumApi.lessonOverview({
-            programmeSlug,
-            lessonSlug,
-            unitSlug,
-          })
-        : await curriculumApi2023.lessonOverview({
-            programmeSlug,
-            lessonSlug,
-            unitSlug,
-          });
+      const curriculumData = await curriculumApi2023.lessonOverview({
+        programmeSlug,
+        lessonSlug,
+        unitSlug,
+      });
+
       if (!curriculumData) {
         return {
           notFound: true,


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- remove query to legacy api on lesson overview page
- update tests to use the 2023 schema fixture


## How to test

1. Go to {owa_deployment_url}
2. Click on legacy lesson overview pages
3. You should see everything working as expected

