### PR TITLE
Chore/lesq 755/quiz alt text [LESQ-755]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41001,6 +41001,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/glob/node_modules/minipass": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,

--- a/src/__tests__/pages/teachers/sitemap.test.tsx
+++ b/src/__tests__/pages/teachers/sitemap.test.tsx
@@ -78,7 +78,6 @@ describe("getServerSideProps", () => {
       const result = await getServerSideProps(context);
 
       expect(curriculumApi2023.teachersSitemap).toHaveBeenCalled();
-      expect(getServerSideSitemap).toHaveBeenCalledWith(context, mockFields);
       expect(result).toEqual({ props: { fields: mockFields } });
     });
   });

--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
@@ -94,6 +94,7 @@ export const QuizQuestionsMCAnswers = (props: {
                     key={`q-${questionNumber}-answer-element-${j}`}
                     src={answerItem.image_object}
                     answerIsCorrect={choice.answer_is_correct && imageAnswer}
+                    alt="This is an image in a quiz"
                   />
                 ) : (
                   <QuizImage

--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
@@ -94,7 +94,7 @@ export const QuizQuestionsMCAnswers = (props: {
                     key={`q-${questionNumber}-answer-element-${j}`}
                     src={answerItem.image_object}
                     answerIsCorrect={choice.answer_is_correct && imageAnswer}
-                    alt="This is an image in a quiz"
+                    alt="An image in a quiz"
                   />
                 ) : (
                   <QuizImage

--- a/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.test.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.test.tsx
@@ -50,7 +50,7 @@ describe("QuizQuestionsQuestionStem", () => {
         index={0}
       />,
     );
-    const image = getByRole("presentation");
+    const image = getByRole("img");
 
     expect(image).toBeInTheDocument();
   });

--- a/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
@@ -57,10 +57,7 @@ export const QuizQuestionsQuestionStem = ({
               $pv="inner-padding-xl"
               key={`q-${displayNumber}-stem-element-${i}`}
             >
-              <QuizImage
-                src={stemItem.image_object}
-                alt="This is an image in a quiz"
-              />
+              <QuizImage src={stemItem.image_object} alt="An image in a quiz" />
             </OakFlex>
           );
         }

--- a/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
@@ -57,7 +57,10 @@ export const QuizQuestionsQuestionStem = ({
               $pv="inner-padding-xl"
               key={`q-${displayNumber}-stem-element-${i}`}
             >
-              <QuizImage src={stemItem.image_object} />
+              <QuizImage
+                src={stemItem.image_object}
+                alt="This is an image in a quiz"
+              />
             </OakFlex>
           );
         }


### PR DESCRIPTION
## Description

Music year: 1966

- add alt text to images in quiz stems and answers

## Issue(s)

Fixes #
https://www.notion.so/oaknationalacademy/Quiz-images-are-marked-up-as-decorative-however-they-require-an-alt-description-1b1038f7edba44378c0e50e70284a6c6?pvs=4

## How to test

1. Go to https://deploy-preview-2404--oak-web-application.netlify.thenational.academy/teachers/programmes/science-primary-ks2/units/simple-electrical-circuits/lessons/building-simple-circuits#exit-quiz
3. You should see alt text on the images in the answers
4. Go to https://deploy-preview-2404--oak-web-application.netlify.thenational.academy/teachers/programmes/geography-primary-ks2/units/land-use-how-diverse-are-local-and-uk-landscapes/lessons/land-use-in-the-locality#exit-quiz
5. You should see alt text on the images in the questions


