### PR TITLE
chore: bump google cloud secret manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "@commitlint/cli": "^18.6.1",
         "@commitlint/config-conventional": "^18.6.3",
         "@commitlint/prompt-cli": "^18.4.4",
-        "@google-cloud/secret-manager": "^5.3.0",
+        "@google-cloud/secret-manager": "^5.6.0",
         "@graphql-codegen/cli": "^5.0.2",
         "@graphql-codegen/typescript": "^4.0.7",
         "@graphql-codegen/typescript-graphql-request": "^6.2.0",
@@ -3383,7 +3383,9 @@
       }
     },
     "node_modules/@google-cloud/secret-manager": {
-      "version": "5.3.0",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-5.6.0.tgz",
+      "integrity": "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.3",
     "@commitlint/prompt-cli": "^18.4.4",
-    "@google-cloud/secret-manager": "^5.3.0",
+    "@google-cloud/secret-manager": "^5.6.0",
     "@graphql-codegen/cli": "^5.0.2",
     "@graphql-codegen/typescript": "^4.0.7",
     "@graphql-codegen/typescript-graphql-request": "^6.2.0",


### PR DESCRIPTION
no breaking changes from the [changelog](https://github.com/googleapis/google-cloud-node/blob/main/packages/google-cloud-secretmanager/CHANGELOG.md)
tested by running dev version and secrets are accessed successfully