### PR TITLE
fix: transcripts for canonical lessons [LESQ-835]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.test.ts
@@ -12,11 +12,6 @@ import lessonOverview, {
   getDownloadsArray,
 } from "./lessonOverview.query";
 
-jest.mock("@/utils/handleTranscript", () => ({
-  getCaptionsFromFile: jest.fn().mockResolvedValue(["transcript", "sentences"]),
-  formatSentences: jest.fn().mockReturnValue("formatted transcript"),
-}));
-
 describe("lessonOverview()", () => {
   test("throws a not found error if no lesson is found", async () => {
     await expect(async () => {
@@ -170,40 +165,6 @@ describe("lessonOverview()", () => {
         programmeSlug: "programme-slug",
       });
     }).rejects.toThrow("Resource not found");
-  });
-  test("gets transcript for new lessons", async () => {
-    const _syntheticUnitvariantLessonsFixture =
-      syntheticUnitvariantLessonsFixture({
-        overrides: {
-          lesson_slug: "lesson-slug-test",
-          unit_slug: "unit-slug-test",
-          programme_slug: "programme-slug-test",
-          is_legacy: false,
-        },
-      });
-
-    const _lessonContentFixture = lessonContentFixture({
-      overrides: {
-        exit_quiz: [],
-        starter_quiz: [],
-        video_title: "video",
-        transcript_sentences: null,
-      },
-    });
-
-    const lesson = await lessonOverview({
-      ...sdk,
-      lessonOverview: jest.fn(() =>
-        Promise.resolve({
-          browseData: [_syntheticUnitvariantLessonsFixture],
-          content: [_lessonContentFixture],
-        }),
-      ),
-    })({
-      lessonSlug: "test",
-    });
-
-    expect(lesson.transcriptSentences).toEqual(["transcript", "sentences"]);
   });
   describe("getCopyrightContent", () => {
     it("should return null if content is null", () => {

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -25,6 +25,7 @@ import OakError from "@/errors/OakError";
 import { Sdk } from "@/node-lib/curriculum-api-2023/sdk";
 import { InputMaybe } from "@/node-lib/sanity-graphql/generated/sdk";
 import keysToCamelCase from "@/utils/snakeCaseConverter";
+import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export const getDownloadsArray = (content: {
   hasSlideDeckAssetObject: boolean;
@@ -290,9 +291,27 @@ const lessonOverviewQuery =
     const browseData = keysToCamelCase(browseDataSnake) as LessonBrowseData;
     const content = keysToCamelCase(contentSnake) as LessonOverviewContent;
 
-    return lessonOverviewSchema.parse(
+    const transformedLesson = lessonOverviewSchema.parse(
       transformedLessonOverviewData(browseData, content, pathways),
     );
+
+    const { videoTitle, transcriptSentences } = transformedLesson;
+    if (videoTitle && !transcriptSentences) {
+      // For new content we need to fetch the captions file from gCloud and parse the result to generate
+      // the transcript sentences.
+      const fileName = `${videoTitle}.vtt`;
+      const transcript = await getCaptionsFromFile(fileName);
+      if (transcript) {
+        transformedLesson.transcriptSentences = transcript;
+      }
+    } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
+      const splitTranscript = transcriptSentences.split(/\r?\n/);
+      const formattedTranscript = formatSentences(splitTranscript);
+
+      transformedLesson.transcriptSentences = formattedTranscript;
+    }
+
+    return transformedLesson;
   };
 
 export default lessonOverviewQuery;

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -25,7 +25,6 @@ import OakError from "@/errors/OakError";
 import { Sdk } from "@/node-lib/curriculum-api-2023/sdk";
 import { InputMaybe } from "@/node-lib/sanity-graphql/generated/sdk";
 import keysToCamelCase from "@/utils/snakeCaseConverter";
-import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
 export const getDownloadsArray = (content: {
   hasSlideDeckAssetObject: boolean;
@@ -291,27 +290,9 @@ const lessonOverviewQuery =
     const browseData = keysToCamelCase(browseDataSnake) as LessonBrowseData;
     const content = keysToCamelCase(contentSnake) as LessonOverviewContent;
 
-    const transformedLesson = lessonOverviewSchema.parse(
+    return lessonOverviewSchema.parse(
       transformedLessonOverviewData(browseData, content, pathways),
     );
-
-    const { videoTitle, transcriptSentences } = transformedLesson;
-    if (videoTitle && !transcriptSentences) {
-      // For new content we need to fetch the captions file from gCloud and parse the result to generate
-      // the transcript sentences.
-      const fileName = `${videoTitle}.vtt`;
-      const transcript = await getCaptionsFromFile(fileName);
-      if (transcript) {
-        transformedLesson.transcriptSentences = transcript;
-      }
-    } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
-      const splitTranscript = transcriptSentences.split(/\r?\n/);
-      const formattedTranscript = formatSentences(splitTranscript);
-
-      transformedLesson.transcriptSentences = formattedTranscript;
-    }
-
-    return transformedLesson;
   };
 
 export default lessonOverviewQuery;

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -23,6 +23,7 @@ import { groupLessonPathways } from "@/components/TeacherComponents/helpers/less
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import OakError from "@/errors/OakError";
 import { LessonOverviewCanonical } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
+import { populateLessonWithTranscript } from "@/utils/handleTranscript";
 
 type PageProps = {
   lesson: LessonOverviewCanonical;
@@ -109,6 +110,7 @@ export const getStaticProps: GetStaticProps<PageProps, URLParams> = async (
           lesson = await curriculumApi2023.lessonOverview({
             lessonSlug,
           });
+          lesson = await populateLessonWithTranscript(lesson);
         }
       }
 

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -17,6 +17,7 @@ import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
 import { LessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
+import { populateLessonWithTranscript } from "@/utils/handleTranscript";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewPageData;
@@ -104,9 +105,11 @@ export const getStaticProps: GetStaticProps<
         };
       }
 
+      const lessonPageData = await populateLessonWithTranscript(curriculumData);
+
       const results: GetStaticPropsResult<LessonOverviewPageProps> = {
         props: {
-          curriculumData,
+          curriculumData: lessonPageData,
         },
       };
 

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -15,9 +15,7 @@ import AppLayout from "@/components/SharedComponents/AppLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
-import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 import { LessonOverview } from "@/components/TeacherViews/LessonOverview/LessonOverview.view";
-import { getCaptionsFromFile, formatSentences } from "@/utils/handleTranscript";
 import { LessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
 
 export type LessonOverviewPageProps = {
@@ -104,22 +102,6 @@ export const getStaticProps: GetStaticProps<
         return {
           notFound: true,
         };
-      }
-
-      const { videoTitle, transcriptSentences } = curriculumData;
-      if (videoTitle && !isSlugLegacy(programmeSlug) && !transcriptSentences) {
-        // For new content we need to fetch the captions file from gCloud and parse the result to generate
-        // the transcript sentences.
-        const fileName = `${videoTitle}.vtt`;
-        const transcript = await getCaptionsFromFile(fileName);
-        if (transcript) {
-          curriculumData.transcriptSentences = transcript;
-        }
-      } else if (transcriptSentences && !Array.isArray(transcriptSentences)) {
-        const splitTranscript = transcriptSentences.split(/\r?\n/);
-        const formattedTranscript = formatSentences(splitTranscript);
-
-        curriculumData.transcriptSentences = formattedTranscript;
       }
 
       const results: GetStaticPropsResult<LessonOverviewPageProps> = {

--- a/src/utils/handleTranscript.test.ts
+++ b/src/utils/handleTranscript.test.ts
@@ -118,6 +118,11 @@ const mockParse = jest
     cues: [],
     errors: ["this is the error message"],
     time: 0,
+  })
+  .mockReturnValueOnce({
+    cues: [{ text: "sentence 1" }, { text: "sentence 2" }],
+    errors: [],
+    time: 0,
   });
 
 jest.mock("webvtt-parser", () => ({
@@ -147,20 +152,17 @@ describe("populateLessonWithTranscript", () => {
   it("handles lessons with transcript sentences", async () => {
     const lesson = await populateLessonWithTranscript(
       lessonOverviewFixture({
-        transcriptSentences: ["sentence 1", "sentence 2"],
+        transcriptSentences: "sentence 1, sentence 2",
       }),
     );
 
-    expect(lesson.transcriptSentences).toEqual(["sentence 1", "sentence 2"]);
+    expect(lesson.transcriptSentences).toEqual(["sentence 1, sentence 2."]);
   });
   it("handles lessons without transcript sentences", async () => {
     const lesson = await populateLessonWithTranscript(
-      lessonOverviewFixture({ videoTitle: "test" }),
+      lessonOverviewFixture({ videoTitle: "test", transcriptSentences: null }),
     );
 
-    expect(lesson.transcriptSentences).toEqual([
-      "this is a sentence",
-      "this is another sentence",
-    ]);
+    expect(lesson.transcriptSentences).toEqual(["sentence 1 sentence 2."]);
   });
 });

--- a/src/utils/handleTranscript.test.ts
+++ b/src/utils/handleTranscript.test.ts
@@ -2,7 +2,10 @@ import {
   getCaptionsFromFile,
   formatSentences,
   removeWebVttCharacters,
+  populateLessonWithTranscript,
 } from "./handleTranscript";
+
+import lessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/lessonOverview.fixture";
 
 describe("removeWebVttCharacters ", () => {
   const sentences = [
@@ -137,5 +140,27 @@ describe("getCaptionFromFile", () => {
     const result = await getCaptionsFromFile("test.vtt");
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe("populateLessonWithTranscript", () => {
+  it("handles lessons with transcript sentences", async () => {
+    const lesson = await populateLessonWithTranscript(
+      lessonOverviewFixture({
+        transcriptSentences: ["sentence 1", "sentence 2"],
+      }),
+    );
+
+    expect(lesson.transcriptSentences).toEqual(["sentence 1", "sentence 2"]);
+  });
+  it("handles lessons without transcript sentences", async () => {
+    const lesson = await populateLessonWithTranscript(
+      lessonOverviewFixture({ videoTitle: "test" }),
+    );
+
+    expect(lesson.transcriptSentences).toEqual([
+      "this is a sentence",
+      "this is another sentence",
+    ]);
   });
 });


### PR DESCRIPTION
## Description

Music year: 2019

[Ticket](https://www.notion.so/oaknationalacademy/Canonical-lessons-do-not-display-transcripts-e65b1527ada8406c939eccc396d6c1de?pvs=4)
- move logic to fetch and transform video transcripts into lesson overview query used by canonical lessons as well

## Issue(s)

Fixes #
canonical lessons not having video transcripts

## How to test

1. Go to https://deploy-preview-2545--oak-web-application.netlify.thenational.academy/teachers/lessons/developing-a-model-for-atoms#video
3. You should see trasncript for the video

## Screenshots

How it used to look (delete if n/a):
<img width="600" alt="Screenshot 2024-06-27 at 14 03 17" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/80bc787e-e238-4c63-a6c8-0a12b3e5778f">

How it should now look:
<img width="600" alt="Screenshot 2024-06-27 at 14 03 50" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/df92284e-d361-4769-a51b-62734b4317a1">


## Checklist

- [x] New lessons have video transcripts on canonical pages
- [x] Legacy lessons still have transcripts on canonical lesson pages
- [x] All non-canonical lesson pages with video should still have a transcript if they had one before
