### PR TITLE
Feat/lesq 753/lesson overview nav a11y

### DIFF
--- a/src/components/TeacherComponents/LessonItemContainer/LessonItemContainer.tsx
+++ b/src/components/TeacherComponents/LessonItemContainer/LessonItemContainer.tsx
@@ -8,6 +8,10 @@ import { Hr } from "@/components/SharedComponents/Typography";
 import AnchorTarget from "@/components/SharedComponents/AnchorTarget";
 import Box from "@/components/SharedComponents/Box";
 
+export const getContainerId = (anchorId: string) => {
+  return `${anchorId}-container`;
+};
+
 /**
  * This replaces the old ExpandingContainer component on the lesson page. It should wrap each item of lesson content.
  *
@@ -67,7 +71,12 @@ export const LessonItemContainer = forwardRef<
   const lowerCaseTitle = title.toLowerCase();
 
   return (
-    <OakFlex $flexDirection="column" $position={"relative"}>
+    <OakFlex
+      $flexDirection="column"
+      $position={"relative"}
+      id={getContainerId(anchorId)}
+      tabIndex={-1}
+    >
       <AnchorTarget id={anchorId} $paddingTop={24} ref={ref} />
       <OakFlex
         $flexDirection={["column", "row"]}

--- a/src/components/TeacherComponents/LessonOverviewAnchorLinks/LessonOverviewAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewAnchorLinks/LessonOverviewAnchorLinks.tsx
@@ -31,10 +31,10 @@ const LessonOverviewAnchorLinks: FC<LessonOverviewAnchorLinksProps> = ({
             variant={isCurrent ? "brushNav" : "minimalNav"}
             $hoverStyles={["underline-link-text"]}
             label={label}
-            disabled={isCurrent}
             isCurrent={isCurrent}
             icon={isCurrent ? "arrow-right" : undefined}
             iconBackground={isCurrent ? "transparent" : undefined}
+            aria-current={isCurrent ? "true" : undefined}
             $iconPosition="trailing"
             key={label}
           />

--- a/src/components/TeacherComponents/LessonOverviewAnchorLinks/LessonOverviewAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewAnchorLinks/LessonOverviewAnchorLinks.tsx
@@ -1,5 +1,7 @@
 import { FC } from "react";
 
+import { getContainerId } from "../LessonItemContainer/LessonItemContainer";
+
 import Button from "@/components/SharedComponents/Button";
 
 type LessonOverviewAnchorLinksProps = {
@@ -24,6 +26,7 @@ const LessonOverviewAnchorLinks: FC<LessonOverviewAnchorLinksProps> = ({
           <Button
             onClick={() => {
               document.getElementById(anchorId)?.scrollIntoView();
+              document.getElementById(getContainerId(anchorId))?.focus();
             }}
             variant={isCurrent ? "brushNav" : "minimalNav"}
             $hoverStyles={["underline-link-text"]}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- remove aria-disabled froma ctive button
- add aria-current=true to active button
- move focus to content after button selection


## How to test

1. Go to {owa_deployment_url}/teachers/programmes/chemistry-secondary-ks4-higher-edexcel/units/separating-substances/lessons/solutions
2. Tab through to content nav buttons and select a section
3. Focus should move into the content and continue from there


## ACs
- [ ]  When a keyboard user selects something from the nav bar, focus should be moved to the top of that section
- [ ]  Remove aria-disabled and instead use “aria-current=new” --*note: new doesn't appear to be a valid value so have used 'true'
