### PR TITLE
Fix/lesq 760/a11y link header [LESQ-760]

### DIFF
--- a/src/components/TeacherComponents/SubjectProgrammeList/SubjectProgrammeList.test.tsx
+++ b/src/components/TeacherComponents/SubjectProgrammeList/SubjectProgrammeList.test.tsx
@@ -15,12 +15,10 @@ describe("ProgrammeList", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole("heading", { level: 3 })[0]?.textContent).toBe(
+      expect(screen.getAllByRole("paragraph")[0]?.textContent).toBe(
         "Foundation",
       );
-      expect(screen.getAllByRole("heading", { level: 3 })[1]?.textContent).toBe(
-        "Higher",
-      );
+      expect(screen.getAllByRole("paragraph")[1]?.textContent).toBe("Higher");
     });
   });
 });

--- a/src/components/TeacherComponents/SubjectProgrammeListItem/SubjectProgrammeListItem.tsx
+++ b/src/components/TeacherComponents/SubjectProgrammeListItem/SubjectProgrammeListItem.tsx
@@ -39,10 +39,9 @@ const SubjectProgrammeListItem: FC<SubjectProgrammeListItemProps> = (props) => {
           {...props.programme}
           data-testid="programme-list-item-link"
           onClick={() => onClick(programme)}
+          aria-label={ariaLabel}
         >
-          <OakP $font={"heading-7"} aria-label={ariaLabel}>
-            {heading}
-          </OakP>
+          <OakP $font={"heading-7"}>{heading}</OakP>
         </OwaLink>
       </OakFlex>
 

--- a/src/components/TeacherComponents/SubjectProgrammeListItem/SubjectProgrammeListItem.tsx
+++ b/src/components/TeacherComponents/SubjectProgrammeListItem/SubjectProgrammeListItem.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { OakHeading, OakFlex } from "@oaknational/oak-components";
+import { OakFlex, OakP } from "@oaknational/oak-components";
 
 import BoxBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BoxBorders";
 import OwaLink from "@/components/SharedComponents/OwaLink";
@@ -40,9 +40,9 @@ const SubjectProgrammeListItem: FC<SubjectProgrammeListItemProps> = (props) => {
           data-testid="programme-list-item-link"
           onClick={() => onClick(programme)}
         >
-          <OakHeading $font={"heading-7"} tag="h3" ariaLabel={ariaLabel}>
+          <OakP $font={"heading-7"} aria-label={ariaLabel}>
             {heading}
-          </OakHeading>
+          </OakP>
         </OwaLink>
       </OakFlex>
 

--- a/src/components/TeacherComponents/SubjectProgrammeListing/SubjectProgrammeListing.test.tsx
+++ b/src/components/TeacherComponents/SubjectProgrammeListing/SubjectProgrammeListing.test.tsx
@@ -71,12 +71,8 @@ describe("SubjectProgrammeListing", () => {
       <SubjectProgrammeListing onClick={onClick} {...curriculumData} />,
     );
 
-    expect(getAllByRole("heading", { level: 3 })[1]?.textContent).toBe(
-      "Higher",
-    );
-    expect(getAllByRole("heading", { level: 3 })[0]?.textContent).toBe(
-      "Foundation",
-    );
+    expect(getAllByRole("paragraph")[1]?.textContent).toBe("Higher");
+    expect(getAllByRole("paragraph")[0]?.textContent).toBe("Foundation");
   });
 
   test("each card items will link have a link to a different query ", () => {


### PR DESCRIPTION
## Description

Music year: 2004

- update subjectProgrammeListItem links to use `p` instead of `heading` for inner text
- update tests

## How to test

1. Go to https://deploy-preview-2401--oak-web-application.netlify.thenational.academy/teachers/key-stages/ks4/subjects/chemistry/programmes
2. Inspect tags of the programme links
3. You should see they are not headings

## Screenshots

How it used to look (delete if n/a):
<img width="523" alt="Screenshot 2024-04-30 at 10 23 34" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/002c3854-f7dd-4f1d-a195-5f1b75016e00">

How it should now look:
<img width="524" alt="Screenshot 2024-04-30 at 10 23 10" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/71d8586e-4444-47d2-9734-0f4888e1a5af">

## Checklist
[] Programme listing page, the programmes listings shouldn’t be header elements  because no content follows them, and screen reader users might expect there to be, given they are header elements