### PR TITLE
[CUR-510] fix: Updated curric approach blog slug on curriculum landing page

### DIFF
--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -144,7 +144,7 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
               <OakTypography $font={"heading-7"} $mb="space-between-xs">
                 <OwaLink
                   page={"blog-single"}
-                  blogSlug="our-approach-to-curriculum"
+                  blogSlug="our-6-principles-guiding-our-approach-to-curriculum"
                   $display={"flex"}
                   $alignItems={"center"}
                 >


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

The link to the curriculum approach previously led to a 404. 

Fixes #

The slug has been updated to the correct blog post

## How to test

1. Go to {owa_deployment_url}
2. Click on curriculum and then curriculum plans
3. You should see the 'Find out more about our approach' - when clicking on this it should lead to the correct blog post

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
