### PR TITLE
fix: landing page font color - LESQ-778

### DIFF
--- a/src/components/GenericPagesComponents/LandingPageTextAndMedia/LandingPageTextAndMedia.tsx
+++ b/src/components/GenericPagesComponents/LandingPageTextAndMedia/LandingPageTextAndMedia.tsx
@@ -32,7 +32,9 @@ const landingPortableTextComponent: PortableTextComponents = {
           $mb="space-between-l"
           $alignItems={"center"}
         >
-          <OakLI $font={["heading-7", "heading-6"]}>{listItemText}</OakLI>
+          <OakLI $color={"black"} $font={["heading-7", "heading-6"]}>
+            {listItemText}
+          </OakLI>
         </OakFlex>
       );
     },


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds black font color

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2387--oak-web-application.netlify.thenational.academy
https://deploy-preview-2387--oak-web-application.netlify.thenational.academy/lp/how-to-use-Oak-in-3-easy-steps

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
