### PR TITLE
chore: update mux video player [LESQ-900]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^8.5.1",
-        "@mux/mux-player-react": "^2.6.0",
+        "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
         "@oaknational/oak-components": "^0.38.0",
         "@oaknational/oak-curriculum-schema": "^1.9.0",
         "@portabletext/react": "^3.0.11",
@@ -7225,22 +7225,22 @@
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.6.0.tgz",
-      "integrity": "sha512-UYDBa1t+3B81Gd0ksOMROd2kx0U6auGOGW1PHh7m74EB+HMYTgYx8PtMYT4kqbQ83evAFBTMxedNuJ14FyzmlA==",
+      "version": "2.7.0-canary.0-7c57cdd",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.7.0-canary.0-7c57cdd.tgz",
+      "integrity": "sha512-wjpE4H88Kv7T+FC0VAezU9kDEWqHyBia+gifPacy0XsJmackfa6GnPq91edrHYUbMPM7634/MXZCqcSBpevuww==",
       "dependencies": {
-        "@mux/mux-video": "0.18.1",
-        "@mux/playback-core": "0.23.1",
-        "media-chrome": "~3.2.1"
+        "@mux/mux-video": "0.19.0-canary.0-7c57cdd",
+        "@mux/playback-core": "0.24.0-canary.0-7c57cdd",
+        "media-chrome": "~3.2.3"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.6.0.tgz",
-      "integrity": "sha512-OtT44Mv3vhhMAuAFLGR1SVuohsCa1hWedW4ro108Z83kzEb0DW7p4q4Z+44eih4N8fkHunn2vKDoszNhCc83zw==",
+      "version": "2.7.0-canary.0-7c57cdd",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.7.0-canary.0-7c57cdd.tgz",
+      "integrity": "sha512-/N/bQvvp2bEq8SxHp3MXjbgOac81dpjzxfP+FJ9Qt4SmTnLl6gosNZgTipUhPomFSLs8tO/KE/z5zZ/EruQBNw==",
       "dependencies": {
-        "@mux/mux-player": "2.6.0",
-        "@mux/playback-core": "0.23.1",
+        "@mux/mux-player": "2.7.0-canary.0-7c57cdd",
+        "@mux/playback-core": "0.24.0-canary.0-7c57cdd",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -7258,22 +7258,22 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.18.1.tgz",
-      "integrity": "sha512-Q8dc8h4Kv9rEDQJzNOs/bmu8iMBRyd6VDOkvyGYgUNt0ddgeMl1IFFM2Keiq9tJ6JeHpyFqXRMFeo3mZxMzCrw==",
+      "version": "0.19.0-canary.0-7c57cdd",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.19.0-canary.0-7c57cdd.tgz",
+      "integrity": "sha512-yHwO391+qr5VMNswUpnNg185I+T6sEnKS1FZfopju1B5pce9LJ8mJcB64SuXl1jn5FVs9ev4wiAbUTmfSjBxIQ==",
       "dependencies": {
-        "@mux/playback-core": "0.23.1",
-        "castable-video": "~1.0.6",
-        "custom-media-element": "~1.2.3",
-        "media-tracks": "~0.3.0"
+        "@mux/playback-core": "0.24.0-canary.0-7c57cdd",
+        "castable-video": "~1.0.9",
+        "custom-media-element": "~1.3.1",
+        "media-tracks": "~0.3.2"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.23.1.tgz",
-      "integrity": "sha512-2sPwjUkxZ4vQLr9igAEw0P7fwPC0PmVORn/Mlewlsbn2fPlYkv1XNKFQ5eFny9HLkNSlRCI9cJDg0xVRIXdpMw==",
+      "version": "0.24.0-canary.0-7c57cdd",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.24.0-canary.0-7c57cdd.tgz",
+      "integrity": "sha512-fVT/JUUgX+ZpJ562HREzTYoOxk6BDbgSZaXmiKx1rDVDfPd4UoiQ+y/caU5kVnMEf3qsIaS0L6nBayex/jjYww==",
       "dependencies": {
-        "hls.js": "~1.5.8",
+        "hls.js": "~1.5.11",
         "mux-embed": "~5.2.0"
       }
     },
@@ -24526,17 +24526,12 @@
       }
     },
     "node_modules/castable-video": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.7.tgz",
-      "integrity": "sha512-n+evSJbDZCBIS/TGD5quVy2EQusEiOcQZ+H/CrVqTYAUqKgAgvGRLBO88Oox9l60OCW2iYJDEmp4Y5jp/Xhsng==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.9.tgz",
+      "integrity": "sha512-VOdme8f2FPSj7Ej+xC/zy1pRlngbqdz/IGHB36dAfj5RNiMCU2eLfVAKN+fi/wSz0+f1PTvee/bM54SaNBV8QQ==",
       "dependencies": {
-        "custom-media-element": "~1.3.0"
+        "custom-media-element": "~1.3.1"
       }
-    },
-    "node_modules/castable-video/node_modules/custom-media-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.3.0.tgz",
-      "integrity": "sha512-Kgi7u8oOZYhSdaV2/hTEfiPap1QdFUfaQjZiL6cFQmiGKU88P8PnAwic7UXInzTdyZyLb9DnjCAiTskh63jzMg=="
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -26296,9 +26291,9 @@
       "dev": true
     },
     "node_modules/custom-media-element": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.2.3.tgz",
-      "integrity": "sha512-xr9Hbrslkjm1fapJP5hL98pySeZmNepBSefQS/XTxynamqPTfRBK5MnhReMOiAj8xvJApVPrVnlYxIrknay8jg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.3.1.tgz",
+      "integrity": "sha512-SOBa/dtxVgEoEu0JMictlnXx0nNUgvuTuZ7ggFeOIzJWmQUPF4gQ/fsvEZycIyQ7JEnwfyEn74+n1a+mzU3A9A=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -32184,9 +32179,9 @@
       "dev": true
     },
     "node_modules/hls.js": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.8.tgz",
-      "integrity": "sha512-hJYMPfLhWO7/7+n4f9pn6bOheCGx0WgvVz7k3ouq3Pp1bja48NN+HeCQu3XCGYzqWQF/wo7Sk6dJAyWVJD8ECA=="
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.11.tgz",
+      "integrity": "sha512-q3We1izi2+qkOO+TvZdHv+dx6aFzdtk3xc1/Qesrvto4thLTT/x/1FK85c5h1qZE4MmMBNgKg+MIW8nxQfxwBw=="
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -38488,9 +38483,9 @@
       "dev": true
     },
     "node_modules/media-chrome": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.2.tgz",
-      "integrity": "sha512-Fjf1rNxlZqVR5nj7a9ay+XpzeKVPMMBltK2XiMOTc5bomxAvyo3vJZ9JKzmAYVoiZ6sbDNWJJVSVf6b3laFwew=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.3.tgz",
+      "integrity": "sha512-DlOlyciT5YgOn5cwGvLWz+OVUVgvyxsRLtfpIQJ11F10+Ix7tDjEqMWsnkL81be9iD3uh/SN35TIk2pRvvEAig=="
     },
     "node_modules/media-tracks": {
       "version": "0.3.2",
@@ -41463,6 +41458,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/glob/node_modules/minipass": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^8.5.1",
-    "@mux/mux-player-react": "^2.6.0",
+    "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
     "@oaknational/oak-components": "^0.38.0",
     "@oaknational/oak-curriculum-schema": "^1.9.0",
     "@portabletext/react": "^3.0.11",


### PR DESCRIPTION
## Description

Music year: 1963

- update to canary version of mux-video-player-react at the recommendation of mux to try and resolve t[he errors we're seeing on Mac/Ios](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/66422ed418f4d300089ccdb8?filters[event.unhandled]=true&filters[event.since]=30d&filters[app.release_stage]=production&sort=events)


## How to test

1. Go to https://deploy-preview-2480--oak-web-application.netlify.thenational.academy
2. Go to a teacher lesson and make sure video works
3. Same for pupils video and CMS video (eg in blogs)

## Checklist

- [ ]  mux dependency is updated
- [ ]  videos still play across the site on supported browsers
    - [ ]  teacher lesson overview
    - [ ]  pupil video
    - [ ]  CMS videos