### PR TITLE
Feat/lesq 762/screen reader resource types [LESQ-762]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -167,7 +167,9 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       // Lesson resources to download
       const lessonResourcesToDownload = screen.getAllByTestId("resourceCard");
       expect(lessonResourcesToDownload.length).toEqual(2);
-      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions");
+      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions", {
+        exact: false,
+      });
 
       expect(exitQuizQuestions).toBeInTheDocument();
       expect(exitQuizQuestions).toHaveAttribute("name", "resources");
@@ -221,8 +223,12 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       const selectAllCheckbox = getByRole("checkbox", { name: "Select all" });
       expect(selectAllCheckbox).toBeChecked();
 
-      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions");
-      const exitQuizAnswers = screen.getByLabelText("Exit quiz answers");
+      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions", {
+        exact: false,
+      });
+      const exitQuizAnswers = screen.getByLabelText("Exit quiz answers", {
+        exact: false,
+      });
 
       expect(exitQuizQuestions).toBeChecked();
       expect(exitQuizAnswers).toBeChecked();
@@ -235,8 +241,12 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       const user = userEvent.setup();
       await user.click(selectAllCheckbox);
 
-      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions");
-      const exitQuizAnswers = screen.getByLabelText("Exit quiz answers");
+      const exitQuizQuestions = screen.getByLabelText("Exit quiz questions", {
+        exact: false,
+      });
+      const exitQuizAnswers = screen.getByLabelText("Exit quiz answers", {
+        exact: false,
+      });
       expect(exitQuizQuestions).not.toBeChecked();
       expect(exitQuizAnswers).not.toBeChecked();
     });

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
@@ -146,6 +146,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
     id,
     name,
     label,
+    subtitle,
     onBlur,
     hasError = false,
     useRadio = false,
@@ -176,7 +177,9 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
           onChange={onChange}
           variant={"withoutLabel"}
           slim={true}
-          ariaLabel={label}
+          ariaLabel={`${label} ${
+            subtitle === "PPTX" ? "powerpoint" : subtitle
+          }`}
           onBlur={onBlur}
           hasError={hasError}
         >


### PR DESCRIPTION
## Description

Music year: 1955

- updates aria label on resource card checkboxes to include resource type
- change 'pptx' to 'powerpoint' for readability

## How to test

1. Go to https://deploy-preview-2487--oak-web-application.netlify.thenational.academy/teachers/programmes/chemistry-secondary-ks4-foundation-edexcel/units/atomic-structure-and-the-periodic-table/lessons/atomic-structure-negligible-electron-mass/downloads?preselected=all
2. Use screen reader to select checkboxes
3. You should get the resource file format along with resource type


## Checklist

- [ ] Resource cards on download page should include file type in the screen reader label
- [ ] powerpoint files should be read as 'powerpoint' not 'pptx'
