### PR TITLE
Update `copy-webpack-plugin` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "@typescript-eslint/parser": "^6.10.0",
         "browserstack-local": "^1.5.5",
         "chromedriver": "^126.0.4",
-        "copy-webpack-plugin": "^11.0.0",
+        "copy-webpack-plugin": "^12.0.2",
         "dotenv": "^16.3.1",
         "esbuild": "^0.19.2",
         "eslint": "^8.48.0",
@@ -16936,19 +16936,20 @@
       }
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "11.0.0",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.1",
-        "globby": "^13.1.1",
+        "globby": "^14.0.0",
         "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0"
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -16970,18 +16971,32 @@
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/globby": {
-      "version": "13.2.2",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17006,11 +17021,12 @@
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/slash": {
-      "version": "4.0.0",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@typescript-eslint/parser": "^6.10.0",
     "browserstack-local": "^1.5.5",
     "chromedriver": "^126.0.4",
-    "copy-webpack-plugin": "^11.0.0",
+    "copy-webpack-plugin": "^12.0.2",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "eslint": "^8.48.0",


### PR DESCRIPTION
## Description
Updated `copy-webpack-plugin` through major version

It's used to copy over mathjax, see `./next.config.ts`

```ts
      config.plugins.push(
        new CopyPlugin({
          patterns: [
            {
              from: path.join(__dirname, "node_modules/mathjax/es5"),
              to: path.join(__dirname, "public/mathjax"),
            },
          ],
        }),
      );
```

**Note**: I've confirmed mathjax still works by visiting `/pupils/programmes/maths-secondary-year-7/units/expressions-and-equations/lessons/highest-common-factor-with-algebraic-terms/starter-quiz`

Min-version of nodejs changed, however we're `>20` anyway 

```
  "engines": {
    "node": ">=20 <21",
    "npm": ">=9.6.5"
  },
```

See following from <https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/CHANGELOG.md>

<img width="693" alt="Screenshot 2024-07-03 at 09 56 36" src="https://github.com/oaknational/Oak-Web-Application/assets/235915/9a44dc25-437c-48a3-b2c5-96fe9bf1ae71">
