### PR TITLE
Feat sticky nav for new plan a lesson - LESQ-782

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^7.3.3",
         "@mux/mux-player-react": "^2.3.1",
-        "@oaknational/oak-components": "^0.27.0",
+        "@oaknational/oak-components": "^0.28.0",
         "@oaknational/oak-curriculum-schema": "^1.5.0",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
@@ -7467,9 +7467,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.27.0.tgz",
-      "integrity": "sha512-KZbE+PkMM3aRknTrmS5niKl76P7oIcRu0NWY6MTaCSSBp6YL5KOGYHR3pxxtQLrmU1WdQgejk8WZirl9pvE7pg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.28.0.tgz",
+      "integrity": "sha512-KdxDuqwrBBXAXgffOEGPaCusbdhIj94UHTQ+WSXm3SQKwfAXN79Nhke54VHjhisedtdYQaXqBwK1//H0GVLAkg==",
       "peerDependencies": {
         "next": "13.4.4 - 14",
         "next-cloudinary": "^5.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^7.3.3",
         "@mux/mux-player-react": "^2.3.1",
-        "@oaknational/oak-components": "^0.26.0",
+        "@oaknational/oak-components": "^0.27.0",
         "@oaknational/oak-curriculum-schema": "^1.5.0",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
@@ -7467,9 +7467,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.26.0.tgz",
-      "integrity": "sha512-e6xM2O3kzYr9Z0NJTs5mSP+95EnxzcAFmVS0eECCjQAVdAC2FZgiWv8y1SmKpz6t7dpRhtFLQME/1ehkO69ttA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.27.0.tgz",
+      "integrity": "sha512-KZbE+PkMM3aRknTrmS5niKl76P7oIcRu0NWY6MTaCSSBp6YL5KOGYHR3pxxtQLrmU1WdQgejk8WZirl9pvE7pg==",
       "peerDependencies": {
         "next": "13.4.4 - 14",
         "next-cloudinary": "^5.20.0",
@@ -40999,15 +40999,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "7.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^7.3.3",
     "@mux/mux-player-react": "^2.3.1",
-    "@oaknational/oak-components": "^0.26.0",
+    "@oaknational/oak-components": "^0.27.0",
     "@oaknational/oak-curriculum-schema": "^1.5.0",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^7.3.3",
     "@mux/mux-player-react": "^2.3.1",
-    "@oaknational/oak-components": "^0.27.0",
+    "@oaknational/oak-components": "^0.28.0",
     "@oaknational/oak-curriculum-schema": "^1.5.0",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",

--- a/src/__tests__/pages/lesson-planning-new.test.tsx
+++ b/src/__tests__/pages/lesson-planning-new.test.tsx
@@ -23,6 +23,11 @@ describe("pages/lesson-planning.tsx", () => {
 
     expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("hero");
   });
+  it("Renders a nav", () => {
+    render(<PlanALesson pageData={testPlanningPageData} />);
+
+    expect(screen.getAllByText("Contents")).toHaveLength(2);
+  });
 
   describe("SEO", () => {
     it.skip("renders the correct SEO details", () => {

--- a/src/__tests__/pages/lesson-planning-new.test.tsx
+++ b/src/__tests__/pages/lesson-planning-new.test.tsx
@@ -25,8 +25,11 @@ describe("pages/lesson-planning.tsx", () => {
   });
   it("Renders a nav", () => {
     render(<PlanALesson pageData={testPlanningPageData} />);
-
+    const nav = screen.getByRole("navigation", {
+      name: "plan a lesson contents",
+    });
     expect(screen.getAllByText("Contents")).toHaveLength(2);
+    expect(nav).toBeInTheDocument();
   });
 
   describe("SEO", () => {

--- a/src/components/GenericPagesComponents/PostPortableText/PostPortableText.tsx
+++ b/src/components/GenericPagesComponents/PostPortableText/PostPortableText.tsx
@@ -63,7 +63,7 @@ type PostPortableTextProps = {
   portableText: PortableTextJSON;
 };
 
-const PostPortableText: FC<PostPortableTextProps> = (props) => {
+export const PostPortableText: FC<PostPortableTextProps> = (props) => {
   const { portableText } = props;
 
   const footnotes = extractFootnotes(portableText);

--- a/src/pages-helpers/homesite/plan-a-lesson/getNavItems.test.tsx
+++ b/src/pages-helpers/homesite/plan-a-lesson/getNavItems.test.tsx
@@ -1,0 +1,13 @@
+import { getNavItems } from "./getNavItems";
+
+import { testPlanALessonPageData } from "@/__tests__/pages/lesson-planning.fixture";
+
+describe("getNavItems function", () => {
+  it("should return valid navigation items excluding form items", () => {
+    const result = getNavItems({ pageData: testPlanALessonPageData });
+    expect(result).toEqual([
+      { title: "test nav content", href: "#test-nav-content" },
+      { title: "test content 2", href: "#test-content-2" },
+    ]);
+  });
+});

--- a/src/pages-helpers/homesite/plan-a-lesson/getNavItems.ts
+++ b/src/pages-helpers/homesite/plan-a-lesson/getNavItems.ts
@@ -1,0 +1,17 @@
+import { PlanALessonProps } from "@/pages/lesson-planning-new";
+
+export const getNavItems = ({ pageData }: PlanALessonProps) => {
+  const navItems = pageData.content
+    .map((section) => {
+      if (section.type === "PlanALessonPageContent") {
+        return {
+          title: section.navigationTitle,
+          href: `#${section.anchorSlug.current}`,
+        };
+      }
+    })
+    .filter(
+      (item): item is { title: string; href: string } => item !== undefined,
+    );
+  return navItems;
+};

--- a/src/pages/lesson-planning-new.tsx
+++ b/src/pages/lesson-planning-new.tsx
@@ -5,6 +5,11 @@ import {
   OakHeading,
   OakMaxWidth,
   OakFlex,
+  OakTertiaryOLNav,
+  OakThemeProvider,
+  oakDefaultTheme,
+  OakAnchorTarget,
+  OakLink,
 } from "@oaknational/oak-components";
 
 import Layout from "@/components/AppComponents/Layout";
@@ -13,6 +18,7 @@ import getPageProps from "@/node-lib/getPageProps";
 import Breadcrumbs from "@/components/SharedComponents/Breadcrumbs";
 import CMSClient from "@/node-lib/cms";
 import { PlanALessonPage } from "@/common-lib/cms-types/planALessonPage";
+import { PortableTextWithDefaults } from "@/components/SharedComponents/PortableText";
 
 export type PlanALessonProps = {
   pageData: PlanALessonPage;
@@ -20,70 +26,128 @@ export type PlanALessonProps = {
 
 // This is the new plan a lesson page currently a template for the layout
 const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
-  return (
-    <Layout
-      seoProps={{
-        ...getSeoProps(pageData.seo),
-        ...{ noFollow: true, noIndex: true },
-      }}
-      $background={"white"}
-    >
-      <OakMaxWidth $pt={"inner-padding-xl"} $pb={"inner-padding-l"}>
-        <Breadcrumbs
-          breadcrumbs={[
-            {
-              oakLinkProps: {
-                page: "home",
-              },
-              label: "Home",
-            },
+  const items = pageData.content
+    .filter((c) => c.type === "PlanALessonPageContent")
+    .map((section) => ({
+      title: section.navigationTitle,
+      href: `#${section.anchorSlug.current}`,
+    }));
 
-            {
-              oakLinkProps: {
-                page: "lesson-planning",
+  return (
+    <OakThemeProvider theme={oakDefaultTheme}>
+      <Layout
+        seoProps={{
+          ...getSeoProps(pageData.seo),
+          ...{ noFollow: true, noIndex: true },
+        }}
+        $background={"white"}
+      >
+        <OakMaxWidth $pt={"inner-padding-xl"} $pb={"inner-padding-l"}>
+          <Breadcrumbs
+            breadcrumbs={[
+              {
+                oakLinkProps: {
+                  page: "home",
+                },
+                label: "Home",
               },
-              label: "Plan a lesson",
-              disabled: true,
-            },
-          ]}
-        />
+
+              {
+                oakLinkProps: {
+                  page: "lesson-planning",
+                },
+                label: "Plan a lesson",
+                disabled: true,
+              },
+            ]}
+          />
+          <OakFlex
+            $ba={"border-solid-l"}
+            $borderColor={"grey60"}
+            $justifyContent={"center"}
+            $alignItems={"center"}
+            $height={"all-spacing-14"}
+            $mb={"space-between-l"}
+          >
+            <OakHeading tag={"h1"} $font={"heading-1"}>
+              {"hero"}
+            </OakHeading>
+          </OakFlex>
+        </OakMaxWidth>
         <OakFlex
-          $ba={"border-solid-l"}
-          $borderColor={"grey60"}
-          $justifyContent={"center"}
-          $alignItems={"center"}
-          $height={"all-spacing-14"}
-          $mb={"space-between-l"}
+          $background={"bg-decorative3-very-subdued"}
+          $display={["block", "block", "none"]}
+          $pv={"inner-padding-xl"}
+          $ph={["inner-padding-m", "inner-padding-none", "inner-padding-none"]}
         >
-          <OakHeading tag={"h1"} $font={"heading-1"}>
-            {"hero"}
-          </OakHeading>
+          <OakMaxWidth>
+            <OakTertiaryOLNav
+              items={items}
+              ariaLabel="plan a lesson contents"
+              title={"Contents"}
+              anchorTarget="plan-a-lesson-contents"
+            />
+          </OakMaxWidth>
         </OakFlex>
-        <OakGrid>
-          <OakGridArea
-            $ba={"border-solid-l"}
-            $borderColor={"grey60"}
-            $colSpan={[12, 12, 3]}
-          >
-            <OakHeading tag={"h2"} $font={"heading-7"}>
-              {"Contents in heading 7 style"}
-            </OakHeading>
-            <OakFlex>{"sticky nav"}</OakFlex>
-          </OakGridArea>
-          <OakGridArea
-            $ba={"border-solid-l"}
-            $borderColor={"grey60"}
-            $colSpan={[12, 12, 6]}
-            $colStart={[1, 1, 5]}
-          >
-            <OakHeading tag={"h2"} $font={"heading-4"}>
-              {"H2 Section title"}
-            </OakHeading>
-            <OakFlex>{"cms content block section"}</OakFlex>
-          </OakGridArea>
-        </OakGrid>
-      </OakMaxWidth>
-    </Layout>
+
+        <OakMaxWidth>
+          <OakGrid>
+            <OakGridArea
+              $colSpan={[12, 3]}
+              $alignSelf={"start"}
+              $position={["static", "static", "sticky"]}
+              $top={"all-spacing-10"}
+              $display={["none", "none", "block"]}
+            >
+              <OakTertiaryOLNav
+                items={items}
+                ariaLabel="plan a lesson contents"
+                title={"Contents"}
+                anchorTarget="#plan-a-lesson-contents"
+              />
+            </OakGridArea>
+            <OakGridArea
+              $ba={"border-solid-l"}
+              $borderColor={"grey60"}
+              $colSpan={[12, 12, 6]}
+              $colStart={[1, 1, 5]}
+            >
+              <OakFlex $flexDirection={"column"}>
+                {pageData.content.map((section, index) => (
+                  <OakFlex
+                    $flexDirection={"column"}
+                    $height={"all-spacing-18"}
+                    key={index}
+                    $position={"relative"}
+                  >
+                    {section.type === "PlanALessonPageContent" && (
+                      <OakAnchorTarget id={section.anchorSlug.current} />
+                    )}
+                    {section.type === "PlanALessonPageContent" && (
+                      <p>{section.anchorSlug.current}</p>
+                    )}
+
+                    <OakHeading tag={"h3"} $font={"heading-5"}>
+                      {section.navigationTitle}
+                    </OakHeading>
+
+                    <PortableTextWithDefaults
+                      value={section.bodyPortableText}
+                    />
+                    <OakLink
+                      iconName="chevron-up"
+                      href={"#plan-a-lesson-contents"}
+                    >
+                      {"Back to contents"}
+                    </OakLink>
+                  </OakFlex>
+                ))}
+              </OakFlex>
+            </OakGridArea>
+          </OakGrid>
+        </OakMaxWidth>
+      </Layout>
+    </OakThemeProvider>
   );
 };
 

--- a/src/pages/lesson-planning-new.tsx
+++ b/src/pages/lesson-planning-new.tsx
@@ -19,19 +19,14 @@ import Breadcrumbs from "@/components/SharedComponents/Breadcrumbs";
 import CMSClient from "@/node-lib/cms";
 import { PlanALessonPage } from "@/common-lib/cms-types/planALessonPage";
 import { PortableTextWithDefaults } from "@/components/SharedComponents/PortableText";
+import { getNavItems } from "@/pages-helpers/homesite/plan-a-lesson/getNavItems";
 
 export type PlanALessonProps = {
   pageData: PlanALessonPage;
 };
 
-// This is the new plan a lesson page currently a template for the layout
 const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
-  const items = pageData.content
-    .filter((c) => c.type === "PlanALessonPageContent")
-    .map((section) => ({
-      title: section.navigationTitle,
-      href: `#${section.anchorSlug.current}`,
-    }));
+  const navItems = getNavItems({ pageData });
 
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
@@ -82,7 +77,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
         >
           <OakMaxWidth>
             <OakTertiaryOLNav
-              items={items}
+              items={navItems}
               ariaLabel="plan a lesson contents"
               title={"Contents"}
               anchorTarget="plan-a-lesson-contents"
@@ -100,7 +95,7 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData }) => {
               $display={["none", "none", "block"]}
             >
               <OakTertiaryOLNav
-                items={items}
+                items={navItems}
                 ariaLabel="plan a lesson contents"
                 title={"Contents"}
                 anchorTarget="#plan-a-lesson-contents"


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds plan a lesson page nav to page
- Connects to cms
- Crudely adds some content without styling

## Acceptance Criteria:

- [x]  Using “sanity data” create sticky contents menu
- [x]  Ensure bullet-point style exists in Oak Components
- [x]  On mobile it is just displayed at the top
- [x]  Click an item in the contents menu and it takes you to the section
- [x]  Focus moves to the section you have selected
- [x]  At the bottom of each section there is a “Return to contents” link

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2416--oak-web-application.netlify.thenational.academy/lesson-planning-new
- Test nav and back to contents buttons


## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
