### PR TITLE
chore: add aria-required to subject-phase picker radiogroups

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -429,7 +429,11 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                 <OakP $mb="space-between-s">
                   Explore our new curricula for 2023/2024.
                 </OakP>
-                <Box role="radiogroup" aria-labelledby={subjectInputId}>
+                <Box
+                  role="radiogroup"
+                  aria-labelledby={subjectInputId}
+                  aria-required="true"
+                >
                   {subjects.map((subject) => (
                     <ButtonContainer
                       className={isSelected(subject) ? "selected" : ""}
@@ -610,6 +614,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                   <Box
                     radioGroup="radiogroup"
                     aria-labelledby={schoolPhaseInputId}
+                    aria-required="true"
                   >
                     {(selectedSubject?.phases ?? phases).map((phase, index) => (
                       <ButtonContainer className="multi-line" key={phase.slug}>
@@ -643,6 +648,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                         <Box
                           role="radiogroup"
                           aria-labelledby={examBoardInputId}
+                          aria-required="true"
                         >
                           {selectedSubject.examboards.map(
                             (examboard, index) => (


### PR DESCRIPTION
## Description

Music year: [1957](https://open.spotify.com/track/4gphxUgq0JSFv2BCLhNDiE?si=686587445de94ae1)

- Adds `aria-required` to each radiogroup in the subject-phase picker modal (subject, phase, exam board)
- Ensures that each group of selectable options is announced as 'required' to screen reader and other AT users.

## Issue(s)

Fixes [this a11y audit finding re: subject-phase picker](https://www.notion.so/oaknationalacademy/Forms-fields-that-are-required-are-not-marked-visually-and-programatically-675790568a754cb2bd8fd662fa196337?pvs=4)

## How to test

1. Go to https://deploy-preview-2548--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Launch your screen reader of choice
3. Open one of the modal dialogs within the subject-phase picker
4. Navigate to a button
6. The button should be announced as required, and as part of a group.

Note: I couldn't get this to work on macOS VoiceOver for some reason, but it shows up fine in the accessibility inspector, and it works as expected on iOS.

## Screenshots

![Screenshot 2024-07-01 at 10 08 34](https://github.com/oaknational/Oak-Web-Application/assets/3018395/6c9cf996-d618-4ee1-9ce2-fb0b6f54c69b)
![IMG_1290](https://github.com/oaknational/Oak-Web-Application/assets/3018395/a9a9e049-028e-492b-ae32-3c7b94c4b610)


## Checklist

- [ ] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
