### PR TITLE
DEMO: Spike/lesq 812/google doc preview [LESQ-812]

### DIFF
--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -508,7 +508,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                               border: "none",
                             }}
                             src={`${additionalMaterialUrl}&rm=minimal`}
-                           />
+                          />
                         </AspectRatio>
                       </Box>
                       <OakTypography $font={"body-1"}>
@@ -519,16 +519,18 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                           <object
                             width="100%"
                             type="application/pdf"
-                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0&zoom=110`}
                           >
                             <OakTypography>
                               It appears you don't have a PDF plugin for this
                               browser.
                               <a
-                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf`}
                               >
                                 Click here to download the PDF file.
-                              </a>
+                              </a>{" "}
+                              (this can link to download page or have analytics
+                              attached)
                             </OakTypography>
                           </object>
                         </AspectRatio>
@@ -541,16 +543,18 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                           <object
                             width="100%"
                             type="application/pdf"
-                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf`}
+                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#zoom=110`}
                           >
                             <OakTypography>
                               It appears you don't have a PDF plugin for this
                               browser.
                               <a
-                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf`}
                               >
                                 Click here to download the PDF file.
-                              </a>
+                              </a>{" "}
+                              (this can link to download page or have analytics
+                              attached)
                             </OakTypography>
                           </object>
                         </AspectRatio>

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -504,10 +504,19 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                         <AspectRatio ratio={"2:3"}>
                           <iframe
                             width="100%"
-                            style={{
-                              border: "none",
-                            }}
                             src={`${additionalMaterialUrl}&rm=minimal`}
+                          />
+                        </AspectRatio>
+                      </Box>
+
+                      <OakTypography $font={"body-1"}>
+                        Example pdf using google viewer:
+                      </OakTypography>
+                      <Box $ba={[3]} $width={"100%"}>
+                        <AspectRatio ratio={"2:3"}>
+                          <iframe
+                            width="100%"
+                            src={`https://docs.google.com/viewer?srcid=1NwGnxDKxtsjfN_02cSvBrayW4tRZET5PdD0yXxTWbjs&pid=explorer&efh=false&a=v&chrome=false&embedded=true`}
                           />
                         </AspectRatio>
                       </Box>

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -47,6 +47,7 @@ import {
   checkIsResourceCopyrightRestricted,
   getIsResourceDownloadable,
 } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/downloadsCopyright";
+import AspectRatio from "@/components/SharedComponents/AspectRatio";
 
 export type LessonOverviewProps = {
   lesson: LessonOverviewAll & { downloads: LessonOverviewDownloads };
@@ -89,11 +90,12 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
     copyrightContent,
     isSpecialist,
     updatedAt,
+    additionalMaterialUrl,
+    videoTitle,
   } = lesson;
   const { track } = useAnalytics();
   const { analyticsUseCase } = useAnalyticsPageProps();
   const commonPathway = getPathway(lesson);
-
   const {
     keyStageSlug,
     keyStageTitle,
@@ -103,6 +105,9 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
     unitSlug,
     programmeSlug,
   } = commonPathway;
+
+  // TODO: if using, get lesson uuid from data instead of video title
+  const lessonUuid = videoTitle?.split("-").slice(0, 3).join("-");
 
   const isLegacyLicense = !lessonCohort || lessonCohort === LEGACY_COHORT;
   const isNew = lessonCohort === NEW_COHORT;
@@ -445,53 +450,113 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                     )}
                   </LessonItemContainer>
                 )}
-                {pageLinks.find((p) => p.label === "Additional material") && (
-                  <LessonItemContainer
-                    isSpecialist={isSpecialist}
-                    ref={additionalMaterialSectionRef}
-                    title={"Additional material"}
-                    anchorId="additional-material"
-                    downloadable={
-                      getIsResourceDownloadable(
-                        "supplementary-docx",
-                        downloads,
-                        copyrightContent,
-                      ) ||
-                      getIsResourceDownloadable(
-                        "supplementary-pdf",
-                        downloads,
-                        copyrightContent,
-                      )
-                    }
-                    shareable={isLegacyLicense && !isSpecialist}
-                    onDownloadButtonClick={() => {
-                      trackDownloadResourceButtonClicked({
-                        downloadResourceButtonName: "additional material",
-                      });
-                    }}
-                    slugs={slugs}
-                    isFinalElement={
-                      pageLinks.findIndex(
-                        (p) => p.label === "Additional material",
-                      ) ===
-                      pageLinks.length - 1
-                    }
-                  >
-                    <OakTypography $font={"body-1"}>
-                      We're sorry, but preview is not currently available.
-                      Download to see additional material.
-                    </OakTypography>
-                    {/* 
-                    Temporary fix for additional material due to unexpected poor rendering of google docs
-                    <OverviewPresentation
-                    asset={additionalMaterialUrl}
-                    isAdditionalMaterial={true}
-                    title={lessonTitle}
-                    isWorksheetLandscape={isWorksheetLandscape}
-                    isWorksheet={true}
-                  /> */}
-                  </LessonItemContainer>
-                )}
+                {pageLinks.find((p) => p.label === "Additional material") &&
+                  !!additionalMaterialUrl && (
+                    <LessonItemContainer
+                      isSpecialist={isSpecialist}
+                      ref={additionalMaterialSectionRef}
+                      title={"Additional material"}
+                      anchorId="additional-material"
+                      downloadable={
+                        getIsResourceDownloadable(
+                          "supplementary-docx",
+                          downloads,
+                          copyrightContent,
+                        ) ||
+                        getIsResourceDownloadable(
+                          "supplementary-pdf",
+                          downloads,
+                          copyrightContent,
+                        )
+                      }
+                      shareable={isLegacyLicense && !isSpecialist}
+                      onDownloadButtonClick={() => {
+                        trackDownloadResourceButtonClicked({
+                          downloadResourceButtonName: "additional material",
+                        });
+                      }}
+                      slugs={slugs}
+                      isFinalElement={
+                        pageLinks.findIndex(
+                          (p) => p.label === "Additional material",
+                        ) ===
+                        pageLinks.length - 1
+                      }
+                    >
+                      {/* <OakTypography $font={"body-1"}>
+                        We're sorry, but preview is not currently available.
+                        Download to see additional material.
+                      </OakTypography> */}
+                      {/* Temporary fix for additional material due to unexpected
+                      poor rendering of google docs */}
+                      {/* <LessonOverviewPresentation
+                        asset={additionalMaterialUrl}
+                        isAdditionalMaterial={true}
+                        title={lessonTitle}
+                        isWorksheetLandscape={isWorksheetLandscape}
+                        isWorksheet={true}
+                      /> */}
+
+                      <OakTypography $font={"body-1"}>
+                        Example Google doc:
+                      </OakTypography>
+                      <Box $ba={[3]} $width={"100%"}>
+                        <AspectRatio ratio={"2:3"}>
+                          <iframe
+                            width="100%"
+                            style={{
+                              border: "none",
+                            }}
+                            src={`${additionalMaterialUrl}&rm=minimal`}
+                           />
+                        </AspectRatio>
+                      </Box>
+                      <OakTypography $font={"body-1"}>
+                        Example PDF without controls:
+                      </OakTypography>
+                      <Box $ba={[3]} $width={"100%"}>
+                        <AspectRatio ratio={"2:3"}>
+                          <object
+                            width="100%"
+                            type="application/pdf"
+                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                          >
+                            <OakTypography>
+                              It appears you don't have a PDF plugin for this
+                              browser.
+                              <a
+                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                              >
+                                Click here to download the PDF file.
+                              </a>
+                            </OakTypography>
+                          </object>
+                        </AspectRatio>
+                      </Box>
+                      <OakTypography $font={"body-1"}>
+                        PDF with controls:
+                      </OakTypography>
+                      <Box $ba={[3]} $width={"100%"}>
+                        <AspectRatio ratio={"2:3"}>
+                          <object
+                            width="100%"
+                            type="application/pdf"
+                            data={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf`}
+                          >
+                            <OakTypography>
+                              It appears you don't have a PDF plugin for this
+                              browser.
+                              <a
+                                href={`https://storage.cloud.google.com/ingested-assets-production/${lessonUuid}/supplementary_resource/PDF.pdf#toolbar=0&navpanes=0`}
+                              >
+                                Click here to download the PDF file.
+                              </a>
+                            </OakTypography>
+                          </object>
+                        </AspectRatio>
+                      </Box>
+                    </LessonItemContainer>
+                  )}
               </OakFlex>
             </OakGridArea>
           </OakGrid>

--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -215,7 +215,7 @@ export async function fetchCurriculumPageBlogs(
   CMSClient: Client,
 ): Promise<SerializedBlogPostPreview[]> {
   const subjectCurriculumBlog = await CMSClient.blogPostBySlug(
-    "how-to-design-a-subject-curriculum-in-7-easy-steps",
+    "how-to-design-a-subject-curriculum",
   );
 
   const refreshCurriculumBlog = await CMSClient.blogPostBySlug(
@@ -223,7 +223,7 @@ export async function fetchCurriculumPageBlogs(
   );
 
   const designUnitBlog = await CMSClient.blogPostBySlug(
-    "how-to-create-a-unit-of-study",
+    "how-to-design-a-unit-of-study",
   );
 
   const blogs = [];


### PR DESCRIPTION
## Description
The preview environments listed below show a few different options for displaying additional materials on the lesson overview page, using:

1. Doogle docs link in an iframe - this looks best in my opinion but you can see when people are in the doc! I can't see any way to disable this, but could spend more time looking into it if we want to pursue this option.
<img width="500" alt="Screenshot 2024-05-07 at 14 02 40" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/6d571850-c3dd-4035-983e-4a4e75c57bc3">    
      
Someone editing the doc 👀 :
<img width="500" alt="Screenshot 2024-05-07 at 13 58 01" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/cc533a7e-49cd-48a6-b47f-e3015587771c">
    
2. Google viewer view as PDF - this looks good, not sure if it's possible to remove the controls from the view but they are quite minimal.  
<img width="500" alt="Screenshot 2024-05-08 at 10 34 21" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/b29e0cd2-73ca-47bd-b47e-def4665ef398">

4. Built in browser pdf viewer, without controls - looks clean but slightly ugly border/background, could look into minimising this if we go this direction, but main downside is it is not automatically enabled on all browsers.  
<img width="500" alt="Screenshot 2024-05-07 at 14 03 47" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/e7b6fcec-8b86-4540-9c72-b89a5e58c9af">
    
On browser without pdf preview enabled:
<img width="500" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/f4220763-d47e-4f35-a864-48ae13f9ffa4">  
    
5. Same as above but with controls showing, allowing zooming, printing directly from page etc
<img width="500" alt="Screenshot 2024-05-07 at 14 05 54" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/862cee42-c4bb-468c-b176-551f39f1e1d9">  
  
### Further work
Option 1 would be the easiest to get up and running, option 2 would require getting the asset ID for the google docs into the app, and options 3 and 4 will require some work to either get the lesson UUID from the MV, or to write a function use the google cloud storage library to fetch the filename to preview (currently the filenames are semi-hardcoded for demo purposes).

## How to test

Single page of materials:
1. Go to https://deploy-preview-2409--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-primary-ks1/units/composition-of-numbers-0-to-5/lessons/solve-problems-using-a-bar-model-to-represent-a-whole-partitioned-into-two-parts#additional-material

Multiple pages of materials:
1. Go to https://deploy-preview-2409--oak-web-application.netlify.thenational.academy/teachers/programmes/biology-secondary-ks4-higher-aqa/units/eukaryotic-and-prokaryotic-cells/lessons/light-microscopy-observing-and-drawing-cells#additional-material
