### PR TITLE
[CUR-796] Missing filtered units in downloads

### DIFF
--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -80,20 +80,11 @@ async function getData(opts: {
         .filter((a) => {
           if (a.keystage_slug === "ks4") {
             const unitIsChildSubject =
-              a.subject_slug &&
-              a.subject_slug === childSubjectSlug &&
-              childSubjectSlug !== null;
+              !childSubjectSlug || a.subject_slug === childSubjectSlug;
             const unitHasCorrectTier =
-              a.tier_slug && a.tier_slug === tierSlug && tierSlug !== null;
-            if (childSubjectSlug && tierSlug) {
-              return unitIsChildSubject && unitHasCorrectTier;
-            }
-            if (childSubjectSlug) {
-              return unitIsChildSubject;
-            }
-            if (tierSlug) {
-              return unitHasCorrectTier;
-            }
+              a.tier_slug === tierSlug || !tierSlug || !a.tier_slug;
+
+            return unitIsChildSubject && unitHasCorrectTier;
           }
           return true;
         })


### PR DESCRIPTION
## Description

Music year: 2005

- Updated filtering for units 

## Issue(s)
- Missing units in Secondary science & maths

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="300" alt="Screenshot 2024-08-05 at 12 38 17" src="https://github.com/user-attachments/assets/d8d70b3f-8a26-4938-ab23-d9ea08ac0cc4">

How it should now look:
<img width="355" alt="Screenshot 2024-08-05 at 12 36 23" src="https://github.com/user-attachments/assets/67fb9856-c374-444e-bf32-7173103d9d04">

Maths Higher
<img width="301" alt="Screenshot 2024-08-05 at 13 03 41" src="https://github.com/user-attachments/assets/618d4cf0-a40f-4d41-8154-ea060fb3a83e">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
