### PR TITLE
fix: sanity image 403s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41479,6 +41479,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/glob/node_modules/minipass": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,

--- a/src/pages/lesson-planning-new.tsx
+++ b/src/pages/lesson-planning-new.tsx
@@ -12,6 +12,7 @@ import {
   OakBox,
   OakLink,
 } from "@oaknational/oak-components";
+import { useMemo } from "react";
 
 import { postToPostListItem, SerializedPost } from ".";
 
@@ -44,6 +45,33 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData, posts }) => {
     withImage: true,
   });
 
+  // Get proxied image URLs
+  const finalHeroUrl = useMemo(
+    () =>
+      pageData.hero.image?.asset?.url
+        ? imageBuilder
+            .image(pageData.hero.image?.asset?.url)
+            .url()
+            ?.toString()
+        : null,
+    [pageData.hero.image?.asset?.url],
+  );
+
+  const finalAuthorUrl = useMemo(
+    () =>
+      pageData.hero.author.image?.asset?.url
+        ? imageBuilder
+            .image(pageData.hero.author.image?.asset?.url)
+            .url()
+            ?.toString()
+        : null,
+    [pageData.hero.author.image?.asset?.url],
+  );
+
+  if (!finalHeroUrl || !finalAuthorUrl) {
+    return null;
+  }
+
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
       <Layout
@@ -63,12 +91,8 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData, posts }) => {
           subHeadingText={
             pageData.hero.summaryPortableText?.[0]?.children?.[0]?.text
           }
-          heroImageSrc={imageBuilder
-            .image(pageData.hero.image?.asset?.url ?? {})
-            .url()}
-          authorImageSrc={imageBuilder
-            .image(pageData.hero.author.image?.asset?.url ?? {})
-            .url()}
+          heroImageSrc={finalHeroUrl}
+          authorImageSrc={finalAuthorUrl}
           breadcrumbs={
             <Breadcrumbs
               breadcrumbs={[


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- wait for final proxied image url
- if this fixes the issue will add a piece of tech debt to move the `CMSImage` component into components library so we are not doing this in multiple places

## Issue(s)

Fixes #
Intermittent 403s on sanity images on lesson planning page

## How to test

1. Go to {owa_deployment_url}/lesson-planning-new
2. Images should load without 403s
