### PR TITLE
chore: bump bugsnag react plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.23.0",
-        "@bugsnag/plugin-react": "^7.19.0",
+        "@bugsnag/plugin-react": "^7.24.0",
         "@google-cloud/storage": "^7.7.0",
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^9.1.1",
@@ -2489,7 +2489,9 @@
       }
     },
     "node_modules/@bugsnag/plugin-react": {
-      "version": "7.22.7",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-react/-/plugin-react-7.24.0.tgz",
+      "integrity": "sha512-YAoS3FPSmz/iiDuOzyr9bYMagv5/9Hdi70BMOVp5mUKaFHlx+wK4shTAFJdnTZr0534mfJMk2NXnY62CN1k28Q==",
       "license": "MIT",
       "peerDependencies": {
         "@bugsnag/core": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "^7.23.0",
-    "@bugsnag/plugin-react": "^7.19.0",
+    "@bugsnag/plugin-react": "^7.24.0",
     "@google-cloud/storage": "^7.7.0",
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^9.1.1",


### PR DESCRIPTION
bumped from 7.19.0 to 7.24.0
only change affecting plugin-react is 
(plugin-react) Modified the polynomial regular expression to remove the ambiguity https://github.com/bugsnag/bugsnag-js/pull/2135
