### PR TITLE
Fix/pupil/quiz mcq and short answer use feedback

### DIFF
--- a/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.stories.tsx
+++ b/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.stories.tsx
@@ -7,15 +7,7 @@ import {
   mcqTextAnswers,
   mcqImageAnswers,
 } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
-import { MCAnswer } from "@/node-lib/curriculum-api-2023/shared.schema";
 import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
-
-const mcqMulitpleCorrectAnswers = [
-  mcqTextAnswers[0],
-  mcqTextAnswers[1],
-  mcqTextAnswers[2],
-  { ...mcqTextAnswers[3], answerIsCorrect: true },
-] as MCAnswer[]; // for some reason TS gets upset about the possibility of undefined inside the answer property even thought that is on the MCAnswer type
 
 const meta = {
   component: QuizResultMCQ,
@@ -49,7 +41,7 @@ export const CorrectSingle: Story = {
   },
   args: {
     answers: mcqTextAnswers,
-    pupilAnswers: 2,
+    feedback: [null, null, "correct", null],
   },
 };
 
@@ -59,7 +51,7 @@ export const IncorrectSingle: Story = {
   },
   args: {
     answers: mcqTextAnswers,
-    pupilAnswers: 0,
+    feedback: ["incorrect", null, null, null],
   },
 };
 
@@ -69,7 +61,7 @@ export const MixedMultiple: Story = {
   },
   args: {
     answers: mcqTextAnswers,
-    pupilAnswers: [0, 2],
+    feedback: ["incorrect", null, "correct", null],
   },
 };
 
@@ -79,7 +71,7 @@ export const IncorrectMultiple: Story = {
   },
   args: {
     answers: mcqTextAnswers,
-    pupilAnswers: [0, 1],
+    feedback: ["incorrect", "incorrect", null, null],
   },
 };
 
@@ -88,8 +80,8 @@ export const CorrectMultiple: Story = {
     return <QuizResultMCQ {...args} />;
   },
   args: {
-    answers: mcqMulitpleCorrectAnswers,
-    pupilAnswers: [2, 3],
+    answers: mcqTextAnswers,
+    feedback: [null, null, "correct", "correct"],
   },
 };
 
@@ -99,6 +91,6 @@ export const WithImages: Story = {
   },
   args: {
     answers: mcqImageAnswers,
-    pupilAnswers: [1, 2],
+    feedback: [null, "incorrect", "correct", null],
   },
 };

--- a/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.test.tsx
+++ b/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.test.tsx
@@ -12,7 +12,11 @@ describe("QuizResultMCQ", () => {
   it("renders the text for all of the answers", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultMCQ answers={mcqTextAnswers} pupilAnswers={2} />,
+        <QuizResultMCQ
+          answers={mcqTextAnswers}
+          feedback={[null, null, null, null]}
+        />
+        ,
       </OakThemeProvider>,
     );
 
@@ -28,7 +32,11 @@ describe("QuizResultMCQ", () => {
   it("renders the image for all of the answers", () => {
     const { getByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultMCQ answers={mcqImageAnswers} pupilAnswers={2} />,
+        <QuizResultMCQ
+          answers={mcqImageAnswers}
+          feedback={[null, null, null, null]}
+        />
+        ,
       </OakThemeProvider>,
     );
 
@@ -42,15 +50,11 @@ describe("QuizResultMCQ", () => {
   });
 
   it("marks correct answers as correct", () => {
-    const correctAnswerIndex = mcqTextAnswers.findIndex(
-      (answer) => answer.answerIsCorrect,
-    );
-
     const { getAllByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultMCQ
           answers={mcqTextAnswers}
-          pupilAnswers={correctAnswerIndex}
+          feedback={["correct", null, null, null]}
         />
         ,
       </OakThemeProvider>,
@@ -62,22 +66,16 @@ describe("QuizResultMCQ", () => {
   });
 
   it("marks incorrect answers as incorrect", () => {
-    const incorrectAnswerIndexes = mcqTextAnswers
-      .map((answer, i) => (answer.answerIsCorrect ? undefined : i))
-      .filter((i) => i !== undefined) as number[]; // TS doesn't know that we've filtered out the undefineds
-
     const { getAllByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultMCQ
           answers={mcqTextAnswers}
-          pupilAnswers={incorrectAnswerIndexes}
+          feedback={[null, "incorrect", "incorrect", null]}
         />
         ,
       </OakThemeProvider>,
     );
-    expect(getAllByAltText("cross")).toHaveLength(
-      incorrectAnswerIndexes.length,
-    );
+    expect(getAllByAltText("cross")).toHaveLength(2);
     expect(() => getAllByAltText("tick")).toThrow(
       "Unable to find an element with the alt text: tick",
     );

--- a/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.tsx
+++ b/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.tsx
@@ -6,7 +6,7 @@ import {
 } from "@oaknational/oak-components";
 
 import { MCAnswer } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
-import { PupilAnswerMCQ } from "@/components/PupilComponents/QuizUtils/questionTypes";
+import { QuestionFeedbackType } from "@/components/PupilComponents/QuizUtils/questionTypes";
 import {
   isImage,
   isText,
@@ -15,30 +15,15 @@ import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
 
 export type QuizResultMCQProps = {
   answers: MCAnswer[];
-  pupilAnswers: PupilAnswerMCQ;
+  feedback: QuestionFeedbackType[];
 };
 
-export const QuizResultMCQ = ({
-  answers,
-  pupilAnswers,
-}: QuizResultMCQProps) => {
+export const QuizResultMCQ = ({ answers, feedback }: QuizResultMCQProps) => {
   const resultItems = answers.map((answer, index) => {
     const text = answer.answer.filter((answer) => answer?.type === "text")[0];
     const image = answer.answer.filter((answer) => answer?.type === "image")[0];
-    const answerSelected = Array.isArray(pupilAnswers)
-      ? pupilAnswers.includes(index)
-      : pupilAnswers === index;
 
-    const feedbackState = (() => {
-      switch (true) {
-        case answerSelected && !answer.answerIsCorrect:
-          return "incorrect";
-        case answerSelected && answer.answerIsCorrect:
-          return "correct";
-        default:
-          return null;
-      }
-    })();
+    const feedbackState = feedback[index];
 
     const imageURL =
       isImage(image) && image?.imageObject?.secureUrl

--- a/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.stories.tsx
+++ b/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.stories.tsx
@@ -3,17 +3,13 @@ import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
 import { QuizResultShortAnswer } from "./QuizResultShortAnswer";
 
-import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
-
 const meta = {
   component: QuizResultShortAnswer,
   decorators: [
     (Story) => (
-      <MathJaxProvider>
-        <OakThemeProvider theme={oakDefaultTheme}>
-          <Story />
-        </OakThemeProvider>
-      </MathJaxProvider>
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <Story />
+      </OakThemeProvider>
     ),
   ],
   parameters: {
@@ -36,17 +32,17 @@ export const Correct: Story = {
     return <QuizResultShortAnswer {...args} />;
   },
   args: {
-    answers: "This is the correct answer",
+    feedback: "correct",
     pupilAnswer: "This is the correct answer",
   },
 };
 
-export const IncorrectSingle: Story = {
+export const Incorrect: Story = {
   render: (args) => {
     return <QuizResultShortAnswer {...args} />;
   },
   args: {
-    answers: "This is the correct answer",
+    feedback: "incorrect",
     pupilAnswer: "This is the incorrect answer",
   },
 };

--- a/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.test.tsx
+++ b/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.test.tsx
@@ -9,8 +9,8 @@ describe("QuizResultShortAnswer", () => {
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultShortAnswer
-          answers={"This is the correct answer"}
           pupilAnswer={"This is the correct answer"}
+          feedback={"correct"}
         />
         ,
       </OakThemeProvider>,
@@ -23,23 +23,8 @@ describe("QuizResultShortAnswer", () => {
     const { getAllByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultShortAnswer
-          answers={"This is the correct answer"}
           pupilAnswer={"This is the correct answer"}
-        />
-        ,
-      </OakThemeProvider>,
-    );
-    expect(getAllByAltText("tick")).toHaveLength(1);
-    expect(() => getAllByAltText("cross")).toThrow(
-      "Unable to find an element with the alt text: cross",
-    );
-  });
-  it("marks correct answers as correct for multipe answers", () => {
-    const { getAllByAltText } = renderWithTheme(
-      <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultShortAnswer
-          answers={["This is the correct answer", "another correct answer"]}
-          pupilAnswer={"This is the correct answer"}
+          feedback={"correct"}
         />
         ,
       </OakThemeProvider>,
@@ -54,23 +39,8 @@ describe("QuizResultShortAnswer", () => {
     const { getAllByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultShortAnswer
-          answers={"This is the correct answer"}
           pupilAnswer={"This is not the correct answer"}
-        />
-        ,
-      </OakThemeProvider>,
-    );
-    expect(getAllByAltText("cross")).toHaveLength(1);
-    expect(() => getAllByAltText("tick")).toThrow(
-      "Unable to find an element with the alt text: tick",
-    );
-  });
-  it("marks incorrect answers as incorrect for multiple correct", () => {
-    const { getAllByAltText } = renderWithTheme(
-      <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultShortAnswer
-          answers={["This is the correct answer", "another correct answer"]}
-          pupilAnswer={"This is not the correct answer"}
+          feedback={"incorrect"}
         />
         ,
       </OakThemeProvider>,

--- a/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.tsx
+++ b/src/components/PupilComponents/QuizResultShortAnswer/QuizResultShortAnswer.tsx
@@ -5,36 +5,23 @@ import {
   OakSpan,
 } from "@oaknational/oak-components";
 
-import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
+import { QuestionFeedbackType } from "@/components/PupilComponents/QuizUtils/questionTypes";
 
 export type QuizResultShortAnswerProps = {
-  answers: string | (string | undefined)[];
   pupilAnswer: string;
+  feedback: QuestionFeedbackType;
 };
 
 export const QuizResultShortAnswer = ({
-  answers,
   pupilAnswer,
+  feedback,
 }: QuizResultShortAnswerProps) => {
-  const feedbackState = (() => {
-    switch (true) {
-      case pupilAnswer === answers:
-        return "correct";
-      case answers.includes(pupilAnswer):
-        return "correct";
-      case pupilAnswer !== answers:
-        return "incorrect";
-    }
-  })();
-
   const resultItem = (
-    <MathJaxWrap>
-      <OakQuizResultItem
-        key={pupilAnswer}
-        standardText={pupilAnswer}
-        feedbackState={feedbackState}
-      />
-    </MathJaxWrap>
+    <OakQuizResultItem
+      key={pupilAnswer}
+      standardText={pupilAnswer}
+      feedbackState={feedback}
+    />
   );
 
   return (


### PR DESCRIPTION
## Description
QuizResultMCQ and QuizResultShortAnswer now implement a feedback prop to take advantage of the feedback data which is stored in the QuizEngineProvider. 

This improves consistency of interfaces, reduces complexity of the components and removes duplication of logic.

## How to test

1. Go to https://deploy-preview-2661--owa-storybook.netlify.app/?path=/story/components-pupilcomponents-quizresultshortanswer

## Checklist

- [x ] Added or updated tests where appropriate
- [x] Updated storybooks
