### PR TITLE
Test: sitemap rendering without size limit

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -45,7 +45,6 @@ module.exports = {
       },
     ],
   },
-  sitemapSize: 7000,
   exclude: [
     // Exclude WIP webinar pages
     "/webinars",

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -21,7 +21,7 @@ const serversideSitemapPaths = [
   "/webinars/categories/sitemap.xml",
   "/teachers/curriculum/sitemap.xml",
   "/teachers/key-stages/sitemap.xml",
-  "/teachers/sitemap.xml",
+  "/teachers/*",
 ];
 const serversideSitemapUrls = serversideSitemapPaths.map(
   (sitemapPath) => new URL(path.join(sitemapBaseUrl, sitemapPath)).href,


### PR DESCRIPTION
## Description

Music year: 2015

- Removes the sitemap size limit 

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2437--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
