### PR TITLE
[CUR-791] Child subject & tier subtitle on title page for docx

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
@@ -17,7 +17,6 @@ describe("1_frontCover", () => {
       } as CombinedCurriculumData,
       slugs: {
         subjectSlug: "",
-        examboardTitle: "",
       } as Slugs,
     });
 

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
@@ -1,3 +1,4 @@
+import { Slugs } from "..";
 import { generateEmptyDocx } from "../docx";
 
 import generate from "./1_frontCover";
@@ -14,6 +15,10 @@ describe("1_frontCover", () => {
         phaseTitle: "",
         examboardTitle: "",
       } as CombinedCurriculumData,
+      slugs: {
+        subjectSlug: "",
+        examboardTitle: "",
+      } as Slugs,
     });
 
     expect(await zipToSnapshotObject(zip.getJsZip())).toMatchSnapshot();

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -1,4 +1,4 @@
-import { relative } from "path";
+import { join } from "path";
 
 import { capitalize } from "lodash";
 
@@ -30,15 +30,15 @@ export default async function generate(
   const images = await insertImages(zip, {
     icon: sanityUrl
       ? makeTransparentIfSanity(sanityUrl, cmToPxDpi(13))
-      : relative(
+      : join(
           process.cwd(),
           "src/pages-helpers/curriculum/docx/builder/images/icon.png",
         ),
-    arrow: relative(
+    arrow: join(
       process.cwd(),
       "src/pages-helpers/curriculum/docx/builder/images/arrow.png",
     ),
-    logo: relative(
+    logo: join(
       process.cwd(),
       "src/pages-helpers/curriculum/docx/builder/images/logo.png",
     ),

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -1,6 +1,8 @@
-import { join } from "path";
+import { relative } from "path";
 
-import { CombinedCurriculumData } from "..";
+import { capitalize } from "lodash";
+
+import { CombinedCurriculumData, Slugs } from "..";
 import { cdata, safeXml, xmlElementToJson } from "../xml";
 import {
   appendBodyElements,
@@ -20,7 +22,7 @@ import { getSubjectIconAsset } from "@/image-data";
 
 export default async function generate(
   zip: JSZipCached,
-  { data }: { data: CombinedCurriculumData },
+  { data, slugs }: { data: CombinedCurriculumData; slugs: Slugs },
 ) {
   const iconKey = data.subjectTitle.toLowerCase();
 
@@ -28,15 +30,15 @@ export default async function generate(
   const images = await insertImages(zip, {
     icon: sanityUrl
       ? makeTransparentIfSanity(sanityUrl, cmToPxDpi(13))
-      : join(
+      : relative(
           process.cwd(),
           "src/pages-helpers/curriculum/docx/builder/images/icon.png",
         ),
-    arrow: join(
+    arrow: relative(
       process.cwd(),
       "src/pages-helpers/curriculum/docx/builder/images/arrow.png",
     ),
-    logo: join(
+    logo: relative(
       process.cwd(),
       "src/pages-helpers/curriculum/docx/builder/images/logo.png",
     ),
@@ -44,9 +46,16 @@ export default async function generate(
 
   const phaseTitle = keyStageFromPhaseTitle(data.phaseTitle);
   const subjectTitle = data.subjectTitle;
-  const examboardTitle = data.examboardTitle
-    ? `${data.examboardTitle} (KS4)`
+
+  const examboardTitle = data.examboardTitle ? `${data.examboardTitle}` : "";
+  const tierTitle = slugs.tierSlug ? `${capitalize(slugs.tierSlug)}` : "";
+  const childSubjectTitle = slugs.childSubjectSlug
+    ? `${capitalize(slugs.childSubjectSlug)}`
     : "";
+
+  const subtitle =
+    [examboardTitle, childSubjectTitle, tierTitle].filter(Boolean).join(", ") +
+    " (KS4)";
 
   const pageXml = safeXml`
     <root>
@@ -97,7 +106,7 @@ export default async function generate(
             <w:color w:val="222222" />
             <w:sz w:val="30" />
           </w:rPr>
-          <w:t>${cdata(examboardTitle)}</w:t>
+          <w:t>${cdata(subtitle)}</w:t>
         </w:r>
       </w:p>
       <w:p>

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -54,8 +54,11 @@ export default async function generate(
     : "";
 
   const subtitle =
-    [examboardTitle, childSubjectTitle, tierTitle].filter(Boolean).join(", ") +
-    " (KS4)";
+    examboardTitle !== "" || tierTitle !== "" || childSubjectTitle || ""
+      ? [examboardTitle, childSubjectTitle, tierTitle]
+          .filter(Boolean)
+          .join(", ") + " (KS4)"
+      : "";
 
   const pageXml = safeXml`
     <root>

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -50,7 +50,7 @@ export default async function generate(
   const examboardTitle = data.examboardTitle ? `${data.examboardTitle}` : "";
   const tierTitle = slugs.tierSlug ? `${capitalize(slugs.tierSlug)}` : "";
   const childSubjectTitle = slugs.childSubjectSlug
-    ? `${capitalize(slugs.childSubjectSlug)}`
+    ? `${capitalize(slugs.childSubjectSlug.split("-").join(" "))}`
     : "";
 
   const subtitle =

--- a/src/pages-helpers/curriculum/docx/index.ts
+++ b/src/pages-helpers/curriculum/docx/index.ts
@@ -35,6 +35,8 @@ export type Slugs = {
   phaseSlug?: string;
   examboardSlug?: string;
   keyStageSlug?: string;
+  tierSlug?: string;
+  childSubjectSlug?: string;
 };
 
 const ENABLE_TIMER = false;
@@ -122,7 +124,7 @@ export default async function docx(data: CombinedCurriculumData, slugs: Slugs) {
 
   // Run through the builders
   const runners = {
-    frontCover: async () => await builder.frontCover(zip, { data }),
+    frontCover: async () => await builder.frontCover(zip, { data, slugs }),
     frontCoverPageLayout: async () =>
       await builder.pageLayout(zip, {
         margins: {

--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -267,7 +267,7 @@ export default async function handler(
       data.combinedCurriculumData?.subjectTitle,
       data.combinedCurriculumData?.phaseTitle,
       data.combinedCurriculumData?.examboardTitle,
-      capitalize(childSubjectSlug),
+      capitalize(childSubjectSlug?.split("-").join(" ")),
       capitalize(tierSlug),
     ]
       .filter(Boolean)

--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -259,6 +259,8 @@ export default async function handler(
       phaseSlug: data.phaseSlug,
       keyStageSlug: data.phaseSlug,
       examboardSlug: data.examboardSlug,
+      tierSlug,
+      childSubjectSlug,
     });
 
     const pageTitle: string = [


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Updated title page to have correct subtitle according to filters 
- Updated filename to have proper formatting (e.g. "Combined-science" becomes "Combined science") for subject titles longer than a word

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="293" alt="Screenshot 2024-08-05 at 15 22 54" src="https://github.com/user-attachments/assets/bd0f0c91-4270-42fd-935b-be26e46c5db1">
<img width="314" alt="Screenshot 2024-08-05 at 15 25 09" src="https://github.com/user-attachments/assets/e3debe29-828c-460b-93ab-e9f25c81db1f">

How it should now look:
<img width="298" alt="Screenshot 2024-08-05 at 15 22 05" src="https://github.com/user-attachments/assets/ddb79f7e-58e7-47c2-9974-d1497b87c8cd">
<img width="310" alt="Screenshot 2024-08-05 at 15 24 23" src="https://github.com/user-attachments/assets/f7148426-a8bc-43c6-8921-91cbb1e0b27f">
English 
<img width="314" alt="Screenshot 2024-08-05 at 15 53 35" src="https://github.com/user-attachments/assets/35784598-6a9c-4138-b208-a4ea1894ef0f">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
