### PR TITLE
feat: new lesson listing query - LESQ-793

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -760,8 +760,6 @@ export type Cat_Contentguidance_Avg_Fields = {
   __typename?: 'cat_contentguidance_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -851,8 +849,6 @@ export type Cat_Contentguidance_Max_Fields = {
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_label?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
@@ -869,8 +865,6 @@ export type Cat_Contentguidance_Min_Fields = {
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_label?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
@@ -979,8 +973,6 @@ export type Cat_Contentguidance_Stddev_Fields = {
   __typename?: 'cat_contentguidance_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -989,8 +981,6 @@ export type Cat_Contentguidance_Stddev_Pop_Fields = {
   __typename?: 'cat_contentguidance_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -999,8 +989,6 @@ export type Cat_Contentguidance_Stddev_Samp_Fields = {
   __typename?: 'cat_contentguidance_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1035,8 +1023,6 @@ export type Cat_Contentguidance_Sum_Fields = {
   __typename?: 'cat_contentguidance_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   contentguidance_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -1096,8 +1082,6 @@ export type Cat_Contentguidance_Var_Pop_Fields = {
   __typename?: 'cat_contentguidance_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1106,8 +1090,6 @@ export type Cat_Contentguidance_Var_Samp_Fields = {
   __typename?: 'cat_contentguidance_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1116,8 +1098,6 @@ export type Cat_Contentguidance_Variance_Fields = {
   __typename?: 'cat_contentguidance_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   contentguidance_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_contentguidance__lessons__count" */
-  lessons_with_contentguidance_count?: Maybe<Scalars['Int']['output']>;
   supervisionlevel_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -1204,8 +1184,6 @@ export type Cat_Examboardspecs_Avg_Fields = {
   __typename?: 'cat_examboardspecs_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Boolean expression to filter rows from the table "cat_examboardspecs". All fields are combined with a logical 'AND'. */
@@ -1230,7 +1208,7 @@ export type Cat_Examboardspecs_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_examboardspecs" */
 export enum Cat_Examboardspecs_Constraint {
-  /** unique or primary key constraint on columns "examboardspecs_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "examboardspecs_id" */
   CatExamboardspecsPkey = 'cat_examboardspecs_pkey'
 }
 
@@ -1283,8 +1261,6 @@ export type Cat_Examboardspecs_Max_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1298,8 +1274,6 @@ export type Cat_Examboardspecs_Min_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1394,8 +1368,6 @@ export type Cat_Examboardspecs_Stddev_Fields = {
   __typename?: 'cat_examboardspecs_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -1403,8 +1375,6 @@ export type Cat_Examboardspecs_Stddev_Pop_Fields = {
   __typename?: 'cat_examboardspecs_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -1412,8 +1382,6 @@ export type Cat_Examboardspecs_Stddev_Samp_Fields = {
   __typename?: 'cat_examboardspecs_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Streaming cursor of the table "cat_examboardspecs" */
@@ -1444,8 +1412,6 @@ export type Cat_Examboardspecs_Sum_Fields = {
   __typename?: 'cat_examboardspecs_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   examboardspecs_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** update columns of table "cat_examboardspecs" */
@@ -1498,8 +1464,6 @@ export type Cat_Examboardspecs_Var_Pop_Fields = {
   __typename?: 'cat_examboardspecs_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate var_samp on columns */
@@ -1507,8 +1471,6 @@ export type Cat_Examboardspecs_Var_Samp_Fields = {
   __typename?: 'cat_examboardspecs_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate variance on columns */
@@ -1516,8 +1478,6 @@ export type Cat_Examboardspecs_Variance_Fields = {
   __typename?: 'cat_examboardspecs_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   examboardspecs_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_examboardspecs__units__count" */
-  units_with_exam_board_specification_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** columns and relationships of "cat_nationalcurriculum" */
@@ -1603,8 +1563,6 @@ export type Cat_Nationalcurriculum_Avg_Fields = {
   __typename?: 'cat_nationalcurriculum_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Boolean expression to filter rows from the table "cat_nationalcurriculum". All fields are combined with a logical 'AND'. */
@@ -1682,8 +1640,6 @@ export type Cat_Nationalcurriculum_Max_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1697,8 +1653,6 @@ export type Cat_Nationalcurriculum_Min_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -1793,8 +1747,6 @@ export type Cat_Nationalcurriculum_Stddev_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -1802,8 +1754,6 @@ export type Cat_Nationalcurriculum_Stddev_Pop_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -1811,8 +1761,6 @@ export type Cat_Nationalcurriculum_Stddev_Samp_Fields = {
   __typename?: 'cat_nationalcurriculum_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Streaming cursor of the table "cat_nationalcurriculum" */
@@ -1843,8 +1791,6 @@ export type Cat_Nationalcurriculum_Sum_Fields = {
   __typename?: 'cat_nationalcurriculum_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** update columns of table "cat_nationalcurriculum" */
@@ -1897,8 +1843,6 @@ export type Cat_Nationalcurriculum_Var_Pop_Fields = {
   __typename?: 'cat_nationalcurriculum_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate var_samp on columns */
@@ -1906,8 +1850,6 @@ export type Cat_Nationalcurriculum_Var_Samp_Fields = {
   __typename?: 'cat_nationalcurriculum_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate variance on columns */
@@ -1915,8 +1857,6 @@ export type Cat_Nationalcurriculum_Variance_Fields = {
   __typename?: 'cat_nationalcurriculum_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   nationalcurriculum_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_nationalcurriculum__units__count" */
-  units_with_national_curriculum_content_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** columns and relationships of "cat_supervisionlevels" */
@@ -2420,11 +2360,7 @@ export type Cat_Tags_Append_Input = {
 export type Cat_Tags_Avg_Fields = {
   __typename?: 'cat_tags_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by avg() on columns of table "cat_tags" */
@@ -2458,7 +2394,7 @@ export type Cat_Tags_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_tags" */
 export enum Cat_Tags_Constraint {
-  /** unique or primary key constraint on columns "_state", "tag_id" */
+  /** unique or primary key constraint on columns "tag_id", "_state" */
   CatTagsPkey = 'cat_tags_pkey'
 }
 
@@ -2510,13 +2446,9 @@ export type Cat_Tags_Max_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_category?: Maybe<Scalars['String']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -2541,13 +2473,9 @@ export type Cat_Tags_Min_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_category?: Maybe<Scalars['String']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -2660,11 +2588,7 @@ export type Cat_Tags_Set_Input = {
 export type Cat_Tags_Stddev_Fields = {
   __typename?: 'cat_tags_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev() on columns of table "cat_tags" */
@@ -2677,11 +2601,7 @@ export type Cat_Tags_Stddev_Order_By = {
 export type Cat_Tags_Stddev_Pop_Fields = {
   __typename?: 'cat_tags_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev_pop() on columns of table "cat_tags" */
@@ -2694,11 +2614,7 @@ export type Cat_Tags_Stddev_Pop_Order_By = {
 export type Cat_Tags_Stddev_Samp_Fields = {
   __typename?: 'cat_tags_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by stddev_samp() on columns of table "cat_tags" */
@@ -2735,11 +2651,7 @@ export type Cat_Tags_Stream_Cursor_Value_Input = {
 export type Cat_Tags_Sum_Fields = {
   __typename?: 'cat_tags_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by sum() on columns of table "cat_tags" */
@@ -2799,11 +2711,7 @@ export type Cat_Tags_Updates = {
 export type Cat_Tags_Var_Pop_Fields = {
   __typename?: 'cat_tags_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by var_pop() on columns of table "cat_tags" */
@@ -2816,11 +2724,7 @@ export type Cat_Tags_Var_Pop_Order_By = {
 export type Cat_Tags_Var_Samp_Fields = {
   __typename?: 'cat_tags_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by var_samp() on columns of table "cat_tags" */
@@ -2833,11 +2737,7 @@ export type Cat_Tags_Var_Samp_Order_By = {
 export type Cat_Tags_Variance_Fields = {
   __typename?: 'cat_tags_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__lessons__count" */
-  lessons_with_tag_count?: Maybe<Scalars['Int']['output']>;
   tag_id?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__cat_tags__units__count" */
-  units_with_tag_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by variance() on columns of table "cat_tags" */
@@ -3865,10 +3765,6 @@ export type Internal_Review_Lessons_Max_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
-  /** A computed field, executes function "internal.function__internal_review_lessons__firstapproval" */
-  firstapproval?: Maybe<Scalars['timestamp']['output']>;
-  /** A computed field, executes function "internal.function__internal_review_lessons__lastapproval" */
-  lastapproval?: Maybe<Scalars['timestamp']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
   release_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -3912,10 +3808,6 @@ export type Internal_Review_Lessons_Min_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
-  /** A computed field, executes function "internal.function__internal_review_lessons__firstapproval" */
-  firstapproval?: Maybe<Scalars['timestamp']['output']>;
-  /** A computed field, executes function "internal.function__internal_review_lessons__lastapproval" */
-  lastapproval?: Maybe<Scalars['timestamp']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
   release_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -8342,7 +8234,7 @@ export type Pf_Developmentstages_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_developmentstages" */
 export enum Pf_Developmentstages_Constraint {
-  /** unique or primary key constraint on columns "_state", "developmentstage_id" */
+  /** unique or primary key constraint on columns "developmentstage_id", "_state" */
   PfDevelopmentstagesPkey = 'pf_developmentstages_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfDevelopmentstagesSlugStateCohortKey = 'pf_developmentstages_slug__state__cohort_key'
@@ -9467,7 +9359,7 @@ export type Pf_Phases_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_phases" */
 export enum Pf_Phases_Constraint {
-  /** unique or primary key constraint on columns "_state", "phase_id" */
+  /** unique or primary key constraint on columns "phase_id", "_state" */
   PfPhasesPkey = 'pf_phases_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfPhasesSlugStateCohortKey = 'pf_phases_slug__state__cohort_key'
@@ -9833,8 +9725,6 @@ export type Pf_Subjects_Avg_Fields = {
   __typename?: 'pf_subjects_avg_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -9918,8 +9808,6 @@ export type Pf_Subjects_Max_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   subject?: Maybe<Scalars['String']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
@@ -9936,8 +9824,6 @@ export type Pf_Subjects_Min_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   subject?: Maybe<Scalars['String']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
@@ -10043,8 +9929,6 @@ export type Pf_Subjects_Stddev_Fields = {
   __typename?: 'pf_subjects_stddev_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10054,8 +9938,6 @@ export type Pf_Subjects_Stddev_Pop_Fields = {
   __typename?: 'pf_subjects_stddev_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10065,8 +9947,6 @@ export type Pf_Subjects_Stddev_Samp_Fields = {
   __typename?: 'pf_subjects_stddev_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10101,8 +9981,6 @@ export type Pf_Subjects_Sum_Fields = {
   __typename?: 'pf_subjects_sum_fields';
   _release_id?: Maybe<Scalars['Int']['output']>;
   display_order?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Int']['output']>;
   subject_parent_id?: Maybe<Scalars['Int']['output']>;
 };
@@ -10161,8 +10039,6 @@ export type Pf_Subjects_Var_Pop_Fields = {
   __typename?: 'pf_subjects_var_pop_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10172,8 +10048,6 @@ export type Pf_Subjects_Var_Samp_Fields = {
   __typename?: 'pf_subjects_var_samp_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10183,8 +10057,6 @@ export type Pf_Subjects_Variance_Fields = {
   __typename?: 'pf_subjects_variance_fields';
   _release_id?: Maybe<Scalars['Float']['output']>;
   display_order?: Maybe<Scalars['Float']['output']>;
-  /** A computed field, executes function "function__pf_subjects__programmes__count" */
-  programmes_count?: Maybe<Scalars['Int']['output']>;
   subject_id?: Maybe<Scalars['Float']['output']>;
   subject_parent_id?: Maybe<Scalars['Float']['output']>;
 };
@@ -10276,7 +10148,7 @@ export type Pf_Tiers_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_tiers" */
 export enum Pf_Tiers_Constraint {
-  /** unique or primary key constraint on columns "_state", "tier_id" */
+  /** unique or primary key constraint on columns "tier_id", "_state" */
   PfTiersPkey = 'pf_tiers_pkey',
   /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
   PfTiersSlugStateCohortKey = 'pf_tiers_slug__state__cohort_key'
@@ -11147,7 +11019,7 @@ export type Programme_Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "programme_threads" */
 export enum Programme_Threads_Constraint {
-  /** unique or primary key constraint on columns "thread_id", "_state", "programme_id" */
+  /** unique or primary key constraint on columns "_state", "thread_id", "programme_id" */
   ProgrammeThreadsPkey = 'programme_threads_pkey'
 }
 
@@ -14263,610 +14135,364 @@ export type Published_Mv_Curriculum_Units_0_3_Variance_Fields = {
   planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0 = {
-  __typename?: 'published_mv_downloads_4_0_0';
-  downloads?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
+/** columns and relationships of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4 = {
+  __typename?: 'published_mv_curriculum_units_0_4';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
 };
 
 
-/** columns and relationships of "published.mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0DownloadsArgs = {
+/** columns and relationships of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4LessonsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** aggregated selection of "published.mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0_Aggregate = {
-  __typename?: 'published_mv_downloads_4_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Downloads_4_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Downloads_4_0_0>;
+
+/** columns and relationships of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** aggregate fields of "published.mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_downloads_4_0_0_aggregate_fields';
+
+/** columns and relationships of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4_Aggregate = {
+  __typename?: 'published_mv_curriculum_units_0_4_aggregate';
+  aggregate?: Maybe<Published_Mv_Curriculum_Units_0_4_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Curriculum_Units_0_4>;
+};
+
+/** aggregate fields of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4_Aggregate_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_aggregate_fields';
+  avg?: Maybe<Published_Mv_Curriculum_Units_0_4_Avg_Fields>;
   count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Downloads_4_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Downloads_4_0_0_Min_Fields>;
+  max?: Maybe<Published_Mv_Curriculum_Units_0_4_Max_Fields>;
+  min?: Maybe<Published_Mv_Curriculum_Units_0_4_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Curriculum_Units_0_4_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Curriculum_Units_0_4_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Curriculum_Units_0_4_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Curriculum_Units_0_4_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Curriculum_Units_0_4_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Curriculum_Units_0_4_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Curriculum_Units_0_4_Variance_Fields>;
 };
 
 
-/** aggregate fields of "published.mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Select_Column>>;
+/** aggregate fields of "published.mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Select_Column>>;
   distinct?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-/** Boolean expression to filter rows from the table "published.mv_downloads_4_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Downloads_4_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Bool_Exp>>;
-  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
+/** aggregate avg on columns */
+export type Published_Mv_Curriculum_Units_0_4_Avg_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_avg_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_curriculum_units_0_4". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Curriculum_Units_0_4_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Bool_Exp>>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<Int_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
 };
 
 /** aggregate max on columns */
-export type Published_Mv_Downloads_4_0_0_Max_Fields = {
-  __typename?: 'published_mv_downloads_4_0_0_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
+export type Published_Mv_Curriculum_Units_0_4_Max_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
 };
 
 /** aggregate min on columns */
-export type Published_Mv_Downloads_4_0_0_Min_Fields = {
-  __typename?: 'published_mv_downloads_4_0_0_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
+export type Published_Mv_Curriculum_Units_0_4_Min_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
 };
 
-/** Ordering options when selecting data from "published.mv_downloads_4_0_0". */
-export type Published_Mv_Downloads_4_0_0_Order_By = {
-  downloads?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
+/** Ordering options when selecting data from "published.mv_curriculum_units_0_4". */
+export type Published_Mv_Curriculum_Units_0_4_Order_By = {
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
 };
 
-/** select columns of table "published.mv_downloads_4_0_0" */
-export enum Published_Mv_Downloads_4_0_0_Select_Column {
+/** select columns of table "published.mv_curriculum_units_0_4" */
+export enum Published_Mv_Curriculum_Units_0_4_Select_Column {
   /** column name */
-  Downloads = 'downloads',
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
   /** column name */
-  ExamBoardSlug = 'examBoardSlug',
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
   /** column name */
-  ExamBoardTitle = 'examBoardTitle',
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
   /** column name */
-  Expired = 'expired',
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
   /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
+  Domain = 'domain',
   /** column name */
-  KeyStageSlug = 'keyStageSlug',
+  DomainId = 'domain_id',
   /** column name */
-  KeyStageTitle = 'keyStageTitle',
+  Examboard = 'examboard',
   /** column name */
-  LessonCohort = 'lessonCohort',
+  ExamboardSlug = 'examboard_slug',
   /** column name */
-  LessonSlug = 'lessonSlug',
+  KeystageSlug = 'keystage_slug',
   /** column name */
-  LessonTitle = 'lessonTitle',
+  Lessons = 'lessons',
   /** column name */
-  ProgrammeSlug = 'programmeSlug',
+  Order = 'order',
   /** column name */
-  SubjectSlug = 'subjectSlug',
+  Phase = 'phase',
   /** column name */
-  SubjectTitle = 'subjectTitle',
+  PhaseSlug = 'phase_slug',
   /** column name */
-  TierSlug = 'tierSlug',
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
   /** column name */
-  TierTitle = 'tierTitle',
+  Slug = 'slug',
   /** column name */
-  UnitSlug = 'unitSlug',
+  Subject = 'subject',
   /** column name */
-  UnitTitle = 'unitTitle'
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  Year = 'year'
 }
 
-/** Streaming cursor of the table "published_mv_downloads_4_0_0" */
-export type Published_Mv_Downloads_4_0_0_Stream_Cursor_Input = {
+/** aggregate stddev on columns */
+export type Published_Mv_Curriculum_Units_0_4_Stddev_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_stddev_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Curriculum_Units_0_4_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_stddev_pop_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Curriculum_Units_0_4_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_stddev_samp_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_curriculum_units_0_4" */
+export type Published_Mv_Curriculum_Units_0_4_Stream_Cursor_Input = {
   /** Stream column input with initial value */
-  initial_value: Published_Mv_Downloads_4_0_0_Stream_Cursor_Value_Input;
+  initial_value: Published_Mv_Curriculum_Units_0_4_Stream_Cursor_Value_Input;
   /** cursor ordering */
   ordering?: InputMaybe<Cursor_Ordering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Published_Mv_Downloads_4_0_0_Stream_Cursor_Value_Input = {
-  downloads?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
+export type Published_Mv_Curriculum_Units_0_4_Stream_Cursor_Value_Input = {
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['Int']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** columns and relationships of "published.mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0 = {
-  __typename?: 'published_mv_downloads_5_0_0';
-  downloads?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
+/** aggregate sum on columns */
+export type Published_Mv_Curriculum_Units_0_4_Sum_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_sum_fields';
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
 };
 
-
-/** columns and relationships of "published.mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0DownloadsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
+/** aggregate var_pop on columns */
+export type Published_Mv_Curriculum_Units_0_4_Var_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_var_pop_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
 };
 
-/** aggregated selection of "published.mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0_Aggregate = {
-  __typename?: 'published_mv_downloads_5_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Downloads_5_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Downloads_5_0_0>;
+/** aggregate var_samp on columns */
+export type Published_Mv_Curriculum_Units_0_4_Var_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_var_samp_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
 };
 
-/** aggregate fields of "published.mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_downloads_5_0_0_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Downloads_5_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Downloads_5_0_0_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_downloads_5_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Downloads_5_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Bool_Exp>>;
-  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Downloads_5_0_0_Max_Fields = {
-  __typename?: 'published_mv_downloads_5_0_0_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Downloads_5_0_0_Min_Fields = {
-  __typename?: 'published_mv_downloads_5_0_0_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_downloads_5_0_0". */
-export type Published_Mv_Downloads_5_0_0_Order_By = {
-  downloads?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_downloads_5_0_0" */
-export enum Published_Mv_Downloads_5_0_0_Select_Column {
-  /** column name */
-  Downloads = 'downloads',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  Expired = 'expired',
-  /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonCohort = 'lessonCohort',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle'
-}
-
-/** Streaming cursor of the table "published_mv_downloads_5_0_0" */
-export type Published_Mv_Downloads_5_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Downloads_5_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Downloads_5_0_0_Stream_Cursor_Value_Input = {
-  downloads?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** columns and relationships of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1 = {
-  __typename?: 'published_mv_downloads_5_0_1';
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  downloads?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1DownloadsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1_Aggregate = {
-  __typename?: 'published_mv_downloads_5_0_1_aggregate';
-  aggregate?: Maybe<Published_Mv_Downloads_5_0_1_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Downloads_5_0_1>;
-};
-
-/** aggregate fields of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1_Aggregate_Fields = {
-  __typename?: 'published_mv_downloads_5_0_1_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Downloads_5_0_1_Max_Fields>;
-  min?: Maybe<Published_Mv_Downloads_5_0_1_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_downloads_5_0_1". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Downloads_5_0_1_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Bool_Exp>>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Downloads_5_0_1_Max_Fields = {
-  __typename?: 'published_mv_downloads_5_0_1_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Downloads_5_0_1_Min_Fields = {
-  __typename?: 'published_mv_downloads_5_0_1_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_downloads_5_0_1". */
-export type Published_Mv_Downloads_5_0_1_Order_By = {
-  copyrightContent?: InputMaybe<Order_By>;
-  downloads?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_downloads_5_0_1" */
-export enum Published_Mv_Downloads_5_0_1_Select_Column {
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  Downloads = 'downloads',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  Expired = 'expired',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonCohort = 'lessonCohort',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle'
-}
-
-/** Streaming cursor of the table "published_mv_downloads_5_0_1" */
-export type Published_Mv_Downloads_5_0_1_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Downloads_5_0_1_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Downloads_5_0_1_Stream_Cursor_Value_Input = {
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  downloads?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
+/** aggregate variance on columns */
+export type Published_Mv_Curriculum_Units_0_4_Variance_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_4_variance_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
 };
 
 /** columns and relationships of "published.mv_downloads_5_0_2" */
@@ -15517,368 +15143,6 @@ export type Published_Mv_Key_Stages_2_0_0_Variance_Fields = {
   display_order?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1 = {
-  __typename?: 'published_mv_lesson_content_0_1';
-  content_guidance?: Maybe<Scalars['jsonb']['output']>;
-  deprecated_fields?: Maybe<Scalars['jsonb']['output']>;
-  equipment_and_resources?: Maybe<Scalars['json']['output']>;
-  exit_quiz?: Maybe<Scalars['jsonb']['output']>;
-  exit_quiz_id?: Maybe<Scalars['Int']['output']>;
-  is_legacy?: Maybe<Scalars['Boolean']['output']>;
-  key_learning_points?: Maybe<Scalars['json']['output']>;
-  lesson_id?: Maybe<Scalars['Int']['output']>;
-  lesson_keywords?: Maybe<Scalars['json']['output']>;
-  lesson_slug?: Maybe<Scalars['String']['output']>;
-  lesson_title?: Maybe<Scalars['String']['output']>;
-  misconceptions_and_common_mistakes?: Maybe<Scalars['json']['output']>;
-  pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
-  starter_quiz?: Maybe<Scalars['jsonb']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Int']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
-  supervision_level?: Maybe<Scalars['String']['output']>;
-  teacher_tips?: Maybe<Scalars['json']['output']>;
-  transcript_sentences?: Maybe<Scalars['String']['output']>;
-  video_id?: Maybe<Scalars['Int']['output']>;
-  video_mux_playback_id?: Maybe<Scalars['String']['output']>;
-  video_title?: Maybe<Scalars['String']['output']>;
-  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Content_GuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Deprecated_FieldsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Equipment_And_ResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Exit_QuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Key_Learning_PointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Lesson_KeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Misconceptions_And_Common_MistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Starter_QuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1Teacher_TipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1_Aggregate = {
-  __typename?: 'published_mv_lesson_content_0_1_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Content_0_1_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Content_0_1>;
-};
-
-/** aggregate fields of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Content_0_1_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Content_0_1_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Content_0_1_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Content_0_1_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Content_0_1_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Content_0_1_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Content_0_1_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Content_0_1_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Content_0_1_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Content_0_1_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Content_0_1_Avg_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_avg_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_content_0_1". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Content_0_1_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Bool_Exp>>;
-  content_guidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  deprecated_fields?: InputMaybe<Jsonb_Comparison_Exp>;
-  equipment_and_resources?: InputMaybe<Json_Comparison_Exp>;
-  exit_quiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exit_quiz_id?: InputMaybe<Int_Comparison_Exp>;
-  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
-  key_learning_points?: InputMaybe<Json_Comparison_Exp>;
-  lesson_id?: InputMaybe<Int_Comparison_Exp>;
-  lesson_keywords?: InputMaybe<Json_Comparison_Exp>;
-  lesson_slug?: InputMaybe<String_Comparison_Exp>;
-  lesson_title?: InputMaybe<String_Comparison_Exp>;
-  misconceptions_and_common_mistakes?: InputMaybe<Json_Comparison_Exp>;
-  pupil_lesson_outcome?: InputMaybe<String_Comparison_Exp>;
-  starter_quiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starter_quiz_id?: InputMaybe<Int_Comparison_Exp>;
-  state?: InputMaybe<String_Comparison_Exp>;
-  supervision_level?: InputMaybe<String_Comparison_Exp>;
-  teacher_tips?: InputMaybe<Json_Comparison_Exp>;
-  transcript_sentences?: InputMaybe<String_Comparison_Exp>;
-  video_id?: InputMaybe<Int_Comparison_Exp>;
-  video_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
-  video_title?: InputMaybe<String_Comparison_Exp>;
-  video_with_sign_language_mux_playback_id?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Content_0_1_Max_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_max_fields';
-  exit_quiz_id?: Maybe<Scalars['Int']['output']>;
-  lesson_id?: Maybe<Scalars['Int']['output']>;
-  lesson_slug?: Maybe<Scalars['String']['output']>;
-  lesson_title?: Maybe<Scalars['String']['output']>;
-  pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Int']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
-  supervision_level?: Maybe<Scalars['String']['output']>;
-  transcript_sentences?: Maybe<Scalars['String']['output']>;
-  video_id?: Maybe<Scalars['Int']['output']>;
-  video_mux_playback_id?: Maybe<Scalars['String']['output']>;
-  video_title?: Maybe<Scalars['String']['output']>;
-  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Content_0_1_Min_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_min_fields';
-  exit_quiz_id?: Maybe<Scalars['Int']['output']>;
-  lesson_id?: Maybe<Scalars['Int']['output']>;
-  lesson_slug?: Maybe<Scalars['String']['output']>;
-  lesson_title?: Maybe<Scalars['String']['output']>;
-  pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Int']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
-  supervision_level?: Maybe<Scalars['String']['output']>;
-  transcript_sentences?: Maybe<Scalars['String']['output']>;
-  video_id?: Maybe<Scalars['Int']['output']>;
-  video_mux_playback_id?: Maybe<Scalars['String']['output']>;
-  video_title?: Maybe<Scalars['String']['output']>;
-  video_with_sign_language_mux_playback_id?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_content_0_1". */
-export type Published_Mv_Lesson_Content_0_1_Order_By = {
-  content_guidance?: InputMaybe<Order_By>;
-  deprecated_fields?: InputMaybe<Order_By>;
-  equipment_and_resources?: InputMaybe<Order_By>;
-  exit_quiz?: InputMaybe<Order_By>;
-  exit_quiz_id?: InputMaybe<Order_By>;
-  is_legacy?: InputMaybe<Order_By>;
-  key_learning_points?: InputMaybe<Order_By>;
-  lesson_id?: InputMaybe<Order_By>;
-  lesson_keywords?: InputMaybe<Order_By>;
-  lesson_slug?: InputMaybe<Order_By>;
-  lesson_title?: InputMaybe<Order_By>;
-  misconceptions_and_common_mistakes?: InputMaybe<Order_By>;
-  pupil_lesson_outcome?: InputMaybe<Order_By>;
-  starter_quiz?: InputMaybe<Order_By>;
-  starter_quiz_id?: InputMaybe<Order_By>;
-  state?: InputMaybe<Order_By>;
-  supervision_level?: InputMaybe<Order_By>;
-  teacher_tips?: InputMaybe<Order_By>;
-  transcript_sentences?: InputMaybe<Order_By>;
-  video_id?: InputMaybe<Order_By>;
-  video_mux_playback_id?: InputMaybe<Order_By>;
-  video_title?: InputMaybe<Order_By>;
-  video_with_sign_language_mux_playback_id?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_content_0_1" */
-export enum Published_Mv_Lesson_Content_0_1_Select_Column {
-  /** column name */
-  ContentGuidance = 'content_guidance',
-  /** column name */
-  DeprecatedFields = 'deprecated_fields',
-  /** column name */
-  EquipmentAndResources = 'equipment_and_resources',
-  /** column name */
-  ExitQuiz = 'exit_quiz',
-  /** column name */
-  ExitQuizId = 'exit_quiz_id',
-  /** column name */
-  IsLegacy = 'is_legacy',
-  /** column name */
-  KeyLearningPoints = 'key_learning_points',
-  /** column name */
-  LessonId = 'lesson_id',
-  /** column name */
-  LessonKeywords = 'lesson_keywords',
-  /** column name */
-  LessonSlug = 'lesson_slug',
-  /** column name */
-  LessonTitle = 'lesson_title',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptions_and_common_mistakes',
-  /** column name */
-  PupilLessonOutcome = 'pupil_lesson_outcome',
-  /** column name */
-  StarterQuiz = 'starter_quiz',
-  /** column name */
-  StarterQuizId = 'starter_quiz_id',
-  /** column name */
-  State = 'state',
-  /** column name */
-  SupervisionLevel = 'supervision_level',
-  /** column name */
-  TeacherTips = 'teacher_tips',
-  /** column name */
-  TranscriptSentences = 'transcript_sentences',
-  /** column name */
-  VideoId = 'video_id',
-  /** column name */
-  VideoMuxPlaybackId = 'video_mux_playback_id',
-  /** column name */
-  VideoTitle = 'video_title',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'video_with_sign_language_mux_playback_id'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Content_0_1_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_stddev_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Content_0_1_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_stddev_pop_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Content_0_1_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_stddev_samp_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_content_0_1" */
-export type Published_Mv_Lesson_Content_0_1_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Content_0_1_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Content_0_1_Stream_Cursor_Value_Input = {
-  content_guidance?: InputMaybe<Scalars['jsonb']['input']>;
-  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
-  equipment_and_resources?: InputMaybe<Scalars['json']['input']>;
-  exit_quiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exit_quiz_id?: InputMaybe<Scalars['Int']['input']>;
-  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
-  key_learning_points?: InputMaybe<Scalars['json']['input']>;
-  lesson_id?: InputMaybe<Scalars['Int']['input']>;
-  lesson_keywords?: InputMaybe<Scalars['json']['input']>;
-  lesson_slug?: InputMaybe<Scalars['String']['input']>;
-  lesson_title?: InputMaybe<Scalars['String']['input']>;
-  misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
-  pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
-  starter_quiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starter_quiz_id?: InputMaybe<Scalars['Int']['input']>;
-  state?: InputMaybe<Scalars['String']['input']>;
-  supervision_level?: InputMaybe<Scalars['String']['input']>;
-  teacher_tips?: InputMaybe<Scalars['json']['input']>;
-  transcript_sentences?: InputMaybe<Scalars['String']['input']>;
-  video_id?: InputMaybe<Scalars['Int']['input']>;
-  video_mux_playback_id?: InputMaybe<Scalars['String']['input']>;
-  video_title?: InputMaybe<Scalars['String']['input']>;
-  video_with_sign_language_mux_playback_id?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Content_0_1_Sum_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_sum_fields';
-  exit_quiz_id?: Maybe<Scalars['Int']['output']>;
-  lesson_id?: Maybe<Scalars['Int']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Int']['output']>;
-  video_id?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Content_0_1_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_var_pop_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Content_0_1_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_var_samp_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Content_0_1_Variance_Fields = {
-  __typename?: 'published_mv_lesson_content_0_1_variance_fields';
-  exit_quiz_id?: Maybe<Scalars['Float']['output']>;
-  lesson_id?: Maybe<Scalars['Float']['output']>;
-  starter_quiz_id?: Maybe<Scalars['Float']['output']>;
-  video_id?: Maybe<Scalars['Float']['output']>;
-};
-
 /** columns and relationships of "published.mv_lesson_content_1_0" */
 export type Published_Mv_Lesson_Content_1_0 = {
   __typename?: 'published_mv_lesson_content_1_0';
@@ -16239,266 +15503,6 @@ export type Published_Mv_Lesson_Content_1_0_Variance_Fields = {
   lesson_id?: Maybe<Scalars['Float']['output']>;
   starter_quiz_id?: Maybe<Scalars['Float']['output']>;
   video_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0 = {
-  __typename?: 'published_mv_lesson_listing_5_0_0';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessons?: Maybe<Scalars['jsonb']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0LessonsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0_Aggregate = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Listing_5_0_0>;
-};
-
-/** aggregate fields of "published.mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Listing_5_0_0_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Avg_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_avg_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_listing_5_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Listing_5_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>>;
-  examboardSlug?: InputMaybe<String_Comparison_Exp>;
-  examboardTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonsCount?: InputMaybe<Bigint_Comparison_Exp>;
-  optionality?: InputMaybe<String_Comparison_Exp>;
-  phaseSlug?: InputMaybe<String_Comparison_Exp>;
-  phaseTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Max_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_max_fields';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Min_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_min_fields';
-  examboardSlug?: Maybe<Scalars['String']['output']>;
-  examboardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-  optionality?: Maybe<Scalars['String']['output']>;
-  phaseSlug?: Maybe<Scalars['String']['output']>;
-  phaseTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_listing_5_0_0". */
-export type Published_Mv_Lesson_Listing_5_0_0_Order_By = {
-  examboardSlug?: InputMaybe<Order_By>;
-  examboardTitle?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessons?: InputMaybe<Order_By>;
-  lessonsCount?: InputMaybe<Order_By>;
-  optionality?: InputMaybe<Order_By>;
-  phaseSlug?: InputMaybe<Order_By>;
-  phaseTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_listing_5_0_0" */
-export enum Published_Mv_Lesson_Listing_5_0_0_Select_Column {
-  /** column name */
-  ExamboardSlug = 'examboardSlug',
-  /** column name */
-  ExamboardTitle = 'examboardTitle',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  Lessons = 'lessons',
-  /** column name */
-  LessonsCount = 'lessonsCount',
-  /** column name */
-  Optionality = 'optionality',
-  /** column name */
-  PhaseSlug = 'phaseSlug',
-  /** column name */
-  PhaseTitle = 'phaseTitle',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_pop_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_stddev_samp_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_listing_5_0_0" */
-export type Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Value_Input = {
-  examboardSlug?: InputMaybe<Scalars['String']['input']>;
-  examboardTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessons?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonsCount?: InputMaybe<Scalars['bigint']['input']>;
-  optionality?: InputMaybe<Scalars['String']['input']>;
-  phaseSlug?: InputMaybe<Scalars['String']['input']>;
-  phaseTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Sum_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_sum_fields';
-  lessonsCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_var_pop_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_var_samp_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Listing_5_0_0_Variance_Fields = {
-  __typename?: 'published_mv_lesson_listing_5_0_0_variance_fields';
-  lessonsCount?: Maybe<Scalars['Float']['output']>;
 };
 
 /** columns and relationships of "published.mv_lesson_listing_5_0_1" */
@@ -18345,1072 +17349,6 @@ export type Published_Mv_Lesson_Overview_5_0_0_Variance_Fields = {
   unitVariantId?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1 = {
-  __typename?: 'published_mv_lesson_overview_5_0_1';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  hasDownloadableResources?: Maybe<Scalars['Boolean']['output']>;
-  isLegacy?: Maybe<Scalars['Boolean']['output']>;
-  isSensitive?: Maybe<Scalars['Boolean']['output']>;
-  isWorksheetLandscape?: Maybe<Scalars['Boolean']['output']>;
-  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  teacherTips?: Maybe<Scalars['jsonb']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1ContentGuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1ExitQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1KeyLearningPointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1LessonEquipmentAndResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1LessonKeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1MisconceptionsAndCommonMistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1StarterQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1TeacherTipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1_Aggregate = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Overview_5_0_1>;
-};
-
-/** aggregate fields of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Overview_5_0_1_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Avg_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_avg_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_overview_5_0_1". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Overview_5_0_1_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>>;
-  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
-  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  hasDownloadableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
-  isSensitive?: InputMaybe<Boolean_Comparison_Exp>;
-  isWorksheetLandscape?: InputMaybe<Boolean_Comparison_Exp>;
-  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonId?: InputMaybe<Int_Comparison_Exp>;
-  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
-  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  presentationUrl?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
-  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
-  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  videoTitle?: InputMaybe<String_Comparison_Exp>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
-  yearSlug?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Max_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_max_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Min_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_min_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_overview_5_0_1". */
-export type Published_Mv_Lesson_Overview_5_0_1_Order_By = {
-  additionalMaterialUrl?: InputMaybe<Order_By>;
-  contentGuidance?: InputMaybe<Order_By>;
-  copyrightContent?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  exitQuiz?: InputMaybe<Order_By>;
-  exitQuizId?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  hasDownloadableResources?: InputMaybe<Order_By>;
-  isLegacy?: InputMaybe<Order_By>;
-  isSensitive?: InputMaybe<Order_By>;
-  isWorksheetLandscape?: InputMaybe<Order_By>;
-  keyLearningPoints?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonEquipmentAndResources?: InputMaybe<Order_By>;
-  lessonId?: InputMaybe<Order_By>;
-  lessonKeywords?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
-  nullUnitVariantId?: InputMaybe<Order_By>;
-  presentationUrl?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  pupilLessonOutcome?: InputMaybe<Order_By>;
-  starterQuiz?: InputMaybe<Order_By>;
-  starterQuizId?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  supervisionLevel?: InputMaybe<Order_By>;
-  teacherTips?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  transcriptSentences?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  unitVariantId?: InputMaybe<Order_By>;
-  videoMuxPlaybackId?: InputMaybe<Order_By>;
-  videoTitle?: InputMaybe<Order_By>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
-  worksheetUrl?: InputMaybe<Order_By>;
-  yearSlug?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_overview_5_0_1" */
-export enum Published_Mv_Lesson_Overview_5_0_1_Select_Column {
-  /** column name */
-  AdditionalMaterialUrl = 'additionalMaterialUrl',
-  /** column name */
-  ContentGuidance = 'contentGuidance',
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  ExitQuiz = 'exitQuiz',
-  /** column name */
-  ExitQuizId = 'exitQuizId',
-  /** column name */
-  Expired = 'expired',
-  /** column name */
-  HasDownloadableResources = 'hasDownloadableResources',
-  /** column name */
-  IsLegacy = 'isLegacy',
-  /** column name */
-  IsSensitive = 'isSensitive',
-  /** column name */
-  IsWorksheetLandscape = 'isWorksheetLandscape',
-  /** column name */
-  KeyLearningPoints = 'keyLearningPoints',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonCohort = 'lessonCohort',
-  /** column name */
-  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
-  /** column name */
-  LessonId = 'lessonId',
-  /** column name */
-  LessonKeywords = 'lessonKeywords',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
-  /** column name */
-  NullUnitVariantId = 'nullUnitVariantId',
-  /** column name */
-  PresentationUrl = 'presentationUrl',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  PupilLessonOutcome = 'pupilLessonOutcome',
-  /** column name */
-  StarterQuiz = 'starterQuiz',
-  /** column name */
-  StarterQuizId = 'starterQuizId',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  SupervisionLevel = 'supervisionLevel',
-  /** column name */
-  TeacherTips = 'teacherTips',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  TranscriptSentences = 'transcriptSentences',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  UnitVariantId = 'unitVariantId',
-  /** column name */
-  VideoMuxPlaybackId = 'videoMuxPlaybackId',
-  /** column name */
-  VideoTitle = 'videoTitle',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
-  /** column name */
-  WorksheetUrl = 'worksheetUrl',
-  /** column name */
-  YearSlug = 'yearSlug',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_stddev_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_stddev_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_stddev_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_overview_5_0_1" */
-export type Published_Mv_Lesson_Overview_5_0_1_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Overview_5_0_1_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Overview_5_0_1_Stream_Cursor_Value_Input = {
-  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
-  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  hasDownloadableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
-  isSensitive?: InputMaybe<Scalars['Boolean']['input']>;
-  isWorksheetLandscape?: InputMaybe<Scalars['Boolean']['input']>;
-  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonId?: InputMaybe<Scalars['Int']['input']>;
-  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
-  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  presentationUrl?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
-  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
-  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  videoTitle?: InputMaybe<Scalars['String']['input']>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
-  yearSlug?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Sum_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_sum_fields';
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_var_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_var_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Overview_5_0_1_Variance_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_1_variance_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2 = {
-  __typename?: 'published_mv_lesson_overview_5_0_2';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  contentGuidance?: Maybe<Scalars['jsonb']['output']>;
-  copyrightContent?: Maybe<Scalars['jsonb']['output']>;
-  downloads?: Maybe<Scalars['jsonb']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  isLegacy?: Maybe<Scalars['Boolean']['output']>;
-  isSensitive?: Maybe<Scalars['Boolean']['output']>;
-  isWorksheetLandscape?: Maybe<Scalars['Boolean']['output']>;
-  keyLearningPoints?: Maybe<Scalars['jsonb']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonEquipmentAndResources?: Maybe<Scalars['jsonb']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonKeywords?: Maybe<Scalars['jsonb']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  misconceptionsAndCommonMistakes?: Maybe<Scalars['jsonb']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuiz?: Maybe<Scalars['jsonb']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  teacherTips?: Maybe<Scalars['jsonb']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2ContentGuidanceArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2CopyrightContentArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2DownloadsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2ExitQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2KeyLearningPointsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2LessonEquipmentAndResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2LessonKeywordsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2MisconceptionsAndCommonMistakesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2StarterQuizArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2TeacherTipsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2_Aggregate = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_aggregate';
-  aggregate?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Lesson_Overview_5_0_2>;
-};
-
-/** aggregate fields of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2_Aggregate_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_aggregate_fields';
-  avg?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Max_Fields>;
-  min?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Lesson_Overview_5_0_2_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Avg_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_avg_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_lesson_overview_5_0_2". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Lesson_Overview_5_0_2_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>>;
-  additionalMaterialUrl?: InputMaybe<String_Comparison_Exp>;
-  contentGuidance?: InputMaybe<Jsonb_Comparison_Exp>;
-  copyrightContent?: InputMaybe<Jsonb_Comparison_Exp>;
-  downloads?: InputMaybe<Jsonb_Comparison_Exp>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  exitQuizId?: InputMaybe<Int_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
-  isSensitive?: InputMaybe<Boolean_Comparison_Exp>;
-  isWorksheetLandscape?: InputMaybe<Boolean_Comparison_Exp>;
-  keyLearningPoints?: InputMaybe<Jsonb_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonEquipmentAndResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonId?: InputMaybe<Int_Comparison_Exp>;
-  lessonKeywords?: InputMaybe<Jsonb_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Jsonb_Comparison_Exp>;
-  nullUnitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  presentationUrl?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  pupilLessonOutcome?: InputMaybe<String_Comparison_Exp>;
-  starterQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
-  starterQuizId?: InputMaybe<Int_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  supervisionLevel?: InputMaybe<String_Comparison_Exp>;
-  teacherTips?: InputMaybe<Jsonb_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  transcriptSentences?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-  unitVariantId?: InputMaybe<Int_Comparison_Exp>;
-  videoMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  videoTitle?: InputMaybe<String_Comparison_Exp>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<String_Comparison_Exp>;
-  worksheetUrl?: InputMaybe<String_Comparison_Exp>;
-  yearSlug?: InputMaybe<String_Comparison_Exp>;
-  yearTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Max_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_max_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Min_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_min_fields';
-  additionalMaterialUrl?: Maybe<Scalars['String']['output']>;
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  presentationUrl?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  pupilLessonOutcome?: Maybe<Scalars['String']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  supervisionLevel?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  transcriptSentences?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-  videoMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  videoTitle?: Maybe<Scalars['String']['output']>;
-  videoWithSignLanguageMuxPlaybackId?: Maybe<Scalars['String']['output']>;
-  worksheetUrl?: Maybe<Scalars['String']['output']>;
-  yearSlug?: Maybe<Scalars['String']['output']>;
-  yearTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_lesson_overview_5_0_2". */
-export type Published_Mv_Lesson_Overview_5_0_2_Order_By = {
-  additionalMaterialUrl?: InputMaybe<Order_By>;
-  contentGuidance?: InputMaybe<Order_By>;
-  copyrightContent?: InputMaybe<Order_By>;
-  downloads?: InputMaybe<Order_By>;
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  exitQuiz?: InputMaybe<Order_By>;
-  exitQuizId?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  isLegacy?: InputMaybe<Order_By>;
-  isSensitive?: InputMaybe<Order_By>;
-  isWorksheetLandscape?: InputMaybe<Order_By>;
-  keyLearningPoints?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonEquipmentAndResources?: InputMaybe<Order_By>;
-  lessonId?: InputMaybe<Order_By>;
-  lessonKeywords?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Order_By>;
-  nullUnitVariantId?: InputMaybe<Order_By>;
-  presentationUrl?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  pupilLessonOutcome?: InputMaybe<Order_By>;
-  starterQuiz?: InputMaybe<Order_By>;
-  starterQuizId?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  supervisionLevel?: InputMaybe<Order_By>;
-  teacherTips?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  transcriptSentences?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-  unitVariantId?: InputMaybe<Order_By>;
-  videoMuxPlaybackId?: InputMaybe<Order_By>;
-  videoTitle?: InputMaybe<Order_By>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Order_By>;
-  worksheetUrl?: InputMaybe<Order_By>;
-  yearSlug?: InputMaybe<Order_By>;
-  yearTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_lesson_overview_5_0_2" */
-export enum Published_Mv_Lesson_Overview_5_0_2_Select_Column {
-  /** column name */
-  AdditionalMaterialUrl = 'additionalMaterialUrl',
-  /** column name */
-  ContentGuidance = 'contentGuidance',
-  /** column name */
-  CopyrightContent = 'copyrightContent',
-  /** column name */
-  Downloads = 'downloads',
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  ExitQuiz = 'exitQuiz',
-  /** column name */
-  ExitQuizId = 'exitQuizId',
-  /** column name */
-  Expired = 'expired',
-  /** column name */
-  IsLegacy = 'isLegacy',
-  /** column name */
-  IsSensitive = 'isSensitive',
-  /** column name */
-  IsWorksheetLandscape = 'isWorksheetLandscape',
-  /** column name */
-  KeyLearningPoints = 'keyLearningPoints',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonCohort = 'lessonCohort',
-  /** column name */
-  LessonEquipmentAndResources = 'lessonEquipmentAndResources',
-  /** column name */
-  LessonId = 'lessonId',
-  /** column name */
-  LessonKeywords = 'lessonKeywords',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  MisconceptionsAndCommonMistakes = 'misconceptionsAndCommonMistakes',
-  /** column name */
-  NullUnitVariantId = 'nullUnitVariantId',
-  /** column name */
-  PresentationUrl = 'presentationUrl',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  PupilLessonOutcome = 'pupilLessonOutcome',
-  /** column name */
-  StarterQuiz = 'starterQuiz',
-  /** column name */
-  StarterQuizId = 'starterQuizId',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  SupervisionLevel = 'supervisionLevel',
-  /** column name */
-  TeacherTips = 'teacherTips',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  TranscriptSentences = 'transcriptSentences',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle',
-  /** column name */
-  UnitVariantId = 'unitVariantId',
-  /** column name */
-  VideoMuxPlaybackId = 'videoMuxPlaybackId',
-  /** column name */
-  VideoTitle = 'videoTitle',
-  /** column name */
-  VideoWithSignLanguageMuxPlaybackId = 'videoWithSignLanguageMuxPlaybackId',
-  /** column name */
-  WorksheetUrl = 'worksheetUrl',
-  /** column name */
-  YearSlug = 'yearSlug',
-  /** column name */
-  YearTitle = 'yearTitle'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Stddev_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_stddev_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_stddev_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_stddev_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_lesson_overview_5_0_2" */
-export type Published_Mv_Lesson_Overview_5_0_2_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Lesson_Overview_5_0_2_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Lesson_Overview_5_0_2_Stream_Cursor_Value_Input = {
-  additionalMaterialUrl?: InputMaybe<Scalars['String']['input']>;
-  contentGuidance?: InputMaybe<Scalars['jsonb']['input']>;
-  copyrightContent?: InputMaybe<Scalars['jsonb']['input']>;
-  downloads?: InputMaybe<Scalars['jsonb']['input']>;
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  exitQuizId?: InputMaybe<Scalars['Int']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
-  isSensitive?: InputMaybe<Scalars['Boolean']['input']>;
-  isWorksheetLandscape?: InputMaybe<Scalars['Boolean']['input']>;
-  keyLearningPoints?: InputMaybe<Scalars['jsonb']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonEquipmentAndResources?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonId?: InputMaybe<Scalars['Int']['input']>;
-  lessonKeywords?: InputMaybe<Scalars['jsonb']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  misconceptionsAndCommonMistakes?: InputMaybe<Scalars['jsonb']['input']>;
-  nullUnitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  presentationUrl?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  pupilLessonOutcome?: InputMaybe<Scalars['String']['input']>;
-  starterQuiz?: InputMaybe<Scalars['jsonb']['input']>;
-  starterQuizId?: InputMaybe<Scalars['Int']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  supervisionLevel?: InputMaybe<Scalars['String']['input']>;
-  teacherTips?: InputMaybe<Scalars['jsonb']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  transcriptSentences?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
-  unitVariantId?: InputMaybe<Scalars['Int']['input']>;
-  videoMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  videoTitle?: InputMaybe<Scalars['String']['input']>;
-  videoWithSignLanguageMuxPlaybackId?: InputMaybe<Scalars['String']['input']>;
-  worksheetUrl?: InputMaybe<Scalars['String']['input']>;
-  yearSlug?: InputMaybe<Scalars['String']['input']>;
-  yearTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Sum_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_sum_fields';
-  exitQuizId?: Maybe<Scalars['Int']['output']>;
-  lessonId?: Maybe<Scalars['Int']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Int']['output']>;
-  starterQuizId?: Maybe<Scalars['Int']['output']>;
-  unitVariantId?: Maybe<Scalars['Int']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Var_Pop_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_var_pop_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Var_Samp_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_var_samp_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Lesson_Overview_5_0_2_Variance_Fields = {
-  __typename?: 'published_mv_lesson_overview_5_0_2_variance_fields';
-  exitQuizId?: Maybe<Scalars['Float']['output']>;
-  lessonId?: Maybe<Scalars['Float']['output']>;
-  nullUnitVariantId?: Maybe<Scalars['Float']['output']>;
-  starterQuizId?: Maybe<Scalars['Float']['output']>;
-  unitVariantId?: Maybe<Scalars['Float']['output']>;
-};
-
 /** columns and relationships of "published.mv_lesson_overview_5_0_3" */
 export type Published_Mv_Lesson_Overview_5_0_3 = {
   __typename?: 'published_mv_lesson_overview_5_0_3';
@@ -20491,6 +18429,194 @@ export type Published_Mv_Lesson_Overview_6_0_0_Variance_Fields = {
   unitVariantId?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0 = {
+  __typename?: 'published_mv_openapi_downloads_1_0_0';
+  exitQuiz?: Maybe<Scalars['jsonb']['output']>;
+  exitQuizAnswers?: Maybe<Scalars['jsonb']['output']>;
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+  slidedeck?: Maybe<Scalars['jsonb']['output']>;
+  starterQuizAnswers?: Maybe<Scalars['jsonb']['output']>;
+  starter_quiz?: Maybe<Scalars['jsonb']['output']>;
+  supplementaryResource?: Maybe<Scalars['jsonb']['output']>;
+  videos?: Maybe<Scalars['jsonb']['output']>;
+  worksheet?: Maybe<Scalars['jsonb']['output']>;
+  worksheetAnswers?: Maybe<Scalars['jsonb']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0ExitQuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0ExitQuizAnswersArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0SlidedeckArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0StarterQuizAnswersArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0Starter_QuizArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0SupplementaryResourceArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0VideosArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0WorksheetArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0WorksheetAnswersArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0_Aggregate = {
+  __typename?: 'published_mv_openapi_downloads_1_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Openapi_Downloads_1_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Openapi_Downloads_1_0_0>;
+};
+
+/** aggregate fields of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_openapi_downloads_1_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Openapi_Downloads_1_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Openapi_Downloads_1_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_openapi_downloads_1_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>>;
+  exitQuiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  exitQuizAnswers?: InputMaybe<Jsonb_Comparison_Exp>;
+  lessonSlug?: InputMaybe<String_Comparison_Exp>;
+  lessonTitle?: InputMaybe<String_Comparison_Exp>;
+  slidedeck?: InputMaybe<Jsonb_Comparison_Exp>;
+  starterQuizAnswers?: InputMaybe<Jsonb_Comparison_Exp>;
+  starter_quiz?: InputMaybe<Jsonb_Comparison_Exp>;
+  supplementaryResource?: InputMaybe<Jsonb_Comparison_Exp>;
+  videos?: InputMaybe<Jsonb_Comparison_Exp>;
+  worksheet?: InputMaybe<Jsonb_Comparison_Exp>;
+  worksheetAnswers?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Openapi_Downloads_1_0_0_Max_Fields = {
+  __typename?: 'published_mv_openapi_downloads_1_0_0_max_fields';
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Openapi_Downloads_1_0_0_Min_Fields = {
+  __typename?: 'published_mv_openapi_downloads_1_0_0_min_fields';
+  lessonSlug?: Maybe<Scalars['String']['output']>;
+  lessonTitle?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_openapi_downloads_1_0_0". */
+export type Published_Mv_Openapi_Downloads_1_0_0_Order_By = {
+  exitQuiz?: InputMaybe<Order_By>;
+  exitQuizAnswers?: InputMaybe<Order_By>;
+  lessonSlug?: InputMaybe<Order_By>;
+  lessonTitle?: InputMaybe<Order_By>;
+  slidedeck?: InputMaybe<Order_By>;
+  starterQuizAnswers?: InputMaybe<Order_By>;
+  starter_quiz?: InputMaybe<Order_By>;
+  supplementaryResource?: InputMaybe<Order_By>;
+  videos?: InputMaybe<Order_By>;
+  worksheet?: InputMaybe<Order_By>;
+  worksheetAnswers?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_openapi_downloads_1_0_0" */
+export enum Published_Mv_Openapi_Downloads_1_0_0_Select_Column {
+  /** column name */
+  ExitQuiz = 'exitQuiz',
+  /** column name */
+  ExitQuizAnswers = 'exitQuizAnswers',
+  /** column name */
+  LessonSlug = 'lessonSlug',
+  /** column name */
+  LessonTitle = 'lessonTitle',
+  /** column name */
+  Slidedeck = 'slidedeck',
+  /** column name */
+  StarterQuizAnswers = 'starterQuizAnswers',
+  /** column name */
+  StarterQuiz = 'starter_quiz',
+  /** column name */
+  SupplementaryResource = 'supplementaryResource',
+  /** column name */
+  Videos = 'videos',
+  /** column name */
+  Worksheet = 'worksheet',
+  /** column name */
+  WorksheetAnswers = 'worksheetAnswers'
+}
+
+/** Streaming cursor of the table "published_mv_openapi_downloads_1_0_0" */
+export type Published_Mv_Openapi_Downloads_1_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Openapi_Downloads_1_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Openapi_Downloads_1_0_0_Stream_Cursor_Value_Input = {
+  exitQuiz?: InputMaybe<Scalars['jsonb']['input']>;
+  exitQuizAnswers?: InputMaybe<Scalars['jsonb']['input']>;
+  lessonSlug?: InputMaybe<Scalars['String']['input']>;
+  lessonTitle?: InputMaybe<Scalars['String']['input']>;
+  slidedeck?: InputMaybe<Scalars['jsonb']['input']>;
+  starterQuizAnswers?: InputMaybe<Scalars['jsonb']['input']>;
+  starter_quiz?: InputMaybe<Scalars['jsonb']['input']>;
+  supplementaryResource?: InputMaybe<Scalars['jsonb']['input']>;
+  videos?: InputMaybe<Scalars['jsonb']['input']>;
+  worksheet?: InputMaybe<Scalars['jsonb']['input']>;
+  worksheetAnswers?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
 /** columns and relationships of "published.mv_openapi_unit_curriculum_content_1_0_1" */
 export type Published_Mv_Openapi_Unit_Curriculum_Content_1_0_1 = {
   __typename?: 'published_mv_openapi_unit_curriculum_content_1_0_1';
@@ -21043,128 +19169,6 @@ export type Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Variance_Fields =
   unitId?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0 = {
-  __typename?: 'published_mv_programme_listing_4_0_0';
-  baseSlug?: Maybe<Scalars['String']['output']>;
-  isLegacy?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmes?: Maybe<Scalars['jsonb']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0ProgrammesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0_Aggregate = {
-  __typename?: 'published_mv_programme_listing_4_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Programme_Listing_4_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Programme_Listing_4_0_0>;
-};
-
-/** aggregate fields of "published.mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_programme_listing_4_0_0_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Programme_Listing_4_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Programme_Listing_4_0_0_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_programme_listing_4_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Programme_Listing_4_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>>;
-  baseSlug?: InputMaybe<String_Comparison_Exp>;
-  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  programmes?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Programme_Listing_4_0_0_Max_Fields = {
-  __typename?: 'published_mv_programme_listing_4_0_0_max_fields';
-  baseSlug?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Programme_Listing_4_0_0_Min_Fields = {
-  __typename?: 'published_mv_programme_listing_4_0_0_min_fields';
-  baseSlug?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_programme_listing_4_0_0". */
-export type Published_Mv_Programme_Listing_4_0_0_Order_By = {
-  baseSlug?: InputMaybe<Order_By>;
-  isLegacy?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  programmes?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_programme_listing_4_0_0" */
-export enum Published_Mv_Programme_Listing_4_0_0_Select_Column {
-  /** column name */
-  BaseSlug = 'baseSlug',
-  /** column name */
-  IsLegacy = 'isLegacy',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  Programmes = 'programmes',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle'
-}
-
-/** Streaming cursor of the table "published_mv_programme_listing_4_0_0" */
-export type Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Value_Input = {
-  baseSlug?: InputMaybe<Scalars['String']['input']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  programmes?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-};
-
 /** columns and relationships of "published.mv_programme_listing_5_0_0" */
 export type Published_Mv_Programme_Listing_5_0_0 = {
   __typename?: 'published_mv_programme_listing_5_0_0';
@@ -21485,206 +19489,6 @@ export type Published_Mv_Search_Page_3_Stream_Cursor_Value_Input = {
   exam_boards?: InputMaybe<Scalars['json']['input']>;
   key_stages?: InputMaybe<Scalars['json']['input']>;
   subjects?: InputMaybe<Scalars['json']['input']>;
-};
-
-/** columns and relationships of "published.mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0 = {
-  __typename?: 'published_mv_share_4_0_0';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  expired?: Maybe<Scalars['Boolean']['output']>;
-  hasShareableResources?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  shareableResources?: Maybe<Scalars['jsonb']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0ShareableResourcesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0_Aggregate = {
-  __typename?: 'published_mv_share_4_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Share_4_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Share_4_0_0>;
-};
-
-/** aggregate fields of "published.mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_share_4_0_0_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Share_4_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Share_4_0_0_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Share_4_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_share_4_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Share_4_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Share_4_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Share_4_0_0_Bool_Exp>>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  expired?: InputMaybe<Boolean_Comparison_Exp>;
-  hasShareableResources?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  lessonCohort?: InputMaybe<String_Comparison_Exp>;
-  lessonSlug?: InputMaybe<String_Comparison_Exp>;
-  lessonTitle?: InputMaybe<String_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  shareableResources?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tierTitle?: InputMaybe<String_Comparison_Exp>;
-  unitSlug?: InputMaybe<String_Comparison_Exp>;
-  unitTitle?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Share_4_0_0_Max_Fields = {
-  __typename?: 'published_mv_share_4_0_0_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Share_4_0_0_Min_Fields = {
-  __typename?: 'published_mv_share_4_0_0_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  lessonCohort?: Maybe<Scalars['String']['output']>;
-  lessonSlug?: Maybe<Scalars['String']['output']>;
-  lessonTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tierTitle?: Maybe<Scalars['String']['output']>;
-  unitSlug?: Maybe<Scalars['String']['output']>;
-  unitTitle?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_share_4_0_0". */
-export type Published_Mv_Share_4_0_0_Order_By = {
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  expired?: InputMaybe<Order_By>;
-  hasShareableResources?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  lessonCohort?: InputMaybe<Order_By>;
-  lessonSlug?: InputMaybe<Order_By>;
-  lessonTitle?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  shareableResources?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tierTitle?: InputMaybe<Order_By>;
-  unitSlug?: InputMaybe<Order_By>;
-  unitTitle?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_share_4_0_0" */
-export enum Published_Mv_Share_4_0_0_Select_Column {
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  Expired = 'expired',
-  /** column name */
-  HasShareableResources = 'hasShareableResources',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LessonCohort = 'lessonCohort',
-  /** column name */
-  LessonSlug = 'lessonSlug',
-  /** column name */
-  LessonTitle = 'lessonTitle',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  ShareableResources = 'shareableResources',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  TierTitle = 'tierTitle',
-  /** column name */
-  UnitSlug = 'unitSlug',
-  /** column name */
-  UnitTitle = 'unitTitle'
-}
-
-/** Streaming cursor of the table "published_mv_share_4_0_0" */
-export type Published_Mv_Share_4_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Share_4_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Share_4_0_0_Stream_Cursor_Value_Input = {
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  expired?: InputMaybe<Scalars['Boolean']['input']>;
-  hasShareableResources?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  lessonCohort?: InputMaybe<Scalars['String']['input']>;
-  lessonSlug?: InputMaybe<Scalars['String']['input']>;
-  lessonTitle?: InputMaybe<Scalars['String']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  shareableResources?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tierTitle?: InputMaybe<Scalars['String']['input']>;
-  unitSlug?: InputMaybe<Scalars['String']['input']>;
-  unitTitle?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** columns and relationships of "published.mv_share_5_0_0" */
@@ -22783,242 +20587,6 @@ export type Published_Mv_Specialist_1_0_3_Variance_Fields = {
   order_in_unit?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0 = {
-  __typename?: 'published_mv_subject_listing_4_0_0';
-  is_legacy?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  keyStages?: Maybe<Scalars['jsonb']['output']>;
-  subjects?: Maybe<Scalars['jsonb']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0KeyStagesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0SubjectsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0_Aggregate = {
-  __typename?: 'published_mv_subject_listing_4_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Subject_Listing_4_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Subject_Listing_4_0_0>;
-};
-
-/** aggregate fields of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_subject_listing_4_0_0_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Subject_Listing_4_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Subject_Listing_4_0_0_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_subject_listing_4_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Subject_Listing_4_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>>;
-  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStages?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjects?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectsUnavailable?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Subject_Listing_4_0_0_Max_Fields = {
-  __typename?: 'published_mv_subject_listing_4_0_0_max_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Subject_Listing_4_0_0_Min_Fields = {
-  __typename?: 'published_mv_subject_listing_4_0_0_min_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_subject_listing_4_0_0". */
-export type Published_Mv_Subject_Listing_4_0_0_Order_By = {
-  is_legacy?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  keyStages?: InputMaybe<Order_By>;
-  subjects?: InputMaybe<Order_By>;
-  subjectsUnavailable?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_subject_listing_4_0_0" */
-export enum Published_Mv_Subject_Listing_4_0_0_Select_Column {
-  /** column name */
-  IsLegacy = 'is_legacy',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  KeyStages = 'keyStages',
-  /** column name */
-  Subjects = 'subjects',
-  /** column name */
-  SubjectsUnavailable = 'subjectsUnavailable'
-}
-
-/** Streaming cursor of the table "published_mv_subject_listing_4_0_0" */
-export type Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Value_Input = {
-  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStages?: InputMaybe<Scalars['jsonb']['input']>;
-  subjects?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectsUnavailable?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** columns and relationships of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0 = {
-  __typename?: 'published_mv_subject_listing_5_0_0';
-  is_legacy?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  keyStages?: Maybe<Scalars['jsonb']['output']>;
-  subjects?: Maybe<Scalars['jsonb']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0KeyStagesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0SubjectsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0_Aggregate = {
-  __typename?: 'published_mv_subject_listing_5_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Subject_Listing_5_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Subject_Listing_5_0_0>;
-};
-
-/** aggregate fields of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_subject_listing_5_0_0_aggregate_fields';
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Subject_Listing_5_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Subject_Listing_5_0_0_Min_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_subject_listing_5_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Subject_Listing_5_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>>;
-  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  keyStages?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjects?: InputMaybe<Jsonb_Comparison_Exp>;
-  subjectsUnavailable?: InputMaybe<String_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Subject_Listing_5_0_0_Max_Fields = {
-  __typename?: 'published_mv_subject_listing_5_0_0_max_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Subject_Listing_5_0_0_Min_Fields = {
-  __typename?: 'published_mv_subject_listing_5_0_0_min_fields';
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  subjectsUnavailable?: Maybe<Scalars['String']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_subject_listing_5_0_0". */
-export type Published_Mv_Subject_Listing_5_0_0_Order_By = {
-  is_legacy?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  keyStages?: InputMaybe<Order_By>;
-  subjects?: InputMaybe<Order_By>;
-  subjectsUnavailable?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_subject_listing_5_0_0" */
-export enum Published_Mv_Subject_Listing_5_0_0_Select_Column {
-  /** column name */
-  IsLegacy = 'is_legacy',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  KeyStages = 'keyStages',
-  /** column name */
-  Subjects = 'subjects',
-  /** column name */
-  SubjectsUnavailable = 'subjectsUnavailable'
-}
-
-/** Streaming cursor of the table "published_mv_subject_listing_5_0_0" */
-export type Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Value_Input = {
-  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  keyStages?: InputMaybe<Scalars['jsonb']['input']>;
-  subjects?: InputMaybe<Scalars['jsonb']['input']>;
-  subjectsUnavailable?: InputMaybe<Scalars['String']['input']>;
-};
-
 /** columns and relationships of "published.mv_subject_listing_5_0_1" */
 export type Published_Mv_Subject_Listing_5_0_1 = {
   __typename?: 'published_mv_subject_listing_5_0_1';
@@ -23703,6 +21271,160 @@ export type Published_Mv_Synthetic_Programmes_By_Year_7_1_0_Stream_Cursor_Value_
   year_slug?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0 = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0';
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  lesson_data?: Maybe<Scalars['jsonb']['output']>;
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  null_unitvariant?: Maybe<Scalars['jsonb']['output']>;
+  programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Lesson_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Null_UnitvariantArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0>;
+};
+
+/** aggregate fields of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  lesson_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  lesson_slug?: InputMaybe<String_Comparison_Exp>;
+  null_unitvariant?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Max_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_max_fields';
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Min_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_min_fields';
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0". */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Order_By = {
+  is_legacy?: InputMaybe<Order_By>;
+  lesson_data?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  null_unitvariant?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export enum Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column {
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  LessonData = 'lesson_data',
+  /** column name */
+  LessonSlug = 'lesson_slug',
+  /** column name */
+  NullUnitvariant = 'null_unitvariant',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitSlug = 'unit_slug'
+}
+
+/** Streaming cursor of the table "published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Stream_Cursor_Value_Input = {
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  lesson_data?: InputMaybe<Scalars['jsonb']['input']>;
+  lesson_slug?: InputMaybe<Scalars['String']['input']>;
+  null_unitvariant?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_slug?: InputMaybe<Scalars['String']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_slug?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
 export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0 = {
   __typename?: 'published_mv_synthetic_unitvariant_lessons_by_year_6_0_0';
@@ -24055,472 +21777,144 @@ export type Published_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Year_6_0_0_Va
   lesson_count?: Maybe<Scalars['Float']['output']>;
 };
 
-/** columns and relationships of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0 = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  isLegacy?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  learningThemes?: Maybe<Scalars['jsonb']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tiers?: Maybe<Scalars['jsonb']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-  units?: Maybe<Scalars['jsonb']['output']>;
+/** columns and relationships of "published.mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0 = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0';
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
 };
 
 
-/** columns and relationships of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0LearningThemesArgs = {
+/** columns and relationships of "published.mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0ThreadsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
-
-/** columns and relationships of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0TiersArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
+/** aggregated selection of "published.mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0_Aggregate = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Threads_By_Unit_1_0_0>;
 };
 
-
-/** columns and relationships of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0UnitsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Aggregate = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
-};
-
-/** aggregate fields of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_aggregate_fields';
-  avg?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Avg_Fields>;
+/** aggregate fields of "published.mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0_Aggregate_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_aggregate_fields';
+  avg?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Avg_Fields>;
   count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Unit_Listing_Page_4_0_0_Variance_Fields>;
+  max?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Threads_By_Unit_1_0_0_Variance_Fields>;
 };
 
 
-/** aggregate fields of "published.mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Select_Column>>;
+/** aggregate fields of "published.mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Select_Column>>;
   distinct?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** aggregate avg on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Avg_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_avg_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Avg_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_avg_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
-/** Boolean expression to filter rows from the table "published.mv_unit_listing_page_4_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  learningThemes?: InputMaybe<Jsonb_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tiers?: InputMaybe<Jsonb_Comparison_Exp>;
-  unitCount?: InputMaybe<Bigint_Comparison_Exp>;
-  units?: InputMaybe<Jsonb_Comparison_Exp>;
+/** Boolean expression to filter rows from the table "published.mv_threads_by_unit_1_0_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
 };
 
 /** aggregate max on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Max_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Max_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_max_fields';
+  unit_id?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate min on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Min_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Min_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_min_fields';
+  unit_id?: Maybe<Scalars['Int']['output']>;
 };
 
-/** Ordering options when selecting data from "published.mv_unit_listing_page_4_0_0". */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Order_By = {
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  isLegacy?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  learningThemes?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tiers?: InputMaybe<Order_By>;
-  unitCount?: InputMaybe<Order_By>;
-  units?: InputMaybe<Order_By>;
+/** Ordering options when selecting data from "published.mv_threads_by_unit_1_0_0". */
+export type Published_Mv_Threads_By_Unit_1_0_0_Order_By = {
+  threads?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
 };
 
-/** select columns of table "published.mv_unit_listing_page_4_0_0" */
-export enum Published_Mv_Unit_Listing_Page_4_0_0_Select_Column {
+/** select columns of table "published.mv_threads_by_unit_1_0_0" */
+export enum Published_Mv_Threads_By_Unit_1_0_0_Select_Column {
   /** column name */
-  ExamBoardSlug = 'examBoardSlug',
+  Threads = 'threads',
   /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  IsLegacy = 'isLegacy',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LearningThemes = 'learningThemes',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  Tiers = 'tiers',
-  /** column name */
-  UnitCount = 'unitCount',
-  /** column name */
-  Units = 'units'
+  UnitId = 'unit_id'
 }
 
 /** aggregate stddev on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_stddev_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Stddev_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_stddev_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** aggregate stddev_pop on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_stddev_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_stddev_pop_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** aggregate stddev_samp on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_stddev_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_stddev_samp_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
-/** Streaming cursor of the table "published_mv_unit_listing_page_4_0_0" */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Stream_Cursor_Input = {
+/** Streaming cursor of the table "published_mv_threads_by_unit_1_0_0" */
+export type Published_Mv_Threads_By_Unit_1_0_0_Stream_Cursor_Input = {
   /** Stream column input with initial value */
-  initial_value: Published_Mv_Unit_Listing_Page_4_0_0_Stream_Cursor_Value_Input;
+  initial_value: Published_Mv_Threads_By_Unit_1_0_0_Stream_Cursor_Value_Input;
   /** cursor ordering */
   ordering?: InputMaybe<Cursor_Ordering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Stream_Cursor_Value_Input = {
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  learningThemes?: InputMaybe<Scalars['jsonb']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tiers?: InputMaybe<Scalars['jsonb']['input']>;
-  unitCount?: InputMaybe<Scalars['bigint']['input']>;
-  units?: InputMaybe<Scalars['jsonb']['input']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Stream_Cursor_Value_Input = {
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** aggregate sum on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Sum_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_sum_fields';
-  unitCount?: Maybe<Scalars['bigint']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Sum_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_sum_fields';
+  unit_id?: Maybe<Scalars['Int']['output']>;
 };
 
 /** aggregate var_pop on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Var_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_var_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Var_Pop_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_var_pop_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** aggregate var_samp on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Var_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_var_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Var_Samp_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_var_samp_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** aggregate variance on columns */
-export type Published_Mv_Unit_Listing_Page_4_0_0_Variance_Fields = {
-  __typename?: 'published_mv_unit_listing_page_4_0_0_variance_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0 = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  isLegacy?: Maybe<Scalars['Boolean']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  learningThemes?: Maybe<Scalars['jsonb']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  tiers?: Maybe<Scalars['jsonb']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-  units?: Maybe<Scalars['jsonb']['output']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0LearningThemesArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0TiersArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0UnitsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_aggregate';
-  aggregate?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_Fields>;
-  nodes: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
-};
-
-/** aggregate fields of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_aggregate_fields';
-  avg?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Max_Fields>;
-  min?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Min_Fields>;
-  stddev?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Fields>;
-  stddev_pop?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Samp_Fields>;
-  sum?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Sum_Fields>;
-  var_pop?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Var_Pop_Fields>;
-  var_samp?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Var_Samp_Fields>;
-  variance?: Maybe<Published_Mv_Unit_Listing_Page_5_0_0_Variance_Fields>;
-};
-
-
-/** aggregate fields of "published.mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Avg_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_avg_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Boolean expression to filter rows from the table "published.mv_unit_listing_page_5_0_0". All fields are combined with a logical 'AND'. */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp = {
-  _and?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>>;
-  _not?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
-  _or?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>>;
-  examBoardSlug?: InputMaybe<String_Comparison_Exp>;
-  examBoardTitle?: InputMaybe<String_Comparison_Exp>;
-  isLegacy?: InputMaybe<Boolean_Comparison_Exp>;
-  keyStageSlug?: InputMaybe<String_Comparison_Exp>;
-  keyStageTitle?: InputMaybe<String_Comparison_Exp>;
-  learningThemes?: InputMaybe<Jsonb_Comparison_Exp>;
-  programmeSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectSlug?: InputMaybe<String_Comparison_Exp>;
-  subjectTitle?: InputMaybe<String_Comparison_Exp>;
-  tierSlug?: InputMaybe<String_Comparison_Exp>;
-  tiers?: InputMaybe<Jsonb_Comparison_Exp>;
-  unitCount?: InputMaybe<Bigint_Comparison_Exp>;
-  units?: InputMaybe<Jsonb_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Max_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_max_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate min on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Min_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_min_fields';
-  examBoardSlug?: Maybe<Scalars['String']['output']>;
-  examBoardTitle?: Maybe<Scalars['String']['output']>;
-  keyStageSlug?: Maybe<Scalars['String']['output']>;
-  keyStageTitle?: Maybe<Scalars['String']['output']>;
-  programmeSlug?: Maybe<Scalars['String']['output']>;
-  subjectSlug?: Maybe<Scalars['String']['output']>;
-  subjectTitle?: Maybe<Scalars['String']['output']>;
-  tierSlug?: Maybe<Scalars['String']['output']>;
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** Ordering options when selecting data from "published.mv_unit_listing_page_5_0_0". */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Order_By = {
-  examBoardSlug?: InputMaybe<Order_By>;
-  examBoardTitle?: InputMaybe<Order_By>;
-  isLegacy?: InputMaybe<Order_By>;
-  keyStageSlug?: InputMaybe<Order_By>;
-  keyStageTitle?: InputMaybe<Order_By>;
-  learningThemes?: InputMaybe<Order_By>;
-  programmeSlug?: InputMaybe<Order_By>;
-  subjectSlug?: InputMaybe<Order_By>;
-  subjectTitle?: InputMaybe<Order_By>;
-  tierSlug?: InputMaybe<Order_By>;
-  tiers?: InputMaybe<Order_By>;
-  unitCount?: InputMaybe<Order_By>;
-  units?: InputMaybe<Order_By>;
-};
-
-/** select columns of table "published.mv_unit_listing_page_5_0_0" */
-export enum Published_Mv_Unit_Listing_Page_5_0_0_Select_Column {
-  /** column name */
-  ExamBoardSlug = 'examBoardSlug',
-  /** column name */
-  ExamBoardTitle = 'examBoardTitle',
-  /** column name */
-  IsLegacy = 'isLegacy',
-  /** column name */
-  KeyStageSlug = 'keyStageSlug',
-  /** column name */
-  KeyStageTitle = 'keyStageTitle',
-  /** column name */
-  LearningThemes = 'learningThemes',
-  /** column name */
-  ProgrammeSlug = 'programmeSlug',
-  /** column name */
-  SubjectSlug = 'subjectSlug',
-  /** column name */
-  SubjectTitle = 'subjectTitle',
-  /** column name */
-  TierSlug = 'tierSlug',
-  /** column name */
-  Tiers = 'tiers',
-  /** column name */
-  UnitCount = 'unitCount',
-  /** column name */
-  Units = 'units'
-}
-
-/** aggregate stddev on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Stddev_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_stddev_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** Streaming cursor of the table "published_mv_unit_listing_page_5_0_0" */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Value_Input = {
-  examBoardSlug?: InputMaybe<Scalars['String']['input']>;
-  examBoardTitle?: InputMaybe<Scalars['String']['input']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
-  keyStageSlug?: InputMaybe<Scalars['String']['input']>;
-  keyStageTitle?: InputMaybe<Scalars['String']['input']>;
-  learningThemes?: InputMaybe<Scalars['jsonb']['input']>;
-  programmeSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
-  subjectTitle?: InputMaybe<Scalars['String']['input']>;
-  tierSlug?: InputMaybe<Scalars['String']['input']>;
-  tiers?: InputMaybe<Scalars['jsonb']['input']>;
-  unitCount?: InputMaybe<Scalars['bigint']['input']>;
-  units?: InputMaybe<Scalars['jsonb']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Sum_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_sum_fields';
-  unitCount?: Maybe<Scalars['bigint']['output']>;
-};
-
-/** aggregate var_pop on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Var_Pop_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_var_pop_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate var_samp on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Var_Samp_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_var_samp_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
-};
-
-/** aggregate variance on columns */
-export type Published_Mv_Unit_Listing_Page_5_0_0_Variance_Fields = {
-  __typename?: 'published_mv_unit_listing_page_5_0_0_variance_fields';
-  unitCount?: Maybe<Scalars['Float']['output']>;
+export type Published_Mv_Threads_By_Unit_1_0_0_Variance_Fields = {
+  __typename?: 'published_mv_threads_by_unit_1_0_0_variance_fields';
+  unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** columns and relationships of "published.mv_unit_listing_page_5_0_1" */
@@ -28951,18 +26345,10 @@ export type Query_Root = {
   published_mv_curriculum_units_0_3: Array<Published_Mv_Curriculum_Units_0_3>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_3" */
   published_mv_curriculum_units_0_3_aggregate: Published_Mv_Curriculum_Units_0_3_Aggregate;
-  /** fetch data from the table: "published.mv_downloads_4_0_0" */
-  published_mv_downloads_4_0_0: Array<Published_Mv_Downloads_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_4_0_0" */
-  published_mv_downloads_4_0_0_aggregate: Published_Mv_Downloads_4_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_downloads_5_0_0" */
-  published_mv_downloads_5_0_0: Array<Published_Mv_Downloads_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_0" */
-  published_mv_downloads_5_0_0_aggregate: Published_Mv_Downloads_5_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_downloads_5_0_1" */
-  published_mv_downloads_5_0_1: Array<Published_Mv_Downloads_5_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_1" */
-  published_mv_downloads_5_0_1_aggregate: Published_Mv_Downloads_5_0_1_Aggregate;
+  /** fetch data from the table: "published.mv_curriculum_units_0_4" */
+  published_mv_curriculum_units_0_4: Array<Published_Mv_Curriculum_Units_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_4" */
+  published_mv_curriculum_units_0_4_aggregate: Published_Mv_Curriculum_Units_0_4_Aggregate;
   /** fetch data from the table: "published.mv_downloads_5_0_2" */
   published_mv_downloads_5_0_2: Array<Published_Mv_Downloads_5_0_2>;
   /** fetch aggregated fields from the table: "published.mv_downloads_5_0_2" */
@@ -28979,18 +26365,10 @@ export type Query_Root = {
   published_mv_key_stages_2_0_0: Array<Published_Mv_Key_Stages_2_0_0>;
   /** fetch aggregated fields from the table: "published.mv_key_stages_2_0_0" */
   published_mv_key_stages_2_0_0_aggregate: Published_Mv_Key_Stages_2_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_content_0_1" */
-  published_mv_lesson_content_0_1: Array<Published_Mv_Lesson_Content_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_content_0_1" */
-  published_mv_lesson_content_0_1_aggregate: Published_Mv_Lesson_Content_0_1_Aggregate;
   /** fetch data from the table: "published.mv_lesson_content_1_0" */
   published_mv_lesson_content_1_0: Array<Published_Mv_Lesson_Content_1_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_content_1_0" */
   published_mv_lesson_content_1_0_aggregate: Published_Mv_Lesson_Content_1_0_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_listing_5_0_0" */
-  published_mv_lesson_listing_5_0_0: Array<Published_Mv_Lesson_Listing_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_0" */
-  published_mv_lesson_listing_5_0_0_aggregate: Published_Mv_Lesson_Listing_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_lesson_listing_5_0_1" */
   published_mv_lesson_listing_5_0_1: Array<Published_Mv_Lesson_Listing_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_1" */
@@ -29007,14 +26385,6 @@ export type Query_Root = {
   published_mv_lesson_overview_5_0_0: Array<Published_Mv_Lesson_Overview_5_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_0" */
   published_mv_lesson_overview_5_0_0_aggregate: Published_Mv_Lesson_Overview_5_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_overview_5_0_1" */
-  published_mv_lesson_overview_5_0_1: Array<Published_Mv_Lesson_Overview_5_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_1" */
-  published_mv_lesson_overview_5_0_1_aggregate: Published_Mv_Lesson_Overview_5_0_1_Aggregate;
-  /** fetch data from the table: "published.mv_lesson_overview_5_0_2" */
-  published_mv_lesson_overview_5_0_2: Array<Published_Mv_Lesson_Overview_5_0_2>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_2" */
-  published_mv_lesson_overview_5_0_2_aggregate: Published_Mv_Lesson_Overview_5_0_2_Aggregate;
   /** fetch data from the table: "published.mv_lesson_overview_5_0_3" */
   published_mv_lesson_overview_5_0_3: Array<Published_Mv_Lesson_Overview_5_0_3>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_3" */
@@ -29023,6 +26393,10 @@ export type Query_Root = {
   published_mv_lesson_overview_6_0_0: Array<Published_Mv_Lesson_Overview_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_6_0_0" */
   published_mv_lesson_overview_6_0_0_aggregate: Published_Mv_Lesson_Overview_6_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_openapi_downloads_1_0_0" */
+  published_mv_openapi_downloads_1_0_0: Array<Published_Mv_Openapi_Downloads_1_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_openapi_downloads_1_0_0" */
+  published_mv_openapi_downloads_1_0_0_aggregate: Published_Mv_Openapi_Downloads_1_0_0_Aggregate;
   /** fetch data from the table: "published.mv_openapi_unit_curriculum_content_1_0_1" */
   published_mv_openapi_unit_curriculum_content_1_0_1: Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_1>;
   /** fetch aggregated fields from the table: "published.mv_openapi_unit_curriculum_content_1_0_1" */
@@ -29031,10 +26405,6 @@ export type Query_Root = {
   published_mv_openapi_unit_curriculum_content_1_0_2: Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2>;
   /** fetch aggregated fields from the table: "published.mv_openapi_unit_curriculum_content_1_0_2" */
   published_mv_openapi_unit_curriculum_content_1_0_2_aggregate: Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Aggregate;
-  /** fetch data from the table: "published.mv_programme_listing_4_0_0" */
-  published_mv_programme_listing_4_0_0: Array<Published_Mv_Programme_Listing_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_programme_listing_4_0_0" */
-  published_mv_programme_listing_4_0_0_aggregate: Published_Mv_Programme_Listing_4_0_0_Aggregate;
   /** fetch data from the table: "published.mv_programme_listing_5_0_0" */
   published_mv_programme_listing_5_0_0: Array<Published_Mv_Programme_Listing_5_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_5_0_0" */
@@ -29047,10 +26417,6 @@ export type Query_Root = {
   published_mv_search_page_3_0_1_aggregate: Published_Mv_Search_Page_3_0_1_Aggregate;
   /** fetch aggregated fields from the table: "published.mv_search_page_3" */
   published_mv_search_page_3_aggregate: Published_Mv_Search_Page_3_Aggregate;
-  /** fetch data from the table: "published.mv_share_4_0_0" */
-  published_mv_share_4_0_0: Array<Published_Mv_Share_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_share_4_0_0" */
-  published_mv_share_4_0_0_aggregate: Published_Mv_Share_4_0_0_Aggregate;
   /** fetch data from the table: "published.mv_share_5_0_0" */
   published_mv_share_5_0_0: Array<Published_Mv_Share_5_0_0>;
   /** fetch aggregated fields from the table: "published.mv_share_5_0_0" */
@@ -29071,14 +26437,6 @@ export type Query_Root = {
   published_mv_specialist_1_0_3: Array<Published_Mv_Specialist_1_0_3>;
   /** fetch aggregated fields from the table: "published.mv_specialist_1_0_3" */
   published_mv_specialist_1_0_3_aggregate: Published_Mv_Specialist_1_0_3_Aggregate;
-  /** fetch data from the table: "published.mv_subject_listing_4_0_0" */
-  published_mv_subject_listing_4_0_0: Array<Published_Mv_Subject_Listing_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_4_0_0" */
-  published_mv_subject_listing_4_0_0_aggregate: Published_Mv_Subject_Listing_4_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_subject_listing_5_0_0" */
-  published_mv_subject_listing_5_0_0: Array<Published_Mv_Subject_Listing_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_0" */
-  published_mv_subject_listing_5_0_0_aggregate: Published_Mv_Subject_Listing_5_0_0_Aggregate;
   /** fetch data from the table: "published.mv_subject_listing_5_0_1" */
   published_mv_subject_listing_5_0_1: Array<Published_Mv_Subject_Listing_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_1" */
@@ -29099,6 +26457,10 @@ export type Query_Root = {
   published_mv_synthetic_programmes_by_year_7_1_0: Array<Published_Mv_Synthetic_Programmes_By_Year_7_1_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_7_1_0" */
   published_mv_synthetic_programmes_by_year_7_1_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_7_1_0_Aggregate;
+  /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_year_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
@@ -29107,14 +26469,10 @@ export type Query_Root = {
   published_mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0: Array<Published_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Year_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0" */
   published_mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0_aggregate: Published_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Year_6_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_unit_listing_page_4_0_0" */
-  published_mv_unit_listing_page_4_0_0: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_4_0_0" */
-  published_mv_unit_listing_page_4_0_0_aggregate: Published_Mv_Unit_Listing_Page_4_0_0_Aggregate;
-  /** fetch data from the table: "published.mv_unit_listing_page_5_0_0" */
-  published_mv_unit_listing_page_5_0_0: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_0" */
-  published_mv_unit_listing_page_5_0_0_aggregate: Published_Mv_Unit_Listing_Page_5_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_threads_by_unit_1_0_0" */
+  published_mv_threads_by_unit_1_0_0: Array<Published_Mv_Threads_By_Unit_1_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_threads_by_unit_1_0_0" */
+  published_mv_threads_by_unit_1_0_0_aggregate: Published_Mv_Threads_By_Unit_1_0_0_Aggregate;
   /** fetch data from the table: "published.mv_unit_listing_page_5_0_1" */
   published_mv_unit_listing_page_5_0_1: Array<Published_Mv_Unit_Listing_Page_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_1" */
@@ -29868,57 +27226,21 @@ export type Query_RootPublished_Mv_Curriculum_Units_0_3_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Downloads_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Select_Column>>;
+export type Query_RootPublished_Mv_Curriculum_Units_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
 };
 
 
-export type Query_RootPublished_Mv_Downloads_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Select_Column>>;
+export type Query_RootPublished_Mv_Curriculum_Units_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Downloads_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Downloads_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Downloads_5_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Downloads_5_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
 };
 
 
@@ -29994,24 +27316,6 @@ export type Query_RootPublished_Mv_Key_Stages_2_0_0_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Lesson_Content_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Content_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-};
-
-
 export type Query_RootPublished_Mv_Lesson_Content_1_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_1_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30027,24 +27331,6 @@ export type Query_RootPublished_Mv_Lesson_Content_1_0_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Lesson_Content_1_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Lesson_Content_1_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Listing_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Listing_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -30120,42 +27406,6 @@ export type Query_RootPublished_Mv_Lesson_Overview_5_0_0_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Lesson_Overview_5_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_5_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_5_0_2Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Lesson_Overview_5_0_2_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-};
-
-
 export type Query_RootPublished_Mv_Lesson_Overview_5_0_3Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_3_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30192,6 +27442,24 @@ export type Query_RootPublished_Mv_Lesson_Overview_6_0_0_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Openapi_Downloads_1_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Openapi_Downloads_1_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Openapi_Unit_Curriculum_Content_1_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30225,24 +27493,6 @@ export type Query_RootPublished_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Aggrega
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Order_By>>;
   where?: InputMaybe<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Programme_Listing_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Programme_Listing_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
 };
 
 
@@ -30297,24 +27547,6 @@ export type Query_RootPublished_Mv_Search_Page_3_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Search_Page_3_Order_By>>;
   where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Share_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Share_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Share_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Share_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Share_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Share_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
 };
 
 
@@ -30408,42 +27640,6 @@ export type Query_RootPublished_Mv_Specialist_1_0_3_AggregateArgs = {
 };
 
 
-export type Query_RootPublished_Mv_Subject_Listing_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Subject_Listing_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Subject_Listing_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Subject_Listing_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-};
-
-
 export type Query_RootPublished_Mv_Subject_Listing_5_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30534,6 +27730,24 @@ export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_7_1_0_AggregateA
 };
 
 
+export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30570,39 +27784,21 @@ export type Query_RootPublished_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Yea
 };
 
 
-export type Query_RootPublished_Mv_Unit_Listing_Page_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Select_Column>>;
+export type Query_RootPublished_Mv_Threads_By_Unit_1_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
 };
 
 
-export type Query_RootPublished_Mv_Unit_Listing_Page_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Select_Column>>;
+export type Query_RootPublished_Mv_Threads_By_Unit_1_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Unit_Listing_Page_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
-};
-
-
-export type Query_RootPublished_Mv_Unit_Listing_Page_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
 };
 
 
@@ -32122,7 +29318,7 @@ export type Quiz_Questions_Bool_Exp = {
 
 /** unique or primary key constraints on table "quiz_questions" */
 export enum Quiz_Questions_Constraint {
-  /** unique or primary key constraint on columns "quiz_id", "question_id", "_state" */
+  /** unique or primary key constraint on columns "question_id", "quiz_id", "_state" */
   QuizQuestionsPkey = 'quiz_questions_pkey'
 }
 
@@ -33292,24 +30488,12 @@ export type Subscription_Root = {
   published_mv_curriculum_units_0_3_aggregate: Published_Mv_Curriculum_Units_0_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_curriculum_units_0_3" */
   published_mv_curriculum_units_0_3_stream: Array<Published_Mv_Curriculum_Units_0_3>;
-  /** fetch data from the table: "published.mv_downloads_4_0_0" */
-  published_mv_downloads_4_0_0: Array<Published_Mv_Downloads_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_4_0_0" */
-  published_mv_downloads_4_0_0_aggregate: Published_Mv_Downloads_4_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_downloads_4_0_0" */
-  published_mv_downloads_4_0_0_stream: Array<Published_Mv_Downloads_4_0_0>;
-  /** fetch data from the table: "published.mv_downloads_5_0_0" */
-  published_mv_downloads_5_0_0: Array<Published_Mv_Downloads_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_0" */
-  published_mv_downloads_5_0_0_aggregate: Published_Mv_Downloads_5_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_downloads_5_0_0" */
-  published_mv_downloads_5_0_0_stream: Array<Published_Mv_Downloads_5_0_0>;
-  /** fetch data from the table: "published.mv_downloads_5_0_1" */
-  published_mv_downloads_5_0_1: Array<Published_Mv_Downloads_5_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_downloads_5_0_1" */
-  published_mv_downloads_5_0_1_aggregate: Published_Mv_Downloads_5_0_1_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_downloads_5_0_1" */
-  published_mv_downloads_5_0_1_stream: Array<Published_Mv_Downloads_5_0_1>;
+  /** fetch data from the table: "published.mv_curriculum_units_0_4" */
+  published_mv_curriculum_units_0_4: Array<Published_Mv_Curriculum_Units_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_4" */
+  published_mv_curriculum_units_0_4_aggregate: Published_Mv_Curriculum_Units_0_4_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_curriculum_units_0_4" */
+  published_mv_curriculum_units_0_4_stream: Array<Published_Mv_Curriculum_Units_0_4>;
   /** fetch data from the table: "published.mv_downloads_5_0_2" */
   published_mv_downloads_5_0_2: Array<Published_Mv_Downloads_5_0_2>;
   /** fetch aggregated fields from the table: "published.mv_downloads_5_0_2" */
@@ -33334,24 +30518,12 @@ export type Subscription_Root = {
   published_mv_key_stages_2_0_0_aggregate: Published_Mv_Key_Stages_2_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_key_stages_2_0_0" */
   published_mv_key_stages_2_0_0_stream: Array<Published_Mv_Key_Stages_2_0_0>;
-  /** fetch data from the table: "published.mv_lesson_content_0_1" */
-  published_mv_lesson_content_0_1: Array<Published_Mv_Lesson_Content_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_content_0_1" */
-  published_mv_lesson_content_0_1_aggregate: Published_Mv_Lesson_Content_0_1_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_content_0_1" */
-  published_mv_lesson_content_0_1_stream: Array<Published_Mv_Lesson_Content_0_1>;
   /** fetch data from the table: "published.mv_lesson_content_1_0" */
   published_mv_lesson_content_1_0: Array<Published_Mv_Lesson_Content_1_0>;
   /** fetch aggregated fields from the table: "published.mv_lesson_content_1_0" */
   published_mv_lesson_content_1_0_aggregate: Published_Mv_Lesson_Content_1_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_content_1_0" */
   published_mv_lesson_content_1_0_stream: Array<Published_Mv_Lesson_Content_1_0>;
-  /** fetch data from the table: "published.mv_lesson_listing_5_0_0" */
-  published_mv_lesson_listing_5_0_0: Array<Published_Mv_Lesson_Listing_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_0" */
-  published_mv_lesson_listing_5_0_0_aggregate: Published_Mv_Lesson_Listing_5_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_listing_5_0_0" */
-  published_mv_lesson_listing_5_0_0_stream: Array<Published_Mv_Lesson_Listing_5_0_0>;
   /** fetch data from the table: "published.mv_lesson_listing_5_0_1" */
   published_mv_lesson_listing_5_0_1: Array<Published_Mv_Lesson_Listing_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_lesson_listing_5_0_1" */
@@ -33376,18 +30548,6 @@ export type Subscription_Root = {
   published_mv_lesson_overview_5_0_0_aggregate: Published_Mv_Lesson_Overview_5_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_5_0_0" */
   published_mv_lesson_overview_5_0_0_stream: Array<Published_Mv_Lesson_Overview_5_0_0>;
-  /** fetch data from the table: "published.mv_lesson_overview_5_0_1" */
-  published_mv_lesson_overview_5_0_1: Array<Published_Mv_Lesson_Overview_5_0_1>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_1" */
-  published_mv_lesson_overview_5_0_1_aggregate: Published_Mv_Lesson_Overview_5_0_1_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_5_0_1" */
-  published_mv_lesson_overview_5_0_1_stream: Array<Published_Mv_Lesson_Overview_5_0_1>;
-  /** fetch data from the table: "published.mv_lesson_overview_5_0_2" */
-  published_mv_lesson_overview_5_0_2: Array<Published_Mv_Lesson_Overview_5_0_2>;
-  /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_2" */
-  published_mv_lesson_overview_5_0_2_aggregate: Published_Mv_Lesson_Overview_5_0_2_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_5_0_2" */
-  published_mv_lesson_overview_5_0_2_stream: Array<Published_Mv_Lesson_Overview_5_0_2>;
   /** fetch data from the table: "published.mv_lesson_overview_5_0_3" */
   published_mv_lesson_overview_5_0_3: Array<Published_Mv_Lesson_Overview_5_0_3>;
   /** fetch aggregated fields from the table: "published.mv_lesson_overview_5_0_3" */
@@ -33400,6 +30560,12 @@ export type Subscription_Root = {
   published_mv_lesson_overview_6_0_0_aggregate: Published_Mv_Lesson_Overview_6_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_lesson_overview_6_0_0" */
   published_mv_lesson_overview_6_0_0_stream: Array<Published_Mv_Lesson_Overview_6_0_0>;
+  /** fetch data from the table: "published.mv_openapi_downloads_1_0_0" */
+  published_mv_openapi_downloads_1_0_0: Array<Published_Mv_Openapi_Downloads_1_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_openapi_downloads_1_0_0" */
+  published_mv_openapi_downloads_1_0_0_aggregate: Published_Mv_Openapi_Downloads_1_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_openapi_downloads_1_0_0" */
+  published_mv_openapi_downloads_1_0_0_stream: Array<Published_Mv_Openapi_Downloads_1_0_0>;
   /** fetch data from the table: "published.mv_openapi_unit_curriculum_content_1_0_1" */
   published_mv_openapi_unit_curriculum_content_1_0_1: Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_1>;
   /** fetch aggregated fields from the table: "published.mv_openapi_unit_curriculum_content_1_0_1" */
@@ -33412,12 +30578,6 @@ export type Subscription_Root = {
   published_mv_openapi_unit_curriculum_content_1_0_2_aggregate: Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_openapi_unit_curriculum_content_1_0_2" */
   published_mv_openapi_unit_curriculum_content_1_0_2_stream: Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2>;
-  /** fetch data from the table: "published.mv_programme_listing_4_0_0" */
-  published_mv_programme_listing_4_0_0: Array<Published_Mv_Programme_Listing_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_programme_listing_4_0_0" */
-  published_mv_programme_listing_4_0_0_aggregate: Published_Mv_Programme_Listing_4_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_programme_listing_4_0_0" */
-  published_mv_programme_listing_4_0_0_stream: Array<Published_Mv_Programme_Listing_4_0_0>;
   /** fetch data from the table: "published.mv_programme_listing_5_0_0" */
   published_mv_programme_listing_5_0_0: Array<Published_Mv_Programme_Listing_5_0_0>;
   /** fetch aggregated fields from the table: "published.mv_programme_listing_5_0_0" */
@@ -33436,12 +30596,6 @@ export type Subscription_Root = {
   published_mv_search_page_3_aggregate: Published_Mv_Search_Page_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_search_page_3" */
   published_mv_search_page_3_stream: Array<Published_Mv_Search_Page_3>;
-  /** fetch data from the table: "published.mv_share_4_0_0" */
-  published_mv_share_4_0_0: Array<Published_Mv_Share_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_share_4_0_0" */
-  published_mv_share_4_0_0_aggregate: Published_Mv_Share_4_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_share_4_0_0" */
-  published_mv_share_4_0_0_stream: Array<Published_Mv_Share_4_0_0>;
   /** fetch data from the table: "published.mv_share_5_0_0" */
   published_mv_share_5_0_0: Array<Published_Mv_Share_5_0_0>;
   /** fetch aggregated fields from the table: "published.mv_share_5_0_0" */
@@ -33472,18 +30626,6 @@ export type Subscription_Root = {
   published_mv_specialist_1_0_3_aggregate: Published_Mv_Specialist_1_0_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_specialist_1_0_3" */
   published_mv_specialist_1_0_3_stream: Array<Published_Mv_Specialist_1_0_3>;
-  /** fetch data from the table: "published.mv_subject_listing_4_0_0" */
-  published_mv_subject_listing_4_0_0: Array<Published_Mv_Subject_Listing_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_4_0_0" */
-  published_mv_subject_listing_4_0_0_aggregate: Published_Mv_Subject_Listing_4_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_subject_listing_4_0_0" */
-  published_mv_subject_listing_4_0_0_stream: Array<Published_Mv_Subject_Listing_4_0_0>;
-  /** fetch data from the table: "published.mv_subject_listing_5_0_0" */
-  published_mv_subject_listing_5_0_0: Array<Published_Mv_Subject_Listing_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_0" */
-  published_mv_subject_listing_5_0_0_aggregate: Published_Mv_Subject_Listing_5_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_subject_listing_5_0_0" */
-  published_mv_subject_listing_5_0_0_stream: Array<Published_Mv_Subject_Listing_5_0_0>;
   /** fetch data from the table: "published.mv_subject_listing_5_0_1" */
   published_mv_subject_listing_5_0_1: Array<Published_Mv_Subject_Listing_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_listing_5_0_1" */
@@ -33514,6 +30656,12 @@ export type Subscription_Root = {
   published_mv_synthetic_programmes_by_year_7_1_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_7_1_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_synthetic_programmes_by_year_7_1_0" */
   published_mv_synthetic_programmes_by_year_7_1_0_stream: Array<Published_Mv_Synthetic_Programmes_By_Year_7_1_0>;
+  /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_synthetic_unitvariant_lessons_by_keystage_6_0_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0_stream: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0>;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_year_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
@@ -33526,18 +30674,12 @@ export type Subscription_Root = {
   published_mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0_aggregate: Published_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Year_6_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0" */
   published_mv_synthetic_unitvariants_with_lesson_ids_by_year_6_0_0_stream: Array<Published_Mv_Synthetic_Unitvariants_With_Lesson_Ids_By_Year_6_0_0>;
-  /** fetch data from the table: "published.mv_unit_listing_page_4_0_0" */
-  published_mv_unit_listing_page_4_0_0: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_4_0_0" */
-  published_mv_unit_listing_page_4_0_0_aggregate: Published_Mv_Unit_Listing_Page_4_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_4_0_0" */
-  published_mv_unit_listing_page_4_0_0_stream: Array<Published_Mv_Unit_Listing_Page_4_0_0>;
-  /** fetch data from the table: "published.mv_unit_listing_page_5_0_0" */
-  published_mv_unit_listing_page_5_0_0: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
-  /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_0" */
-  published_mv_unit_listing_page_5_0_0_aggregate: Published_Mv_Unit_Listing_Page_5_0_0_Aggregate;
-  /** fetch data from the table in a streaming manner: "published.mv_unit_listing_page_5_0_0" */
-  published_mv_unit_listing_page_5_0_0_stream: Array<Published_Mv_Unit_Listing_Page_5_0_0>;
+  /** fetch data from the table: "published.mv_threads_by_unit_1_0_0" */
+  published_mv_threads_by_unit_1_0_0: Array<Published_Mv_Threads_By_Unit_1_0_0>;
+  /** fetch aggregated fields from the table: "published.mv_threads_by_unit_1_0_0" */
+  published_mv_threads_by_unit_1_0_0_aggregate: Published_Mv_Threads_By_Unit_1_0_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_threads_by_unit_1_0_0" */
+  published_mv_threads_by_unit_1_0_0_stream: Array<Published_Mv_Threads_By_Unit_1_0_0>;
   /** fetch data from the table: "published.mv_unit_listing_page_5_0_1" */
   published_mv_unit_listing_page_5_0_1: Array<Published_Mv_Unit_Listing_Page_5_0_1>;
   /** fetch aggregated fields from the table: "published.mv_unit_listing_page_5_0_1" */
@@ -34539,78 +31681,28 @@ export type Subscription_RootPublished_Mv_Curriculum_Units_0_3_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Select_Column>>;
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Select_Column>>;
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Downloads_4_0_0_StreamArgs = {
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_4_StreamArgs = {
   batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Downloads_4_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Downloads_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Downloads_5_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Downloads_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Downloads_5_0_1_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Downloads_5_0_1_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Downloads_5_0_1_Bool_Exp>;
+  cursor: Array<InputMaybe<Published_Mv_Curriculum_Units_0_4_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_4_Bool_Exp>;
 };
 
 
@@ -34714,31 +31806,6 @@ export type Subscription_RootPublished_Mv_Key_Stages_2_0_0_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Lesson_Content_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Content_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Content_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Content_0_1_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Content_0_1_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Content_0_1_Bool_Exp>;
-};
-
-
 export type Subscription_RootPublished_Mv_Lesson_Content_1_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Content_1_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34761,31 +31828,6 @@ export type Subscription_RootPublished_Mv_Lesson_Content_1_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Lesson_Content_1_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Lesson_Content_1_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Listing_5_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Listing_5_0_0_Bool_Exp>;
 };
 
 
@@ -34889,56 +31931,6 @@ export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_0_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_1Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_1_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_1_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_1_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_1_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_2Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_2_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_2_Order_By>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_2_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Lesson_Overview_5_0_2_Bool_Exp>;
-};
-
-
 export type Subscription_RootPublished_Mv_Lesson_Overview_5_0_3Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Lesson_Overview_5_0_3_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34989,6 +31981,31 @@ export type Subscription_RootPublished_Mv_Lesson_Overview_6_0_0_StreamArgs = {
 };
 
 
+export type Subscription_RootPublished_Mv_Openapi_Downloads_1_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Openapi_Downloads_1_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Openapi_Downloads_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Openapi_Downloads_1_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Openapi_Downloads_1_0_0_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Openapi_Unit_Curriculum_Content_1_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -35036,31 +32053,6 @@ export type Subscription_RootPublished_Mv_Openapi_Unit_Curriculum_Content_1_0_2_
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Openapi_Unit_Curriculum_Content_1_0_2_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Programme_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Programme_Listing_4_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Programme_Listing_4_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Programme_Listing_4_0_0_Bool_Exp>;
 };
 
 
@@ -35136,31 +32128,6 @@ export type Subscription_RootPublished_Mv_Search_Page_3_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Search_Page_3_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Search_Page_3_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Share_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Share_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Share_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Share_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Share_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Share_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Share_4_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Share_4_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Share_4_0_0_Bool_Exp>;
 };
 
 
@@ -35289,56 +32256,6 @@ export type Subscription_RootPublished_Mv_Specialist_1_0_3_StreamArgs = {
 };
 
 
-export type Subscription_RootPublished_Mv_Subject_Listing_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_4_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Subject_Listing_4_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Subject_Listing_5_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Subject_Listing_5_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Subject_Listing_5_0_0_Bool_Exp>;
-};
-
-
 export type Subscription_RootPublished_Mv_Subject_Listing_5_0_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Subject_Listing_5_0_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -35464,6 +32381,31 @@ export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_7_1_0_Str
 };
 
 
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_6_0_0_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -35514,53 +32456,28 @@ export type Subscription_RootPublished_Mv_Synthetic_Unitvariants_With_Lesson_Ids
 };
 
 
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_4_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Select_Column>>;
+export type Subscription_RootPublished_Mv_Threads_By_Unit_1_0_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_4_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Select_Column>>;
+export type Subscription_RootPublished_Mv_Threads_By_Unit_1_0_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_4_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
+  order_by?: InputMaybe<Array<Published_Mv_Threads_By_Unit_1_0_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
 };
 
 
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_4_0_0_StreamArgs = {
+export type Subscription_RootPublished_Mv_Threads_By_Unit_1_0_0_StreamArgs = {
   batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_4_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0Args = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Published_Mv_Unit_Listing_Page_5_0_0_Order_By>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
-};
-
-
-export type Subscription_RootPublished_Mv_Unit_Listing_Page_5_0_0_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Stream_Cursor_Input>>;
-  where?: InputMaybe<Published_Mv_Unit_Listing_Page_5_0_0_Bool_Exp>;
+  cursor: Array<InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Threads_By_Unit_1_0_0_Bool_Exp>;
 };
 
 
@@ -36689,7 +33606,7 @@ export type Thirdpartycontent_Bool_Exp = {
 
 /** unique or primary key constraints on table "thirdpartycontent" */
 export enum Thirdpartycontent_Constraint {
-  /** unique or primary key constraint on columns "_state", "thirdpartycontent_id" */
+  /** unique or primary key constraint on columns "thirdpartycontent_id", "_state" */
   ThirdpartycontentPkey = 'thirdpartycontent_pkey'
 }
 
@@ -37450,7 +34367,7 @@ export type Thread_Units_Bool_Exp = {
 
 /** unique or primary key constraints on table "thread_units" */
 export enum Thread_Units_Constraint {
-  /** unique or primary key constraint on columns "unit_id", "thread_id", "_state" */
+  /** unique or primary key constraint on columns "unit_id", "_state", "thread_id" */
   ThreadUnitsPkey = 'thread_units_pkey'
 }
 
@@ -38103,7 +35020,7 @@ export type Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "threads" */
 export enum Threads_Constraint {
-  /** unique or primary key constraint on columns "thread_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "thread_id" */
   ThreadsPkey = 'threads_pkey'
 }
 
@@ -38666,7 +35583,7 @@ export type Tpc_Media_Bool_Exp = {
 
 /** unique or primary key constraints on table "tpc_media" */
 export enum Tpc_Media_Constraint {
-  /** unique or primary key constraint on columns "_state", "media_id" */
+  /** unique or primary key constraint on columns "media_id", "_state" */
   TpcMediaPkey = 'tpc_media_pkey'
 }
 
@@ -39603,8 +36520,6 @@ export type Units_Max_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   intro_video_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__units__last_updated_lesson_review_date" */
-  last_updated_lesson_review_date?: Maybe<Scalars['timestamptz']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -39650,8 +36565,6 @@ export type Units_Min_Fields = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   intro_video_id?: Maybe<Scalars['Int']['output']>;
-  /** A computed field, executes function "function__units__last_updated_lesson_review_date" */
-  last_updated_lesson_review_date?: Maybe<Scalars['timestamptz']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -40985,7 +37898,7 @@ export type Unitvariants_Bool_Exp = {
 export enum Unitvariants_Constraint {
   /** unique or primary key constraint on columns "unitvariant_id", "_state" */
   UnitvariantsPkey = 'unitvariants_pkey',
-  /** unique or primary key constraint on columns "programme_fields", "unit_id", "_state" */
+  /** unique or primary key constraint on columns "unit_id", "programme_fields", "_state" */
   UnitvariantsUnitIdProgrammeFieldsStateKey = 'unitvariants_unit_id_programme_fields__state_key'
 }
 
@@ -41603,7 +38516,7 @@ export type Videocaptions_Bool_Exp = {
 
 /** unique or primary key constraints on table "videocaptions" */
 export enum Videocaptions_Constraint {
-  /** unique or primary key constraint on columns "_state", "caption_id" */
+  /** unique or primary key constraint on columns "caption_id", "_state" */
   VideocaptionsPkey = 'videocaptions_pkey'
 }
 
@@ -42201,7 +39114,7 @@ export type Videos_Bool_Exp = {
 
 /** unique or primary key constraints on table "videos" */
 export enum Videos_Constraint {
-  /** unique or primary key constraint on columns "_state", "video_id" */
+  /** unique or primary key constraint on columns "video_id", "_state" */
   VideosPkey = 'videos_pkey'
 }
 
@@ -42720,7 +39633,7 @@ export type LessonListingQueryVariables = Exact<{
 }>;
 
 
-export type LessonListingQuery = { __typename?: 'query_root', unit: Array<{ __typename?: 'published_mv_lesson_listing_5_0_1', programmeSlug?: string | null, unitSlug?: string | null, unitTitle?: string | null, keyStageSlug?: string | null, keyStageTitle?: string | null, subjectSlug?: string | null, subjectTitle?: string | null, tierTitle?: string | null, lessons?: any | null, yearTitle?: string | null, examBoardSlug?: string | null, examBoardTitle?: string | null }> };
+export type LessonListingQuery = { __typename?: 'query_root', unit: Array<{ __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0', unit_slug?: string | null, lesson_data?: any | null, lesson_slug?: string | null, is_legacy?: boolean | null, programme_slug?: string | null, unit_data?: any | null, null_unitvariant?: any | null, programme_fields?: any | null, supplementary_data?: any | null }> };
 
 export type LessonOverviewQueryVariables = Exact<{
   programmeSlug: Scalars['String']['input'];
@@ -43022,21 +39935,18 @@ export const LessonDownloadsCanonicalDocument = gql`
     `;
 export const LessonListingDocument = gql`
     query lessonListing($programmeSlug: String!, $unitSlug: String!) {
-  unit: published_mv_lesson_listing_5_0_1(
-    where: {programmeSlug: {_eq: $programmeSlug}, unitSlug: {_eq: $unitSlug}}
+  unit: published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0(
+    where: {unit_slug: {_eq: $unitSlug}, programme_slug: {_eq: $programmeSlug}}
   ) {
-    programmeSlug
-    unitSlug
-    unitTitle
-    keyStageSlug
-    keyStageTitle
-    subjectSlug
-    subjectTitle
-    examBoardSlug: examboardSlug
-    examBoardTitle: examboardTitle
-    tierTitle
-    lessons
-    yearTitle
+    unit_slug
+    lesson_data
+    lesson_slug
+    is_legacy
+    programme_slug
+    unit_data
+    null_unitvariant
+    programme_fields
+    supplementary_data
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.gql
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.gql
@@ -1,21 +1,18 @@
 query lessonListing($programmeSlug: String!, $unitSlug: String!) {
-  unit: published_mv_lesson_listing_5_0_1(
+  unit: published_mv_synthetic_unitvariant_lessons_by_keystage_6_0_0(
     where: {
-      programmeSlug: { _eq: $programmeSlug }
-      unitSlug: { _eq: $unitSlug }
+      unit_slug: { _eq: $unitSlug }
+      programme_slug: { _eq: $programmeSlug }
     }
   ) {
-    programmeSlug
-    unitSlug
-    unitTitle
-    keyStageSlug
-    keyStageTitle
-    subjectSlug
-    subjectTitle
-    examBoardSlug: examboardSlug
-    examBoardTitle: examboardTitle
-    tierTitle
-    lessons
-    yearTitle
+    unit_slug
+    lesson_data
+    lesson_slug
+    is_legacy
+    programme_slug
+    unit_data
+    null_unitvariant
+    programme_fields
+    supplementary_data
   }
 }

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
@@ -14,41 +14,7 @@ describe("lessonListing()", () => {
       });
     }).rejects.toThrow(`Resource not found`);
   });
-  test("first unit is returned if multiple units in response", async () => {
-    const unit = await lessonListing({
-      ...sdk,
-      lessonListing: jest.fn(() =>
-        Promise.resolve({
-          unit: [
-            {
-              programmeSlug: "programme-slug-0",
-              unitSlug: "unit-slug",
-              unitTitle: "unit-title",
-              subjectSlug: "subject-slug",
-              subjectTitle: "subject-title",
-              keyStageSlug: "key-stage-slug",
-              keyStageTitle: "key-stage-title",
-              lessons: [],
-            },
-            {
-              programmeSlug: "programme-slug-1",
-              unitSlug: "unit-slug",
-              unitTitle: "unit-title",
-              subjectSlug: "subject-slug",
-              subjectTitle: "subject-title",
-              keyStageSlug: "key-stage-slug",
-              keyStageTitle: "key-stage-title",
-              lessons: [],
-            },
-          ],
-        }),
-      ),
-    })({
-      programmeSlug: "programme-slug",
-      unitSlug: "unit-slug",
-    });
-    expect(unit.programmeSlug).toEqual("programme-slug-0");
-  });
+
   test("throws a Zod error if the response is invalid", async () => {
     await expect(async () => {
       await lessonListing({
@@ -74,6 +40,6 @@ describe("lessonListing()", () => {
         programmeSlug: "programme-slug",
         unitSlug: "unit-slug",
       });
-    }).rejects.toThrow(`unitSlug`);
+    }).rejects.toThrow(`lesson_slug`);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
@@ -1,45 +1,96 @@
+import { syntheticUnitvariantLessonsFixture } from "@oaknational/oak-curriculum-schema";
+
 import sdk from "../../sdk";
 
-import lessonListing from "./lessonListing.query";
+import lessonListing, {
+  getTransformedLessons,
+  getTransformedUnit,
+} from "./lessonListing.query";
 
 describe("lessonListing()", () => {
-  test("throws a not found error if no unit is found", async () => {
-    await expect(async () => {
-      await lessonListing({
-        ...sdk,
-        lessonListing: jest.fn(() => Promise.resolve({ unit: [] })),
-      })({
-        programmeSlug: "programme-slug",
-        unitSlug: "unit-slug",
-      });
-    }).rejects.toThrow(`Resource not found`);
-  });
+  describe("lessonListing query", () => {
+    test("throws a not found error if no unit is found", async () => {
+      await expect(async () => {
+        await lessonListing({
+          ...sdk,
+          lessonListing: jest.fn(() => Promise.resolve({ unit: [] })),
+        })({
+          programmeSlug: "programme-slug",
+          unitSlug: "unit-slug",
+        });
+      }).rejects.toThrow(`Resource not found`);
+    });
 
-  test("throws a Zod error if the response is invalid", async () => {
-    await expect(async () => {
-      await lessonListing({
-        ...sdk,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        lessonListing: jest.fn(() =>
-          Promise.resolve({
-            unit: [
-              {
-                programmeSlug: "programme-slug",
-                unitTitle: "unit-title",
-                subjectSlug: "subject-slug",
-                subjectTitle: "subject-title",
-                keyStageSlug: "key-stage-slug",
-                keyStageTitle: "key-stage-title",
-                lessons: [],
-              },
-            ],
-          }),
-        ),
-      })({
+    test("throws a Zod error if the response is invalid", async () => {
+      await expect(async () => {
+        await lessonListing({
+          ...sdk,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          lessonListing: jest.fn(() =>
+            Promise.resolve({
+              unit: [
+                {
+                  programmeSlug: "programme-slug",
+                  unitTitle: "unit-title",
+                  subjectSlug: "subject-slug",
+                  subjectTitle: "subject-title",
+                  keyStageSlug: "key-stage-slug",
+                  keyStageTitle: "key-stage-title",
+                  lessons: [],
+                },
+              ],
+            }),
+          ),
+        })({
+          programmeSlug: "programme-slug",
+          unitSlug: "unit-slug",
+        });
+      }).rejects.toThrow(`lesson_slug`);
+    });
+  });
+  describe("transform functions", () => {
+    test("getTransformedUnit returns the correct data", async () => {
+      const transformedLessons = getTransformedUnit(
+        syntheticUnitvariantLessonsFixture(),
+        [],
+      );
+      expect(transformedLessons).toEqual({
+        examBoardSlug: null,
+        examBoardTitle: null,
+        keyStageSlug: "ks1",
+        keyStageTitle: "Key stage 1",
+        lessons: [],
         programmeSlug: "programme-slug",
+        subjectSlug: "maths",
+        subjectTitle: "Maths",
+        tierSlug: null,
+        tierTitle: null,
         unitSlug: "unit-slug",
+        unitTitle: "unit-title",
+        yearTitle: "Year 1",
       });
-    }).rejects.toThrow(`lesson_slug`);
+    });
+    test("getTransformedLessons returns the correct data", async () => {
+      const transformedLessons = getTransformedLessons({
+        unit: [syntheticUnitvariantLessonsFixture()],
+      });
+      expect(transformedLessons).toEqual([
+        {
+          description: "lesson-description",
+          expired: false,
+          hasCopyrightMaterial: false,
+          lessonCohort: "2023-2024",
+          lessonSlug: "lesson-slug",
+          lessonTitle: "lesson-title",
+          orderInUnit: 1,
+          presentationCount: 0,
+          pupilLessonOutcome: "pupil-lesson-outcome",
+          quizCount: 0,
+          videoCount: 0,
+          worksheetCount: 0,
+        },
+      ]);
+    });
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
@@ -6,6 +6,7 @@ import lessonListing, {
   getTransformedLessons,
   getTransformedUnit,
 } from "./lessonListing.query";
+import lessonListingSchema from "./lessonListing.schema";
 
 describe("lessonListing()", () => {
   describe("lessonListing query", () => {
@@ -19,6 +20,99 @@ describe("lessonListing()", () => {
           unitSlug: "unit-slug",
         });
       }).rejects.toThrow(`Resource not found`);
+    });
+
+    test("it returns data in the correct shape", async () => {
+      const res = await lessonListing({
+        ...sdk,
+        lessonListing: jest.fn(() =>
+          Promise.resolve({
+            unit: [syntheticUnitvariantLessonsFixture()],
+          }),
+        ),
+      })({
+        programmeSlug: "programme-slug",
+        unitSlug: "unit-slug",
+      });
+
+      expect(lessonListingSchema.parse(res)).toEqual({
+        programmeSlug: "programme-slug",
+        keyStageSlug: "ks1",
+        keyStageTitle: "Key stage 1",
+        subjectSlug: "maths",
+        subjectTitle: "Maths",
+        unitSlug: "unit-slug",
+        unitTitle: "unit-title",
+        tierSlug: null,
+        tierTitle: null,
+        examBoardSlug: null,
+        examBoardTitle: null,
+        yearTitle: "Year 1",
+        lessons: [
+          {
+            lessonSlug: "lesson-slug",
+            lessonTitle: "lesson-title",
+            description: "lesson-description",
+            pupilLessonOutcome: "pupil-lesson-outcome",
+            expired: false,
+            quizCount: 0,
+            videoCount: 0,
+            presentationCount: 0,
+            worksheetCount: 0,
+            hasCopyrightMaterial: false,
+            orderInUnit: 1,
+            lessonCohort: "2023-2024",
+          },
+        ],
+      });
+    });
+    test("it returns lessons in the correct order", async () => {
+      const lessonListingFixture2 = syntheticUnitvariantLessonsFixture({
+        overrides: {
+          supplementary_data: { unit_order: 2, order_in_unit: 2 },
+          lesson_data: {
+            lesson_id: 1,
+            lesson_uid: "lesson-uid",
+            title: "lesson-title-2",
+            description: "lesson-description-2",
+            slug: "lesson-slug",
+            pupil_lesson_outcome: "pupil-lesson-outcome",
+            key_learning_points: [{}],
+            equipment_and_resources: null,
+            content_guidance_details: null,
+            content_guidance: null,
+            supervision_level: null,
+            thirdpartycontent_list: null,
+            misconceptions_and_common_mistakes: null,
+            keywords: null,
+            video_id: null,
+            sign_language_video_id: null,
+            quiz_id_starter: null,
+            quiz_id_exit: null,
+            asset_id_slidedeck: null,
+            asset_id_worksheet: null,
+            copyright_content: null,
+            _state: "published",
+            _cohort: "2023-2024",
+            deprecated_fields: null,
+          },
+        },
+      });
+
+      const res = await lessonListing({
+        ...sdk,
+        lessonListing: jest.fn(() =>
+          Promise.resolve({
+            unit: [lessonListingFixture2, syntheticUnitvariantLessonsFixture()],
+          }),
+        ),
+      })({
+        programmeSlug: "programme-slug",
+        unitSlug: "unit-slug",
+      });
+
+      expect(res.lessons[0]?.lessonTitle).toEqual("lesson-title");
+      expect(res.lessons[1]?.lessonTitle).toEqual("lesson-title-2");
     });
 
     test("throws a Zod error if the response is invalid", async () => {

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
@@ -7,10 +7,59 @@ import { Sdk } from "../../sdk";
 import OakError from "../../../../errors/OakError";
 import { lessonListSchema } from "../../shared.schema";
 import { toSentenceCase } from "../../helpers";
+import { LessonListingQuery } from "../../generated/sdk";
 
 import lessonListingSchema, {
   LessonListingPageData,
 } from "./lessonListing.schema";
+
+export const getTransformedLessons = (res: LessonListingQuery) => {
+  return res.unit
+    .map((l) => {
+      const lesson = syntheticUnitvariantLessonsSchema.parse(l);
+      const transformedLesson = {
+        lessonSlug: lesson.lesson_slug,
+        lessonTitle: lesson.lesson_data.title,
+        description:
+          lesson.lesson_data.description ||
+          lesson.lesson_data.pupil_lesson_outcome,
+        pupilLessonOutcome: lesson.lesson_data.pupil_lesson_outcome,
+        expired: lesson.lesson_data.deprecated_fields?.expired || false,
+        quizCount:
+          (lesson.lesson_data.quiz_id_starter ? 1 : 0) +
+          (lesson.lesson_data.quiz_id_exit ? 1 : 0),
+        videoCount: lesson.lesson_data.video_id ? 1 : 0,
+        presentationCount: lesson.lesson_data.asset_id_slidedeck ? 1 : 0,
+        worksheetCount: lesson.lesson_data.asset_id_worksheet ? 1 : 0,
+        hasCopyrightMaterial: false, // this is hardcoded to false in previous lesson listing mv (data tools)
+        orderInUnit: lesson.supplementary_data.order_in_unit,
+        lessonCohort: lesson.lesson_data._cohort,
+      };
+      return transformedLesson;
+    })
+    .sort((a, b) => a.orderInUnit - b.orderInUnit);
+};
+
+export const getTransformedUnit = (
+  unit: SyntheticUnitvariantLessons,
+  parsedLessons: LessonListingPageData["lessons"],
+): LessonListingPageData => {
+  return {
+    programmeSlug: unit.programme_slug,
+    keyStageSlug: unit.programme_fields.keystage_slug,
+    keyStageTitle: toSentenceCase(unit.programme_fields.keystage_description),
+    subjectSlug: unit.programme_fields.subject_slug,
+    subjectTitle: unit.programme_fields.subject,
+    unitSlug: unit.unit_slug,
+    unitTitle: unit.unit_data.title,
+    tierSlug: unit.programme_fields.tier_slug,
+    tierTitle: unit.programme_fields.tier_description,
+    examBoardSlug: unit.programme_fields.examboard_slug,
+    examBoardTitle: unit.programme_fields.examboard,
+    yearTitle: unit.programme_fields.year_description,
+    lessons: parsedLessons,
+  };
+};
 
 const lessonListingQuery =
   (sdk: Sdk) => async (args: { programmeSlug: string; unitSlug: string }) => {
@@ -21,59 +70,10 @@ const lessonListingQuery =
     if (!unit) {
       throw new OakError({ code: "curriculum-api/not-found" });
     }
-
-    const unitLessons = res.unit
-      .map((l) => {
-        const lesson = syntheticUnitvariantLessonsSchema.parse(l);
-        const transformedLesson = {
-          lessonSlug: lesson.lesson_slug,
-          lessonTitle: lesson.lesson_data.title,
-          description:
-            lesson.lesson_data.description ||
-            lesson.lesson_data.pupil_lesson_outcome,
-          pupilLessonOutcome: lesson.lesson_data.pupil_lesson_outcome,
-          expired: lesson.lesson_data.deprecated_fields?.expired || false,
-          quizCount:
-            (lesson.lesson_data.quiz_id_starter ? 1 : 0) +
-            (lesson.lesson_data.quiz_id_exit ? 1 : 0),
-          videoCount: lesson.lesson_data.video_id ? 1 : 0,
-          presentationCount: lesson.lesson_data.asset_id_slidedeck ? 1 : 0,
-          worksheetCount: lesson.lesson_data.asset_id_worksheet ? 1 : 0,
-          hasCopyrightMaterial: false, // this is hardcoded to false in previous lesson listing mv  (data tools)
-          orderInUnit: lesson.supplementary_data.order_in_unit,
-          lessonCohort: lesson.lesson_data._cohort,
-        };
-        return transformedLesson;
-      })
-      .sort((a, b) => a.orderInUnit - b.orderInUnit);
-
-    const parsedUnit = syntheticUnitvariantLessonsSchema.parse(unit);
+    const unitLessons = getTransformedLessons(res);
     const parsedLessons = lessonListSchema.parse(unitLessons);
-
-    const getTransformedUnit = (
-      data: SyntheticUnitvariantLessons,
-    ): LessonListingPageData => {
-      return {
-        programmeSlug: data.programme_slug,
-        keyStageSlug: data.programme_fields.keystage_slug,
-        keyStageTitle: toSentenceCase(
-          data.programme_fields.keystage_description,
-        ),
-        subjectSlug: data.programme_fields.subject_slug,
-        subjectTitle: data.programme_fields.subject,
-        unitSlug: data.unit_slug,
-        unitTitle: data.unit_data.title,
-        tierSlug: data.programme_fields.tier_slug,
-        tierTitle: data.programme_fields.tier_description,
-        examBoardSlug: data.programme_fields.examboard_slug,
-        examBoardTitle: data.programme_fields.examboard,
-        yearTitle: data.programme_fields.year_description,
-        lessons: parsedLessons,
-      };
-    };
-
-    const transformedUnit = getTransformedUnit(parsedUnit);
-
+    const parsedUnit = syntheticUnitvariantLessonsSchema.parse(unit);
+    const transformedUnit = getTransformedUnit(parsedUnit, parsedLessons);
     return lessonListingSchema.parse(transformedUnit);
   };
 

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
@@ -1,9 +1,16 @@
-import errorReporter from "../../../../common-lib/error-reporter";
-import OakError from "../../../../errors/OakError";
+import {
+  SyntheticUnitvariantLessons,
+  syntheticUnitvariantLessonsSchema,
+} from "@oaknational/oak-curriculum-schema";
+
 import { Sdk } from "../../sdk";
+import OakError from "../../../../errors/OakError";
+import { lessonListSchema } from "../../shared.schema";
 import { toSentenceCase } from "../../helpers";
 
-import lessonListingSchema from "./lessonListing.schema";
+import lessonListingSchema, {
+  LessonListingPageData,
+} from "./lessonListing.schema";
 
 const lessonListingQuery =
   (sdk: Sdk) => async (args: { programmeSlug: string; unitSlug: string }) => {
@@ -15,21 +22,59 @@ const lessonListingQuery =
       throw new OakError({ code: "curriculum-api/not-found" });
     }
 
-    if (res.unit.length > 1) {
-      const error = new OakError({
-        code: "curriculum-api/uniqueness-assumption-violated",
-      });
-      errorReporter("curriculum-api-2023::lessonListing")(error, {
-        severity: "warning",
-        ...args,
-        res,
-      });
-    }
+    const unitLessons = res.unit
+      .map((l) => {
+        const lesson = syntheticUnitvariantLessonsSchema.parse(l);
+        const transformedLesson = {
+          lessonSlug: lesson.lesson_slug,
+          lessonTitle: lesson.lesson_data.title,
+          description:
+            lesson.lesson_data.description ||
+            lesson.lesson_data.pupil_lesson_outcome,
+          pupilLessonOutcome: lesson.lesson_data.pupil_lesson_outcome,
+          expired: lesson.lesson_data.deprecated_fields?.expired || false,
+          quizCount:
+            (lesson.lesson_data.quiz_id_starter ? 1 : 0) +
+            (lesson.lesson_data.quiz_id_exit ? 1 : 0),
+          videoCount: lesson.lesson_data.video_id ? 1 : 0,
+          presentationCount: lesson.lesson_data.asset_id_slidedeck ? 1 : 0,
+          worksheetCount: lesson.lesson_data.asset_id_worksheet ? 1 : 0,
+          hasCopyrightMaterial: false, // this is hardcoded to false in previous lesson listing mv  (data tools)
+          orderInUnit: lesson.supplementary_data.order_in_unit,
+          lessonCohort: lesson.lesson_data._cohort,
+        };
+        return transformedLesson;
+      })
+      .sort((a, b) => a.orderInUnit - b.orderInUnit);
 
-    return lessonListingSchema.parse({
-      ...unit,
-      keyStageTitle: unit.keyStageTitle && toSentenceCase(unit.keyStageTitle),
-    });
+    const parsedUnit = syntheticUnitvariantLessonsSchema.parse(unit);
+    const parsedLessons = lessonListSchema.parse(unitLessons);
+
+    const getTransformedUnit = (
+      data: SyntheticUnitvariantLessons,
+    ): LessonListingPageData => {
+      return {
+        programmeSlug: data.programme_slug,
+        keyStageSlug: data.programme_fields.keystage_slug,
+        keyStageTitle: toSentenceCase(
+          data.programme_fields.keystage_description,
+        ),
+        subjectSlug: data.programme_fields.subject_slug,
+        subjectTitle: data.programme_fields.subject,
+        unitSlug: data.unit_slug,
+        unitTitle: data.unit_data.title,
+        tierSlug: data.programme_fields.tier_slug,
+        tierTitle: data.programme_fields.tier_description,
+        examBoardSlug: data.programme_fields.examboard_slug,
+        examBoardTitle: data.programme_fields.examboard,
+        yearTitle: data.programme_fields.year_description,
+        lessons: parsedLessons,
+      };
+    };
+
+    const transformedUnit = getTransformedUnit(parsedUnit);
+
+    return lessonListingSchema.parse(transformedUnit);
   };
 
 export default lessonListingQuery;

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -247,6 +247,8 @@ export const lessonListSchema = z.array(
   }),
 );
 
+export type LessonListSchema = z.infer<typeof lessonListSchema>;
+
 export const legacyAssetObjectSchema = z
   .object({
     google_drive: z.object({


### PR DESCRIPTION
## Description

Music year: 2019

- updates the lesson listing page to use the new browse mv
- updates tests

## Issue(s)


## How to test

1. Go to https://deploy-preview-2426--oak-web-application.netlify.thenational.academy
Lesson listing pages should look the same (sorry Jack)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
