### PR TITLE
Lesq 872 final changes to plan a lesson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^8.5.1",
         "@mux/mux-player-react": "^2.6.0",
-        "@oaknational/oak-components": "^0.34.0",
+        "@oaknational/oak-components": "^0.37.2",
         "@oaknational/oak-curriculum-schema": "^1.8.0",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.7",
@@ -7517,9 +7517,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.34.0.tgz",
-      "integrity": "sha512-H7tOu4eTyGLwEyuApYNCCu51OOcWmR282yQdCXoPzS4npFzEgVIT5/X4TWHSJNJWAD16nCXq9qdi0AYe/R+42w==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-0.37.2.tgz",
+      "integrity": "sha512-hjWkKQaV4WAcZsY1ZAbnlXngtYixgIonwRvLG0YTk7mi4cWaS6PddlbUdcZtrrua2OgDzbeNeC42KGcpmX65qw==",
       "dependencies": {
         "@storybook/test": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@mux/mux-node": "^8.5.1",
     "@mux/mux-player-react": "^2.6.0",
     "@oaknational/oak-curriculum-schema": "^1.8.0",
-    "@oaknational/oak-components": "^0.34.0",
+    "@oaknational/oak-components": "^0.37.2",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.7",
     "@sanity/asset-utils": "^1.3.0",

--- a/src/components/GenericPagesComponents/BlogAndWebinarList/BlogAndWebinarList.test.tsx
+++ b/src/components/GenericPagesComponents/BlogAndWebinarList/BlogAndWebinarList.test.tsx
@@ -22,6 +22,7 @@ const blogAndWebinarListData: BlogAndWebinarListProps = {
   backgroundColor: "white",
   displayOnPhone: true,
   showImageOnTablet: true,
+  title: "Stay up to date",
 };
 
 describe("components/BlogAndWebinarList", () => {

--- a/src/components/GenericPagesComponents/BlogAndWebinarList/BlogAndWebinarList.tsx
+++ b/src/components/GenericPagesComponents/BlogAndWebinarList/BlogAndWebinarList.tsx
@@ -18,6 +18,7 @@ export type BlogAndWebinarListProps = {
   backgroundColor: OakColorToken;
   displayOnPhone: boolean;
   isBackgroundWhite?: boolean;
+  title: string;
 };
 
 const BlogAndWebinarList: FC<BlogAndWebinarListProps> = ({
@@ -26,6 +27,7 @@ const BlogAndWebinarList: FC<BlogAndWebinarListProps> = ({
   backgroundColor,
   displayOnPhone,
   isBackgroundWhite,
+  title,
 }) => {
   return (
     <OakBox
@@ -48,7 +50,7 @@ const BlogAndWebinarList: FC<BlogAndWebinarListProps> = ({
           $font={"heading-5"}
           $mb={["space-between-m", "space-between-none"]}
         >
-          Stay up to date
+          {title}
         </OakHeading>
         <OakFlex $flexDirection={"row"}>
           <OakTypography $mr={"space-between-s"} $font={"heading-7"}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -110,6 +110,7 @@ const Teachers: NextPage<TeachersHomePageProps> = (props) => {
           backgroundColor="white"
           displayOnPhone={true}
           isBackgroundWhite={true}
+          title={"Stay up to date"}
         />
       </MaxWidth>
       <Flex $background={"lavender50"} $width={"100%"}>

--- a/src/pages/lesson-planning-new.tsx
+++ b/src/pages/lesson-planning-new.tsx
@@ -125,73 +125,89 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData, posts }) => {
                 anchorTarget="plan-a-lesson-contents"
               />
             </OakGridArea>
+
             <OakGridArea
               $colSpan={[12, 12, 6]}
               $colStart={[1, 1, 5]}
-              $mh={"space-between-s"}
+              $mh={["space-between-s", null, null]}
+              $justifyContent={"center"}
             >
-              {pageData.content.map((section, index, sections) => {
-                const isLastSection = index === sections.length - 1;
-                if (section.type === "PlanALessonPageFormBlock") {
-                  return (
-                    <OakFlex
-                      key={`${section.navigationTitle} ${index}`}
-                      $mb={
-                        !isLastSection
-                          ? "space-between-xxxl"
-                          : "space-between-m2"
-                      }
-                      $flexDirection={"column"}
-                      $display={["none", "none", "flex"]}
-                    >
-                      <LandingPageSignUpForm formTitle={"Don't miss out"} />
-                    </OakFlex>
-                  );
-                }
-
-                return (
-                  <OakBox
-                    key={`${section.navigationTitle} ${index}`}
-                    $position={"relative"}
-                    $mb={
-                      !isLastSection ? "space-between-xxxl" : "space-between-m2"
-                    }
-                  >
-                    <OakAnchorTarget id={section.anchorSlug.current} />
-                    <LessonPlanningBlog
-                      title={section.navigationTitle}
-                      blogPortableText={section.bodyPortableText}
-                    />
-                    <OakBox
-                      $display={["block", "block", "none"]}
-                      $mt={"space-between-m2"}
-                    >
-                      <OakLink
-                        iconName="arrow-up"
-                        href={"#plan-a-lesson-contents"}
-                        isTrailingIcon
-                      >
-                        {"Back to contents"}
-                      </OakLink>
-                    </OakBox>
-                  </OakBox>
-                );
-              })}
-              {isNewsletterForm && (
-                <OakBox
-                  $mb={"space-between-l"}
-                  $display={["block", "none", "none"]}
+              <OakFlex
+                $width={"100%"}
+                $flexDirection={"column"}
+                $alignItems={"center"}
+              >
+                <OakFlex
+                  $minWidth={[null, "all-spacing-22"]}
+                  $maxWidth={"all-spacing-22"}
+                  $flexDirection={"column"}
                 >
-                  <LandingPageSignUpForm formTitle="Don't miss out" />
-                </OakBox>
-              )}
+                  {pageData.content.map((section, index, sections) => {
+                    const isLastSection = index === sections.length - 1;
+                    if (section.type === "PlanALessonPageFormBlock") {
+                      return (
+                        <OakFlex
+                          key={`${section.navigationTitle} ${index}`}
+                          $mb={
+                            !isLastSection
+                              ? "space-between-xxxl"
+                              : "space-between-m2"
+                          }
+                          $flexDirection={"column"}
+                        >
+                          <LandingPageSignUpForm formTitle={"Don't miss out"} />
+                        </OakFlex>
+                      );
+                    }
+
+                    return (
+                      <OakBox
+                        key={`${section.navigationTitle} ${index}`}
+                        $position={"relative"}
+                        $mb={
+                          !isLastSection
+                            ? "space-between-xxxl"
+                            : "space-between-m2"
+                        }
+                      >
+                        <OakAnchorTarget id={section.anchorSlug.current} />
+                        <LessonPlanningBlog
+                          title={section.navigationTitle}
+                          blogPortableText={section.bodyPortableText}
+                        />
+                        <OakBox
+                          $display={["block", "block", "none"]}
+                          $mt={"space-between-m2"}
+                        >
+                          <OakLink
+                            iconName="arrow-up"
+                            href={"#plan-a-lesson-contents"}
+                            isTrailingIcon
+                          >
+                            {"Back to contents"}
+                          </OakLink>
+                        </OakBox>
+                      </OakBox>
+                    );
+                  })}
+                  {isNewsletterForm && (
+                    <OakBox
+                      $mb={"space-between-l"}
+                      $display={["block", "none", "none"]}
+                    >
+                      <LandingPageSignUpForm formTitle="Don't miss out" />
+                    </OakBox>
+                  )}
+                </OakFlex>
+              </OakFlex>
             </OakGridArea>
           </OakGrid>
           <BlogAndWebinarList
             backgroundColor={"grey20"}
             showImageOnTablet
             blogListPosts={blogListPosts}
-            displayOnPhone={false}
+            displayOnPhone={true}
+            title={"Latest lesson planning blogs"}
           />
         </OakMaxWidth>
       </Layout>


### PR DESCRIPTION
## Description

[Figma](https://www.figma.com/design/XappQ4iolvVw6Ii3EmNKXD/Pillar-page%3A-Plan-a-lesson?node-id=6987-11429&m=dev)

## Acceptance Criteria:

- [x]  Author name should not be a heading
- [x]  The form should display wherever it is in the content blocks, it shouldn’t move to the bottom of the page when the screen view gets narrower
- [x]  Max width of content should be 640px (max-width: var(--Primitives-All-spacing-all-spacing-22, 640px); on all views (even tablet)
- [x]  in the blog section at the end, could the heading be "**Latest lesson planning blogs**" rather than “Stay up to date”?
- [x]  The blog shouldn’t disappear at narrower widths (copy what the homepage does)

[[Dev ticket checklist](https://www.notion.so/Dev-ticket-checklist-5317535736fe47fb984a3591a1bd7616?pvs=21)](https://www.notion.so/Dev-ticket-checklist-5317535736fe47fb984a3591a1bd7616?pvs=21)

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
