### PR TITLE
Update React, remove a provider that doesn't do anything in React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "posthog-js": "^1.96.1",
         "posthog-node": "^3.3.0",
         "querystring-es3": "^0.2.1",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-aria": "^3.32.1",
         "react-cookie": "^6.1.1",
         "react-dom": "^18.2.0",
@@ -35894,8 +35894,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "posthog-js": "^1.96.1",
     "posthog-node": "^3.3.0",
     "querystring-es3": "^0.2.1",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-aria": "^3.32.1",
     "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 import type { AppProps } from "next/app";
 import { ThemeProvider } from "styled-components";
-import { SSRProvider } from "@react-aria/ssr";
 import { OverlayProvider } from "react-aria";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
@@ -41,21 +40,19 @@ const OakWebApplication: FC<OakWebApplicationProps> = ({
       <CookieConsentProvider>
         <ThemeProvider theme={theme}>
           <ErrorBoundary>
-            <SSRProvider>
-              <PostHogProvider client={posthog}>
-                <AnalyticsProvider {...analyticsOptions}>
-                  <DefaultSeo />
-                  <OverlayProvider>
-                    <MenuProvider>
-                      <ToastProvider>
-                        <Component {...pageProps} />
-                        <AppHooks />
-                      </ToastProvider>
-                    </MenuProvider>
-                  </OverlayProvider>
-                </AnalyticsProvider>
-              </PostHogProvider>
-            </SSRProvider>
+            <PostHogProvider client={posthog}>
+              <AnalyticsProvider {...analyticsOptions}>
+                <DefaultSeo />
+                <OverlayProvider>
+                  <MenuProvider>
+                    <ToastProvider>
+                      <Component {...pageProps} />
+                      <AppHooks />
+                    </ToastProvider>
+                  </MenuProvider>
+                </OverlayProvider>
+              </AnalyticsProvider>
+            </PostHogProvider>
           </ErrorBoundary>
           <SpriteSheet />
           <InlineSpriteSheet />


### PR DESCRIPTION
How to test: the app still works, sorry @jack-skerrett-oak ! It's a minor version change, so I don't expect issues.

P.s. Storybook built on re-run, but that doesn't update the commit statuses in GitHub.