### PR TITLE
Update `change-case` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/uuid": "^9.0.7",
         "better-react-mathjax": "^2.0.3",
         "buffer": "^6.0.3",
-        "change-case": "^4.1.2",
+        "change-case": "^5.4.4",
         "crypto-browserify": "^3.12.0",
         "date-fns": "^2.30.0",
         "favicons": "^7.1.5",
@@ -3860,6 +3860,26 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/tslib": {
@@ -15815,6 +15835,7 @@
     },
     "node_modules/camel-case": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -15890,7 +15911,9 @@
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -15963,22 +15986,9 @@
       }
     },
     "node_modules/change-case": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
     },
     "node_modules/change-case-all": {
       "version": "1.0.15",
@@ -15995,6 +16005,26 @@
         "title-case": "^3.0.3",
         "upper-case": "^2.0.2",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/change-case-all/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/char-regex": {
@@ -16700,7 +16730,9 @@
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -21486,7 +21518,9 @@
     },
     "node_modules/header-case": {
       "version": "2.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
@@ -32354,6 +32388,7 @@
     },
     "node_modules/param-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -32473,6 +32508,7 @@
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -32485,7 +32521,9 @@
     },
     "node_modules/path-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -35876,7 +35914,9 @@
     },
     "node_modules/sentence-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -39184,6 +39224,7 @@
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -39191,6 +39232,7 @@
     },
     "node_modules/upper-case-first": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/uuid": "^9.0.7",
     "better-react-mathjax": "^2.0.3",
     "buffer": "^6.0.3",
-    "change-case": "^4.1.2",
+    "change-case": "^5.4.4",
     "crypto-browserify": "^3.12.0",
     "date-fns": "^2.30.0",
     "favicons": "^7.1.5",


### PR DESCRIPTION
## Description
The `change-case` dependency has changed to fill in some edge cases. However we only use it to `camelCase` simple keys, see [`./netlify/plugins/slack-reporting/slack/get_slack_config.js`](https://github.com/oaknational/Oak-Web-Application/blob/8281ded025612d3ee1b0ac8a9fe58ce3a39063ec/netlify/plugins/slack-reporting/slack/get_slack_config.js#L3-L6)
