### PR TITLE
fix: add a not found page to catch 404s and redirect to 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+export default function NotFound() {
+  const router = useRouter();
+  return router.replace("/404");
+}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- We have added pages for auth in the app router, and this takes precedence over the pages router, so all 404s are currently using the app router's default `not-found` page without any oak theming
- Creating the 404 page in the app router requires a bit more work, so this adds a little hack to redirect to the existing themed 404 page we have in pages router, until we can get that work done
- A tech debt ticket will be added to upgrade the `not-found` and remove the 404 page

## How to test

1. Go to {owa_deployment_url} anywhere
2. Update the url with an invalid slug eg {owa_deployment_url}/teachers/lessons/not-a-real-lesson
3. You should see the oak 404 page

## Screenshots

How it used to look (delete if n/a):
<img width="600" alt="Screenshot 2024-08-21 at 13 21 27" src="https://github.com/user-attachments/assets/36ca5fae-99d9-4e10-bcda-3f878c5cc4a6">


How it should now look:
<img width="600" alt="Screenshot 2024-08-21 at 13 20 49" src="https://github.com/user-attachments/assets/add234ec-803a-4f1e-8b31-62921974a9da">

## Checklist

- [ ] Oak themed 404 page should be shown when an invalid url is accessed
- [ ] the 'back' button should go back to the last valid owa url (if applicable)
- [ ] the 'home' button should take you home
