### PR TITLE
feat: add copyright notice link to footer [LESQ-763]

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/index.test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/index.test.tsx
@@ -52,7 +52,7 @@ const mockCMS = (willErr = false) => ({
   blogPostBySlug: jest.fn((slug) => {
     if (willErr) throw new Error("Missing blog post");
     switch (slug) {
-      case "how-to-design-a-subject-curriculum":
+      case "how-to-design-a-subject-curriculum-in-7-easy-steps":
         return {
           id: "1",
           title: "blog 1",
@@ -68,7 +68,7 @@ const mockCMS = (willErr = false) => ({
           date: new Date("2021-12-01"),
           category: { title: "category", slug: "category" },
         };
-      case "how-to-design-a-unit-of-study":
+      case "how-to-create-a-unit-of-study":
         return {
           id: "3",
           title: "blog 3",

--- a/src/browser-lib/fixtures/footerSections.ts
+++ b/src/browser-lib/fixtures/footerSections.ts
@@ -83,6 +83,7 @@ const footerSections: FooterSections = {
       { text: "Cookie policy", href: "/legal/cookie-policy" },
       { text: "Manage cookie settings", type: "consent-manager-toggle" },
       { text: "Terms & conditions", href: "/legal/terms-and-conditions" },
+      { text: "Copyright notice", href: "/legal/copyright-notice" },
       {
         text: "Accessibility statement",
         href: "/legal/accessibility-statement",

--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -10,7 +10,7 @@ function getDeploymentTestUrls() {
     // Public pages
     "/",
     "/lesson-planning",
-    "/develop-your-curriculum-in-7-easy-steps",
+    "/develop-your-curriculum",
     "/support-your-team",
     "/contact-us",
     "/about-us/who-we-are",

--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -10,7 +10,7 @@ function getDeploymentTestUrls() {
     // Public pages
     "/",
     "/lesson-planning",
-    "/develop-your-curriculum",
+    "/develop-your-curriculum-in-7-easy-steps",
     "/support-your-team",
     "/contact-us",
     "/about-us/who-we-are",
@@ -19,7 +19,7 @@ function getDeploymentTestUrls() {
     "/about-us/partners",
     "/about-us/work-with-us",
     "/blog",
-    "/blog/how-to-design-a-unit-of-study",
+    "/blog/how-to-create-a-unit-of-study",
     "/blog/evolution-of-oak",
     "/blog/join-the-childrens-mental-health-week-assembly-2022",
     "/webinars/effective-feedback-a-practical-guide-to-using-feedback-to-enhance-student",

--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -215,7 +215,7 @@ export async function fetchCurriculumPageBlogs(
   CMSClient: Client,
 ): Promise<SerializedBlogPostPreview[]> {
   const subjectCurriculumBlog = await CMSClient.blogPostBySlug(
-    "how-to-design-a-subject-curriculum",
+    "how-to-design-a-subject-curriculum-in-7-easy-steps",
   );
 
   const refreshCurriculumBlog = await CMSClient.blogPostBySlug(
@@ -223,7 +223,7 @@ export async function fetchCurriculumPageBlogs(
   );
 
   const designUnitBlog = await CMSClient.blogPostBySlug(
-    "how-to-design-a-unit-of-study",
+    "how-to-create-a-unit-of-study",
   );
 
   const blogs = [];


### PR DESCRIPTION
## Description

Music year: 2011

- publish copyright page in sanity
- add link to footer
- once this is deployed we can ask Jim to remove redirect

There was also a bug with some blog post URLs being out of date so updated those as well


## How to test

1. Go to https://deploy-preview-2360--oak-web-application.netlify.thenational.academy/legal/copyright-notice
3. You should see the page
4. go to https://deploy-preview-2360--oak-web-application.netlify.thenational.academy/teachers/curriculum
5. the links to blog posts should all work

## Screenshots

How it should now look:

<img width="600" alt="Screenshot 2024-04-16 at 11 39 29" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/5634e441-9bc3-4cf5-969f-e76e666e2400">


