### PR TITLE
[PUPIL-811] Hide inline svg spritesheet

### DIFF
--- a/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSheet.tsx
+++ b/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSheet.tsx
@@ -9,7 +9,7 @@ import { FC } from "react";
 import InlineSpriteSheetSvg from "@/image-data/generated/inline-sprite.svg";
 
 const InlineSpriteSheet: FC = () => {
-  return <InlineSpriteSheetSvg />;
+  return <InlineSpriteSheetSvg width="0" height="0" />;
 };
 
 export default InlineSpriteSheet;

--- a/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSheet.tsx
+++ b/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSheet.tsx
@@ -9,7 +9,11 @@ import { FC } from "react";
 import InlineSpriteSheetSvg from "@/image-data/generated/inline-sprite.svg";
 
 const InlineSpriteSheet: FC = () => {
-  return <InlineSpriteSheetSvg width="0" height="0" />;
+  return (
+    <div style={{ display: "none" }}>
+      <InlineSpriteSheetSvg />
+    </div>
+  );
 };
 
 export default InlineSpriteSheet;


### PR DESCRIPTION
## Description

Music year: 1953

This wraps the inline svg sprite with a div and hides it. Applying the style to the sprite itself results in all the svgs within the spritesheet getting that style (seems odd I know), so the only option was to add the extra div.

This was introduced with the recent fix for the latest version of Chrome where svgs on the site stopped displaying.

## How to test

1. Go to https://deploy-preview-2515--oak-web-application.netlify.thenational.academy
2. Click on any page, there should be no svg visible at the bottom of the page.
3. Test other areas of the site to check svgs are working
4. Check if this has resolved drag and drop issue in pupil quizzes 

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off (N/A)
- [x] Approved by product owner (N/A)
- [x] Does this PR update a package with a breaking change
