### PR TITLE
feat: fixed type issue with `./SharedComponents/Input`

### DIFF
--- a/src/components/CurriculumComponents/OakComponentsKitchen/Autocomplete/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Autocomplete/index.tsx
@@ -19,7 +19,7 @@ type AutocompleteProps = {
   children: CollectionChildren<HTMLDivElement>;
 };
 const Autocomplete = (props: AutocompleteProps) => {
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const listBoxRef = useRef(null);
   const popoverRef = useRef(null);
   const { contains } = useFilter({ sensitivity: "base" });
@@ -64,7 +64,6 @@ const Autocomplete = (props: AutocompleteProps) => {
         placeholder={props.inputProps.placeholder}
         value={String(inputProps.value)}
         $mb={0}
-        // @ts-expect-error: unsure what type it's after here...
         ref={inputRef}
       />
       {isOpen && (

--- a/src/components/SharedComponents/Input/Input.tsx
+++ b/src/components/SharedComponents/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { FC, forwardRef } from "react";
+import { forwardRef } from "react";
 import styled from "styled-components";
 import { OakSpan } from "@oaknational/oak-components";
 
@@ -129,65 +129,63 @@ type InputProps = UnstyledInputProps &
     label: string;
     error?: string;
   };
-const Input: FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(
-  (props, ref) => {
-    const { id, icon, label, error, isOptional, isRequired, ...inputProps } =
-      props;
-    const errorId = `${id}-error`;
-    const labelId = `${id}-label`;
-    return (
-      <>
-        {error && <FieldError id={errorId}>{error}</FieldError>}
-        <InputFieldWrap
-          $mb={props.$mb ?? 32}
-          $alignItems="center"
-          $background="white"
-          $width={"100%"}
-        >
-          <Flex $width={"100%"} $position={"relative"}>
-            <BoxBorders gapPosition="rightTop" />
-            <Flex $position={"absolute"}>
-              <RotatedInputLabel
-                aria-hidden="true"
-                background={error ? "red" : "lemon"}
-                color={error ? "white" : "black"}
-                htmlFor={id}
-                id={labelId}
-                $font={"heading-7"}
-                data-testid="rotated-input-label"
-              >
-                {isRequired && (
-                  <OakSpan>
-                    {props.label}{" "}
-                    <OakSpan $font={"heading-light-7"}>(required)</OakSpan>
-                  </OakSpan>
-                )}
-                {isOptional && (
-                  <OakSpan>
-                    {props.label}{" "}
-                    <OakSpan $font={"heading-light-7"}>(optional)</OakSpan>
-                  </OakSpan>
-                )}
-                {!isRequired && !isOptional && props.label}
-              </RotatedInputLabel>
-            </Flex>
-
-            <StyledInput
-              {...inputProps}
-              icon={icon}
-              ref={ref}
-              id={id}
-              aria-invalid={Boolean(error)}
-              aria-describedby={error ? errorId : undefined}
-              aria-labelledby={labelId}
-            />
-            {icon && <InputIcon $pa={8} size={40} name={icon} />}
-            <InputFocusUnderline aria-hidden="true" name={"underline-1"} />
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  const { id, icon, label, error, isOptional, isRequired, ...inputProps } =
+    props;
+  const errorId = `${id}-error`;
+  const labelId = `${id}-label`;
+  return (
+    <>
+      {error && <FieldError id={errorId}>{error}</FieldError>}
+      <InputFieldWrap
+        $mb={props.$mb ?? 32}
+        $alignItems="center"
+        $background="white"
+        $width={"100%"}
+      >
+        <Flex $width={"100%"} $position={"relative"}>
+          <BoxBorders gapPosition="rightTop" />
+          <Flex $position={"absolute"}>
+            <RotatedInputLabel
+              aria-hidden="true"
+              background={error ? "red" : "lemon"}
+              color={error ? "white" : "black"}
+              htmlFor={id}
+              id={labelId}
+              $font={"heading-7"}
+              data-testid="rotated-input-label"
+            >
+              {isRequired && (
+                <OakSpan>
+                  {props.label}{" "}
+                  <OakSpan $font={"heading-light-7"}>(required)</OakSpan>
+                </OakSpan>
+              )}
+              {isOptional && (
+                <OakSpan>
+                  {props.label}{" "}
+                  <OakSpan $font={"heading-light-7"}>(optional)</OakSpan>
+                </OakSpan>
+              )}
+              {!isRequired && !isOptional && props.label}
+            </RotatedInputLabel>
           </Flex>
-        </InputFieldWrap>
-      </>
-    );
-  },
-);
+
+          <StyledInput
+            {...inputProps}
+            icon={icon}
+            ref={ref}
+            id={id}
+            aria-invalid={Boolean(error)}
+            aria-describedby={error ? errorId : undefined}
+            aria-labelledby={labelId}
+          />
+          {icon && <InputIcon $pa={8} size={40} name={icon} />}
+          <InputFocusUnderline aria-hidden="true" name={"underline-1"} />
+        </Flex>
+      </InputFieldWrap>
+    </>
+  );
+});
 
 export default Input;


### PR DESCRIPTION
## Description

- No functional changes just removed `FC<InputProps>` from `<Input/>`'s type so I can remove `@ts-expect-error:`


Previous error is as follows

```
src/components/CurriculumComponents/OakComponentsKitchen/Autocomplete/index.tsx:67:9 - error TS2578: Unused '@ts-expect-error' directive.

67         // @ts-expect-error: unsure what type it's after here...
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/components/CurriculumComponents/OakComponentsKitchen/Autocomplete/index.tsx:67

husky - pre-push hook exited with code 2 (error)
error: failed to push some refs to 'github.com:oaknational/Oak-Web-Application.git'

```
