### PR TITLE
LESQ-932: Threads dropdown bug

### DIFF
--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -236,6 +236,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
 
                   {learningThemes.length > 1 && (
                     <MobileFilters
+                      $position={tiers.length === 0 ? "absolute" : "relative"}
                       providedId={learningThemesFilterId}
                       label="Threads"
                       $mt={0}


### PR DESCRIPTION
## Description

Music year: 2002

- Fixes threads dropdown bug so it renders at full screen

## Issue(s)

Fixes #LESQ-932

## How to test

1. Go to https://deploy-preview-2629--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks4-aqa/units or any subject with threads 
2. You should see dropdown renders at full width on mobile

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2024-07-22 at 14 47 54](https://github.com/user-attachments/assets/96eee755-aed9-469e-ab20-400bfa822f6a)

How it should now look:
![Screenshot 2024-07-22 at 14 47 19](https://github.com/user-attachments/assets/a2dce446-595a-45e0-84f1-837860185378)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
