### PR TITLE
Fix/lesq 829/maths core new [LESQ-829]

### DIFF
--- a/src/node-lib/curriculum-api-2023/helpers/index.test.ts
+++ b/src/node-lib/curriculum-api-2023/helpers/index.test.ts
@@ -42,11 +42,15 @@ describe("filterOutCoreTier", () => {
   ];
 
   test("returns all tiers when subject and key stage are in the hasCoreTier set", () => {
-    expect(filterOutCoreTier("maths", "ks4", sampleTiers)).toEqual(sampleTiers);
+    expect(filterOutCoreTier(true, "maths", "ks4", sampleTiers)).toEqual(
+      sampleTiers,
+    );
   });
 
   test('filters out "core" tier when not in the hasCoreTier set', () => {
-    expect(filterOutCoreTier("combined-science", "ks4", sampleTiers)).toEqual([
+    expect(
+      filterOutCoreTier(false, "combined-science", "ks4", sampleTiers),
+    ).toEqual([
       {
         tierSlug: "foundation",
         tierTitle: "Foundation",
@@ -61,6 +65,6 @@ describe("filterOutCoreTier", () => {
   });
 
   test("returns null for null arguments", () => {
-    expect(filterOutCoreTier(null, null, null)).toBeNull();
+    expect(filterOutCoreTier(false, null, null, null)).toBeNull();
   });
 });

--- a/src/node-lib/curriculum-api-2023/helpers/index.ts
+++ b/src/node-lib/curriculum-api-2023/helpers/index.ts
@@ -8,6 +8,7 @@ export const toSentenceCase = (str: string) => {
  this function removes core from programmes that shouldn't have Core as an option*/
 const hasCoreTierSet = new Set(["maths-ks4"]);
 export const filterOutCoreTier = (
+  legacy: boolean,
   subjectSlug?: string | null,
   keyStageSlug?: string | null,
   tiers?: TierSchema | null,
@@ -17,7 +18,7 @@ export const filterOutCoreTier = (
   }
   const key = `${subjectSlug}-${keyStageSlug}`;
   return tiers.filter((tier) => {
-    if (!hasCoreTierSet.has(key)) {
+    if (!hasCoreTierSet.has(key) || !legacy) {
       return tier.tierSlug !== "core";
     } else {
       return tier;

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
@@ -26,11 +26,14 @@ const unitListingQuery =
       });
     }
 
+    const isLegacy = programme.programmeSlug?.endsWith("-l") ?? false;
+
     return unitListingSchema.parse({
       ...programme,
       tiers:
         programme.tiers &&
         filterOutCoreTier(
+          isLegacy,
           programme.subjectSlug,
           programme.keyStageSlug,
           programme.tiers,


### PR DESCRIPTION
## Description

Music year: 2007

- only include core tier in legacy maths

## Issue(s)

Fixes #
Core tier available on the unit listing page for new maths ks4 units

## How to test

1. Go to https://deploy-preview-2413--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-foundation/units
3. You should see no core tab
4. Go to https://deploy-preview-2413--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-foundation-l/units
5. Yu should see core tab
6. programme listing page and other subjects should be unaffected

## Screenshots

How it should now look:
<img width="700" alt="Screenshot 2024-05-08 at 11 54 07" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/5d065db0-1dd6-456f-bda9-724250265f3c">
