### PR TITLE
fix: wrap requestLessonResources in try catch

### DIFF
--- a/src/pages-helpers/pupil/lessons-pages/getProps.ts
+++ b/src/pages-helpers/pupil/lessons-pages/getProps.ts
@@ -95,9 +95,22 @@ export const getProps = ({
           })
         : resolveOakHref({ page: "pupil-year-index" });
 
-    const { transcriptSentences, hasWorksheet } = await requestLessonResources({
-      lessonContent: content,
-    });
+    const { transcriptSentences, hasWorksheet } = await (async () => {
+      try {
+        const { transcriptSentences, hasWorksheet } =
+          await requestLessonResources({
+            lessonContent: content,
+          });
+
+        return { transcriptSentences, hasWorksheet };
+      } catch (e) {
+        if (page === "preview") {
+          return { transcriptSentences: [], hasWorksheet: false };
+        } else {
+          throw e;
+        }
+      }
+    })();
 
     const results: GetStaticPropsResult<PupilExperienceViewProps> = {
       props: {


### PR DESCRIPTION

## Issue(s)

When previewing pages the video transcripts aren't yet created by the ingest process . This means that attempts to find them result in an error creating a 404.

Fixes #

Wrap the call to requestLessonResources in a try/catch and then conditionally throw the error depending whether it's a preview page or not.

## How to test

1. Go to https://deploy-preview-2708--oak-web-application.netlify.thenational.academy/pupils/beta/previews/lessons/natural-selection-at-the-genetic-level/overview
2. should be visible where as on production it is a 404


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
