### PR TITLE
[CUR-559] Added back page to docx generation

### DIFF
--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/index.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/index.ts
@@ -25,6 +25,7 @@ import { unitPreviousPatch } from "./patches/unitPrevious";
 import { unitNextPatch } from "./patches/unitNext";
 import { mainThreadsPatch } from "./patches/mainThreads";
 import { notUndefined } from "./patches/util";
+import { backPatch } from "./patches/back";
 
 import {
   CurriculumOverviewMVData,
@@ -57,6 +58,7 @@ export default async function CurriculumDownlodsPatch(
             partnerNamePatch(combinedCurriculumData),
             yearPatch(),
             threadsTablePatch(combinedCurriculumData),
+            backPatch(combinedCurriculumData),
             endOfDocumentPatch(),
           ]);
         },

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/back.test.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/back.test.ts
@@ -1,0 +1,41 @@
+import { CombinedCurriculumData } from "..";
+
+import { backPatch } from "./back";
+
+describe("back", () => {
+  it("should modify node if present", async () => {
+    const patcher = backPatch({
+      curriculumPartner: {
+        name: "TESTING_PARTNER",
+      },
+    } as CombinedCurriculumData);
+
+    const node = await patcher({
+      type: "text",
+      text: "testing {{=BACK.PARTNER_NAME}} a node",
+    });
+
+    expect(node).toEqual({
+      type: "text",
+      text: "testing TESTING_PARTNER a node",
+    });
+  });
+
+  it("should not modify invalid element", async () => {
+    const patcher = await backPatch({
+      curriculumPartner: {
+        name: "TESTING_PARTNER",
+      },
+    } as CombinedCurriculumData);
+
+    const node = await patcher({
+      type: "text",
+      text: "testing {{=FOOBAR}} a node",
+    });
+
+    expect(node).toEqual({
+      type: "text",
+      text: "testing {{=FOOBAR}} a node",
+    });
+  });
+});

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/back.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/back.ts
@@ -1,0 +1,21 @@
+import type { Element } from "xml-js";
+
+import { CombinedCurriculumData } from "..";
+
+import { textIncludes, textReplacer } from "./util";
+
+export function backPatch(combinedCurriculumData: CombinedCurriculumData) {
+  return async (el: Element) => {
+    if (el.type === "text" && textIncludes(el.text, "{{=BACK.PARTNER_NAME}}")) {
+      return {
+        type: "text",
+        text: textReplacer(
+          el.text,
+          "{{=BACK.PARTNER_NAME}}",
+          combinedCurriculumData.curriculumPartner.name,
+        ),
+      };
+    }
+    return el;
+  };
+}


### PR DESCRIPTION
## Description
Added finalised version of back page to docx file generation 

## Issue(s)

`CUR-559`

## How to test

1. Go to https://deploy-preview-2430--oak-web-application.netlify.thenational.academy/teachers/curriculum/docx-poc/select
2. Choose a subject via the autoComplete
3. Download the docx template - linked on the page
4. Download the rendered document
5. Check the back page is present and correct

## Screenshots

<img width="432" alt="Screenshot 2024-05-17 at 12 25 38" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/c2d48d7b-c610-4a88-8601-bc99b331f981">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
