### PR TITLE
[CUR-560] docx thread details

### DIFF
--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/__snapshots__/mainThreads.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/__snapshots__/mainThreads.test.ts.snap
@@ -1,0 +1,3367 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coverPatch should modify node for KS1-2 1`] = `
+"{
+  "type": "element",
+  "name": "$FRAGMENT$",
+  "elements": [
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 8"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 8"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_3"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 8"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_4"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 9"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_5"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 9"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_6"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 9"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_7"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 10"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_8"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 10"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "name": "$FRAGMENT$",
+      "elements": [
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:pageBreakBefore"
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "attributes": {
+                    "xml:space": "preserve"
+                  },
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Thread: "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "36"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "TEST_9"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:rPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:b"
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:sz",
+                      "attributes": {
+                        "w:val": "28"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Year 10"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:numPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:ilvl",
+                      "attributes": {
+                        "w:val": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:numId",
+                      "attributes": {
+                        "w:val": "3"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "element",
+                  "name": "w:ind",
+                  "attributes": {
+                    "w:left": "426"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Unit undefined: undefined"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:num": "2",
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:r",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:t"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "element",
+          "name": "w:p",
+          "elements": [
+            {
+              "type": "element",
+              "name": "w:pPr",
+              "elements": [
+                {
+                  "type": "element",
+                  "name": "w:sectPr",
+                  "elements": [
+                    {
+                      "type": "element",
+                      "name": "w:type",
+                      "attributes": {
+                        "w:val": "continuous"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgSz",
+                      "attributes": {
+                        "w:w": "11909",
+                        "w:h": "16834"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:pgMar",
+                      "attributes": {
+                        "w:top": "567",
+                        "w:right": "709",
+                        "w:bottom": "709",
+                        "w:left": "709",
+                        "w:header": "720",
+                        "w:footer": "720",
+                        "w:gutter": "0"
+                      }
+                    },
+                    {
+                      "type": "element",
+                      "name": "w:cols",
+                      "attributes": {
+                        "w:space": "720"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"
+`;

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.test.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.test.ts
@@ -1,0 +1,82 @@
+import { CombinedCurriculumData } from "..";
+
+import { mainThreadsPatch } from "./mainThreads";
+
+describe("coverPatch", () => {
+  it("should modify node for KS1-2", async () => {
+    const patcher = mainThreadsPatch({
+      units: [
+        {
+          year: "8",
+          threads: [
+            {
+              slug: "test1",
+              title: "TEST_1",
+            },
+            {
+              slug: "test2",
+              title: "TEST_2",
+            },
+            {
+              slug: "test3",
+              title: "TEST_3",
+            },
+          ],
+        },
+        {
+          year: "9",
+          threads: [
+            {
+              slug: "test4",
+              title: "TEST_4",
+            },
+            {
+              slug: "test5",
+              title: "TEST_5",
+            },
+            {
+              slug: "test6",
+              title: "TEST_6",
+            },
+          ],
+        },
+        {
+          year: "10",
+          threads: [
+            {
+              slug: "test7",
+              title: "TEST_7",
+            },
+            {
+              slug: "test8",
+              title: "TEST_8",
+            },
+            {
+              slug: "test9",
+              title: "TEST_9",
+            },
+          ],
+        },
+      ],
+    } as CombinedCurriculumData);
+
+    const output = await patcher();
+    const json = JSON.stringify(output, null, 2);
+
+    expect(json).toContain("Year 8");
+    expect(json).toContain("Year 9");
+    expect(json).toContain("Year 10");
+
+    expect(json).toContain("TEST_1");
+    expect(json).toContain("TEST_2");
+    expect(json).toContain("TEST_3");
+    expect(json).toContain("TEST_4");
+    expect(json).toContain("TEST_5");
+    expect(json).toContain("TEST_6");
+    expect(json).toContain("TEST_7");
+    expect(json).toContain("TEST_8");
+    expect(json).toContain("TEST_9");
+
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.ts
@@ -1,119 +1,124 @@
-import { chunk } from "lodash";
+import { Element } from "xml-js";
 
 import { xmlElementToJson } from "../../xml";
 import { CombinedCurriculumData } from "..";
 
 import { createThreadOptions, threadUnitByYear } from "./util";
 
+import { Unit } from "@/components/CurriculumComponents/CurriculumVisualiser";
+
+function sortByOrder(units: Unit[]) {
+  return [...units].sort((a, b) => a.order - b.order);
+}
+
 export function mainThreadsPatch(data: CombinedCurriculumData) {
   return async () => {
-    const container = xmlElementToJson(`<w:sectPr />`);
-    container.elements = createThreadOptions(data.units).map(
-      (thread, threadIndex) => {
-        const threadContainer = xmlElementToJson(`<w:sectPr />`);
-        const threadInfo = threadUnitByYear(data.units, thread.slug);
+    const container = {
+      type: "element",
+      name: "$FRAGMENT$",
+      elements: [],
+    } as Element;
 
-        const rawXml = `
-      <root>
-        <w:p>
-          <w:pPr>
-              ${threadIndex > 0 && `<w:pageBreakBefore/>`}
-              ${/*<w:pStyle w:val="Heading2"/>*/ ""}
+    container.elements = createThreadOptions(data.units).map((thread) => {
+      const threadInfo = threadUnitByYear(data.units, thread.slug);
+
+      let rawXml = `
+          <w:p>
+            <w:pPr>
+              <w:pageBreakBefore/>
+            </w:pPr>
+            <w:r>
+              <w:t xml:space="preserve">Thread: </w:t>
+            </w:r>
+            <w:r>
               <w:rPr>
-                  <w:color w:val="222222"/>
+                <w:b/>
               </w:rPr>
-          </w:pPr>
-          <w:r>
-              <w:rPr>
-                  <w:rFonts w:ascii="Lexend Light" w:eastAsia="Lexend Light" w:hAnsi="Lexend Light" w:cs="Lexend Light"/>
-                  <w:b w:val="0"/>
-                  <w:color w:val="222222"/>
-              </w:rPr>
-              <w:t>Thread:</w:t>
-          </w:r>
-          <w:r>
-              <w:rPr>
-                  <w:color w:val="222222"/>
-              </w:rPr>
-              <w:t xml:space="preserve"> ${thread.title}</w:t>
-          </w:r>
-        </w:p>
-        <w:tbl>
-            <w:tblPr>
-                <w:tblStyle w:val="TableGrid"/>
-                <w:tblW w:w="0" w:type="auto"/>
-                <w:tblBorders>
-                    <w:top w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                    <w:left w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                    <w:bottom w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                    <w:right w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                    <w:insideH w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                    <w:insideV w:val="none" w:sz="0" w:space="0" w:color="auto"/>
-                </w:tblBorders>
-                <w:tblLook w:val="04A0" w:firstRow="1" w:lastRow="0" w:firstColumn="1" w:lastColumn="0" w:noHBand="0" w:noVBand="1"/>
-            </w:tblPr>
-            <w:tblGrid>
-                <w:gridCol w:w="5240"/>
-                <w:gridCol w:w="5241"/>
-            </w:tblGrid>
-            ${chunk(Object.entries(threadInfo), 2)
-              .map((rowUnits) => {
+              <w:t>${thread.title}</w:t>
+            </w:r>
+          </w:p>
+
+          <w:p>
+            <w:r>
+              <w:t></w:t>
+            </w:r>
+          </w:p>
+        `;
+
+      for (const [year, units] of Object.entries(threadInfo)) {
+        rawXml += `
+            <w:p>
+              <w:r>
+                <w:rPr>
+                  <w:b/>
+                </w:rPr>
+                <w:t>Year ${year}</w:t>
+              </w:r>
+            </w:p>
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:type w:val="continuous"/>
+                  <w:pgSz w:w="11909" w:h="16834"/>
+                  <w:pgMar w:top="567" w:right="709" w:bottom="709" w:left="709" w:header="720" w:footer="720" w:gutter="0"/>
+                  <w:cols w:space="720"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+            ${sortByOrder(units)
+              .map((unit) => {
                 return `
-                <w:tr>
-                  ${rowUnits
-                    .map(([year, threadUnits]) => {
-                      return `
-                      <w:tc>
-                        <w:tcPr>
-                            <w:tcW w:w="5240" w:type="dxa"/>
-                        </w:tcPr>
-                        <w:p w14:paraId="5E38E0C5" w14:textId="77777777" w:rsidR="00CC26C2" w:rsidRDefault="00CC26C2" w:rsidP="00CC26C2">
-                          <w:pPr>
-                              <w:pStyle w:val="Heading3"/>
-                              <w:widowControl w:val="0"/>
-                          </w:pPr>
-                          <w:r>
-                              <w:t>Year ${year}</w:t>
-                          </w:r>
-                        </w:p>
-                        ${threadUnits
-                          .map(({ unit }) => {
-                            return `
-                            <w:p w14:paraId="4713D6A2" w14:textId="77777777" w:rsidR="00CC26C2" w:rsidRDefault="00CC26C2" w:rsidP="00CC26C2">
-                              <w:pPr>
-                                  <w:numPr>
-                                      <w:ilvl w:val="0"/>
-                                      <w:numId w:val="4"/>
-                                  </w:numPr>
-                                  <w:ind w:left="425"/>
-                                  <w:rPr>
-                                      <w:color w:val="222222"/>
-                                  </w:rPr>
-                              </w:pPr>
-                              <w:r>
-                                  <w:rPr>
-                                      <w:color w:val="222222"/>
-                                  </w:rPr>
-                                  <w:t>UNIT ${unit.order}: ${unit.title}</w:t>
-                              </w:r>
-                            </w:p>
-                          `;
-                          })
-                          .join("")}
-                      </w:tc>
-                    `;
-                    })
-                    .join("")}
-                </w:tr>
+                <w:p>
+                  <w:pPr>
+                    <w:numPr>
+                      <w:ilvl w:val="0"/>
+                      <w:numId w:val="3"/>
+                    </w:numPr>
+                    <w:ind w:left="426"/>
+                  </w:pPr>
+                  <w:r>
+                    <w:t>Unit ${unit.order}: ${unit.title}</w:t>
+                  </w:r>
+                </w:p>
               `;
               })
               .join("")}
-        </w:tbl>
-      </root>`;
-        threadContainer.elements = xmlElementToJson(rawXml).elements;
-        return threadContainer;
-      },
-    );
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:type w:val="continuous"/>
+                  <w:pgSz w:w="11909" w:h="16834"/>
+                  <w:pgMar w:top="567" w:right="709" w:bottom="709" w:left="709" w:header="720" w:footer="720" w:gutter="0"/>
+                  <w:cols w:num="2" w:space="720"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+
+            <w:p>
+              <w:r>
+                <w:t></w:t>
+              </w:r>
+            </w:p>
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:type w:val="continuous"/>
+                  <w:pgSz w:w="11909" w:h="16834"/>
+                  <w:pgMar w:top="567" w:right="709" w:bottom="709" w:left="709" w:header="720" w:footer="720" w:gutter="0"/>
+                  <w:cols w:space="720"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+          `;
+      }
+
+      return {
+        type: "element",
+        name: "$FRAGMENT$",
+        elements: xmlElementToJson(`<root>${rawXml}</root>`).elements,
+      };
+    });
+
     return container;
   };
 }

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/mainThreads.ts
@@ -28,10 +28,14 @@ export function mainThreadsPatch(data: CombinedCurriculumData) {
               <w:pageBreakBefore/>
             </w:pPr>
             <w:r>
+              <w:rPr>
+                <w:sz w:val="36"/>
+              </w:rPr>
               <w:t xml:space="preserve">Thread: </w:t>
             </w:r>
             <w:r>
               <w:rPr>
+                <w:sz w:val="36"/>
                 <w:b/>
               </w:rPr>
               <w:t>${thread.title}</w:t>
@@ -51,6 +55,7 @@ export function mainThreadsPatch(data: CombinedCurriculumData) {
               <w:r>
                 <w:rPr>
                   <w:b/>
+                  <w:sz w:val="28"/>
                 </w:rPr>
                 <w:t>Year ${year}</w:t>
               </w:r>

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/util.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/util.ts
@@ -30,7 +30,7 @@ export const textReplacer = (
 };
 
 export function threadUnitByYear(units: Unit[], threadSlug: string) {
-  const output = {} as Record<string, { thread: Thread; unit: Unit }[]>;
+  const output = {} as Record<string, Unit[]>;
 
   units.forEach((unit: Unit) => {
     unit.threads.forEach((thread) => {
@@ -38,12 +38,9 @@ export function threadUnitByYear(units: Unit[], threadSlug: string) {
         output[unit.year] = output[unit.year] ?? [];
         if (
           output[unit.year] &&
-          !output[unit.year]!.find(({ unit: u }) => u.slug === unit.slug)
+          !output[unit.year]!.find((u) => u.slug === unit.slug)
         ) {
-          output[unit.year]!.push({
-            thread,
-            unit,
-          });
+          output[unit.year]!.push(unit);
         }
       }
     });

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/util.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/util.ts
@@ -38,7 +38,8 @@ export function threadUnitByYear(units: Unit[], threadSlug: string) {
         output[unit.year] = output[unit.year] ?? [];
         if (
           output[unit.year] &&
-          !output[unit.year]!.find((u) => u.slug === unit.slug)
+          // Check if unit is not already within output
+          !output[unit.year]!.find((yearUnit) => yearUnit.slug === unit.slug)
         ) {
           output[unit.year]!.push(unit);
         }


### PR DESCRIPTION
## Description

- Added thread details pages to curriculum generated `.docx` 

## Issue(s)

`CUR-560`

## How to test

1. Go to https://deploy-preview-2445--oak-web-application.netlify.thenational.academy/teachers/curriculum/docx-poc/select
2. Choose a subject via the autoComplete
3. Download the docx template - linked on the page
4. Download the rendered document
5. Check the cover page is present and correct

## Screenshots

<img width="602" alt="Screenshot 2024-05-22 at 14 00 06" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/a6c68f76-30ef-43e1-bb32-e96a7c74fe2b">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
