### PR TITLE
[CUR-429] Refactored school details and terms form into component

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
@@ -1,12 +1,5 @@
-import {
-  ChangeEvent,
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useState,
-} from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { useRouter } from "next/router";
-import { Controller } from "react-hook-form";
 import styled from "styled-components";
 import {
   OakFlex,
@@ -16,32 +9,25 @@ import {
   OakUL,
   OakLI,
   OakP,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import Box from "@/components/SharedComponents/Box";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import getFormattedDetailsForTracking from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
-import getDownloadFormErrorMessage from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
-import {
-  ErrorKeysType,
-  ResourceFormProps,
-} from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
+import { ResourceFormProps } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
 import LoadingButton from "@/components/SharedComponents/Button/LoadingButton";
 import { useResourceFormState } from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState";
-import CopyrightNotice from "@/components/TeacherComponents/CopyrightNotice";
-import DetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
-import SchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
-import TermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
 import FieldError from "@/components/SharedComponents/FieldError";
 import Icon from "@/components/SharedComponents/Icon";
-import OakLink from "@/components/SharedComponents/OwaLink";
-import Input from "@/components/SharedComponents/Input";
 import ResourceCard from "@/components/TeacherComponents/ResourceCard";
 import useLocalStorageForDownloads from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useLocalStorageForDownloads";
 import createAndClickHiddenDownloadLink from "@/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink";
 import RadioGroup from "@/components/SharedComponents/RadioButtons/RadioGroup";
 import { useHubspotSubmit } from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useHubspotSubmit";
+import TermsAgreementForm from "@/components/TeacherComponents/TermsAgreementForm";
 
 export type CurriculumDownload = {
   label: string;
@@ -212,14 +198,6 @@ function CurriculumDownloads(
     }
   };
 
-  const getFormErrorMessages = () => {
-    const errorKeyArray = Object.keys(form.errors);
-    const errorMessage = getDownloadFormErrorMessage(
-      errorKeyArray as ErrorKeysType[],
-    );
-    return errorMessage;
-  };
-
   useEffect(() => {
     if (hasSetPreselectedDownload) {
       return;
@@ -320,114 +298,18 @@ function CurriculumDownloads(
                 </CardsContainer>
               </OakGridArea>
               <OakGridArea $colSpan={[12, 12, 5]}>
-                <OakHeading
-                  tag="h2"
-                  $font={["heading-6", "heading-5"]}
-                  $mb={["space-between-m", "space-between-m2"]}
-                >
-                  Your details
-                </OakHeading>
-                {form.errors.school && (
-                  <FieldError id="school-error">
-                    {form.errors.school?.message}
-                  </FieldError>
-                )}
-                {isLocalStorageLoading ? (
-                  <OakP $mb={"space-between-s"}>Loading...</OakP>
-                ) : (
-                  <OakFlex
-                    $flexDirection="column"
-                    $gap={"space-between-m"}
-                    $mb={"space-between-s"}
-                  >
-                    {shouldDisplayDetailsCompleted ? (
-                      <DetailsCompleted
-                        email={emailFromLocalStorage}
-                        school={schoolNameFromLocalStorage}
-                        onEditClick={handleEditDetailsCompletedClick}
-                      />
-                    ) : (
-                      <Box $maxWidth={[null, 420, 420]}>
-                        <SchoolDetails
-                          errors={form.errors}
-                          setSchool={setSchool}
-                          initialValue={schoolIdFromLocalStorage ?? undefined}
-                          initialSchoolName={
-                            schoolNameFromLocalStorage?.length &&
-                            schoolNameFromLocalStorage?.length > 0
-                              ? schoolNameFromLocalStorage
-                                  .charAt(0)
-                                  .toUpperCase() +
-                                schoolNameFromLocalStorage.slice(1)
-                              : undefined
-                          }
-                        />
-
-                        <Input
-                          id={"email"}
-                          data-testid="inputEmail"
-                          label="Email"
-                          autoComplete="email"
-                          placeholder="Enter email address here"
-                          isOptional={true}
-                          {...form.register("email")}
-                          error={form.errors?.email?.message}
-                        />
-                        <OakP $font="body-3" $mb={"space-between-l"}>
-                          Join over 100k teachers and get free resources and
-                          other helpful content by email. Unsubscribe at any
-                          time. Read our{" "}
-                          <OakLink
-                            page="legal"
-                            legalSlug="privacy-policy"
-                            $isInline
-                            htmlAnchorProps={{
-                              target: "_blank",
-                              "aria-label":
-                                "Privacy policy (opens in a new tab)",
-                            }}
-                          >
-                            privacy policy
-                            <Icon
-                              name="external"
-                              verticalAlign="bottom"
-                              size={20}
-                            />
-                          </OakLink>
-                          .
-                        </OakP>
-                        <Controller
-                          control={form.control}
-                          name="terms"
-                          render={({
-                            field: { value, onChange, name, onBlur },
-                          }) => {
-                            const onChangeHandler = (
-                              e: ChangeEvent<HTMLInputElement>,
-                            ) => {
-                              onChange(e.target.checked);
-                              form.trigger();
-                            };
-                            return (
-                              <TermsAndConditionsCheckbox
-                                name={name}
-                                checked={value}
-                                onChange={onChangeHandler}
-                                onBlur={onBlur}
-                                id={"terms"}
-                                errorMessage={form.errors?.terms?.message}
-                              />
-                            );
-                          }}
-                        />
-                      </Box>
-                    )}
-                    <CopyrightNotice
-                      showPostAlbCopyright={true}
-                      openLinksExternally={true}
-                    />
-                  </OakFlex>
-                )}
+                <TermsAgreementForm
+                  form={form}
+                  email={emailFromLocalStorage}
+                  schoolId={schoolIdFromLocalStorage}
+                  schoolName={schoolNameFromLocalStorage}
+                  isLoading={isLocalStorageLoading}
+                  setSchool={setSchool}
+                  showSavedDetails={shouldDisplayDetailsCompleted}
+                  handleEditDetailsCompletedClick={
+                    handleEditDetailsCompletedClick
+                  }
+                />
                 {hasFormErrors && (
                   <OakFlex $flexDirection={"row"} $mb={"space-between-s"}>
                     <Icon name="content-guidance" $color={"red"} />
@@ -436,7 +318,7 @@ function CurriculumDownloads(
                         To complete correct the following:
                       </OakP>
                       <OakUL $mr={"space-between-m"} data-testid="errorList">
-                        {getFormErrorMessages().map((err, i) => {
+                        {getFormErrorMessages(form.errors).map((err, i) => {
                           return (
                             <OakLI $color={"red"} key={i}>
                               {err}
@@ -447,34 +329,36 @@ function CurriculumDownloads(
                     </OakFlex>
                   </OakFlex>
                 )}
-                <LoadingButton
-                  type="button"
-                  onClick={(event) =>
-                    void form.handleSubmit(onFormSubmit)(event)
-                  }
-                  text={"Download PDF"}
-                  icon={"download"}
-                  isLoading={isAttemptingDownload}
-                  disabled={
-                    hasFormErrors ||
-                    (!form.formState.isValid && !localStorageDetails)
-                  }
-                  loadingText={"Downloading..."}
-                />
-                {hasSuccessfullyDownloaded && (
-                  <OakP $mt={"space-between-m"} data-testid="downloadSuccess">
-                    Download Successful!
-                  </OakP>
-                )}
-                {apiError && !hasFormErrors && (
-                  <FieldError
-                    id="download-error"
-                    variant={"large"}
-                    withoutMarginBottom
-                  >
-                    {apiError}
-                  </FieldError>
-                )}
+                <OakBox $mt={"space-between-s"}>
+                  <LoadingButton
+                    type="button"
+                    onClick={(event) =>
+                      void form.handleSubmit(onFormSubmit)(event)
+                    }
+                    text={"Download PDF"}
+                    icon={"download"}
+                    isLoading={isAttemptingDownload}
+                    disabled={
+                      hasFormErrors ||
+                      (!form.formState.isValid && !localStorageDetails)
+                    }
+                    loadingText={"Downloading..."}
+                  />
+                  {hasSuccessfullyDownloaded && (
+                    <OakP $mt={"space-between-m"} data-testid="downloadSuccess">
+                      Download Successful!
+                    </OakP>
+                  )}
+                  {apiError && !hasFormErrors && (
+                    <FieldError
+                      id="download-error"
+                      variant={"large"}
+                      withoutMarginBottom
+                    >
+                      {apiError}
+                    </FieldError>
+                  )}
+                </OakBox>
               </OakGridArea>
             </OakGrid>
           </form>

--- a/src/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted.tsx
+++ b/src/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted.tsx
@@ -32,6 +32,7 @@ const ResourcePageDetailsCompleted: FC<ResourcePageDetailsCompletedProps> = ({
       $height={"max-content"}
       $position="relative"
       $background="grey30"
+      data-testid="details-completed"
     >
       <BrushBorders color="grey30" />
       <OakFlex

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -1,7 +1,6 @@
-import { ChangeEvent, FC } from "react";
+import { FC } from "react";
 import {
   Control,
-  Controller,
   FieldErrors,
   UseFormRegister,
   UseFormTrigger,
@@ -14,26 +13,17 @@ import {
   OakFlex,
 } from "@oaknational/oak-components";
 
-import {
-  ErrorKeysType,
-  ResourceFormProps,
-} from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { ResourceFormProps } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import NoResourcesToDownload from "@/components/TeacherComponents/NoResourcesToDownload";
-import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
 import { ResourcePageDetailsCompletedProps } from "@/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted";
-import ResourcePageSchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
 import { ResourcePageSchoolDetailsProps } from "@/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails";
-import ResourcePageTermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
-import CopyrightNotice from "@/components/TeacherComponents/CopyrightNotice";
+import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
+import TermsAgreementForm from "@/components/TeacherComponents/TermsAgreementForm";
 import NoResourcesToShare from "@/components/TeacherComponents/NoResourcesToShare";
-import getDownloadFormErrorMessage from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
-import { P } from "@/components/SharedComponents/Typography";
 import FieldError from "@/components/SharedComponents/FieldError";
 import Box from "@/components/SharedComponents/Box";
 import Checkbox from "@/components/SharedComponents/Checkbox";
 import Flex from "@/components/SharedComponents/Flex.deprecated";
-import Input from "@/components/SharedComponents/Input";
-import OwaLink from "@/components/SharedComponents/OwaLink";
 import Icon from "@/components/SharedComponents/Icon";
 
 /** Generic layout component for Downloads and Share page */
@@ -61,16 +51,7 @@ export type ResourcePageLayoutProps = ResourcePageDetailsCompletedProps &
   };
 
 const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
-  const hasFormErrors = Object.keys(props.errors)?.length > 0;
-  const getFormErrorMessages = () => {
-    const errorKeyArray = Object.keys(props.errors);
-
-    const errorMessage = getDownloadFormErrorMessage(
-      errorKeyArray as ErrorKeysType[],
-    );
-
-    return errorMessage;
-  };
+  const hasFormErrors = Object.keys(props.errors).length > 0;
   return (
     <Box $width="100%">
       <OakFlex
@@ -115,145 +96,62 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
             $gap={16}
             $maxWidth={420}
           >
-            <OakHeading
-              tag="h2"
-              $font={["heading-6", "heading-5"]}
-              $mb={["space-between-m", "space-between-m2"]}
-            >
-              Your details
-            </OakHeading>
-            {props.errors.school && (
-              <FieldError id="school-error">
-                {props.errors.school?.message}
-              </FieldError>
-            )}
-            {props.showNoResources ? (
-              props.page === "download" ? (
+            {props.showNoResources &&
+              (props.page === "download" ? (
                 <NoResourcesToDownload />
               ) : (
                 <NoResourcesToShare />
-              )
-            ) : (
+              ))}
+            {!props.showNoResources && (
               <>
-                {props.showLoading ? (
-                  <OakP $mt="space-between-m">Loading...</OakP>
-                ) : (
-                  <OakFlex $flexDirection="column" $gap="all-spacing-6">
-                    {props.showSavedDetails ? (
-                      <ResourcePageDetailsCompleted
-                        email={props.email}
-                        school={props.school}
-                        onEditClick={props.onEditClick}
-                      />
-                    ) : (
-                      <Box $maxWidth={[null, 420, 420]}>
-                        <ResourcePageSchoolDetails
-                          errors={props.errors}
-                          setSchool={props.setSchool}
-                          initialValue={props.schoolId ?? undefined}
-                          initialSchoolName={
-                            props.school?.length && props.school?.length > 0
-                              ? props.school.charAt(0).toUpperCase() +
-                                props.school.slice(1)
-                              : undefined
-                          }
-                        />
-
-                        <Input
-                          id={"email"}
-                          data-testid="input-email"
-                          label="Email"
-                          autoComplete="email"
-                          placeholder="Enter email address here"
-                          isOptional={true}
-                          {...props.register("email")}
-                          error={props.errors?.email?.message}
-                        />
-                        <P $font="body-3" $mt={-20} $mb={48}>
-                          Join over 100k teachers and get free resources and
-                          other helpful content by email. Unsubscribe at any
-                          time. Read our{" "}
-                          <OwaLink
-                            page="legal"
-                            legalSlug="privacy-policy"
-                            $isInline
-                            htmlAnchorProps={{
-                              target: "_blank",
-                              "aria-label":
-                                "Privacy policy (opens in a new tab)",
-                            }}
-                          >
-                            privacy policy
-                            <Icon
-                              name="external"
-                              verticalAlign="bottom"
-                              size={20}
-                              data-testid="external-link-icon"
-                            />
-                          </OwaLink>
-                          .
-                        </P>
-                        <Controller
-                          control={props.control}
-                          name="terms"
-                          render={({
-                            field: { value, onChange, name, onBlur },
-                          }) => {
-                            const onChangeHandler = (
-                              e: ChangeEvent<HTMLInputElement>,
-                            ) => {
-                              onChange(e.target.checked);
-                              props.triggerForm();
-                            };
-                            return (
-                              <ResourcePageTermsAndConditionsCheckbox
-                                name={name}
-                                checked={value}
-                                onChange={onChangeHandler}
-                                onBlur={onBlur}
-                                id={"terms"}
-                                errorMessage={props.errors?.terms?.message}
-                                zIndex={"neutral"}
-                              />
-                            );
-                          }}
-                        />
-                      </Box>
-                    )}
-                    <CopyrightNotice
-                      showPostAlbCopyright={props.showPostAlbCopyright}
-                      openLinksExternally={true}
-                    />
+                <TermsAgreementForm
+                  form={{
+                    control: props.control,
+                    register: props.register,
+                    errors: props.errors,
+                    trigger: props.triggerForm,
+                  }}
+                  isLoading={props.showLoading}
+                  email={props.email}
+                  schoolId={props.schoolId}
+                  schoolName={props.school}
+                  setSchool={props.setSchool}
+                  showSavedDetails={props.showSavedDetails}
+                  handleEditDetailsCompletedClick={props.onEditClick}
+                  showPostAlbCopyright={props.showPostAlbCopyright}
+                />
+                {hasFormErrors && (
+                  <OakFlex $flexDirection={"row"}>
+                    <Icon name="content-guidance" $color={"red"} />
+                    <OakFlex $flexDirection={"column"}>
+                      <OakP $ml="space-between-sssx" $color={"red"}>
+                        To complete correct the following:
+                      </OakP>
+                      <OakUL $mr="space-between-m">
+                        {getFormErrorMessages(props.errors).map((err, i) => {
+                          return (
+                            <OakLI $color={"red"} key={i}>
+                              {err}
+                            </OakLI>
+                          );
+                        })}
+                      </OakUL>
+                    </OakFlex>
                   </OakFlex>
                 )}
-              </>
-            )}
-            {hasFormErrors && (
-              <OakFlex $flexDirection={"row"}>
-                <Icon name="content-guidance" $color={"red"} />
-                <OakFlex $flexDirection={"column"}>
-                  <OakP $ml="space-between-sssx" $color={"red"}>
-                    To complete correct the following:
-                  </OakP>
-                  <OakUL $mr="space-between-m">
-                    {getFormErrorMessages().map((err) => {
-                      return <OakLI $color={"red"}>{err}</OakLI>;
-                    })}
-                  </OakUL>
-                </OakFlex>
-              </OakFlex>
-            )}
-            {props.cta}
+                {props.cta}
 
-            {props.apiError && !hasFormErrors && (
-              <FieldError
-                id="download-error"
-                data-testid="download-error"
-                variant={"large"}
-                withoutMarginBottom
-              >
-                {props.apiError}
-              </FieldError>
+                {props.apiError && !hasFormErrors && (
+                  <FieldError
+                    id="download-error"
+                    data-testid="download-error"
+                    variant={"large"}
+                    withoutMarginBottom
+                  >
+                    {props.apiError}
+                  </FieldError>
+                )}
+              </>
             )}
           </Flex>
         </OakFlex>

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.stories.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import Component, {
+  TermsAgreementFormProps,
+} from "@/components/TeacherComponents/TermsAgreementForm";
+import { useResourceFormState } from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState";
+import { CurriculumDownload } from "@/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads";
+
+type Story = StoryObj<typeof Component>;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  parameters: {
+    controls: {
+      exclude: ["form", "setSchool", "handleEditDetailsCompletedClick"],
+    },
+  },
+  render: (args) => {
+    return <Wrapper {...args} />;
+  },
+};
+export default meta;
+
+export const TermsAgreementForm: Story = {
+  args: {
+    isLoading: false,
+    showSavedDetails: false,
+  },
+};
+
+const resources: CurriculumDownload[] = [];
+
+const Wrapper = (args: TermsAgreementFormProps) => {
+  const formState = useResourceFormState({
+    curriculumResources: resources,
+    type: "curriculum",
+  });
+  return <Component {...args} form={formState.form} />;
+};

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
@@ -1,0 +1,71 @@
+import { queryByAttribute } from "@testing-library/react";
+import { FieldErrors, useForm } from "react-hook-form";
+
+import TermsAgreementForm, {
+  TermsAgreementFormProps,
+} from "./TermsAgreementForm";
+
+import { ResourceFormProps } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+
+type TermsAgreementFormPropsOptionalForm = Omit<
+  TermsAgreementFormProps,
+  "form"
+> & {
+  errors?: FieldErrors<ResourceFormProps>;
+};
+
+const render = renderWithProviders();
+
+const Wrapper = (props: TermsAgreementFormPropsOptionalForm) => {
+  const { control, register, trigger } = useForm<ResourceFormProps>();
+
+  return (
+    <TermsAgreementForm
+      {...props}
+      form={{ control, register, trigger, errors: props.errors || {} }}
+    />
+  );
+};
+
+describe("TermsAgreementForm (School, email and terms form within the teacher and curriculum journey)", () => {
+  it("Shows school error message when error object is passed in", async () => {
+    const errorMessage = `Select school, type 'homeschool' or tick 'My school isn't listed'`;
+    const errors: FieldErrors<ResourceFormProps> = {
+      school: {
+        message: errorMessage,
+        type: "too_small",
+      },
+    };
+    const { container } = render(<Wrapper errors={errors} />);
+
+    const error = queryByAttribute("id", container, "school-error");
+    expect(error).toBeInTheDocument();
+    expect(error).toHaveTextContent(errorMessage);
+  });
+
+  it("Shows loading", async () => {
+    const { getByTestId } = render(<Wrapper isLoading={true} />);
+    const loadingElement = getByTestId("loading");
+    expect(loadingElement).toBeInTheDocument();
+  });
+
+  it("Shows DetailsCompleted component", async () => {
+    const { getByTestId } = render(<Wrapper showSavedDetails={true} />);
+    const detailsCompletedComponent = getByTestId("details-completed");
+    expect(detailsCompletedComponent).toBeInTheDocument();
+  });
+
+  it("Shows newsletter policy", async () => {
+    const { getByTestId } = render(<Wrapper />);
+    const detailsCompletedComponent = getByTestId("newsletter-policy");
+    expect(detailsCompletedComponent).toBeInTheDocument();
+  });
+
+  it("Shows ResourcePageTermsAndConditionsCheckbox component", async () => {
+    // Render the component with required props
+    const { getByTestId } = render(<Wrapper />);
+    const detailsCompletedComponent = getByTestId("termsCheckbox");
+    expect(detailsCompletedComponent).toBeInTheDocument();
+  });
+});

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -1,0 +1,160 @@
+import { ChangeEvent, FC } from "react";
+import {
+  Control,
+  Controller,
+  FieldErrors,
+  UseFormRegister,
+  UseFormTrigger,
+} from "react-hook-form";
+import { OakFlex, OakHeading, OakP } from "@oaknational/oak-components";
+
+import FieldError from "@/components/SharedComponents/FieldError";
+import Box from "@/components/SharedComponents/Box";
+import OakLink from "@/components/SharedComponents/OwaLink";
+import Input from "@/components/SharedComponents/Input";
+import Icon from "@/components/SharedComponents/Icon";
+import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
+import ResourcePageSchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
+import ResourcePageTermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
+import CopyrightNotice from "@/components/TeacherComponents/CopyrightNotice";
+import { ResourceFormProps } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { P } from "@/components/SharedComponents/Typography";
+
+export type TermsAgreementFormProps = {
+  form: {
+    control: Control<ResourceFormProps>;
+    register: UseFormRegister<ResourceFormProps>;
+    errors: FieldErrors<ResourceFormProps>;
+    trigger: UseFormTrigger<ResourceFormProps>;
+  };
+  isLoading?: boolean;
+  email?: string;
+  schoolId?: string;
+  schoolName?: string;
+  setSchool?: (school: string) => void;
+  showSavedDetails?: boolean;
+  handleEditDetailsCompletedClick?: () => void;
+  showPostAlbCopyright?: boolean;
+};
+
+const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
+  form,
+  isLoading = false,
+  email = "",
+  schoolId = "",
+  schoolName = "",
+  setSchool = () => {},
+  showSavedDetails = false,
+  handleEditDetailsCompletedClick = () => {},
+  showPostAlbCopyright = true,
+}) => {
+  return (
+    <>
+      <OakHeading
+        tag="h2"
+        $font={["heading-6", "heading-5"]}
+        $mb={["space-between-m", "space-between-m2"]}
+      >
+        Your details
+      </OakHeading>
+      {form?.errors.school && (
+        <FieldError id="school-error">{form.errors.school?.message}</FieldError>
+      )}
+      {isLoading && (
+        <OakP $mb={"space-between-m"} data-testid="loading">
+          Loading...
+        </OakP>
+      )}
+      {!isLoading && (
+        <OakFlex $flexDirection="column" $gap={"space-between-m"}>
+          {showSavedDetails ? (
+            <ResourcePageDetailsCompleted
+              email={email}
+              school={schoolName}
+              onEditClick={handleEditDetailsCompletedClick}
+            />
+          ) : (
+            <Box $maxWidth={[null, 420, 420]}>
+              <ResourcePageSchoolDetails
+                errors={form.errors}
+                setSchool={setSchool}
+                initialValue={schoolId ?? undefined}
+                initialSchoolName={
+                  schoolName?.length && schoolName?.length > 0
+                    ? schoolName.charAt(0).toUpperCase() + schoolName.slice(1)
+                    : undefined
+                }
+              />
+
+              <Input
+                id={"email"}
+                data-testid="inputEmail"
+                label="Email"
+                autoComplete="email"
+                placeholder="Enter email address here"
+                isOptional={true}
+                {...form.register("email")}
+                error={form.errors?.email?.message}
+              />
+              <P
+                $font="body-3"
+                $mt={-20}
+                $mb={48}
+                data-testid="newsletter-policy"
+              >
+                Join over 100k teachers and get free resources and other helpful
+                content by email. Unsubscribe at any time. Read our{" "}
+                <OakLink
+                  page="legal"
+                  legalSlug="privacy-policy"
+                  $isInline
+                  htmlAnchorProps={{
+                    target: "_blank",
+                    "aria-label": "Privacy policy (opens in a new tab)",
+                  }}
+                >
+                  privacy policy
+                  <Icon
+                    name="external"
+                    verticalAlign="bottom"
+                    size={20}
+                    data-testid="external-link-icon"
+                  />
+                </OakLink>
+                .
+              </P>
+              <Controller
+                control={form.control}
+                name="terms"
+                render={({ field: { value, onChange, name, onBlur } }) => {
+                  const onChangeHandler = (
+                    e: ChangeEvent<HTMLInputElement>,
+                  ) => {
+                    onChange(e.target.checked);
+                    form.trigger();
+                  };
+                  return (
+                    <ResourcePageTermsAndConditionsCheckbox
+                      name={name}
+                      checked={value}
+                      onChange={onChangeHandler}
+                      onBlur={onBlur}
+                      id={"terms"}
+                      errorMessage={form.errors?.terms?.message}
+                    />
+                  );
+                }}
+              />
+            </Box>
+          )}
+          <CopyrightNotice
+            showPostAlbCopyright={showPostAlbCopyright}
+            openLinksExternally={true}
+          />
+        </OakFlex>
+      )}
+    </>
+  );
+};
+
+export default TermsAgreementForm;

--- a/src/components/TeacherComponents/TermsAgreementForm/index.ts
+++ b/src/components/TeacherComponents/TermsAgreementForm/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TermsAgreementForm";
+export type { TermsAgreementFormProps } from "./TermsAgreementForm";

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage.tsx
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage.tsx
@@ -1,11 +1,16 @@
-import type { ErrorKeysType } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { FieldErrors } from "react-hook-form";
+
+import type {
+  ErrorKeysType,
+  ResourceFormProps,
+} from "@/components/TeacherComponents/types/downloadAndShare.types";
 
 type ErrorMessagesAndOrderType = {
   order: number;
   message: string;
 };
 
-const getDownloadFormErrorMessage = (errorsArray: ErrorKeysType[]) => {
+export const getDownloadFormErrorMessage = (errorsArray: ErrorKeysType[]) => {
   const errorMessagesAndOrder: Record<
     ErrorKeysType,
     ErrorMessagesAndOrderType
@@ -37,6 +42,16 @@ const getDownloadFormErrorMessage = (errorsArray: ErrorKeysType[]) => {
     .filter(Boolean);
 
   return errorMessagesArray;
+};
+
+export const getFormErrorMessages = (
+  errors: FieldErrors<ResourceFormProps>,
+) => {
+  const errorKeyArray = Object.keys(errors);
+  const errorMessage = getDownloadFormErrorMessage(
+    errorKeyArray as ErrorKeysType[],
+  );
+  return errorMessage;
 };
 
 export default getDownloadFormErrorMessage;


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

Refactoring to allow one component to be used in the following areas - 

- Lesson resource downloads page
- Previously released curricula page
- New "Curriculum downloads" page

There is a new storybook component here - (to add url)
<img width="200" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/60848894-e3e8-42f4-9918-46a7262dfe3c">

This consists of some pre-existing smaller components, and encapsulates the area of the the form which is common in all 3 pages listed above.

**NOTE**: Site functionality and visuals should be identical with 2 exceptions -

1. On the lesson downloads page, when there are no resources available for download or share, it used to display a message below the "Your Details" H1 tag, now this message is shown instead of the whole component (see screenshots). This was done to remove the "resources" logic an behaviour out of that area.

| Current | New |
|----------|----------|
| ![image](https://github.com/oaknational/Oak-Web-Application/assets/587241/b721e3ca-c5f7-46a3-9b75-a6198c67fb92) | ![image](https://github.com/oaknational/Oak-Web-Application/assets/587241/4d6e3db9-b683-45c1-9af2-a0de657adbab) |

2. Some padding has changed on the "previously released curricula" page to match the lesson downloads view (Join over 100k section is a bit tighter up). 

| Current | New |
|----------|----------|
| <img width="1168" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/9d5603df-a635-4fdf-8776-0504dad2b0b9"> | <img width="1167" alt="image" src="https://github.com/oaknational/Oak-Web-Application/assets/587241/32d90fa1-debe-4abd-820c-352ee1613b74"> |

## How to test

Regression testing in the 2 areas of the site that have downloads is needed.

(to add url)
(to add url)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
