### PR TITLE
[CUR-451] Removing new banner and updating header hierarchy

### DIFF
--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -18,11 +18,9 @@ import CurriculumVisualiser, {
 import UnitsTabMobile from "../UnitsTabMobile/UnitsTabMobile";
 
 import Box from "@/components/SharedComponents/Box";
-import Card from "@/components/SharedComponents/Card/Card";
 import { CurriculumUnitsTabData } from "@/node-lib/curriculum-api-2023";
 import Radio from "@/components/SharedComponents/RadioButtons/Radio";
 import RadioGroup from "@/components/SharedComponents/RadioButtons/RadioGroup";
-import Icon from "@/components/SharedComponents/Icon";
 import UnitTabBanner from "@/components/CurriculumComponents/UnitTabBanner";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
@@ -372,45 +370,10 @@ const UnitsTab: FC<UnitsTabProps> = ({ data, examboardSlug }) => {
         >
           Unit sequence
         </OakHeading>
-        <Card
-          $background={"lemon30"}
-          $pa={0}
-          $pl={96}
-          $mb={[16, 48]}
-          $display={["none", "block"]}
-        >
-          <Box
-            $background={"lemon"}
-            $height={"100%"}
-            $left={0}
-            $position={"absolute"}
-            $top={0}
-            $width={[64, 96]}
-            $textAlign={"center"}
-          >
-            <Icon
-              name={"bell"}
-              size={[48]}
-              $position={"relative"}
-              $transform={"translateY(-50%)"}
-              $top={"50%"}
-            />
-          </Box>
-          <Box $pa={20}>
-            <OakHeading
-              tag="h3"
-              $font={"heading-7"}
-              $mb="space-between-xs"
-              data-testid="units-heading"
-            >
-              Introducing our new curriculum sequence for 2023/2024!
-            </OakHeading>
-            <OakP>
-              Units that make up our curricula are fully sequenced, and aligned
-              to the national curriculum.
-            </OakP>
-          </Box>
-        </Card>
+        <OakP $mb={"space-between-xl"} data-testid="units-heading">
+          Units that make up our curricula are fully sequenced, and aligned to
+          the national curriculum.
+        </OakP>
         <UnitsTabMobile
           updateMobileHeaderScroll={updateMobileHeaderScroll}
           selectedThread={selectedThread}
@@ -430,7 +393,7 @@ const UnitsTab: FC<UnitsTabProps> = ({ data, examboardSlug }) => {
               $display={["none", "block"]}
               data-testid="threads-filter-desktop"
             >
-              <OakHeading tag={"h4"} $font={"heading-7"} $mb="space-between-xs">
+              <OakHeading tag={"h3"} $font={"heading-7"} $mb="space-between-xs">
                 Highlight a thread
               </OakHeading>
               <OakP $mb="space-between-xs">
@@ -495,7 +458,7 @@ const UnitsTab: FC<UnitsTabProps> = ({ data, examboardSlug }) => {
               $display={["none", "block"]}
               data-testid="year-group-filter-desktop"
             >
-              <OakHeading tag={"h4"} $font={"heading-7"} $mb="space-between-xs">
+              <OakHeading tag={"h3"} $font={"heading-7"} $mb="space-between-xs">
                 Year group
               </OakHeading>
               <RadioGroup

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -365,12 +365,16 @@ const UnitsTab: FC<UnitsTabProps> = ({ data, examboardSlug }) => {
         <OakHeading
           tag="h2"
           $mb="space-between-m"
-          $ml="space-between-xs"
+          $ml={["space-between-s", "space-between-none"]}
           $font={["heading-5", "heading-4"]}
         >
           Unit sequence
         </OakHeading>
-        <OakP $mb={"space-between-xl"} data-testid="units-heading">
+        <OakP
+          $mh={["space-between-s", "space-between-none"]}
+          $mb={"space-between-xl"}
+          data-testid="units-heading"
+        >
           Units that make up our curricula are fully sequenced, and aligned to
           the national curriculum.
         </OakP>


### PR DESCRIPTION
## Description

Regression in the curriculum visualiser. We removed the new banner, but it has re-appeared 😕.  

This is the original ticket - https://www.notion.so/oaknationalacademy/Remove-New-tags-and-labels-from-curriculum-journey-584312705f2240498c84dbfd4bb4b928

Banner should be replaced with new copy and the heading structure should remain hierarchical

## How to test

1. Go to https://deploy-preview-2352--oak-web-application.netlify.thenational.academy/teachers/curriculum/maths-secondary/units

## Screenshots

How it used to look (delete if n/a):
<kbd><img width="1281" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/67ecd172-b9bf-4e50-b42d-41728346511e"></kbd>

How it should now look:
<kbd><img width="1291" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/81c0228f-61bd-422a-bd9b-48d9b8342b2e"></kbd>

New hierarchy
<kbd><img width="320" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/5855b372-df97-4fa7-b367-686e2858dfc2" style="border:2px solid green"></kbd>


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
