### PR TITLE
fix(sec): encode URI when DOM text is reinterpreted as HTML

### DIFF
--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.tsx
@@ -5,7 +5,7 @@ export const createLink = () => {
 
 export const hideAndClickDownloadLink = (url: string, a: HTMLAnchorElement) => {
   a.style.display = "none";
-  a.href = url;
+  a.href = encodeURI(url);
   a.setAttribute("download", "download.zip");
   document.body.appendChild(a);
   a.click();


### PR DESCRIPTION
## Description

Fixing DOM text reinterpreted as HTML alert

## Issue(s)

```
export const hideAndClickDownloadLink = (url: string, a: HTMLAnchorElement) => {
  a.style.display = "none";
  a.href = URL;
```
is reinterpreted as HTML without escaping meta-characters.

## Fixes

[DOM text reinterpreted as HTML](https://github.com/oaknational/Oak-Web-Application/security/code-scanning/51)

## How to test

1. Go to https://deploy-preview-2593--oak-web-application.netlify.thenational.academy
2. Click on /teachers/curriculum/
3. You should be able to download curriculum plans
4. CodeQL should remove errors when scanning
