### PR TITLE
Lesq 751   radio buttons in fieldset with legend - LESQ-751

### DIFF
--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -97,6 +97,7 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
       </OakFlex>
       <ButtonAsLink
         label="Preview as a pupil"
+        aria-label="Share lesson with pupils"
         icon="external"
         $iconPosition="trailing"
         variant="minimal"

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -97,7 +97,6 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
       </OakFlex>
       <ButtonAsLink
         label="Preview as a pupil"
-        aria-label="Share lesson with pupils"
         icon="external"
         $iconPosition="trailing"
         variant="minimal"

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -11,6 +11,7 @@ import {
   OakP,
   OakUL,
   OakFlex,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import { ResourceFormProps } from "@/components/TeacherComponents/types/downloadAndShare.types";
@@ -69,28 +70,44 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
           $flexDirection={["column", "column", "row"]}
           $gap="all-spacing-9"
         >
-          <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
-            <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>
-              {props.resourcesHeader}
-            </OakHeading>
-            <FieldError id={"downloads-error"} withoutMarginBottom>
-              {props.errors?.resources?.message}
-            </FieldError>
-            {!props.hideSelectAll && (
-              <Box $maxWidth="max-content">
-                <Checkbox
-                  checked={props.selectAllChecked}
-                  onChange={props.handleToggleSelectAll}
-                  id="select-all"
-                  name="select-all"
-                  variant="withLabel"
-                  labelText="Select all"
-                  labelFontWeight={600}
-                />
-              </Box>
-            )}
-            {props.cardGroup}
-          </Flex>
+          <OakBox
+            $pa={"inner-padding-none"}
+            $ba={"border-solid-none"}
+            as="fieldset"
+          >
+            <OakBox
+              as="legend"
+              $position="absolute"
+              $width="all-spacing-0"
+              $height="all-spacing-0"
+              $pa={"inner-padding-none"}
+              $overflow="hidden"
+            >
+              {`${props.page} ${props.resourcesHeader} checkbox's`}
+            </OakBox>
+            <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
+              <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>
+                {props.resourcesHeader}
+              </OakHeading>
+              <FieldError id={"downloads-error"} withoutMarginBottom>
+                {props.errors?.resources?.message}
+              </FieldError>
+              {!props.hideSelectAll && (
+                <Box $maxWidth="max-content">
+                  <Checkbox
+                    checked={props.selectAllChecked}
+                    onChange={props.handleToggleSelectAll}
+                    id="select-all"
+                    name="select-all"
+                    variant="withLabel"
+                    labelText="Select all"
+                    labelFontWeight={600}
+                  />
+                </Box>
+              )}
+              {props.cardGroup}
+            </Flex>
+          </OakBox>
           <Flex
             $flexDirection="column"
             $alignSelf="center"

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -73,18 +73,20 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
           <OakBox
             $pa={"inner-padding-none"}
             $ba={"border-solid-none"}
-            as="fieldset"
+            as={props.page === "download" ? "fieldset" : "box"}
           >
-            <OakBox
-              as="legend"
-              $position="absolute"
-              $width="all-spacing-0"
-              $height="all-spacing-0"
-              $pa={"inner-padding-none"}
-              $overflow="hidden"
-            >
-              {`${props.page} ${props.resourcesHeader}`}
-            </OakBox>
+            {props.page === "download" && (
+              <OakBox
+                as="legend"
+                $position="absolute"
+                $width="all-spacing-0"
+                $height="all-spacing-0"
+                $pa={"inner-padding-none"}
+                $overflow="hidden"
+              >
+                {`Select resources to ${props.page}`}
+              </OakBox>
+            )}
             <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
               <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>
                 {props.resourcesHeader}

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -83,7 +83,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
               $pa={"inner-padding-none"}
               $overflow="hidden"
             >
-              {`${props.page} ${props.resourcesHeader} checkbox's`}
+              {`${props.page} ${props.resourcesHeader}`}
             </OakBox>
             <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
               <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -96,7 +96,6 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
         <Checkbox
           checked={checkboxValue}
           onChange={onCheckboxChange}
-          // aria-label={"my school isn't listed"}
           id={`checkbox-not-listed`}
           name={"checkbox-not-listed"}
           zIndex={"neutral"}

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -96,7 +96,7 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
         <Checkbox
           checked={checkboxValue}
           onChange={onCheckboxChange}
-          aria-label={"my school isn't listed"}
+          // aria-label={"my school isn't listed"}
           id={`checkbox-not-listed`}
           name={"checkbox-not-listed"}
           zIndex={"neutral"}

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import { FieldErrorsImpl } from "react-hook-form";
-import { OakFlex } from "@oaknational/oak-components";
+import { OakBox, OakFlex } from "@oaknational/oak-components";
 
 import ResourcePageSchoolPicker from "@/components/TeacherComponents/ResourcePageSchoolPicker";
 import useSchoolPicker from "@/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker";
@@ -72,7 +72,17 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
     setSchoolPickerInputValue(value);
   };
   return (
-    <>
+    <OakBox $pa={"inner-padding-none"} $ba={"border-solid-none"} as="fieldset">
+      <OakBox
+        as="legend"
+        $position="absolute"
+        $width="all-spacing-0"
+        $height="all-spacing-0"
+        $pa={"inner-padding-none"}
+        $overflow="hidden"
+      >
+        School details
+      </OakBox>
       <ResourcePageSchoolPicker
         hasError={errors?.school !== undefined}
         schoolPickerInputValue={schoolPickerInputValue}
@@ -94,7 +104,7 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
           data-testid={"checkbox-download"}
         />
       </OakFlex>
-    </>
+    </OakBox>
   );
 };
 


### PR DESCRIPTION
## Description

Music year: 1960

- Add fieldset and legend to checkbox group for resources (downloads not share)
- Adds fieldset and legend to school picker and 'school not listed' checkbox 


## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2489--oak-web-application.netlify.thenational.academy
download : downloads lesson resources group should be read out 
school picker and checkbox: school details group school be read out.


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
