### PR TITLE
feat: improve aria form error messaging - LESQ-758

### DIFF
--- a/src/components/GenericPagesComponents/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/GenericPagesComponents/NewsletterForm/NewsletterForm.tsx
@@ -79,6 +79,7 @@ const NewsletterForm: FC<NewsletterFormProps> = ({
 
   return (
     <Form
+      noValidate
       onSubmit={handleSubmit(async (data) => {
         setLoading(true);
         setError("");

--- a/src/components/SharedComponents/FieldError/FieldError.tsx
+++ b/src/components/SharedComponents/FieldError/FieldError.tsx
@@ -10,6 +10,7 @@ type FieldErrorProps = {
   children: ReactNode;
   withoutMarginBottom?: boolean;
   variant?: FieldErrorVariant | null;
+  ariaLive?: "off" | "polite" | "assertive";
 };
 
 const FieldError = (props: FieldErrorProps) => {
@@ -34,6 +35,7 @@ const FieldError = (props: FieldErrorProps) => {
         $color="red"
         $font={variant === "large" ? ["body-2-bold", "body-1-bold"] : "body-2"}
         id={id}
+        aria-live={props.ariaLive || "off"}
       >
         {children}
       </OakSpan>

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -149,6 +149,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
                     data-testid="download-error"
                     variant={"large"}
                     withoutMarginBottom
+                    ariaLive="polite"
                   >
                     {props.apiError}
                   </FieldError>

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -95,7 +95,9 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
           labelText={"My school isn't listed"}
           data-testid={"checkbox-download"}
           aria-invalid={errors?.school?.message ? true : false}
-          aria-describedby={"school-error"}
+          aria-describedby={
+            errors?.school?.message ? "school-error" : undefined
+          }
         />
       </OakFlex>
     </>

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -81,6 +81,8 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
         label={"School"}
         setSelectedSchool={setSelectedSchool}
         required={true}
+        aria-invalid={errors?.school?.message ? true : false}
+        aria-describedby={"school-error"}
       />
       <OakFlex $mt="space-between-xs" $mb="space-between-m2">
         <Checkbox
@@ -92,6 +94,8 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
           zIndex={"neutral"}
           labelText={"My school isn't listed"}
           data-testid={"checkbox-download"}
+          aria-invalid={errors?.school?.message ? true : false}
+          aria-describedby={"school-error"}
         />
       </OakFlex>
     </>

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/ResourcePageSchoolPicker.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/ResourcePageSchoolPicker.tsx
@@ -15,6 +15,7 @@ type ResourcePageSchoolPickerProps = Omit<
   label: string;
   hasError: boolean;
   required?: boolean;
+  errorId?: string;
 };
 
 export type School = {
@@ -38,6 +39,7 @@ export type School = {
 const ResourcePageSchoolPicker: FC<ResourcePageSchoolPickerProps> = (props) => {
   return (
     <ResourcePageSearchComboBox
+      errorId={props.errorId}
       hasError={props.hasError}
       label={props.label}
       inputValue={props.schoolPickerInputValue}

--- a/src/components/TeacherComponents/ResourcePageSearchComboBox/ResourcePageSearchComboBox.tsx
+++ b/src/components/TeacherComponents/ResourcePageSearchComboBox/ResourcePageSearchComboBox.tsx
@@ -22,7 +22,11 @@ import BoxBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BoxB
 // Reuse the ListBox and Popover from your component library. See below for details.
 
 const ResourcePageSearchComboBox = <T extends School>(
-  props: ComboBoxStateOptions<T> & { hasError?: boolean; required?: boolean },
+  props: ComboBoxStateOptions<T> & {
+    hasError?: boolean;
+    required?: boolean;
+    errorId?: string;
+  },
 ) => {
   // Setup filter function and state.
   const { contains } = useFilter({ sensitivity: "base" });
@@ -98,8 +102,9 @@ const ResourcePageSearchComboBox = <T extends School>(
           aria-labelledby={labelId}
           data-testid={"search-combobox-input"}
           placeholder={"Type school name, postcode, or ‘homeschool’"}
-          aria-describedby={undefined}
+          aria-describedby={props.errorId ? props.errorId : undefined}
           required={required}
+          aria-invalid={hasError}
         />
         <DropdownFocusUnderline
           isFocusVisible={state.isFocused}

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
@@ -16,7 +16,7 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
   <>
     {errorMessage && (
       <Box $mb={16}>
-        <FieldError id={"terms-error"} withoutMarginBottom>
+        <FieldError ariaLive="polite" id={"terms-error"} withoutMarginBottom>
           {errorMessage}
         </FieldError>
       </Box>

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -60,7 +60,9 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
         Your details
       </OakHeading>
       {form?.errors.school && (
-        <FieldError id="school-error">{form.errors.school?.message}</FieldError>
+        <FieldError ariaLive="polite" id="school-error">
+          {form.errors.school?.message}
+        </FieldError>
       )}
       {isLoading && (
         <OakP $mb={"space-between-m"} data-testid="loading">


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Turns browser validation off for newsletter form (this was blocking custom form messages)
- Adds area live option for field error (on downloads and share where button is disabled this will read out errors to user)
- Adds aria invalid to school group 
- Adds described by to resources page inputs



## How to test

Users using screen reader should be notified of errors

1. Go to https://deploy-preview-2485--oak-web-application.netlify.thenational.academy
- newsletter form  - https://deploy-preview-2485--oak-web-application.netlify.thenational.academy/#teachers
- downloads form - https://deploy-preview-2485--oak-web-application.netlify.thenational.academy/teachers/programmes/computing-non-gcse-secondary-ks4-l/units/it-and-the-world-of-work-c47e/lessons/the-modern-world-of-work-65jpcd/downloads?preselected=all



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
