### PR TITLE
fix: update netlify slack plugin code to esm syntax

### DIFF
--- a/netlify/plugins/slack-reporting/index.js
+++ b/netlify/plugins/slack-reporting/index.js
@@ -1,13 +1,13 @@
-const { getAppVersion, getIsPluginDisabled } = require("../lib");
+import { getAppVersion, getIsPluginDisabled } from "../lib";
 
-const {
+import {
   createBuildStartedSlackMessage,
   createBuildCompleteSlackMessage,
-} = require("./slack/create_slack_message");
-const getSlackConfig = require("./slack/get_slack_config");
-const sendMessage = require("./slack/send_message");
+} from "./slack/create_slack_message";
+import getSlackConfig from "./slack/get_slack_config";
+import sendMessage from "./slack/send_message";
 
-module.exports = function slackBuildReporterPlugin() {
+export default function slackBuildReporterPlugin() {
   let sharedInfo = {};
 
   /**
@@ -208,4 +208,4 @@ module.exports = function slackBuildReporterPlugin() {
       }
     },
   };
-};
+}

--- a/netlify/plugins/slack-reporting/slack/create_slack_message/build_complete.js
+++ b/netlify/plugins/slack-reporting/slack/create_slack_message/build_complete.js
@@ -1,4 +1,4 @@
-const validateConfig = require("./validate_config");
+import validateConfig from "./validate_config";
 
 /**
  * Construct a "build complete" Slack message using Block Kit format.
@@ -90,4 +90,4 @@ function createSlackBuildCompleteMessage(config) {
   };
 }
 
-module.exports = createSlackBuildCompleteMessage;
+export default createSlackBuildCompleteMessage;

--- a/netlify/plugins/slack-reporting/slack/create_slack_message/build_started.js
+++ b/netlify/plugins/slack-reporting/slack/create_slack_message/build_started.js
@@ -1,4 +1,4 @@
-const validateConfig = require("./validate_config");
+import validateConfig from "./validate_config";
 
 /**
  * Construct a "build started" Slack message using Block Kit format.
@@ -50,4 +50,4 @@ function createBuildStartedSlackMessage(config) {
   };
 }
 
-module.exports = createBuildStartedSlackMessage;
+export default createBuildStartedSlackMessage;

--- a/netlify/plugins/slack-reporting/slack/create_slack_message/index.js
+++ b/netlify/plugins/slack-reporting/slack/create_slack_message/index.js
@@ -1,7 +1,7 @@
-const createBuildStartedSlackMessage = require("./build_started").default;
-const createBuildCompleteSlackMessage = require("./build_complete").default;
+import createBuildStartedSlackMessage from "./build_started";
+import createBuildCompleteSlackMessage from "./build_complete";
 
-module.exports = {
+export default {
   createBuildStartedSlackMessage,
   createBuildCompleteSlackMessage,
 };

--- a/netlify/plugins/slack-reporting/slack/create_slack_message/index.js
+++ b/netlify/plugins/slack-reporting/slack/create_slack_message/index.js
@@ -1,5 +1,5 @@
-const createBuildStartedSlackMessage = require("./build_started");
-const createBuildCompleteSlackMessage = require("./build_complete");
+const createBuildStartedSlackMessage = require("./build_started").default;
+const createBuildCompleteSlackMessage = require("./build_complete").default;
 
 module.exports = {
   createBuildStartedSlackMessage,

--- a/netlify/plugins/slack-reporting/slack/create_slack_message/validate_config.js
+++ b/netlify/plugins/slack-reporting/slack/create_slack_message/validate_config.js
@@ -8,7 +8,7 @@
  *
  * @throws {TypeError} Throws if the config has missing values.
  */
-module.exports = function validateConfig(configKeys, config) {
+export default function validateConfig(configKeys, config) {
   const checkedConfig = {};
   const missingValueLabel = "<-- MISSING VALUE";
   configKeys.forEach(
@@ -22,4 +22,4 @@ module.exports = function validateConfig(configKeys, config) {
       \nreceived:\n${JSON.stringify(checkedConfig, undefined, 2)}`,
     );
   }
-};
+}

--- a/netlify/plugins/slack-reporting/slack/get_slack_config.js
+++ b/netlify/plugins/slack-reporting/slack/get_slack_config.js
@@ -1,4 +1,4 @@
-const { camelCase } = require("change-case");
+import { camelCase } from "change-case";
 
 const SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN";
 const SLACK_SIGNING_SECRET = "SLACK_SIGNING_SECRET";
@@ -24,7 +24,7 @@ const slackConfigKeys = [
  * @returns {SlackConfig} The Slack app config.
  * @throws {TypeError} Throws if necessary env variables are undefined.
  */
-module.exports = function getSlackConfig() {
+export default function getSlackConfig() {
   const missingValueLabel = "<-- MISSING VALUE";
   const slackConfigEntries = slackConfigKeys.map((key) => [
     camelCase(key.replace("SLACK_", "")),
@@ -44,4 +44,4 @@ module.exports = function getSlackConfig() {
   }
 
   return slackConfig;
-};
+}

--- a/netlify/plugins/slack-reporting/slack/send_message.js
+++ b/netlify/plugins/slack-reporting/slack/send_message.js
@@ -9,7 +9,7 @@
 // For a more general set up with interactivity see https://api.slack.com/start/building/bolt-js .
 
 // https://api.slack.com/start/building/bolt-js
-const { App } = require("@slack/bolt");
+import { App } from "@slack/bolt";
 
 /**
  * Send a message to a Slack channel via a Slack app.
@@ -20,7 +20,7 @@ const { App } = require("@slack/bolt");
  * @param {string} slackConfig.signingSecret The Slack app's signing secret.
  * @param {string} slackConfig.channelId The Slack channel ID to report to. The app must be a member of the channel.
  */
-module.exports = async function sendMessage(slackMessage, slackConfig) {
+export default async function sendMessage(slackMessage, slackConfig) {
   const encodedBlocks = JSON.stringify(slackMessage.blocks);
   const shortText = slackMessage.shortText;
 
@@ -45,4 +45,4 @@ module.exports = async function sendMessage(slackMessage, slackConfig) {
   } catch (error) {
     console.error(error);
   }
-};
+}


### PR DESCRIPTION
## Description

Music year: 1998

- update slack-reporting netlify plugin to esm
- this looks to be faling since updating the  `Netlify/plugin-nextjs` dependancy

## Issue(s)

Fixes #
[Builds failing due to plugin error](https://app.netlify.com/sites/oak-web-application/deploys?filter=main)

## Testing
As far as I can tell the slack plugin only runs on production builds, so I'm not sure how to test it properly
