### PR TITLE
Fix/unit options not displaying

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -10,7 +10,6 @@ import CurriculumInfoPage, {
   formatCurriculumUnitsData,
   createThreadOptions,
   createYearOptions,
-  findDuplicateUnitSlugs,
   createInitialYearFilterSelection,
   createUnitsListingByYear,
 } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[tab]";
@@ -693,15 +692,6 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
       expect(createYearOptions(unitData)).toEqual(
         scienceSecondaryAQAYearOptions,
       );
-    });
-  });
-
-  describe("findDuplicateUnitSlugs", () => {
-    it("Should find duplicate slugs for units", () => {
-      const duplicateSlug =
-        "coordination-and-control-maintaining-a-constant-internal-environment";
-      const duplicateSlugs = new Set([duplicateSlug]);
-      expect(findDuplicateUnitSlugs(unitData)).toEqual(duplicateSlugs);
     });
   });
 

--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -620,11 +620,13 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
     });
 
     it("should return expected props", async () => {
+      const unitsTabFixture = curriculumUnitsTabFixture();
+      unitsTabFixture.units.sort((a, b) => a.order - b.order);
       mockCMSClient.curriculumOverviewPage.mockResolvedValue(
         curriculumOverviewCMSFixture(),
       );
       mockedCurriculumOverview.mockResolvedValue(curriculumOverviewMVFixture());
-      mockedCurriculumUnits.mockResolvedValue(curriculumUnitsTabFixture());
+      mockedCurriculumUnits.mockResolvedValue(unitsTabFixture);
       mockedFetchSubjectPhasePickerData.mockResolvedValue(subjectPhaseOptions);
 
       const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
@@ -641,7 +643,8 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
           subjectPhaseOptions: subjectPhaseOptions,
           curriculumOverviewSanityData: curriculumOverviewCMSFixture(),
           curriculumOverviewTabData: curriculumOverviewMVFixture(),
-          curriculumUnitsFormattedData: curriculumUnitsFormattedData,
+          curriculumUnitsFormattedData:
+            formatCurriculumUnitsData(unitsTabFixture),
         },
       });
     });

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -128,7 +128,6 @@ const curriculumVisualiserFixture = {
       disciplines: [],
     },
   },
-  duplicateUnitSlugs: new Set("unit-1"),
   mobileHeaderScrollOffset: 148,
   selectedThread: null,
   setVisibleMobileYearRefID: jest.fn(() => {}),

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -75,7 +75,6 @@ type CurriculumVisualiserProps = {
   handleSelectSubject: (year: string, subject: Subject) => void;
   handleSelectTier: (year: string, tier: Tier) => void;
   handleSelectDiscipline: (year: string, discipline: Discipline) => void;
-  duplicateUnitSlugs: Set<string>;
   mobileHeaderScrollOffset?: number;
   setUnitData: (unit: Unit) => void;
   setVisibleMobileYearRefID: (refID: string) => void;

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -66,16 +66,10 @@ export function createProgrammeSlug(
 
 const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
   // Initialize constants
-  const {
-    yearData,
-    threadOptions,
-    yearOptions,
-    initialYearSelection,
-    duplicateUnitSlugs: duplicateUnitSlugsList,
-  } = formattedData;
+  const { yearData, threadOptions, yearOptions, initialYearSelection } =
+    formattedData;
   const { examboardSlug } = trackingData;
   // Flattened duplicate slugs into array for getStaticProps, so casting back into a Set
-  const duplicateUnitSlugs = new Set(duplicateUnitSlugsList);
   const { track } = useAnalytics();
   const { analyticsUseCase } = useAnalyticsPageProps();
   const [unitData, setUnitData] = useState<Unit | null>(null);
@@ -349,7 +343,6 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
             handleSelectSubject={handleSelectSubject}
             handleSelectTier={handleSelectTier}
             handleSelectDiscipline={handleSelectDiscipline}
-            duplicateUnitSlugs={duplicateUnitSlugs}
             mobileHeaderScrollOffset={mobileHeaderScrollOffset}
             setUnitData={setUnitData}
             selectedThread={selectedThread}

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -442,6 +442,9 @@ export const getStaticProps: GetStaticProps<
         };
       }
       const curriculumUnitsTabData = await curriculumApi.curriculumUnits(slugs);
+
+      // Sort the units to have examboard versions first - this is so non-examboard units are removed
+      // in the visualiser
       curriculumUnitsTabData.units.sort((a) => {
         if (a.examboard) {
           return -1;
@@ -449,6 +452,7 @@ export const getStaticProps: GetStaticProps<
         return 1;
       });
 
+      // Sort by unit order
       curriculumUnitsTabData.units.sort((a, b) => a.order - b.order);
 
       const curriculumUnitsFormattedData = formatCurriculumUnitsData(

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -77,7 +77,6 @@ export type CurriculumUnitsFormattedData = {
   threadOptions: Thread[];
   yearOptions: string[];
   initialYearSelection: YearSelection;
-  duplicateUnitSlugs: string[];
 };
 
 export type CurriculumInfoPageProps = {
@@ -269,20 +268,6 @@ export function createYearOptions(units: Unit[]): string[] {
   return yearOptions;
 }
 
-export function findDuplicateUnitSlugs(units: Unit[]): Set<string> {
-  const duplicateUnitSlugs = new Set<string>();
-  const unitSlugs = new Set<string>();
-  units.forEach((unit: Unit) => {
-    // Check for duplicate unit slugs
-    if (unitSlugs.has(unit.slug)) {
-      duplicateUnitSlugs.add(unit.slug);
-    } else {
-      unitSlugs.add(unit.slug);
-    }
-  });
-  return duplicateUnitSlugs;
-}
-
 export function createInitialYearFilterSelection(
   yearData: CurriculumUnitsYearData,
 ): YearSelection {
@@ -411,14 +396,12 @@ export function formatCurriculumUnitsData(
   const yearData = createUnitsListingByYear(units);
   const threadOptions = createThreadOptions(units);
   const yearOptions = createYearOptions(units);
-  const duplicateUnitSlugs = findDuplicateUnitSlugs(units);
   const initialYearSelection = createInitialYearFilterSelection(yearData);
   const formattedDataCurriculumUnits = {
     yearData,
     threadOptions,
     yearOptions,
     initialYearSelection,
-    duplicateUnitSlugs: Array.from(duplicateUnitSlugs),
   };
   return formattedDataCurriculumUnits;
 }
@@ -459,6 +442,13 @@ export const getStaticProps: GetStaticProps<
         };
       }
       const curriculumUnitsTabData = await curriculumApi.curriculumUnits(slugs);
+      curriculumUnitsTabData.units.sort((a) => {
+        if (a.examboard) {
+          return -1;
+        }
+        return 1;
+      });
+
       curriculumUnitsTabData.units.sort((a, b) => a.order - b.order);
 
       const curriculumUnitsFormattedData = formatCurriculumUnitsData(


### PR DESCRIPTION
## Description

Music year: 2005

- Removed references to duplicated data in tab and curric visualiser
- Updated tests 
- Sorted data by exam board

## Issue(s)
The unit options were not displaying correctly after filtering for duplicate units

Fixes #
Sorted data by exam board so that the first option being filtered is the correct one for secondary units


## How to test

1. Go to https://deploy-preview-2439--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}
![Screenshot 2024-05-21 at 10 52 45](https://github.com/oaknational/Oak-Web-Application/assets/32605982/706f9a39-9ca4-492c-b5a4-a8025414bd9f)

How it should now look:
{screenshots}
![Screenshot 2024-05-21 at 10 52 58](https://github.com/oaknational/Oak-Web-Application/assets/32605982/61e40760-d645-4da7-b8af-e56fabc12358)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
