### PR TITLE
fix: specialist worksheet download [LESQ-739]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonDownload/specialistLessonDownload.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonDownload/specialistLessonDownload.query.ts
@@ -51,8 +51,8 @@ export const constructDownloadsArray = (
   };
   const worksheetPdf = {
     exists:
-      typeof lesson.worksheet_asset_object
-        ?.google_drive_downloadable_version === "string",
+      typeof lesson.worksheet_asset_object?.google_drive_downloadable_version
+        ?.url === "string",
     type: "worksheet-pdf" as const,
     label: "Worksheet",
     ext: "pdf",
@@ -60,8 +60,8 @@ export const constructDownloadsArray = (
   };
   const worksheetPptx = {
     exists:
-      typeof lesson.worksheet_asset_object
-        ?.google_drive_downloadable_version === "string",
+      typeof lesson.worksheet_asset_object?.google_drive_downloadable_version
+        ?.url === "string",
     type: "worksheet-pptx" as const,
     label: "Worksheet",
     ext: "pptx",

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.query.ts
@@ -55,7 +55,7 @@ const specialistLessonListingQuery =
             subjectSlug: lesson.combined_programme_fields.subject_slug,
             subjectTitle: lesson.combined_programme_fields.subject,
             developmentStageSlug:
-              lesson.combined_programme_fields.developmentstage_slug,
+              lesson.combined_programme_fields.developmentstage_slug ?? null,
             developmentStageTitle:
               lesson.combined_programme_fields.developmentstage ?? "",
             unitSlug: lesson.unit_slug,

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonOverview/specialistLessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonOverview/specialistLessonOverview.query.ts
@@ -38,14 +38,14 @@ export const constructDownloadsArray = (
   };
   const worksheetPdf = {
     exists:
-      typeof lesson.worksheet_asset_object
-        ?.google_drive_downloadable_version === "string",
+      typeof lesson.worksheet_asset_object?.google_drive_downloadable_version
+        ?.url === "string",
     type: "worksheet-pdf" as const,
   };
   const worksheetPptx = {
     exists:
-      typeof lesson.worksheet_asset_object
-        ?.google_drive_downloadable_version === "string",
+      typeof lesson.worksheet_asset_object?.google_drive_downloadable_version
+        ?.url === "string",
     type: "worksheet-pptx" as const,
   };
 


### PR DESCRIPTION
## Description

Music year: 1984

- check agains the correct field for worksheet download on lesson overview and downloads page

## Issue(s)

Fixes #
speciallist worksheets can't be downloaded

## How to test

1. Go to https://deploy-preview-2362--oak-web-application.netlify.thenational.academy/teachers/specialist/programmes/sensory-integration/units/oral-breathing-6e66/lessons/getting-ready-for-bed-chh38d#worksheet
2. Click on download worksheet
3. You should see to download page with worksheet downloadable

## Screenshots

How it used to look (delete if n/a):
<img width="600" alt="Screenshot 2024-04-17 at 08 42 04" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/67485ae2-3ffb-4cf5-b484-e9795ad6b05e">

How it should now look:
<img width="600" alt="Screenshot 2024-04-17 at 08 42 15" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/c43da28a-733a-4868-8441-8c74bd9e745f">
