### PR TITLE
fix(a11y): add 'new' to aria-label where appropriate

### DIFF
--- a/src/components/GenericPagesComponents/HomepageTabImageButton/HomePageTabImageButton.test.tsx
+++ b/src/components/GenericPagesComponents/HomepageTabImageButton/HomePageTabImageButton.test.tsx
@@ -102,6 +102,20 @@ describe("HomePageTabImageButton", () => {
     // Would check visibility, but the new icon is not visible on smaller viewports.
   });
 
+  test("adds '(New)' to aria-label when showNewIcon prop set to true", async () => {
+    const { getByRole } = renderWithTheme(
+      <HomePageTabImageButton
+        label="Click me"
+        title={""}
+        activeImageSlug={"magic-carpet"}
+        passiveImageSlug="magic-carpet"
+        showNewIcon={true}
+      />,
+    );
+    const button = getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Click me (New)");
+  });
+
   test("Doesn't show a new icon when showNewIcon prop omitted", () => {
     const { queryAllByTestId } = renderWithTheme(
       <HomePageTabImageButton

--- a/src/components/GenericPagesComponents/HomepageTabImageButton/HomePageTabImageButton.tsx
+++ b/src/components/GenericPagesComponents/HomepageTabImageButton/HomePageTabImageButton.tsx
@@ -93,7 +93,7 @@ const HomePageTabImageButton = forwardRef<
   const {
     onClick,
     label,
-    labelSuffixA11y,
+    labelSuffixA11y = props.showNewIcon ? "(New)" : undefined,
     "aria-label": ariaLabel,
     htmlButtonProps = {},
     disabled,


### PR DESCRIPTION
## Description

Music year: 1995

- adds `(New)` to aria label and title when the 'new' icon is visible
- adds test

1. Go to https://deploy-preview-2351--oak-web-application.netlify.thenational.academy
2. Hover over the 'AI Experiments' button
3. Should see the title tooltip reading 'AI Experiments (New)'
4. Check the `aria-label` of this button
5. Should be 'AI Experiments (New)'

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
