### PR TITLE
PUPIL-720 feat(subjects): fix padding on subject list

### DIFF
--- a/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
+++ b/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
@@ -54,7 +54,7 @@ export const PupilViewsSubjectListing = ({
         $flexDirection={"column"}
         $alignItems={"center"}
       >
-        <OakHeading $font={"heading-5"} tag="h1">
+        <OakHeading $font={["heading-6", "heading-5"]} tag="h1">
           Now choose a subject
         </OakHeading>
 

--- a/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
+++ b/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
@@ -45,7 +45,8 @@ export const PupilViewsSubjectListing = ({
     >
       <OakFlex
         $background={"bg-primary"}
-        $pa={"inner-padding-xl"}
+        $pt={["inner-padding-xl5", "inner-padding-xl7"]}
+        $ph={["inner-padding-l", "inner-padding-xl"]}
         $borderRadius={"border-radius-l"}
         $ba={"border-solid-s"}
         $borderColor={"border-decorative1-stronger"}


### PR DESCRIPTION
## Description

Music year: 2010

fix padding on subject list

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2462--oak-web-application.netlify.thenational.academy
3. You should see correct padding

## Screenshots

<img width="293" alt="Screenshot 2024-06-03 at 15 23 13" src="https://github.com/oaknational/Oak-Web-Application/assets/48293828/25978fe1-f81e-4841-90ee-ca4104d02111">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
