### PR TITLE
Fix docx -> google drive rendering issues

### DIFF
--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/__snapshots__/threadsTable.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/__snapshots__/threadsTable.test.ts.snap
@@ -139,7 +139,7 @@ exports[`threadsTablePatch should return units table 1`] = `
           "elements": [
             {
               "attributes": {
-                "w:w": "3505",
+                "w:w": "10515",
               },
               "name": "w:gridCol",
               "type": "element",

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/threadsTable.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/threadsTable.ts
@@ -99,7 +99,7 @@ export function threadsTablePatch(
                     </w:tblBorders>
                 </w:tblPr>
                 <w:tblGrid>
-                    <w:gridCol w:w="3505"/>
+                    <w:gridCol w:w="10515"/>
                 </w:tblGrid>
                 ${rows.join("")}
             </w:tbl>

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/units.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/units.ts
@@ -177,11 +177,9 @@ function buildUnitOptionTitle(
                     <w:color w:val="222222"/>
                     <w:sz w:val="32"/>
                 </w:rPr>
-                <w:t>
-                    Option ${cdata(unitOptionIndex + 1)}: ${cdata(
-                      unitOption.title,
-                    )}
-                </w:t>
+                <w:t>Option ${cdata(unitOptionIndex + 1)}: ${cdata(
+                  unitOption.title,
+                )}</w:t>
             </w:r>
 
             <w:r>

--- a/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/units.ts
+++ b/src/pages-helpers/curriculum/docx/curriculum-download-patcher/patches/units.ts
@@ -606,20 +606,7 @@ function buildUnit(
                     <w:t>Threads</w:t>
                 </w:r>
             </w:p>
-            <w:p>
-                <w:pPr>
-                    <w:widowControl w:val="0"/>
-                    <w:rPr>
-                        <w:color w:val="222222"/>
-                    </w:rPr>
-                </w:pPr>
-                <w:r>
-                    <w:rPr>
-                        <w:color w:val="222222"/>
-                    </w:rPr>
-                    <w:t>${threads}</w:t>
-                </w:r>
-            </w:p>
+            ${threads}
             <w:p>
                 <w:pPr>
                     <w:ind w:left="30" w:hanging="30"/>
@@ -702,17 +689,7 @@ function buildUnit(
                     <w:t>Lessons in unit</w:t>
                 </w:r>
             </w:p>
-            <w:p>
-                <w:pPr>
-                    <w:ind w:right="-1032"/>
-                </w:pPr>
-                <w:r>
-                    <w:rPr>
-                        <w:color w:val="222222"/>
-                    </w:rPr>
-                    <w:t>${lessons}</w:t>
-                </w:r>
-            </w:p>
+            ${lessons}
             <w:p>
                 <w:pPr>
                     <w:ind w:right="-1032"/>


### PR DESCRIPTION
## Description
Issues fixes

 - Because of invalid nesting in our docx files XML, the google drive docx-renderer was failing to render lessons/threads
 - Threads overview table was too small when rendered in google drive
 - Optionality issue with whitespace
 
 ## Screenshots
 
<img width="300" alt="Screenshot 2024-06-12 at 13 03 19" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/da2fa46c-ffd9-47ac-abc4-1385386d8f16">
<img width="300" alt="Screenshot 2024-06-12 at 12 54 07" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/b8c208b4-8f19-47d0-885f-e7d9a4e80550">


 
<img width="300" alt="Screenshot 2024-06-12 at 13 03 01" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/b0b0ba6a-020a-4afc-b601-e838977df0d0">
<img width="300" alt="Screenshot 2024-06-12 at 12 53 35" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/6c3a2ea1-5479-49a6-a7e0-d0438ff8019e">

<img width="300" alt="Screenshot 2024-06-12 at 16 24 07" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/d8a0af99-403c-4fc2-91e8-0cdd3ba52dec">
<img width="300" alt="Screenshot 2024-06-12 at 16 44 43" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/f58bb4a7-ce25-4312-be90-7ecfcf7ad7ea">



## How to test

1. Go to https://deploy-preview-2502--oak-web-application.netlify.thenational.academy/teachers/curriculum/docx-poc/select
2. Generate a document
3. Upload the google drive and check issues described above are resolved
