### PR TITLE
LESQ-1007: Add user onboarding details to clerk

### DIFF
--- a/clerk.d.ts
+++ b/clerk.d.ts
@@ -1,0 +1,36 @@
+export {};
+
+declare global {
+  /**
+   * Public metadata for the user
+   *
+   * 🚨 When removing keys or altering types be sure to deprecate and/or perform a data migration to bring
+   * user data inline with the new schema
+   */
+  interface UserPublicMetadata {
+    /**
+     * The origin of the app through which the user first onboarded.
+     *
+     * 🚨 This should be set once by the Oak app the user first onboarded through.
+     */
+    sourceApp?: string;
+    /**
+     * ISO 3166-1 alpha-2 country code the user's IP address was geo-located as being within at the time of onboarding.
+     *
+     * This value could be incorrect or set to a value of XX if their IP is missing/incorrectly located by Cloudflare.
+     *
+     * 🚨 This should be set once by the Oak app the user first onboarded through.
+     */
+    region?: string;
+    owa?: {
+      /**
+       * Indicates that the user self-identified as a teacher when onboarding.
+       */
+      isTeacher?: boolean;
+      /**
+       * Indicates that the user has been onboarded
+       */
+      isOnboarded?: boolean;
+    };
+  }
+}

--- a/src/__tests__/__helpers__/mockUser.ts
+++ b/src/__tests__/__helpers__/mockUser.ts
@@ -1,28 +1,88 @@
 import { useUser } from "@clerk/nextjs";
+import { currentUser } from "@clerk/nextjs/server";
 
 type UseUserReturn = ReturnType<typeof useUser>;
 type UserResource = NonNullable<UseUserReturn["user"]>;
+type CurrentUser = NonNullable<Awaited<ReturnType<typeof currentUser>>>;
 
+/**
+ * Mock client-side user object
+ */
 export const mockUser = {
   id: "user-123",
   publicMetadata: {},
   reload: jest.fn(),
 } as unknown as UserResource;
 
+/**
+ * Mock return value for a logged in state
+ *
+ * Use with the `useUser` hook
+ */
 export const mockLoggedIn: UseUserReturn & { user: UserResource } = {
   user: mockUser,
   isLoaded: true,
   isSignedIn: true,
 };
 
+/**
+ * Mock return value for a logged out state
+ *
+ * Use with the `useUser` hook
+ */
 export const mockLoggedOut: UseUserReturn = {
   user: null,
   isLoaded: true,
   isSignedIn: false,
 };
 
+/**
+ * Mock return value for the user loading state
+ *
+ * Use with the `useUser` hook
+ */
 export const mockLoadingUser: UseUserReturn = {
   user: undefined,
   isLoaded: false,
   isSignedIn: undefined,
+};
+
+/**
+ * Provides a mock return value for the backend `currentUser()`
+ */
+export const mockCurrentUser: CurrentUser = {
+  id: "123",
+  passwordEnabled: false,
+  totpEnabled: false,
+  backupCodeEnabled: false,
+  twoFactorEnabled: false,
+  banned: false,
+  locked: false,
+  createdAt: 0,
+  updatedAt: 0,
+  imageUrl: "",
+  hasImage: false,
+  primaryEmailAddressId: null,
+  primaryPhoneNumberId: null,
+  primaryWeb3WalletId: null,
+  lastSignInAt: null,
+  externalId: null,
+  username: null,
+  firstName: null,
+  lastName: null,
+  publicMetadata: {},
+  privateMetadata: {},
+  unsafeMetadata: {},
+  emailAddresses: [],
+  phoneNumbers: [],
+  web3Wallets: [],
+  externalAccounts: [],
+  samlAccounts: [],
+  lastActiveAt: null,
+  createOrganizationEnabled: false,
+  createOrganizationsLimit: null,
+  primaryEmailAddress: null,
+  primaryPhoneNumber: null,
+  primaryWeb3Wallet: null,
+  fullName: null,
 };

--- a/src/app/api/auth/onboarding/route.test.ts
+++ b/src/app/api/auth/onboarding/route.test.ts
@@ -25,29 +25,47 @@ jest.mock("@clerk/nextjs/server", () => {
 });
 
 describe("/api/auth/onboarding", () => {
+  const req = new Request("http://example.com", {
+    method: "POST",
+    body: JSON.stringify({ "owa:isTeacher": true }),
+  });
+
   beforeEach(() => {
     authReturn = { userId: "123" };
   });
 
   it("requires authentication", async () => {
     authReturn = { userId: null };
-    const response = await POST();
+    const response = await POST(req);
 
     expect(response.status).toBe(401);
   });
 
   it("marks the user as onboarded", async () => {
-    const response = await POST();
+    const response = await POST(req);
 
     expect(clerkClient().users.updateUserMetadata).toHaveBeenCalledWith("123", {
       publicMetadata: {
+        "owa:isTeacher": true,
         "owa:onboarded": true,
       },
     });
     expect(response.status).toBe(200);
 
     await expect(response.json()).resolves.toEqual({
+      "owa:isTeacher": true,
       "owa:onboarded": true,
     });
+  });
+
+  it("handles validation errors", async () => {
+    const response = await POST(
+      new Request("http://example.com", {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/src/app/api/auth/onboarding/route.test.ts
+++ b/src/app/api/auth/onboarding/route.test.ts
@@ -31,7 +31,7 @@ describe("/api/auth/onboarding", () => {
   beforeEach(() => {
     req = new Request("http://example.com", {
       method: "POST",
-      body: JSON.stringify({ "owa:isTeacher": true }),
+      body: JSON.stringify({ isTeacher: true }),
       headers: {
         referer: "http://example.com/foo",
       },
@@ -52,16 +52,20 @@ describe("/api/auth/onboarding", () => {
 
     expect(clerkClient().users.updateUserMetadata).toHaveBeenCalledWith("123", {
       publicMetadata: expect.objectContaining({
-        "owa:isTeacher": true,
-        "owa:onboarded": true,
+        owa: {
+          isTeacher: true,
+          isOnboarded: true,
+        },
       }),
     });
     expect(response.status).toBe(200);
 
     await expect(response.json()).resolves.toEqual(
       expect.objectContaining({
-        "owa:isTeacher": true,
-        "owa:onboarded": true,
+        owa: {
+          isTeacher: true,
+          isOnboarded: true,
+        },
       }),
     );
   });

--- a/src/app/api/auth/onboarding/route.ts
+++ b/src/app/api/auth/onboarding/route.ts
@@ -11,9 +11,12 @@ export async function POST(req: Request) {
   }
 
   try {
-    const data = onboardingSchema.parse(await req.json());
+    const owaData = onboardingSchema.parse(await req.json());
     const sourceApp = user.publicMetadata.sourceApp ?? getReferrerOrigin(req);
-    const publicMetadata = { ...data, sourceApp, "owa:onboarded": true };
+    const publicMetadata: UserPublicMetadata = {
+      sourceApp,
+      owa: { ...owaData, isOnboarded: true },
+    };
 
     await clerkClient().users.updateUserMetadata(user.id, {
       publicMetadata,

--- a/src/common-lib/schemas/onboarding.ts
+++ b/src/common-lib/schemas/onboarding.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const onboardingSchema = z.object({
+  "owa:isTeacher": z.boolean(),
+});
+export type OnboardingSchema = z.infer<typeof onboardingSchema>;

--- a/src/common-lib/schemas/onboarding.ts
+++ b/src/common-lib/schemas/onboarding.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
 export const onboardingSchema = z.object({
-  "owa:isTeacher": z.boolean(),
+  isTeacher: z.boolean(),
 });
 export type OnboardingSchema = z.infer<typeof onboardingSchema>;

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
@@ -74,21 +74,13 @@ describe("Onboarding form", () => {
   );
 
   describe.each<[string, OnboardingFormState, OnboardingSchema]>([
-    [
-      "of school selection",
-      { school: "Grange Hill" },
-      { "owa:isTeacher": true },
-    ],
+    ["of school selection", { school: "Grange Hill" }, { isTeacher: true }],
     [
       "of manual school selection",
       { manualSchoolName: "Grange Hill" },
-      { "owa:isTeacher": true },
+      { isTeacher: true },
     ],
-    [
-      "of role selection",
-      { role: "teacher-trainer" },
-      { "owa:isTeacher": false },
-    ],
+    ["of role selection", { role: "teacher-trainer" }, { isTeacher: false }],
   ])("on submit %s", (__, formState, onboardingPayload) => {
     beforeEach(() => {
       mockRouter.setCurrentUrl("/onboarding?returnTo=/downloads");
@@ -107,7 +99,7 @@ describe("Onboarding form", () => {
     it("redirects the user back to the page they came from", async () => {
       jest
         .spyOn(onboardingActions, "onboardUser")
-        .mockResolvedValue({ "owa:isTeacher": true, "owa:onboarded": true });
+        .mockResolvedValue({ owa: { isTeacher: true, isOnboarded: true } });
 
       await submitForm(formState);
 

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
@@ -10,6 +10,7 @@ import * as onboardingActions from "./onboardingActions";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
+import type { OnboardingSchema } from "@/common-lib/schemas/onboarding";
 
 jest.mock("@/browser-lib/hubspot/forms");
 jest.mock("./onboardingActions");
@@ -72,10 +73,23 @@ describe("Onboarding form", () => {
     },
   );
 
-  describe.each<[string, OnboardingFormState]>([
-    ["of school selection", { school: "Grange Hill" }],
-    ["of role selection", { role: "teacher-trainer" }],
-  ])("on submit %s", (__, formState) => {
+  describe.each<[string, OnboardingFormState, OnboardingSchema]>([
+    [
+      "of school selection",
+      { school: "Grange Hill" },
+      { "owa:isTeacher": true },
+    ],
+    [
+      "of manual school selection",
+      { manualSchoolName: "Grange Hill" },
+      { "owa:isTeacher": true },
+    ],
+    [
+      "of role selection",
+      { role: "teacher-trainer" },
+      { "owa:isTeacher": false },
+    ],
+  ])("on submit %s", (__, formState, onboardingPayload) => {
     beforeEach(() => {
       mockRouter.setCurrentUrl("/onboarding?returnTo=/downloads");
     });
@@ -85,13 +99,15 @@ describe("Onboarding form", () => {
 
       await submitForm(formState);
 
-      expect(onboardingActions.onboardUser).toHaveBeenCalled();
+      expect(onboardingActions.onboardUser).toHaveBeenCalledWith(
+        onboardingPayload,
+      );
     });
 
     it("redirects the user back to the page they came from", async () => {
       jest
         .spyOn(onboardingActions, "onboardUser")
-        .mockResolvedValue({ "owa:onboarded": true });
+        .mockResolvedValue({ "owa:isTeacher": true, "owa:onboarded": true });
 
       await submitForm(formState);
 

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -68,7 +68,7 @@ const OnboardingForm = ({
       const isTeacher = "school" in data || "manualSchoolName" in data;
 
       try {
-        await onboardUser({ "owa:isTeacher": isTeacher });
+        await onboardUser({ isTeacher });
         await user?.reload();
       } catch (error) {
         setSubmitError("Something went wrong. Please try again.");

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -65,8 +65,10 @@ const OnboardingForm = ({
         query: router.query,
       });
     } else {
+      const isTeacher = "school" in data || "manualSchoolName" in data;
+
       try {
-        await onboardUser();
+        await onboardUser({ "owa:isTeacher": isTeacher });
         await user?.reload();
       } catch (error) {
         setSubmitError("Something went wrong. Please try again.");

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
@@ -7,7 +7,9 @@ import OakError from "@/errors/OakError";
 describe(onboardUser, () => {
   beforeAll(() => {
     fetchMock.enableMocks();
-    fetchMock.doMock(JSON.stringify({ "owa:onboarded": true }));
+    fetchMock.doMock(
+      JSON.stringify({ owa: { isOnboarded: true, isTeacher: true } }),
+    );
   });
 
   afterAll(() => {
@@ -15,22 +17,25 @@ describe(onboardUser, () => {
   });
 
   it("makes a request to mark the user as onboarded", async () => {
-    await onboardUser({ "owa:isTeacher": true });
+    await onboardUser({ isTeacher: true });
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringMatching("/api/auth/onboarding"),
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ "owa:isTeacher": true }),
+        body: JSON.stringify({ isTeacher: true }),
       }),
     );
   });
 
   describe("when successful", () => {
     it("returns the response JSON", async () => {
-      await expect(onboardUser({ "owa:isTeacher": true })).resolves.toEqual({
-        "owa:onboarded": true,
+      await expect(onboardUser({ isTeacher: true })).resolves.toEqual({
+        owa: {
+          isOnboarded: true,
+          isTeacher: true,
+        },
       });
     });
   });
@@ -44,7 +49,7 @@ describe(onboardUser, () => {
         };
       });
 
-      await expect(onboardUser({ "owa:isTeacher": true })).rejects.toEqual(
+      await expect(onboardUser({ isTeacher: true })).rejects.toEqual(
         expect.any(OakError),
       );
     });

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
@@ -15,17 +15,21 @@ describe(onboardUser, () => {
   });
 
   it("makes a request to mark the user as onboarded", async () => {
-    await onboardUser();
+    await onboardUser({ "owa:isTeacher": true });
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringMatching("/api/auth/onboarding"),
-      { method: "POST" },
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ "owa:isTeacher": true }),
+      }),
     );
   });
 
   describe("when successful", () => {
     it("returns the response JSON", async () => {
-      await expect(onboardUser()).resolves.toEqual({
+      await expect(onboardUser({ "owa:isTeacher": true })).resolves.toEqual({
         "owa:onboarded": true,
       });
     });
@@ -40,7 +44,9 @@ describe(onboardUser, () => {
         };
       });
 
-      await expect(onboardUser()).rejects.toEqual(expect.any(OakError));
+      await expect(onboardUser({ "owa:isTeacher": true })).rejects.toEqual(
+        expect.any(OakError),
+      );
     });
   });
 });

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
@@ -11,7 +11,7 @@ const reportError = errorReporter("onboardingActions");
  */
 export async function onboardUser(
   data: OnboardingSchema,
-): Promise<OnboardingSchema & { "owa:onboarded": true }> {
+): Promise<UserPublicMetadata> {
   try {
     const response = await fetch(apiRoute, {
       method: "POST",

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
@@ -1,4 +1,5 @@
 import errorReporter from "@/common-lib/error-reporter";
+import type { OnboardingSchema } from "@/common-lib/schemas/onboarding";
 import OakError from "@/errors/OakError";
 
 const apiRoute = "/api/auth/onboarding";
@@ -8,10 +9,16 @@ const reportError = errorReporter("onboardingActions");
 /**
  * Makes a request to mark the user as onboarded in Clerk
  */
-export async function onboardUser(): Promise<{ "owa:onboarded": true }> {
+export async function onboardUser(
+  data: OnboardingSchema,
+): Promise<OnboardingSchema & { "owa:onboarded": true }> {
   try {
     const response = await fetch(apiRoute, {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
     });
     if (!response.ok) {
       throw new OakError({

--- a/src/hocs/withOnboardingRequired.test.tsx
+++ b/src/hocs/withOnboardingRequired.test.tsx
@@ -70,7 +70,7 @@ describe(withOnboardingRequired, () => {
         ...mockLoggedIn,
         user: {
           ...mockLoggedIn.user,
-          publicMetadata: { "owa:onboarded": true },
+          publicMetadata: { owa: { isOnboarded: true } },
         },
       };
     });

--- a/src/hocs/withOnboardingRequired.tsx
+++ b/src/hocs/withOnboardingRequired.tsx
@@ -10,11 +10,11 @@ export function withOnboardingRequired<P extends object>(
   Component: ComponentType<P>,
   FallbackComponent?: ComponentType<PropsWithChildren>,
 ) {
-  function WrappedComponent(props: P) {
+  function WrappedComponent(props: Readonly<P>) {
     const { useUser } = useFeatureFlaggedClerk();
     useRequireOnboarding();
 
-    if (!useUser().user?.publicMetadata?.["owa:onboarded"]) {
+    if (!useUser().user?.publicMetadata?.owa?.isOnboarded) {
       if (FallbackComponent) {
         return (
           <FallbackComponent>

--- a/src/hooks/useRequireOnboarding.test.ts
+++ b/src/hooks/useRequireOnboarding.test.ts
@@ -50,7 +50,7 @@ describe(useRequireOnboarding, () => {
           ...mockLoggedIn,
           user: {
             ...mockLoggedIn.user,
-            publicMetadata: { "owa:onboarded": true },
+            publicMetadata: { owa: { isOnboarded: true } },
           },
         };
       });

--- a/src/hooks/useRequireOnboarding.ts
+++ b/src/hooks/useRequireOnboarding.ts
@@ -22,7 +22,7 @@ export function useRequireOnboarding() {
       return;
     }
 
-    if (user && !user.publicMetadata["owa:onboarded"]) {
+    if (user && !user.publicMetadata?.owa?.isOnboarded) {
       router.replace({
         pathname: resolveOakHref({ page: "onboarding" }),
         query: { returnTo: router.asPath },

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -3,6 +3,7 @@ import { oakDefaultTheme, OakThemeProvider } from "@oaknational/oak-components";
 
 import OnboardingView from "@/components/TeacherViews/Onboarding/Onboarding.view";
 import withFeatureFlag from "@/hocs/withFeatureFlag";
+import { withPageAuthRequired } from "@/hocs/withPageAuthRequired";
 
 const OnboardingComponent: NextPage = () => {
   return (
@@ -12,6 +13,9 @@ const OnboardingComponent: NextPage = () => {
   );
 };
 
-const OnboardingPage = withFeatureFlag(OnboardingComponent, "use-auth-owa");
+const OnboardingPage = withFeatureFlag(
+  withPageAuthRequired(OnboardingComponent),
+  "use-auth-owa",
+);
 
 export default OnboardingPage;

--- a/src/pages/onboarding/role-selection.tsx
+++ b/src/pages/onboarding/role-selection.tsx
@@ -14,8 +14,8 @@ const RoleSelectionComponent: NextPage = () => {
 };
 
 const RoleSelectionPage = withFeatureFlag(
-  RoleSelectionComponent,
+  withPageAuthRequired(RoleSelectionComponent),
   "use-auth-owa",
 );
 
-export default withPageAuthRequired(RoleSelectionPage);
+export default RoleSelectionPage;

--- a/src/pages/onboarding/school-selection.tsx
+++ b/src/pages/onboarding/school-selection.tsx
@@ -14,8 +14,8 @@ const SchoolSelectionComponent: NextPage = () => {
 };
 
 const SchoolSelectionPage = withFeatureFlag(
-  SchoolSelectionComponent,
+  withPageAuthRequired(SchoolSelectionComponent),
   "use-auth-owa",
 );
 
-export default withPageAuthRequired(SchoolSelectionPage);
+export default SchoolSelectionPage;


### PR DESCRIPTION
## Description

Music year: 1994

- sets `{ owa: { isTeacher } }` in the user's Clerk public metadata depending on their onboarding choices, we can use this to authorise access to resources later.
- sets `sourceApp` in the user's Clerk public metadata to the origin of the app from which the user first onboarded. In production this will be `https://www.thenational.academy` we can use this to attribute sign-ups to OWA.


## How to test

1. Go to https://deploy-preview-2713--oak-web-application.netlify.thenational.academy/onboarding
2. Login if necessary
3. Onboard as a teacher picking a school or entering one manually
4. Find your account in Clerk and verify that your public metadata contains `{ owa: { isTeacher: true } }`
5. Repeat 1. but onboard as a non-teacher
6. Reload your account in Clerk and verify that your public metadata contains `{ owa: { isTeacher: false } }`

## Screenshots


https://github.com/user-attachments/assets/aae86564-e655-4e4a-89c9-7e2a595c3de4


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
