### PR TITLE
chore: add sitemap to next-sitemap config

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -21,6 +21,7 @@ const serversideSitemapPaths = [
   "/webinars/categories/sitemap.xml",
   "/teachers/curriculum/sitemap.xml",
   "/teachers/key-stages/sitemap.xml",
+  "/teachers/sitemap.xml",
 ];
 const serversideSitemapUrls = serversideSitemapPaths.map(
   (sitemapPath) => new URL(path.join(sitemapBaseUrl, sitemapPath)).href,


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds sitemap to the next-sitemap config so page does not error

## Issue(s)

Fixes 

- Currently sitemap is throwing an error, required to add to the config to resolve this

## Screenshots

How it used to look (delete if n/a):
<img width="1706" alt="Screenshot 2024-05-07 at 10 16 12" src="https://github.com/oaknational/Oak-Web-Application/assets/91190841/78843fe3-b39f-472b-ad46-70bfd3f6e041">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
