### PR TITLE
[FEC-73] Change npm version in engine field to get dependabot running again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
       },
       "engines": {
         "node": ">=20 <21",
-        "npm": ">=10"
+        "npm": ">=9.6.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -41457,15 +41457,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "7.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
   },
   "engines": {
     "node": ">=20 <21",
-    "npm": ">=10"
+    "npm": ">=9.6.5"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
## Description
As mentioned in https://github.com/dependabot/dependabot-core/issues/9277#issue-2183840900 hopefully changing the `npm` version in the `engine` field to `>=9.6.5` will get dependabot running again and creating PRs.

The original error we're trying to overcome is

```
Dependabot uses Node.js v20.14.0
 and NPM 10.7.0
. Due to the engine-strict setting, the update will not succeed.
```

## Issue(s)
`FEC-73`

## How to test
We can't test the actual fix prior to merge, hopefully it'll work once merged and dependabot will start working again.

With regards to the deployed code, nothing should change as our github action workflows run with particular versions of node/npm anyway.