### PR TITLE
[CUR-682] Added a11y skip link to curriculum visualiser

### DIFF
--- a/src/__tests__/__helpers__/renderWithProviders.tsx
+++ b/src/__tests__/__helpers__/renderWithProviders.tsx
@@ -19,6 +19,7 @@ import { MemoryRouterProvider } from "next-router-mock/MemoryRouterProvider";
 import { ThemeProvider } from "styled-components";
 import { OverlayProvider } from "react-aria";
 import { MemoryRouterProviderProps } from "next-router-mock/dist/MemoryRouterProvider/MemoryRouterProvider";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
 import "../../browser-lib/oak-globals/oakGlobals";
 import ErrorBoundary from "../../components/AppComponents/ErrorBoundary";
@@ -38,6 +39,7 @@ export type ProviderProps = {
 type ProviderPropsByName = {
   cookieConsent: { __testMockValue: CookieConsentContext };
   theme: { theme: OakTheme };
+  oakTheme: { theme: typeof oakDefaultTheme };
   errorBoundary: Record<string, never>;
   analytics: Record<string, never>;
   router: MemoryRouterProviderProps;
@@ -58,6 +60,7 @@ const providersByName: {
 } = {
   cookieConsent: [MockedCookieConsentProvider],
   theme: [ThemeProvider, { theme }],
+  oakTheme: [OakThemeProvider, { theme: oakDefaultTheme }],
   errorBoundary: [ErrorBoundary],
   analytics: [MockedAnalyticsProvider],
   router: [MemoryRouterProvider],

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -242,6 +242,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
 
   return (
     <OakGridArea
+      id="content"
       $colSpan={[12, 9]}
       data-testid="curriculum-visualiser"
       ref={visualiserRef}

--- a/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/SkipLink.stories.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/SkipLink.stories.tsx
@@ -1,0 +1,26 @@
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import { Meta, StoryObj } from "@storybook/react";
+
+import Component from ".";
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const TestComponent = () => {
+  return (
+    <OakThemeProvider theme={oakDefaultTheme}>
+      <p>There is a skip link under this paragraph</p>
+      <Component href="#testing">Skip to content</Component>
+      <p>There is a skip link above this paragraph</p>
+    </OakThemeProvider>
+  );
+};
+
+export const SkipLink: Story = {
+  render: TestComponent,
+};

--- a/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/SkipLink.test.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/SkipLink.test.tsx
@@ -1,0 +1,28 @@
+import { act } from "react-dom/test-utils";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+
+import SkipLink from ".";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+describe("SkipLink", () => {
+  test("functions as expected", async () => {
+    const { baseElement, getByTestId } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <SkipLink href="foo">test</SkipLink>
+      </OakThemeProvider>,
+    );
+
+    const element = getByTestId("skip-link");
+    expect(element.style.position).toEqual("absolute");
+    expect(element.style.left).toEqual("-10000px");
+
+    act(() => {
+      element.focus();
+    });
+
+    expect(element.style.position).toEqual("");
+    expect(element.style.left).toEqual("");
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SkipLink functions as expected 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-aXZVg sc-gFqAkR byGiag eKlxvq"
+    >
+      <div
+        class="sc-aXZVg eruIHC grey-shadow"
+      />
+      <div
+        class="sc-aXZVg eruIHC yellow-shadow"
+      />
+      <a
+        class="sc-eldPxv sc-fPXMVe exjdrA ilyVBN internal-button"
+        data-testid="skip-link"
+        href="foo"
+        style=""
+      >
+        <div
+          class="sc-aXZVg sc-gEvEer gqPLj krHAKs"
+        >
+          <span
+            class="sc-eqUAAy dBieuz"
+          >
+            test
+          </span>
+        </div>
+      </a>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/SkipLink/index.tsx
@@ -1,0 +1,30 @@
+import {
+  OakSecondaryButton,
+  OakSecondaryButtonProps,
+} from "@oaknational/oak-components";
+import { ReactNode, useState } from "react";
+
+const SkipLink = (
+  props: Omit<OakSecondaryButtonProps, "element"> & {
+    children: ReactNode;
+    href: string;
+  },
+) => {
+  const [isFocussed, setIsFocussed] = useState(false);
+  const { children, ...buttonProps } = props;
+
+  return (
+    <OakSecondaryButton
+      {...buttonProps}
+      data-testid="skip-link"
+      element="a"
+      onFocus={() => setIsFocussed(true)}
+      onBlur={() => setIsFocussed(false)}
+      style={isFocussed ? {} : { position: "absolute", left: "-10000px" }}
+    >
+      {children}
+    </OakSecondaryButton>
+  );
+};
+
+export default SkipLink;

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -17,6 +17,7 @@ import CurriculumVisualiser, {
   isVisibleUnit,
 } from "../CurriculumVisualiser/CurriculumVisualiser";
 import UnitsTabMobile from "../UnitsTabMobile/UnitsTabMobile";
+import SkipLink from "../OakComponentsKitchen/SkipLink";
 
 import Box from "@/components/SharedComponents/Box";
 import Radio from "@/components/SharedComponents/RadioButtons/Radio";
@@ -254,6 +255,7 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
                     None highlighted
                   </Radio>
                 </Box>
+                <SkipLink href="#content">Skip to units</SkipLink>
                 {threadOptions.map((threadOption) => {
                   const isSelected = isSelectedThread(threadOption);
                   const highlightedCount = highlightedUnitCount();

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -246,6 +246,7 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
                 value={selectedThread ? selectedThread.slug : ""}
                 onChange={handleSelectThread}
               >
+                <SkipLink href="#content">Skip to units</SkipLink>
                 <Box $mv={16}>
                   <Radio
                     aria-label={"None highlighted"}
@@ -255,7 +256,6 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
                     None highlighted
                   </Radio>
                 </Box>
-                <SkipLink href="#content">Skip to units</SkipLink>
                 {threadOptions.map((threadOption) => {
                   const isSelected = isSelectedThread(threadOption);
                   const highlightedCount = highlightedUnitCount();

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -6,6 +6,7 @@ import {
 } from "next";
 import React, { MutableRefObject } from "react";
 import { useRouter } from "next/router";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
 import CMSClient from "@/node-lib/cms";
 import { CurriculumOverviewSanityData } from "@/common-lib/cms-types";
@@ -148,36 +149,38 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
   }
 
   return (
-    <AppLayout
-      seoProps={{
-        ...getSeoProps({
-          title: buildCurriculumMetadata({
-            metadataType: "title",
-            subjectSlug: subjectSlug,
-            examboardSlug: examboardSlug,
-            keyStagesData: keyStagesData,
-            tab: tab,
+    <OakThemeProvider theme={oakDefaultTheme}>
+      <AppLayout
+        seoProps={{
+          ...getSeoProps({
+            title: buildCurriculumMetadata({
+              metadataType: "title",
+              subjectSlug: subjectSlug,
+              examboardSlug: examboardSlug,
+              keyStagesData: keyStagesData,
+              tab: tab,
+            }),
+            description: buildCurriculumMetadata({
+              metadataType: "description",
+              subjectSlug: subjectSlug,
+              examboardSlug: examboardSlug,
+              keyStagesData: keyStagesData,
+              tab: tab,
+            }),
           }),
-          description: buildCurriculumMetadata({
-            metadataType: "description",
-            subjectSlug: subjectSlug,
-            examboardSlug: examboardSlug,
-            keyStagesData: keyStagesData,
-            tab: tab,
-          }),
-        }),
-      }}
-      $background={"white"}
-    >
-      <CurriculumHeader
-        subjectPhaseOptions={subjectPhaseOptions}
-        curriculumSelectionSlugs={curriculumSelectionSlugs}
-        color1="mint"
-        color2="mint30"
-      />
+        }}
+        $background={"white"}
+      >
+        <CurriculumHeader
+          subjectPhaseOptions={subjectPhaseOptions}
+          curriculumSelectionSlugs={curriculumSelectionSlugs}
+          color1="mint"
+          color2="mint30"
+        />
 
-      <Box $background={"white"}>{tabContent}</Box>
-    </AppLayout>
+        <Box $background={"white"}>{tabContent}</Box>
+      </AppLayout>
+    </OakThemeProvider>
   );
 };
 


### PR DESCRIPTION
## Description
Added skip links to curriculum visualiser and a `<SkipLink/>` component to `./CurriculumComponents/OakComponentsKitchen`

## Issue(s)

`CUR-682`

## How to test

1. Go to https://deploy-preview-2519--oak-web-application.netlify.thenational.academy/teachers/curriculum/science-secondary-aqa/units
2. Tab through content until you see the "Skip to units" should appear when highlighted.
3. Upon hitting enter, focus should jump to top of units 

<img width="737" alt="Screenshot 2024-06-19 at 17 50 14" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/bc88d3c3-cc74-4e14-89d1-97db0cd574ca">

