### PR TITLE
LESQ-847: Render teacher sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -22,6 +22,7 @@ const serversideSitemapPaths = [
   "/teachers/curriculum/sitemap.xml",
   "/teachers/key-stages/sitemap.xml",
   "/teachers/sitemap.xml",
+  "/teachers/sitemap-1.xml",
 ];
 const serversideSitemapUrls = serversideSitemapPaths.map(
   (sitemapPath) => new URL(path.join(sitemapBaseUrl, sitemapPath)).href,

--- a/src/__tests__/pages/teachers/sitemap-1.test.tsx
+++ b/src/__tests__/pages/teachers/sitemap-1.test.tsx
@@ -1,7 +1,7 @@
 import { getServerSideSitemap } from "next-sitemap";
 import { GetServerSidePropsContext } from "next";
 
-import { getServerSideProps } from "@/pages/teachers/sitemap.xml";
+import { getServerSideProps } from "@/pages/teachers/sitemap-1.xml";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 jest.mock("next-sitemap");

--- a/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
@@ -7,10 +7,11 @@ describe("teacher sitemap query", () => {
     await expect(async () => {
       await teacherSitemap({
         ...sdk,
+
         teachersSitemap: jest.fn(() =>
           Promise.resolve({ teachersSitemap: [] }),
         ),
-      })();
+      })(false);
     }).rejects.toThrow(`Resource not found`);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
@@ -7,11 +7,10 @@ describe("teacher sitemap query", () => {
     await expect(async () => {
       await teacherSitemap({
         ...sdk,
-
         teachersSitemap: jest.fn(() =>
           Promise.resolve({ teachersSitemap: [] }),
         ),
-      });
+      })();
     }).rejects.toThrow(`Resource not found`);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.test.ts
@@ -11,7 +11,7 @@ describe("teacher sitemap query", () => {
         teachersSitemap: jest.fn(() =>
           Promise.resolve({ teachersSitemap: [] }),
         ),
-      })(false);
+      });
     }).rejects.toThrow(`Resource not found`);
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.ts
@@ -10,7 +10,7 @@ const teachersSitemapSchema = z.array(
   }),
 );
 
-const teachersSitemap = (sdk: Sdk) => async () => {
+const teachersSitemap = (sdk: Sdk) => async (firstHalf: boolean) => {
   const res = await sdk.teachersSitemap();
 
   if (!res || res.teachersSitemap.length === 0) {
@@ -24,7 +24,12 @@ const teachersSitemap = (sdk: Sdk) => async () => {
     throw new OakError({ code: "curriculum-api/not-found" });
   }
 
-  return teachersSitemapSchema.parse(res.teachersSitemap);
+  const middleIndex = Math.floor(res.teachersSitemap.length / 2);
+  const selectedHalf = firstHalf
+    ? res.teachersSitemap.slice(0, middleIndex)
+    : res.teachersSitemap.slice(middleIndex);
+
+  return teachersSitemapSchema.parse(selectedHalf);
 };
 
 export default teachersSitemap;

--- a/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query.ts
@@ -10,7 +10,9 @@ const teachersSitemapSchema = z.array(
   }),
 );
 
-const teachersSitemap = (sdk: Sdk) => async (firstHalf: boolean) => {
+export type TeachersSitemap = z.infer<typeof teachersSitemapSchema>;
+
+const teachersSitemap = (sdk: Sdk) => async () => {
   const res = await sdk.teachersSitemap();
 
   if (!res || res.teachersSitemap.length === 0) {
@@ -24,12 +26,7 @@ const teachersSitemap = (sdk: Sdk) => async (firstHalf: boolean) => {
     throw new OakError({ code: "curriculum-api/not-found" });
   }
 
-  const middleIndex = Math.floor(res.teachersSitemap.length / 2);
-  const selectedHalf = firstHalf
-    ? res.teachersSitemap.slice(0, middleIndex)
-    : res.teachersSitemap.slice(middleIndex);
-
-  return teachersSitemapSchema.parse(selectedHalf);
+  return teachersSitemapSchema.parse(res.teachersSitemap);
 };
 
 export default teachersSitemap;

--- a/src/pages/teachers/sitemap-1.xml/index.tsx
+++ b/src/pages/teachers/sitemap-1.xml/index.tsx
@@ -20,14 +20,13 @@ export const generateURLFields = (urls: URLFields) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const teacherSiteMap = await curriculumApi2023.teachersSitemap();
-
   const fields = generateURLFields(teacherSiteMap);
 
   const middleIndex = Math.floor(fields.length / 2);
 
-  const firstHalf = fields.slice(0, middleIndex);
+  const secondHalf = fields.slice(middleIndex);
 
-  return getServerSideSitemap(context, firstHalf);
+  return getServerSideSitemap(context, secondHalf);
 };
 
 export default function Sitemap() {}

--- a/src/pages/teachers/sitemap-1.xml/index.tsx
+++ b/src/pages/teachers/sitemap-1.xml/index.tsx
@@ -2,31 +2,17 @@ import { GetServerSideProps } from "next";
 import { getServerSideSitemap } from "next-sitemap";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { generateURLFields } from "@/utils/generateSitemapUrlFields";
 
 /**
  * Get all sitemap url construct sitemap entries for them.
  */
 
-export type URLFields = { urls: string }[];
-
-export const generateURLFields = (urls: URLFields) => {
-  return urls.map((url) => {
-    return {
-      loc: url.urls,
-      lastmod: new Date().toISOString(),
-    };
-  });
-};
-
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const teacherSiteMap = await curriculumApi2023.teachersSitemap();
+  const teacherSiteMap = await curriculumApi2023.teachersSitemap(false);
   const fields = generateURLFields(teacherSiteMap);
 
-  const middleIndex = Math.floor(fields.length / 2);
-
-  const secondHalf = fields.slice(middleIndex);
-
-  return getServerSideSitemap(context, secondHalf);
+  return getServerSideSitemap(context, fields);
 };
 
 export default function Sitemap() {}

--- a/src/pages/teachers/sitemap-1.xml/index.tsx
+++ b/src/pages/teachers/sitemap-1.xml/index.tsx
@@ -2,15 +2,21 @@ import { GetServerSideProps } from "next";
 import { getServerSideSitemap } from "next-sitemap";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { generateURLFields } from "@/utils/generateSitemapUrlFields";
+import {
+  generateURLFields,
+  splitURLsInHalf,
+} from "@/utils/generateSitemapUrlFields";
 
 /**
  * Get all sitemap url construct sitemap entries for them.
  */
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const teacherSiteMap = await curriculumApi2023.teachersSitemap(false);
-  const fields = generateURLFields(teacherSiteMap);
+  const teacherSiteMap = await curriculumApi2023.teachersSitemap();
+
+  const sitemapData = splitURLsInHalf(teacherSiteMap, false);
+
+  const fields = generateURLFields(sitemapData);
 
   return getServerSideSitemap(context, fields);
 };

--- a/src/pages/teachers/sitemap.xml/index.tsx
+++ b/src/pages/teachers/sitemap.xml/index.tsx
@@ -2,32 +2,18 @@ import { GetServerSideProps } from "next";
 import { getServerSideSitemap } from "next-sitemap";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { generateURLFields } from "@/utils/generateSitemapUrlFields";
 
 /**
  * Get all sitemap url construct sitemap entries for them.
  */
 
-export type URLFields = { urls: string }[];
-
-export const generateURLFields = (urls: URLFields) => {
-  return urls.map((url) => {
-    return {
-      loc: url.urls,
-      lastmod: new Date().toISOString(),
-    };
-  });
-};
-
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const teacherSiteMap = await curriculumApi2023.teachersSitemap();
+  const teacherSiteMap = await curriculumApi2023.teachersSitemap(true);
 
   const fields = generateURLFields(teacherSiteMap);
 
-  const middleIndex = Math.floor(fields.length / 2);
-
-  const firstHalf = fields.slice(0, middleIndex);
-
-  return getServerSideSitemap(context, firstHalf);
+  return getServerSideSitemap(context, fields);
 };
 
 export default function Sitemap() {}

--- a/src/pages/teachers/sitemap.xml/index.tsx
+++ b/src/pages/teachers/sitemap.xml/index.tsx
@@ -2,16 +2,21 @@ import { GetServerSideProps } from "next";
 import { getServerSideSitemap } from "next-sitemap";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { generateURLFields } from "@/utils/generateSitemapUrlFields";
+import {
+  generateURLFields,
+  splitURLsInHalf,
+} from "@/utils/generateSitemapUrlFields";
 
 /**
  * Get all sitemap url construct sitemap entries for them.
  */
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const teacherSiteMap = await curriculumApi2023.teachersSitemap(true);
+  const teacherSiteMap = await curriculumApi2023.teachersSitemap();
 
-  const fields = generateURLFields(teacherSiteMap);
+  const sitemapData = splitURLsInHalf(teacherSiteMap, true);
+
+  const fields = generateURLFields(sitemapData);
 
   return getServerSideSitemap(context, fields);
 };

--- a/src/utils/generateSitemapUrlFields.test.tsx
+++ b/src/utils/generateSitemapUrlFields.test.tsx
@@ -1,4 +1,8 @@
-import { generateURLFields, URLFields } from "@/utils/generateSitemapUrlFields";
+import {
+  generateURLFields,
+  splitURLsInHalf,
+  URLFields,
+} from "@/utils/generateSitemapUrlFields";
 
 describe("generateURLFields function", () => {
   it("should map each url.urls to loc and generate a lastmod date", () => {
@@ -42,5 +46,30 @@ describe("generateURLFields function", () => {
     ];
     const result = generateURLFields(urls);
     expect(result[0]?.lastmod).toBe(result[1]?.lastmod);
+  });
+});
+
+describe("splitURLsInHalf", () => {
+  const urls = [
+    { urls: "url1" },
+    { urls: "url2" },
+    { urls: "url3" },
+    { urls: "url4" },
+  ];
+  it("should return the first half of the array when firstHalf is true", () => {
+    const result = splitURLsInHalf(urls, true);
+    expect(result).toEqual([{ urls: "url1" }, { urls: "url2" }]);
+  });
+
+  it("should return the second half of the array when firstHalf is false", () => {
+    const result = splitURLsInHalf(urls, false);
+    expect(result).toEqual([{ urls: "url3" }, { urls: "url4" }]);
+  });
+
+  it("should handle odd-length arrays correctly", () => {
+    const resultFirstHalf = splitURLsInHalf(urls.slice(0, 3), true);
+    const resultSecondHalf = splitURLsInHalf(urls.slice(0, 3), false);
+    expect(resultFirstHalf).toEqual([{ urls: "url1" }]);
+    expect(resultSecondHalf).toEqual([{ urls: "url2" }, { urls: "url3" }]);
   });
 });

--- a/src/utils/generateSitemapUrlFields.test.tsx
+++ b/src/utils/generateSitemapUrlFields.test.tsx
@@ -1,0 +1,46 @@
+import { generateURLFields, URLFields } from "@/utils/generateSitemapUrlFields";
+
+describe("generateURLFields function", () => {
+  it("should map each url.urls to loc and generate a lastmod date", () => {
+    const urls = [
+      { urls: "https://example.com" },
+      { urls: "https://example.org" },
+    ];
+    const result = generateURLFields(urls);
+    expect(result.length).toBe(urls.length);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        loc: "https://example.com",
+        lastmod: expect.any(String),
+      }),
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        loc: "https://example.org",
+        lastmod: expect.any(String),
+      }),
+    );
+  });
+
+  it("should handle an empty array", () => {
+    const urls = [] as URLFields;
+    const result = generateURLFields(urls);
+    expect(result).toEqual([]);
+  });
+
+  it("should generate an ISO date string for lastmod", () => {
+    const urls = [{ urls: "https://example.com" }];
+    const result = generateURLFields(urls);
+    const dateRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
+    expect(result[0]?.lastmod).toMatch(dateRegex);
+  });
+
+  it("should generate the same lastmod date for all URLs in a single call", () => {
+    const urls = [
+      { urls: "https://example.com" },
+      { urls: "https://example.org" },
+    ];
+    const result = generateURLFields(urls);
+    expect(result[0]?.lastmod).toBe(result[1]?.lastmod);
+  });
+});

--- a/src/utils/generateSitemapUrlFields.ts
+++ b/src/utils/generateSitemapUrlFields.ts
@@ -1,3 +1,5 @@
+import { TeachersSitemap } from "@/node-lib/curriculum-api-2023/queries/teachersSitemap/teacherSitemap.query";
+
 export type URLFields = { urls: string }[];
 
 export const generateURLFields = (urls: URLFields) => {
@@ -7,4 +9,9 @@ export const generateURLFields = (urls: URLFields) => {
       lastmod: new Date().toISOString(),
     };
   });
+};
+
+export const splitURLsInHalf = (urls: TeachersSitemap, firstHalf: boolean) => {
+  const middleIndex = Math.floor(urls.length / 2);
+  return firstHalf ? urls.slice(0, middleIndex) : urls.slice(middleIndex);
 };

--- a/src/utils/generateSitemapUrlFields.ts
+++ b/src/utils/generateSitemapUrlFields.ts
@@ -1,0 +1,10 @@
+export type URLFields = { urls: string }[];
+
+export const generateURLFields = (urls: URLFields) => {
+  return urls.map((url) => {
+    return {
+      loc: url.urls,
+      lastmod: new Date().toISOString(),
+    };
+  });
+};


### PR DESCRIPTION
## Description

Music year: 1950

- Adds a second sitemap page and breaks into half to prevent the crashing of a single page
- Additional functions and test files or halving URL added
- Adds the second sitemap page to the config

## Issue(s)

Fixes #LESQ-847

## How to test

1. Go to https://deploy-preview-2455--oak-web-application.netlify.thenational.academy/teachers/sitemap.xml
1. https://deploy-preview-2455--oak-web-application.netlify.thenational.academy/teachers/sitemap-1.xml
2. Should have the sitemap rendering

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
