### PR TITLE
Update `snakecase-keys` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-string-replace": "^1.1.1",
         "react-transition-group": "^4.4.5",
         "semver": "^7.5.4",
-        "snakecase-keys": "^5.5.0",
+        "snakecase-keys": "^8.0.1",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "styled-components": "^5.3.6",
@@ -36219,22 +36219,24 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "5.5.0",
-      "license": "MIT",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-8.0.1.tgz",
+      "integrity": "sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
-        "type-fest": "^3.12.0"
+        "type-fest": "^4.15.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/snakecase-keys/node_modules/type-fest": {
-      "version": "3.13.1",
-      "license": "(MIT OR CC0-1.0)",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
+      "integrity": "sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-string-replace": "^1.1.1",
     "react-transition-group": "^4.4.5",
     "semver": "^7.5.4",
-    "snakecase-keys": "^5.5.0",
+    "snakecase-keys": "^8.0.1",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "styled-components": "^5.3.6",


### PR DESCRIPTION
This is used in the `search-api` see [`src/context/Search/search-api/2023/fetchResults.ts`](https://github.com/oaknational/Oak-Web-Application/blob/8281ded025612d3ee1b0ac8a9fe58ce3a39063ec/src/context/Search/search-api/2023/fetchResults.ts)

I've manually tested `/teachers/search` route and all seems fine.