### PR TITLE
[CUR-643] Update `follow-redirects` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30331,9 +30331,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Description

- Updated `follow-redirects` as per https://github.com/oaknational/Oak-Web-Application/security/dependabot/92

See https://github.com/follow-redirects/follow-redirects/compare/v1.15.3...v1.15.6 for dependency changes

## Issue(s)

`CUR-643`

## How to test
Minor changes to redirects shouldn't effect our users. To test generally check app works as expected 