### PR TITLE
[CUR-407] Resolving errors and warnings in the curriculum unit tests

### DIFF
--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import styled from "styled-components";
 import {
   OakP,
   OakHeading,
@@ -20,6 +21,11 @@ import { CurriculumSelectionSlugs } from "@/pages/teachers/curriculum/[subjectPh
 import CMSImage from "@/components/SharedComponents/CMSImage";
 import CMSVideo from "@/components/SharedComponents/CMSVideo";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
+
+const ULNoStyles = styled(OakUL)`
+  padding-inline-start: 0;
+  list-style-type: none;
+`;
 
 export type OverviewTabProps = {
   data: {
@@ -82,10 +88,11 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         ));
         return (
           <OakLI
-            $mb="space-between-sssx"
+            $mb={["space-between-xs"]}
+            $mr="space-between-none"
             key={`${firstItem.split(" ").join("-")}`}
           >
-            {createBullet(firstItem, i)}
+            <ULNoStyles>{createBullet(firstItem, i)}</ULNoStyles>
             <OakUL>{bullets}</OakUL>
           </OakLI>
         );

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { waitFor } from "@testing-library/react";
+import { act, waitFor } from "@testing-library/react";
 
 import UnitsTab, { createProgrammeSlug } from "./UnitsTab";
 
@@ -14,9 +14,8 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
   __esModule: true,
   default: () => ({
     track: {
-      curriculumThreadHighlighted: (...args: unknown[]) =>
-        curriculumThreadHighlighted(...args),
-      yearGroupSelected: (...args: unknown[]) => yearGroupSelected(...args),
+      curriculumThreadHighlighted,
+      yearGroupSelected,
     },
   }),
 }));
@@ -475,19 +474,21 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
     const { findAllByTestId } = render(
       <UnitsTab data={data} examboardSlug={null} />,
     );
-    let unitCards = await findAllByTestId("unit-card");
-    expect(unitCards).toHaveLength(2);
+
+    await act(async () => {
+      const unitCards = await findAllByTestId("unit-card");
+      expect(unitCards).toHaveLength(2);
+    });
+
     const domainButtons = await findAllByTestId("domain-button");
     // When there are domains, "All" button is added, so 3 expected
     expect(domainButtons).toHaveLength(3);
     if (!domainButtons[1]) {
       throw new Error("Missing second domain button");
     }
-    userEvent.click(domainButtons[1]);
-    await waitFor(async () => {
-      unitCards = await findAllByTestId("unit-card");
-      expect(unitCards).toHaveLength(1);
-    });
+    await userEvent.click(domainButtons[1]);
+    const unitCards = await findAllByTestId("unit-card");
+    expect(unitCards).toHaveLength(1);
   });
 
   test("user can filter units by discipline", async () => {

--- a/src/components/SharedComponents/RadioButtons/Radio.tsx
+++ b/src/components/SharedComponents/RadioButtons/Radio.tsx
@@ -12,6 +12,71 @@ import { RadioContext } from "./RadioGroup";
 
 import getColorByName from "@/styles/themeHelpers/getColorByName";
 
+const StyledRadio = styled.span<{
+  isSelected: boolean;
+  isFocusVisible: boolean;
+  hasError?: boolean;
+}>`
+  height: 24px;
+  width: 24px;
+  border: 2px solid
+    ${(props) =>
+      props.isFocusVisible
+        ? getColorByName("black")
+        : getColorByName("grey50")};
+  ${(props) =>
+    props.hasError &&
+    css`
+      border: 2px solid ${getColorByName("red")};
+    `}
+  border-radius: 50%;
+  display: flex;
+  flex-grow: 0;
+  flex-shrink: 0;
+  align-items: center;
+  background: white;
+  justify-content: center;
+  cursor: pointer;
+  margin-right: 16px;
+  ${(props) =>
+    props.isFocusVisible &&
+    css`
+      box-shadow: 0 0 0 2px ${getColorByName("lemon")};
+    `}
+
+  &::after {
+    content: "";
+    height: ${(props) => (props.isSelected ? "20px" : "16px")};
+    width: ${(props) => (props.isSelected ? "20px" : "16px")};
+    background: ${(props) =>
+      props.isSelected ? getColorByName("black") : getColorByName("white")};
+    display: block;
+    position: absolute;
+    border-radius: 50%;
+    ${(props) =>
+      props.isSelected &&
+      css`
+        border: 2px solid ${getColorByName("white")};
+      `}
+  }
+
+  &:active {
+    border: 2px solid ${getColorByName("black")};
+    box-shadow: 0 0 0 3px ${getColorByName("lemon")};
+  }
+
+  &:hover {
+    &::after {
+      background: ${getColorByName("black")};
+    }
+  }
+
+  &:focus {
+    border: 2px solid ${getColorByName("black")};
+    box-shadow: 0 0 0 3px ${getColorByName("lemon")};
+  }
+`;
+
 const Radio: FC<AriaRadioProps> = (props) => {
   const { children } = props;
   const stateOrNull = useContext(RadioContext);
@@ -22,71 +87,6 @@ const Radio: FC<AriaRadioProps> = (props) => {
 
   inputProps.name = useId();
   inputProps.id = useId();
-
-  const StyledRadio = styled.span<{
-    isSelected: boolean;
-    isFocusVisible: boolean;
-    hasError?: boolean;
-  }>`
-    height: 24px;
-    width: 24px;
-    border: 2px solid
-      ${(props) =>
-        props.isFocusVisible
-          ? getColorByName("black")
-          : getColorByName("grey50")};
-    ${(props) =>
-      props.hasError &&
-      css`
-        border: 2px solid ${getColorByName("red")};
-      `}
-    border-radius: 50%;
-    display: flex;
-    flex-grow: 0;
-    flex-shrink: 0;
-    align-items: center;
-    background: white;
-    justify-content: center;
-    cursor: pointer;
-    margin-right: 16px;
-    ${(props) =>
-      props.isFocusVisible &&
-      css`
-        box-shadow: 0 0 0 2px ${getColorByName("lemon")};
-      `}
-
-    &::after {
-      content: "";
-      height: ${(props) => (props.isSelected ? "20px" : "16px")};
-      width: ${(props) => (props.isSelected ? "20px" : "16px")};
-      background: ${(props) =>
-        props.isSelected ? getColorByName("black") : getColorByName("white")};
-      display: block;
-      position: absolute;
-      border-radius: 50%;
-      ${(props) =>
-        props.isSelected &&
-        css`
-          border: 2px solid ${getColorByName("white")};
-        `}
-    }
-
-    &:active {
-      border: 2px solid ${getColorByName("black")};
-      box-shadow: 0 0 0 3px ${getColorByName("lemon")};
-    }
-
-    &:hover {
-      &::after {
-        background: ${getColorByName("black")};
-      }
-    }
-
-    &:focus {
-      border: 2px solid ${getColorByName("black")};
-      box-shadow: 0 0 0 3px ${getColorByName("lemon")};
-    }
-  `;
 
   return (
     <label

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
@@ -19,7 +19,7 @@ export const formatSchoolName = (
     <OakSpan $font={"heading-light-7"}>
       {splitSchoolName.map((splitSchoolNameItem: string, index: number) => {
         return (
-          <OakSpan>
+          <OakSpan key={index}>
             {`${splitSchoolNameItem}`}
             {index < splitSchoolName.length - 1 && (
               <OakSpan


### PR DESCRIPTION
## Description

Resolving the warnings and errors that are seen when running `npm t curriculum` which I hope covers most if not all curriculum based unit tests.

NOTE - One test did require the UL and LI tags to be adjusted, it does result in slightly different vertical spacing, but I believe it looks better now.

| Current | New |
|----------|----------|
| ![image](https://github.com/oaknational/Oak-Web-Application/assets/587241/9f3de078-92f0-45e4-a8da-f5a54c0599a1) | ![image](https://github.com/oaknational/Oak-Web-Application/assets/587241/60ca6b11-0cc1-4e59-9965-f7c6b4b8630e) |

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/music-secondary-edexcel/overview
2. Check visuals and accessibility

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
