### PR TITLE
feat(optionality-unit-title): for optionality units page make optiona…

### DIFF
--- a/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
+++ b/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
@@ -54,9 +54,9 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
     <OakPupilJourneyHeader
       iconBackground={phaseSlug}
       iconName={`subject-${subjectSlug}`}
-      title={optionality ? optionality : unitData?.title}
+      title={optionality || unitData?.title}
       breadcrumbs={breadcrumb}
-      optionalityTitle={optionality ? unitData?.title : undefined}
+      optionalityTitle={optionality && unitData?.title}
     />
   );
 

--- a/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
+++ b/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
@@ -54,9 +54,9 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
     <OakPupilJourneyHeader
       iconBackground={phaseSlug}
       iconName={`subject-${subjectSlug}`}
-      title={unitData?.title}
+      title={optionality ? optionality : unitData?.title}
       breadcrumbs={breadcrumb}
-      optionalityTitle={optionality}
+      optionalityTitle={optionality ? unitData?.title : undefined}
     />
   );
 

--- a/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
+++ b/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
@@ -54,7 +54,7 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
     <OakPupilJourneyHeader
       iconBackground={phaseSlug}
       iconName={`subject-${subjectSlug}`}
-      title={optionality || unitData?.title}
+      title={optionality ?? unitData?.title}
       breadcrumbs={breadcrumb}
       optionalityTitle={optionality && unitData?.title}
     />


### PR DESCRIPTION
…ility main title

## Description

Music year: 1974

### Acceptance criteria

- [x]  Optionality unit title is the larger text
- [x]  Unit title is smaller text
- [x]  pa11y and percy test pass

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2526--oak-web-application.netlify.thenational.academy/pupils/programmes/english-secondary-year-10-aqa/units/modern-text-first-study-152/lessons
2. 
3. You should see that the optionality title is the main title

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
