### PR TITLE
fix: only combine unit listing pages for ks1-4 maths [LESQ-949]

### DIFF
--- a/src/__tests__/pages/teachers/key-stages/[keyStageSlug]/subjects/index.test.tsx
+++ b/src/__tests__/pages/teachers/key-stages/[keyStageSlug]/subjects/index.test.tsx
@@ -195,5 +195,39 @@ describe("pages/key-stages/[keyStageSlug]/subjects", () => {
       expect(maths?.old).toBeNull();
       expect(maths?.new?.subjectSlug).toBe("maths");
     });
+    it("should not combine counts for EYFS maths", async () => {
+      const mockEyfsMathsResponse = {
+        keyStageSlug: "early-years-foundation-stage",
+        keyStageTitle: "Early years foundation stage",
+        subjects: [
+          {
+            subjectSlug: "maths",
+            subjectTitle: "Maths",
+            unitCount: 1,
+            lessonCount: 6,
+            programmeSlug: "maths-early-years-foundation-stage-l",
+            programmeCount: 1,
+          },
+        ],
+        keyStages: [],
+      };
+      (curriculumApi.subjectListingPage as jest.Mock).mockResolvedValueOnce(
+        mockEyfsMathsResponse,
+      );
+      (curriculumApi.subjectListingPage as jest.Mock).mockResolvedValueOnce(
+        mockEyfsMathsResponse,
+      );
+      const res = (await getStaticProps({
+        params: {
+          keyStageSlug: "early-years-foundation-stage",
+        },
+      })) as { props: SubjectListingPageProps };
+
+      const maths = res?.props.subjects.find((s) => s.subjectSlug === "maths");
+      expect(maths?.old).not.toBeNull();
+      expect(maths?.new).toBeNull();
+      expect(maths?.old?.unitCount).toBe(1);
+      expect(maths?.old?.lessonCount).toBe(6);
+    });
   });
 });

--- a/src/__tests__/pages/teachers/key-stages/[keyStageSlug]/subjects/index.test.tsx
+++ b/src/__tests__/pages/teachers/key-stages/[keyStageSlug]/subjects/index.test.tsx
@@ -38,6 +38,50 @@ describe("pages/key-stages/[keyStageSlug]/subjects", () => {
       );
     });
   });
+  it("Renders maths with correct counts in EYFS", () => {
+    renderWithProviders()(
+      <SubjectListingPage
+        {...props}
+        keyStageSlug="early-years-foundation-stage"
+        keyStageTitle="Early years foundation stage"
+        subjects={[
+          {
+            subjectSlug: "maths",
+            old: {
+              subjectSlug: "maths",
+              subjectTitle: "Maths",
+              unitCount: 1,
+              lessonCount: 6,
+              programmeSlug: "maths-early-years-foundation-stage",
+              programmeCount: 2,
+            },
+            new: {
+              subjectSlug: "maths",
+              subjectTitle: "Maths",
+              unitCount: 1,
+              lessonCount: 6,
+              programmeSlug: "maths-early-years-foundation-stage",
+              programmeCount: 1,
+            },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Maths")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Maths: 1 unit, 6 lessons" }),
+    ).toBeInTheDocument();
+  });
+  it("renders correct counts for non EYFS subjects", () => {
+    renderWithProviders()(<SubjectListingPage {...props} />);
+
+    expect(screen.getByText("Biology")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Biology: 6 units, 35 lessons - new content",
+      }),
+    ).toBeInTheDocument();
+  });
 
   describe("SEO", () => {
     it("renders the correct SEO details ", async () => {

--- a/src/components/TeacherComponents/SubjectListingCardDouble/SubjectListingCardDouble.test.tsx
+++ b/src/components/TeacherComponents/SubjectListingCardDouble/SubjectListingCardDouble.test.tsx
@@ -104,7 +104,7 @@ describe("SubjectListingCardDouble", () => {
     expect(cardClickTarget).toBeInTheDocument();
     expect(cardClickTarget).toHaveAttribute(
       "href",
-      "/teachers/programmes/biology-secondary-ks4/units",
+      "/teachers/programmes/maths-secondary-ks4/units",
     );
   });
   test("new units are labeled as 'new'", () => {

--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
@@ -16,6 +16,7 @@ import {
   StemImageObject,
 } from "@/node-lib/curriculum-api-2023/shared.schema";
 import removeLegacySlugSuffix from "@/utils/slugModifiers/removeLegacySlugSuffix";
+import isSlugEYFS from "@/utils/slugModifiers/isSlugEYFS";
 
 /**
  * Returns the intersection different pathways.
@@ -294,12 +295,13 @@ export const getBreadcrumbsForLessonPathway = (
     unitTitle,
   } = lesson;
 
-  const programmeSlugForMathsUnits =
-    subjectTitle === "Maths"
-      ? programmeSlug
-        ? removeLegacySlugSuffix(programmeSlug)
-        : null
-      : programmeSlug;
+  let programmeSlugForMathsUnits = programmeSlug;
+
+  if (subjectTitle === "Maths") {
+    if (programmeSlug && !isSlugEYFS(programmeSlug)) {
+      programmeSlugForMathsUnits = removeLegacySlugSuffix(programmeSlug);
+    }
+  }
 
   const nullableBreadcrumbs: (Breadcrumb | null)[] = [
     {

--- a/src/node-lib/curriculum-api-2023/fixtures/subjectListing.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/subjectListing.fixture.ts
@@ -49,7 +49,7 @@ const subjectPagePropsFixture = (
           subjectTitle: "Maths",
           unitCount: 6,
           lessonCount: 35,
-          programmeSlug: "biology-secondary-ks4",
+          programmeSlug: "maths-secondary-ks4",
           programmeCount: 1,
         },
       },
@@ -76,7 +76,6 @@ const subjectPagePropsFixture = (
         },
       },
     ],
-
     ...partial,
   };
 };

--- a/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
+++ b/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
@@ -151,7 +151,7 @@ export const getStaticProps: GetStaticProps<
           : foundSubject;
       };
 
-      // We are trialling combining the maths subjects from the legacy and new curriculums
+      // We are trialling combining the maths subjects from the legacy and new curriculums in ks1-4
       const getMaths = () => {
         const newMaths = curriculumData.subjects.find(
           (subject) => subject.subjectSlug === "maths",
@@ -184,7 +184,7 @@ export const getStaticProps: GetStaticProps<
       };
 
       const getOldSubjects = (subjectSlug: string) => {
-        if (subjectSlug === "maths") {
+        if (subjectSlug === "maths" && !isEyfs) {
           return null;
         } else {
           return getSubject(curriculumDataLegacy, subjectSlug, true);
@@ -194,7 +194,7 @@ export const getStaticProps: GetStaticProps<
       const getNewSubjects = (subjectSlug: string) => {
         if (isEyfs) {
           return null;
-        } else if (subjectSlug === "maths") {
+        } else if (subjectSlug === "maths" && !isEyfs) {
           return getMaths();
         } else {
           return getSubject(curriculumData, subjectSlug, false);

--- a/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
+++ b/src/pages/teachers/key-stages/[keyStageSlug]/subjects/index.tsx
@@ -166,26 +166,36 @@ export const getStaticProps: GetStaticProps<
           };
         }
 
-        const progCount =
-          newMaths.programmeCount === 1 && legacyMaths.programmeCount === 1
-            ? 1
-            : Math.max(newMaths.programmeCount, legacyMaths.programmeCount);
+        const programmeCount = Math.max(
+          newMaths.programmeCount,
+          legacyMaths.programmeCount,
+        );
+        const unitCount = isEyfs
+          ? legacyMaths.unitCount
+          : newMaths.unitCount + legacyMaths.unitCount;
+        const lessonCount = isEyfs
+          ? legacyMaths.lessonCount
+          : newMaths.lessonCount + legacyMaths.lessonCount;
 
         const combinedMaths: KeyStageSubjectData = {
           programmeSlug: newMaths.programmeSlug,
-          programmeCount: progCount,
+          programmeCount,
           subjectSlug: newMaths.subjectSlug,
           subjectTitle: newMaths.subjectTitle,
-          unitCount: newMaths.unitCount + legacyMaths.unitCount,
-          lessonCount: newMaths.lessonCount + legacyMaths.lessonCount,
+          unitCount,
+          lessonCount,
         };
 
         return combinedMaths;
       };
 
       const getOldSubjects = (subjectSlug: string) => {
-        if (subjectSlug === "maths" && !isEyfs) {
-          return null;
+        if (subjectSlug === "maths") {
+          if (isEyfs) {
+            return getMaths();
+          } else {
+            return null;
+          }
         } else {
           return getSubject(curriculumDataLegacy, subjectSlug, true);
         }
@@ -194,7 +204,7 @@ export const getStaticProps: GetStaticProps<
       const getNewSubjects = (subjectSlug: string) => {
         if (isEyfs) {
           return null;
-        } else if (subjectSlug === "maths" && !isEyfs) {
+        } else if (subjectSlug === "maths") {
           return getMaths();
         } else {
           return getSubject(curriculumData, subjectSlug, false);

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -43,6 +43,7 @@ import { SpecialistUnit } from "@/node-lib/curriculum-api-2023/queries/specialis
 import { UnitListingData } from "@/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema";
 import { toSentenceCase } from "@/node-lib/curriculum-api-2023/helpers";
 import NewContentBanner from "@/components/TeacherComponents/NewContentBanner/NewContentBanner";
+import isSlugEYFS from "@/utils/slugModifiers/isSlugEYFS";
 
 export type UnitListingPageProps = {
   curriculumData: UnitListingData;
@@ -325,14 +326,14 @@ export const getStaticProps: GetStaticProps<
         throw new Error("No context.params");
       }
       const { programmeSlug } = context.params;
-
+      const isEyfs = isSlugEYFS(programmeSlug);
       try {
         const curriculumData = await curriculumApi2023.unitListing({
           programmeSlug,
         });
 
         // We are trialling combining the new and legacy curriculum data for Maths
-        if (programmeSlug.startsWith("maths")) {
+        if (programmeSlug.startsWith("maths") && !isEyfs) {
           const legacyCurriculumData = await curriculumApi2023.unitListing({
             programmeSlug: programmeSlug + "-l",
           });

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -38,6 +38,7 @@ import { NEW_COHORT } from "@/config/cohort";
 import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 import NewContentBanner from "@/components/TeacherComponents/NewContentBanner/NewContentBanner";
 import removeLegacySlugSuffix from "@/utils/slugModifiers/removeLegacySlugSuffix";
+import isSlugEYFS from "@/utils/slugModifiers/isSlugEYFS";
 
 export type LessonListingPageProps = {
   curriculumData: LessonListingPageData;
@@ -133,7 +134,7 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
               oakLinkProps: {
                 page: "unit-index",
                 programmeSlug:
-                  subjectSlug === "maths"
+                  subjectSlug === "maths" && !isSlugEYFS(programmeSlug)
                     ? removeLegacySlugSuffix(programmeSlug)
                     : programmeSlug,
               },


### PR DESCRIPTION
## Description

Music year: 2003

- EYFS was being excluded in the logic for combining new and legacy maths, as there is only legacy content
- this includes EYFS for maths subject only and doesn't combine counts

## Issue(s)

Fixes #
Maths EYFS gone missing from the site

## How to test

1. Go to https://deploy-preview-2559--oak-web-application.netlify.thenational.academy/teachers/key-stages/early-years-foundation-stage/subjects
3. You should see a card for maths
4. Click through and the counts should be correct
5. There should be no 'new' tag on any of the content

## Screenshots

How it used to look (delete if n/a):
<img width="600" alt="Screenshot 2024-07-03 at 08 34 33" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/f4768f60-496c-4019-8bd3-ee9a8455f70d">

How it should now look:
<img width="600" alt="Screenshot 2024-07-03 at 08 34 44" src="https://github.com/oaknational/Oak-Web-Application/assets/45038878/5719a76e-c25d-4a20-a8c3-553aba3b2467">
