### PR TITLE
Lesq 754] add aria live=polite 

### DIFF
--- a/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.test.tsx
+++ b/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.test.tsx
@@ -71,4 +71,15 @@ describe("Copy link button", () => {
     const clipboardText = await navigator.clipboard.readText();
     expect(clipboardText).toBe("https://example.com");
   });
+  it("has aria-live polite", async () => {
+    const { getByLabelText } = renderWithTheme(
+      <ToastProvider>
+        <CopyLinkButton />
+      </ToastProvider>,
+    );
+
+    const button = getByLabelText("Copy to clipboard");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-live", "polite");
+  });
 });

--- a/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.tsx
+++ b/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.tsx
@@ -37,6 +37,7 @@ const CopyLinkButton: FC<CopyLinkButtonProps> = (props) => {
 
   return (
     <IconButton
+      aria-live={"polite"}
       icon={"share"}
       aria-label={label}
       onClick={copyLink}

--- a/src/components/SharedComponents/Button/LoadingButton/LoadingButton.test.tsx
+++ b/src/components/SharedComponents/Button/LoadingButton/LoadingButton.test.tsx
@@ -42,4 +42,26 @@ describe("Loading button", () => {
     expect(button).toHaveAttribute("aria-disabled");
     expect(button).toHaveTextContent("Loading...");
   });
+  it("should have aria-live polite", async () => {
+    let loading = false;
+    const setLoading = () => {
+      loading = true;
+    };
+    renderWithTheme(
+      <LoadingButton
+        text="Click"
+        isLoading={loading}
+        loadingText="Loading..."
+        onClick={setLoading}
+        type="button"
+        icon="bell"
+        disabled={false}
+        ariaLive="polite"
+      />,
+    );
+
+    const loadingButton = screen.getByLabelText("Click");
+
+    expect(loadingButton).toHaveAttribute("aria-live", "polite");
+  });
 });

--- a/src/components/SharedComponents/Button/LoadingButton/LoadingButton.tsx
+++ b/src/components/SharedComponents/Button/LoadingButton/LoadingButton.tsx
@@ -21,6 +21,7 @@ type LoadingButtonProps = {
   disabled: boolean;
   success?: boolean;
   ariaLabel?: string;
+  ariaLive?: "off" | "polite" | "assertive";
   onClick: MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
 } & (
   | {
@@ -131,6 +132,7 @@ const LoadingButton: FC<LoadingButtonProps> = (props) => {
       aria-label={props.ariaLabel ?? props.text}
       color={props.success ? "oakGreen" : "black"}
       data-testid="loadingButton"
+      aria-live={props.ariaLive}
     >
       <ButtonContent {...props} />
     </StyledButton>
@@ -142,6 +144,7 @@ const LoadingButton: FC<LoadingButtonProps> = (props) => {
       target={props.external ? "_blank" : undefined}
       color={props.success ? "oakGreen" : "black"}
       onClick={onClick}
+      aria-live={props.ariaLive}
     >
       <ButtonContent {...props} />
     </StyledLink>

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
@@ -51,6 +51,7 @@ const LessonShareLinks: FC<{
           success={isShareSuccessful}
           type="button"
           ariaLabel="Copy link to clipboard"
+          aria-live={"polite"}
           onClick={() =>
             copyToClipboard(
               getHrefForSocialSharing({


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- adds aria-live  "polite" to blog copy to clipboard and share page

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
