### PR TITLE
chore: bump google cloud storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bugsnag/js": "^7.23.0",
         "@bugsnag/plugin-react": "^7.24.0",
-        "@google-cloud/storage": "^7.7.0",
+        "@google-cloud/storage": "^7.11.2",
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^9.1.1",
         "@mux/mux-node": "^8.5.1",
@@ -3396,7 +3396,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.10.0",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
+      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -3405,10 +3407,10 @@
         "abort-controller": "^3.0.0",
         "async-retry": "^1.3.3",
         "duplexify": "^4.1.3",
-        "ent": "^2.2.0",
         "fast-xml-parser": "^4.3.0",
         "gaxios": "^6.0.2",
         "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
         "mime": "^3.0.0",
         "p-limit": "^3.0.1",
         "retry-request": "^7.0.0",
@@ -18329,10 +18331,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/ent": {
-      "version": "2.2.0",
-      "license": "MIT"
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
@@ -21677,7 +21675,6 @@
     },
     "node_modules/html-entities": {
       "version": "2.5.2",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@bugsnag/js": "^7.23.0",
     "@bugsnag/plugin-react": "^7.24.0",
-    "@google-cloud/storage": "^7.7.0",
+    "@google-cloud/storage": "^7.11.2",
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^9.1.1",
     "@mux/mux-node": "^8.5.1",


### PR DESCRIPTION
Used to download video transcripts from google cloud buckets
Bump from 7.10 to 7.11.2
changelog shows no breaking changes
https://github.com/googleapis/nodejs-storage/blob/main/CHANGELOG.md
Tested by loading legacy and cycle 1 pages with video transcripts without error