### PR TITLE
chore: bump google cloud storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bugsnag/js": "^7.23.0",
         "@bugsnag/plugin-react": "^7.24.0",
         "@clerk/nextjs": "^5.3.1",
-        "@google-cloud/storage": "^7.11.2",
+        "@google-cloud/storage": "^7.12.1",
         "@hookform/resolvers": "^3.7.0",
         "@hubspot/api-client": "^11.1.0",
         "@mux/mux-node": "^8.8.0",
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
-      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.12.1.tgz",
+      "integrity": "sha512-Z3ZzOnF3YKLuvpkvF+TjQ6lztxcAyTILp+FjKonmVpEwPa9vFvxpZjubLR4sB6bf19i/8HL2AXRjA0YFgHFRmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -4144,7 +4144,7 @@
         "abort-controller": "^3.0.0",
         "async-retry": "^1.3.3",
         "duplexify": "^4.1.3",
-        "fast-xml-parser": "^4.3.0",
+        "fast-xml-parser": "^4.4.1",
         "gaxios": "^6.0.2",
         "google-auth-library": "^9.6.3",
         "html-entities": "^2.5.2",
@@ -20380,7 +20380,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.6",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",
@@ -37291,6 +37293,8 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "license": "MIT"
     },
     "node_modules/stubs": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@bugsnag/js": "^7.23.0",
     "@bugsnag/plugin-react": "^7.24.0",
     "@clerk/nextjs": "^5.3.1",
-    "@google-cloud/storage": "^7.11.2",
+    "@google-cloud/storage": "^7.12.1",
     "@hookform/resolvers": "^3.7.0",
     "@hubspot/api-client": "^11.1.0",
     "@mux/mux-node": "^8.8.0",


### PR DESCRIPTION
bumps to @google-cloud/storage@"^7.12.1" 
addresses security issue with fast-xml-parser by bumping to 4.4.1