### PR TITLE
[CUR-516] Fix protocol in curriculum sitemap

### DIFF
--- a/src/node-lib/curriculum-api-2023/fixtures/curriculumSiteMap.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/curriculumSiteMap.fixture.ts
@@ -1,106 +1,106 @@
 export const generatedFields = [
   {
-    loc: "http:/example.com/teachers/curriculum/english-primary/overview",
+    loc: "http://example.com/teachers/curriculum/english-primary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/english-secondary-aqa/overview",
+    loc: "http://example.com/teachers/curriculum/english-secondary-aqa/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/english-secondary-edexcel/overview",
+    loc: "http://example.com/teachers/curriculum/english-secondary-edexcel/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/geography-primary/overview",
+    loc: "http://example.com/teachers/curriculum/geography-primary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/geography-secondary/overview",
+    loc: "http://example.com/teachers/curriculum/geography-secondary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-primary/overview",
+    loc: "http://example.com/teachers/curriculum/history-primary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-secondary-aqa/overview",
+    loc: "http://example.com/teachers/curriculum/history-secondary-aqa/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-secondary-edexcel/overview",
+    loc: "http://example.com/teachers/curriculum/history-secondary-edexcel/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/maths-primary/overview",
+    loc: "http://example.com/teachers/curriculum/maths-primary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/maths-secondary/overview",
+    loc: "http://example.com/teachers/curriculum/maths-secondary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/music-secondary/overview",
+    loc: "http://example.com/teachers/curriculum/music-secondary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/science-primary/overview",
+    loc: "http://example.com/teachers/curriculum/science-primary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/science-secondary/overview",
+    loc: "http://example.com/teachers/curriculum/science-secondary/overview",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/english-primary/units",
+    loc: "http://example.com/teachers/curriculum/english-primary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/english-secondary-aqa/units",
+    loc: "http://example.com/teachers/curriculum/english-secondary-aqa/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/english-secondary-edexcel/units",
+    loc: "http://example.com/teachers/curriculum/english-secondary-edexcel/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/geography-primary/units",
+    loc: "http://example.com/teachers/curriculum/geography-primary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/geography-secondary/units",
+    loc: "http://example.com/teachers/curriculum/geography-secondary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-primary/units",
+    loc: "http://example.com/teachers/curriculum/history-primary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-secondary-aqa/units",
+    loc: "http://example.com/teachers/curriculum/history-secondary-aqa/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/history-secondary-edexcel/units",
+    loc: "http://example.com/teachers/curriculum/history-secondary-edexcel/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/maths-primary/units",
+    loc: "http://example.com/teachers/curriculum/maths-primary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/maths-secondary/units",
+    loc: "http://example.com/teachers/curriculum/maths-secondary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/music-secondary/units",
+    loc: "http://example.com/teachers/curriculum/music-secondary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/science-primary/units",
+    loc: "http://example.com/teachers/curriculum/science-primary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
   {
-    loc: "http:/example.com/teachers/curriculum/science-secondary/units",
+    loc: "http://example.com/teachers/curriculum/science-secondary/units",
     lastmod: "2023-10-18T15:14:41.553Z",
   },
 ];

--- a/src/pages/teachers/curriculum/sitemap.xml/index.tsx
+++ b/src/pages/teachers/curriculum/sitemap.xml/index.tsx
@@ -46,13 +46,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const fields = [];
   for (const tab of ["overview", "units"]) {
     for (const slug of curriculumPathSlugs) {
+      const url = new URL(sitemapBaseUrl);
+      url.pathname = path.join(basePath, slug, tab);
+
       fields.push({
-        loc: path.join(sitemapBaseUrl, basePath, slug, tab),
+        loc: url.href,
         lastmod: new Date().toISOString(),
       });
     }
   }
-
   return getServerSideSitemap(context, fields);
 };
 


### PR DESCRIPTION
## Description
The curriculum sitemap had `https:/` rather than `https://` because it was using `path.join(...)` with strips out duplicate slashes `/`

## Issue(s)

`CUR-516`

## How to test

1. Go to https://deploy-preview-2481--oak-web-application.netlify.thenational.academy/teachers/curriculum/sitemap.xml
2. Check the sitemap has the correct protocol
