### PR TITLE
[CUR-639] Update `webpack-dev-middleware` as per security warning in github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52501,9 +52501,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.1.tgz",
-      "integrity": "sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.3.tgz",
+      "integrity": "sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",


### PR DESCRIPTION
## Description

- Updated `webpack-dev-middleware` as per https://github.com/oaknational/Oak-Web-Application/security/dependabot/93

## Issue(s)

`CUR-639`

## How to test
Check storybook and tests (which this module is a dep of) works ok.
