### PR TITLE
[ENG-813] Consent banner stacked in front of modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^8.5.1",
         "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-        "@oaknational/oak-components": "^1.0.2",
+        "@oaknational/oak-components": "^1.0.3",
         "@oaknational/oak-consent-client": "^1.0.0",
         "@oaknational/oak-curriculum-schema": "^1.16.0",
         "@portabletext/react": "^3.0.11",
@@ -6421,9 +6421,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.0.2.tgz",
-      "integrity": "sha512-xwGAKEvDC+ayIfhU7n1zW4/x342Xzo8GO/FwprgYVb3YrBIWDCs7s27tinlCn9S3vZsSQJ2TXBhJYZibLB6RGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.0.3.tgz",
+      "integrity": "sha512-YLyNq0zuCYECAP2VKkXbLbX9JvpPU7v9TvS9Hi9BmFbnXAEvE6NMetnBIfLtHLDpZIEGh2DqiaiKfsUhKsro0g==",
       "dependencies": {
         "@storybook/test": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^8.5.1",
     "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-    "@oaknational/oak-components": "^1.0.2",
+    "@oaknational/oak-components": "^1.0.3",
     "@oaknational/oak-consent-client": "^1.0.0",
     "@oaknational/oak-curriculum-schema": "^1.16.0",
     "@portabletext/react": "^3.0.11",

--- a/src/browser-lib/cookie-consent/CookieConsentProvider.tsx
+++ b/src/browser-lib/cookie-consent/CookieConsentProvider.tsx
@@ -70,7 +70,7 @@ const CookieConsentContextProvider = (props: PropsWithChildren) => {
     <cookieConsentContext.Provider
       {...props}
       // This value should not be memoised as it should always trigger a render whenever `state` changes
-      value={{ getConsentState, showConsentManager }}
+      value={{ getConsentState, showConsentManager }} //NOSONAR
     />
   );
 };
@@ -92,11 +92,7 @@ const CookieConsentUIProvider = ({ children }: PropsWithChildren) => {
       {children}
       <OakThemeProvider theme={oakDefaultTheme}>
         {isMounted && (
-          <OakCookieConsent
-            policyURL="/legal/cookie-policy"
-            isFixed
-            zIndex={99999}
-          />
+          <OakCookieConsent policyURL="/legal/cookie-policy" isFixed />
         )}
       </OakThemeProvider>
     </OakCookieConsentProvider>

--- a/src/components/AppComponents/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.test.tsx
@@ -15,9 +15,9 @@ describe("components/AppHeader", () => {
   });
 
   test("it should be the teachers header colour", () => {
-    const { getByRole } = render(<AppHeader />);
+    const { getByTestId } = render(<AppHeader />);
 
-    expect(getByRole("banner")).toHaveStyle(
+    expect(getByTestId("app-header")).toHaveStyle(
       "background-color: rgb(255, 255, 255);",
     );
   });

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -35,75 +35,79 @@ const AppHeader: FC<HeaderProps> = () => {
   const selectedArea = useSelectedArea();
 
   return (
-    <StyledHeader
-      $background="white"
-      as="header"
-      $justifyContent={["space-between"]}
-      $alignItems={["center"]}
-      $zIndex="fixedHeader"
-      $position={"relative"}
-    >
-      <OakFlex
-        $justifyContent={"space-between"}
-        $flexGrow={1}
-        $alignItems={"center"}
+    <header>
+      <StyledHeader
+        $background="white"
+        $justifyContent={["space-between"]}
+        $alignItems={["center"]}
+        $zIndex="fixedHeader"
+        $position={"relative"}
+        data-testid="app-header"
       >
-        <OakFlex $justifyContent={"center"} $alignItems={"center"}>
-          <OwaLink page={"home"}>
-            <Box $display={["block", "none"]}>
-              <Logo height={48} width={31} variant="without text" />
-            </Box>
-            <Box $display={["none", "block"]}>
-              <Logo variant="with text" height={48} width={104} />
-            </Box>
-          </OwaLink>
-        </OakFlex>
-        <OakFlex $alignItems={"center"} $gap="all-spacing-6" $font="heading-7">
-          <OwaLink
-            page={"home"}
-            $focusStyles={["underline"]}
-            $isSelected={true}
+        <OakFlex
+          $justifyContent={"space-between"}
+          $flexGrow={1}
+          $alignItems={"center"}
+        >
+          <OakFlex $justifyContent={"center"} $alignItems={"center"}>
+            <OwaLink page={"home"}>
+              <Box $display={["block", "none"]}>
+                <Logo height={48} width={31} variant="without text" />
+              </Box>
+              <Box $display={["none", "block"]}>
+                <Logo variant="with text" height={48} width={104} />
+              </Box>
+            </OwaLink>
+          </OakFlex>
+          <OakFlex
+            $alignItems={"center"}
+            $gap="all-spacing-6"
+            $font="heading-7"
           >
-            Teachers
-            {selectedArea == siteAreas.teachers && (
-              <ActiveLinkUnderline name="horizontal-rule" />
-            )}
-          </OwaLink>
-          <OakFlex $alignItems="center" $gap="all-spacing-1">
             <OwaLink
-              page="pupil-year-index"
+              page={"home"}
               $focusStyles={["underline"]}
-              htmlAnchorProps={{
-                onClick: () =>
-                  track.classroomSelected({ navigatedFrom: "header" }),
-                "aria-label": "Pupils browse years",
-              }}
+              $isSelected={true}
             >
-              Pupils
-              {selectedArea == siteAreas.pupils && (
+              Teachers
+              {selectedArea == siteAreas.teachers && (
                 <ActiveLinkUnderline name="horizontal-rule" />
               )}
             </OwaLink>
+            <OakFlex $alignItems="center" $gap="all-spacing-1">
+              <OwaLink
+                page="pupil-year-index"
+                $focusStyles={["underline"]}
+                htmlAnchorProps={{
+                  onClick: () =>
+                    track.classroomSelected({ navigatedFrom: "header" }),
+                  "aria-label": "Pupils browse years",
+                }}
+              >
+                Pupils
+                {selectedArea == siteAreas.pupils && (
+                  <ActiveLinkUnderline name="horizontal-rule" />
+                )}
+              </OwaLink>
+            </OakFlex>
+            <IconButton
+              aria-label="Menu"
+              icon={"hamburger"}
+              variant={"minimal"}
+              size={"large"}
+              ref={menuButtonRef}
+              onClick={openMenu}
+              aria-expanded={open}
+            />
           </OakFlex>
-          <IconButton
-            aria-label="Menu"
-            icon={"hamburger"}
-            variant={"minimal"}
-            size={"large"}
-            ref={menuButtonRef}
-            onClick={openMenu}
-            aria-expanded={open}
-          />
         </OakFlex>
+        <AppHeaderUnderline />
+      </StyledHeader>
 
-        <AppHeaderMenu menuButtonRef={menuButtonRef}>
-          <AppHeaderBurgerMenuSections
-            burgerMenuSections={burgerMenuSections}
-          />
-        </AppHeaderMenu>
-      </OakFlex>
-      <AppHeaderUnderline />
-    </StyledHeader>
+      <AppHeaderMenu menuButtonRef={menuButtonRef}>
+        <AppHeaderBurgerMenuSections burgerMenuSections={burgerMenuSections} />
+      </AppHeaderMenu>
+    </header>
   );
 };
 

--- a/src/components/AppComponents/AppHeaderMenu/AppHeaderMenu.tsx
+++ b/src/components/AppComponents/AppHeaderMenu/AppHeaderMenu.tsx
@@ -93,7 +93,7 @@ const AppHeaderMenu: FC<AppHeaderMenuProps> = ({ children, menuButtonRef }) => {
       onExited={removeFocus}
     >
       {(state) => (
-        <Box $position="absolute" ref={ref}>
+        <Box $position="absolute" ref={ref} $zIndex="modalDialog">
           <MenuBackdrop state={state} />
           <FocusOn
             enabled={open}


### PR DESCRIPTION
## Description

Music year: [1957](https://www.youtube.com/watch?v=V_FAqr6rP4w)

## Issue(s)

Fixes the consent banner rendering above modals blocking interaction.

## How to test

Scenario 1: Modals
1. Open https://deploy-preview-2554--oak-web-application.netlify.thenational.academy/teachers/curriculum/science-primary/units in an incognito session
2. Click “Unit info” on any of the cards
3. You should see the modal above the consent banner

Scenario 2: Burger menu
1. Open https://deploy-preview-2554--oak-web-application.netlify.thenational.academy in an incognito session
2. Click the burger menu icon in the top right
3. You should see the menu above the consent banner

## Screenshots

How it used to look
![Screenshot 2024-06-27 at 15 57 51](https://github.com/oaknational/Oak-Web-Application/assets/122096/b93009e3-f291-4173-b9e0-2728c24ee520)
![Screenshot 2024-06-27 at 15 48 46](https://github.com/oaknational/Oak-Web-Application/assets/122096/b74e2d3d-6b41-49b9-b86d-edc4dc977070)


How it should now look:
<img width="2358" alt="Screenshot 2024-07-01 at 14 59 23" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/66716dcb-80ac-45ea-b558-360fcfd9a2f8">
<img width="2358" alt="Screenshot 2024-07-01 at 14 59 18" src="https://github.com/oaknational/Oak-Web-Application/assets/122096/9b8d0531-e746-45d3-9345-c7efaf622e6b">


## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [x] Does this PR update a package with a breaking change
