### PR TITLE
fix: a11y colour contrast [LESQ-759]

### DIFF
--- a/src/components/SharedComponents/CategoryFilterList/CategoryFilterListItem.tsx
+++ b/src/components/SharedComponents/CategoryFilterList/CategoryFilterListItem.tsx
@@ -61,10 +61,10 @@ const CategoryFilterListItem = <T extends CategoryLinkProps>(
     <OakLI
       $display="flex"
       $font={"heading-7"}
-      $opacity={isSelected ? "semi-opaque" : "opaque"}
       $position="relative"
       $overflow="visible"
       $alignItems="center"
+      $color={!isSelected ? "black" : "grey60"}
       $mb="space-between-xs"
     >
       <OwaLink


### PR DESCRIPTION
## Description

Music year: 1985
[Ticket](https://www.notion.so/oaknationalacademy/I-want-colours-with-high-enough-contrast-c9efbbf4e46d454fa6c42515cec66974?pvs=4)
- use a predefined colour (`grey60`) instead of opacity (50%) for selected filter list item on unit listing thread list

## Issue(s)

Fixes #
Insufficient contrast between text and background colour

## How to test

1. Go to https://deploy-preview-2461--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks3/units
3. You should see the colour of the selected filter item satisfies a11y guidelines

## Screenshots

How it used to look (delete if n/a):
<img width="500" alt="Screenshot 2024-06-03 at 13 39 08" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/d134faf9-33e1-45f0-bcb5-aaada1ec0695">


How it should now look:
<img width="500" alt="Screenshot 2024-06-03 at 13 41 18" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/7f6cce93-6633-4fe8-b3fd-ec70c221d5d2">

