### PR TITLE
Update `date-fns` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "buffer": "^6.0.3",
         "change-case": "^4.1.2",
         "crypto-browserify": "^3.12.0",
-        "date-fns": "^2.30.0",
+        "date-fns": "^3.6.0",
         "favicons": "^7.1.5",
         "gleap": "^13.2.8",
         "html-react-parser": "^4.2.2",
@@ -17517,17 +17517,12 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dateformat": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "buffer": "^6.0.3",
     "change-case": "^4.1.2",
     "crypto-browserify": "^3.12.0",
-    "date-fns": "^2.30.0",
+    "date-fns": "^3.6.0",
     "favicons": "^7.1.5",
     "gleap": "^13.2.8",
     "html-react-parser": "^4.2.2",


### PR DESCRIPTION
## Description
Updates `date-fns` from `2.30.0` to `3.6.0`

Effected areas of website are the blog

```bash
grep -r date-fns src 
# src/utils/isUpcomingWebinar.ts:import { isFuture } from "date-fns";
# src/components/SharedComponents/PostList/usePostList.ts:import { isPast } from "date-fns";
```

The `isFuture` and `isPast` API's have not changed between versions. 