### PR TITLE
Update MVs which filter out cycle 2 programmes

### DIFF
--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -26750,6 +26750,182 @@ export type Published_Mv_Subject_Phase_Options_0_2_Variance_Fields = {
   display_order?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3 = {
+  __typename?: 'published_mv_subject_phase_options_0_3';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  examboards?: Maybe<Scalars['jsonb']['output']>;
+  phases?: Maybe<Scalars['jsonb']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3ExamboardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3PhasesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3_Aggregate = {
+  __typename?: 'published_mv_subject_phase_options_0_3_aggregate';
+  aggregate?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Subject_Phase_Options_0_3>;
+};
+
+/** aggregate fields of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3_Aggregate_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_aggregate_fields';
+  avg?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Max_Fields>;
+  min?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Subject_Phase_Options_0_3_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Avg_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_avg_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_subject_phase_options_0_3". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Subject_Phase_Options_0_3_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>>;
+  display_order?: InputMaybe<Int_Comparison_Exp>;
+  examboards?: InputMaybe<Jsonb_Comparison_Exp>;
+  phases?: InputMaybe<Jsonb_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Max_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_max_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Min_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_min_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_subject_phase_options_0_3". */
+export type Published_Mv_Subject_Phase_Options_0_3_Order_By = {
+  display_order?: InputMaybe<Order_By>;
+  examboards?: InputMaybe<Order_By>;
+  phases?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_subject_phase_options_0_3" */
+export enum Published_Mv_Subject_Phase_Options_0_3_Select_Column {
+  /** column name */
+  DisplayOrder = 'display_order',
+  /** column name */
+  Examboards = 'examboards',
+  /** column name */
+  Phases = 'phases',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Title = 'title'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Stddev_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_stddev_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_stddev_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_stddev_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_subject_phase_options_0_3" */
+export type Published_Mv_Subject_Phase_Options_0_3_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Subject_Phase_Options_0_3_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Subject_Phase_Options_0_3_Stream_Cursor_Value_Input = {
+  display_order?: InputMaybe<Scalars['Int']['input']>;
+  examboards?: InputMaybe<Scalars['jsonb']['input']>;
+  phases?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Sum_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_sum_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Var_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_var_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Var_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_var_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Subject_Phase_Options_0_3_Variance_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_3_variance_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_subject_phase_options_1" */
 export type Published_Mv_Subject_Phase_Options_1 = {
   __typename?: 'published_mv_subject_phase_options_1';
@@ -32536,6 +32712,10 @@ export type Query_Root = {
   published_mv_subject_phase_options_0_2: Array<Published_Mv_Subject_Phase_Options_0_2>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_2" */
   published_mv_subject_phase_options_0_2_aggregate: Published_Mv_Subject_Phase_Options_0_2_Aggregate;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_3" */
+  published_mv_subject_phase_options_0_3: Array<Published_Mv_Subject_Phase_Options_0_3>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_3" */
+  published_mv_subject_phase_options_0_3_aggregate: Published_Mv_Subject_Phase_Options_0_3_Aggregate;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -33986,6 +34166,24 @@ export type Query_RootPublished_Mv_Subject_Phase_Options_0_2_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_2_Order_By>>;
   where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_2_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_3Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
 };
 
 
@@ -37097,6 +37295,12 @@ export type Subscription_Root = {
   published_mv_subject_phase_options_0_2_aggregate: Published_Mv_Subject_Phase_Options_0_2_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_2" */
   published_mv_subject_phase_options_0_2_stream: Array<Published_Mv_Subject_Phase_Options_0_2>;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_3" */
+  published_mv_subject_phase_options_0_3: Array<Published_Mv_Subject_Phase_Options_0_3>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_3" */
+  published_mv_subject_phase_options_0_3_aggregate: Published_Mv_Subject_Phase_Options_0_3_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_3" */
+  published_mv_subject_phase_options_0_3_stream: Array<Published_Mv_Subject_Phase_Options_0_3>;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -39062,6 +39266,31 @@ export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_2_StreamArgs =
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Subject_Phase_Options_0_2_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_2_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_3Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_3_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_3_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_3_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_3_Bool_Exp>;
 };
 
 
@@ -48330,7 +48559,7 @@ export type SubjectListingQuery = { __typename?: 'query_root', subjectLessons: A
 export type SubjectPhaseOptionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubjectPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_subject_phase_options_0_1', title?: string | null, slug?: string | null, phases?: any | null, examboards?: any | null }> };
+export type SubjectPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_subject_phase_options_0_3', title?: string | null, slug?: string | null, phases?: any | null, examboards?: any | null, state?: string | null }> };
 
 export type SubjectPhaseOptionsIncludeNewQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -49055,11 +49284,12 @@ export const SubjectListingDocument = gql`
     `;
 export const SubjectPhaseOptionsDocument = gql`
     query subjectPhaseOptions {
-  options: published_mv_subject_phase_options_0_1 {
+  options: published_mv_subject_phase_options_0_3 {
     title
     slug
     phases
     examboards
+    state
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -4880,6 +4880,542 @@ export type Internal_Review_Lessons_Variance_Order_By = {
   lesson_id?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts = {
+  __typename?: 'internal_tpc_contracts';
+  _cohort: Scalars['String']['output'];
+  _deleted: Scalars['Boolean']['output'];
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state: Scalars['String']['output'];
+  contract_id: Scalars['Int']['output'];
+  contract_name?: Maybe<Scalars['String']['output']>;
+  contract_object: Scalars['jsonb']['output'];
+  contract_uid?: Maybe<Scalars['bpchar']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  effective_date?: Maybe<Scalars['date']['output']>;
+  end_date?: Maybe<Scalars['date']['output']>;
+  external_id?: Maybe<Scalars['String']['output']>;
+  external_url?: Maybe<Scalars['String']['output']>;
+  restrictions?: Maybe<Scalars['jsonb']['output']>;
+  signing_side?: Maybe<Scalars['String']['output']>;
+  territory?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+
+/** columns and relationships of "internal.tpc_contracts" */
+export type Internal_Tpc_ContractsContract_ObjectArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "internal.tpc_contracts" */
+export type Internal_Tpc_ContractsRestrictionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Aggregate = {
+  __typename?: 'internal_tpc_contracts_aggregate';
+  aggregate?: Maybe<Internal_Tpc_Contracts_Aggregate_Fields>;
+  nodes: Array<Internal_Tpc_Contracts>;
+};
+
+/** aggregate fields of "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Aggregate_Fields = {
+  __typename?: 'internal_tpc_contracts_aggregate_fields';
+  avg?: Maybe<Internal_Tpc_Contracts_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Internal_Tpc_Contracts_Max_Fields>;
+  min?: Maybe<Internal_Tpc_Contracts_Min_Fields>;
+  stddev?: Maybe<Internal_Tpc_Contracts_Stddev_Fields>;
+  stddev_pop?: Maybe<Internal_Tpc_Contracts_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Internal_Tpc_Contracts_Stddev_Samp_Fields>;
+  sum?: Maybe<Internal_Tpc_Contracts_Sum_Fields>;
+  var_pop?: Maybe<Internal_Tpc_Contracts_Var_Pop_Fields>;
+  var_samp?: Maybe<Internal_Tpc_Contracts_Var_Samp_Fields>;
+  variance?: Maybe<Internal_Tpc_Contracts_Variance_Fields>;
+};
+
+
+/** aggregate fields of "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** order by aggregate values of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Aggregate_Order_By = {
+  avg?: InputMaybe<Internal_Tpc_Contracts_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Internal_Tpc_Contracts_Max_Order_By>;
+  min?: InputMaybe<Internal_Tpc_Contracts_Min_Order_By>;
+  stddev?: InputMaybe<Internal_Tpc_Contracts_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Internal_Tpc_Contracts_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Internal_Tpc_Contracts_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Internal_Tpc_Contracts_Sum_Order_By>;
+  var_pop?: InputMaybe<Internal_Tpc_Contracts_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Internal_Tpc_Contracts_Var_Samp_Order_By>;
+  variance?: InputMaybe<Internal_Tpc_Contracts_Variance_Order_By>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Internal_Tpc_Contracts_Append_Input = {
+  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
+  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Internal_Tpc_Contracts_Avg_Fields = {
+  __typename?: 'internal_tpc_contracts_avg_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by avg() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Avg_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "internal.tpc_contracts". All fields are combined with a logical 'AND'. */
+export type Internal_Tpc_Contracts_Bool_Exp = {
+  _and?: InputMaybe<Array<Internal_Tpc_Contracts_Bool_Exp>>;
+  _cohort?: InputMaybe<String_Comparison_Exp>;
+  _deleted?: InputMaybe<Boolean_Comparison_Exp>;
+  _not?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+  _or?: InputMaybe<Array<Internal_Tpc_Contracts_Bool_Exp>>;
+  _release_id?: InputMaybe<Int_Comparison_Exp>;
+  _state?: InputMaybe<String_Comparison_Exp>;
+  contract_id?: InputMaybe<Int_Comparison_Exp>;
+  contract_name?: InputMaybe<String_Comparison_Exp>;
+  contract_object?: InputMaybe<Jsonb_Comparison_Exp>;
+  contract_uid?: InputMaybe<Bpchar_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  effective_date?: InputMaybe<Date_Comparison_Exp>;
+  end_date?: InputMaybe<Date_Comparison_Exp>;
+  external_id?: InputMaybe<String_Comparison_Exp>;
+  external_url?: InputMaybe<String_Comparison_Exp>;
+  restrictions?: InputMaybe<Jsonb_Comparison_Exp>;
+  signing_side?: InputMaybe<String_Comparison_Exp>;
+  territory?: InputMaybe<String_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "internal.tpc_contracts" */
+export enum Internal_Tpc_Contracts_Constraint {
+  /** unique or primary key constraint on columns "_state", "external_id" */
+  TpcContractsExternalIdStateKey = 'tpc_contracts_external_id__state_key',
+  /** unique or primary key constraint on columns "external_url", "_state" */
+  TpcContractsExternalUrlStateKey = 'tpc_contracts_external_url__state_key',
+  /** unique or primary key constraint on columns "_state", "contract_id" */
+  TpcContractsPkey = 'tpc_contracts_pkey'
+}
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Internal_Tpc_Contracts_Delete_At_Path_Input = {
+  contract_object?: InputMaybe<Array<Scalars['String']['input']>>;
+  restrictions?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Internal_Tpc_Contracts_Delete_Elem_Input = {
+  contract_object?: InputMaybe<Scalars['Int']['input']>;
+  restrictions?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Internal_Tpc_Contracts_Delete_Key_Input = {
+  contract_object?: InputMaybe<Scalars['String']['input']>;
+  restrictions?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** input type for incrementing numeric columns in table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Inc_Input = {
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  contract_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Insert_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  contract_id?: InputMaybe<Scalars['Int']['input']>;
+  contract_name?: InputMaybe<Scalars['String']['input']>;
+  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
+  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  effective_date?: InputMaybe<Scalars['date']['input']>;
+  end_date?: InputMaybe<Scalars['date']['input']>;
+  external_id?: InputMaybe<Scalars['String']['input']>;
+  external_url?: InputMaybe<Scalars['String']['input']>;
+  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
+  signing_side?: InputMaybe<Scalars['String']['input']>;
+  territory?: InputMaybe<Scalars['String']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate max on columns */
+export type Internal_Tpc_Contracts_Max_Fields = {
+  __typename?: 'internal_tpc_contracts_max_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  contract_id?: Maybe<Scalars['Int']['output']>;
+  contract_name?: Maybe<Scalars['String']['output']>;
+  contract_uid?: Maybe<Scalars['bpchar']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  effective_date?: Maybe<Scalars['date']['output']>;
+  end_date?: Maybe<Scalars['date']['output']>;
+  external_id?: Maybe<Scalars['String']['output']>;
+  external_url?: Maybe<Scalars['String']['output']>;
+  signing_side?: Maybe<Scalars['String']['output']>;
+  territory?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by max() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Max_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+  contract_name?: InputMaybe<Order_By>;
+  contract_uid?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  effective_date?: InputMaybe<Order_By>;
+  end_date?: InputMaybe<Order_By>;
+  external_id?: InputMaybe<Order_By>;
+  external_url?: InputMaybe<Order_By>;
+  signing_side?: InputMaybe<Order_By>;
+  territory?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Internal_Tpc_Contracts_Min_Fields = {
+  __typename?: 'internal_tpc_contracts_min_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  contract_id?: Maybe<Scalars['Int']['output']>;
+  contract_name?: Maybe<Scalars['String']['output']>;
+  contract_uid?: Maybe<Scalars['bpchar']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  effective_date?: Maybe<Scalars['date']['output']>;
+  end_date?: Maybe<Scalars['date']['output']>;
+  external_id?: Maybe<Scalars['String']['output']>;
+  external_url?: Maybe<Scalars['String']['output']>;
+  signing_side?: Maybe<Scalars['String']['output']>;
+  territory?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by min() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Min_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+  contract_name?: InputMaybe<Order_By>;
+  contract_uid?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  effective_date?: InputMaybe<Order_By>;
+  end_date?: InputMaybe<Order_By>;
+  external_id?: InputMaybe<Order_By>;
+  external_url?: InputMaybe<Order_By>;
+  signing_side?: InputMaybe<Order_By>;
+  territory?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Mutation_Response = {
+  __typename?: 'internal_tpc_contracts_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Internal_Tpc_Contracts>;
+};
+
+/** on_conflict condition type for table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_On_Conflict = {
+  constraint: Internal_Tpc_Contracts_Constraint;
+  update_columns?: Array<Internal_Tpc_Contracts_Update_Column>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "internal.tpc_contracts". */
+export type Internal_Tpc_Contracts_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _deleted?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+  contract_name?: InputMaybe<Order_By>;
+  contract_object?: InputMaybe<Order_By>;
+  contract_uid?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  effective_date?: InputMaybe<Order_By>;
+  end_date?: InputMaybe<Order_By>;
+  external_id?: InputMaybe<Order_By>;
+  external_url?: InputMaybe<Order_By>;
+  restrictions?: InputMaybe<Order_By>;
+  signing_side?: InputMaybe<Order_By>;
+  territory?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: internal.tpc_contracts */
+export type Internal_Tpc_Contracts_Pk_Columns_Input = {
+  _state: Scalars['String']['input'];
+  contract_id: Scalars['Int']['input'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Internal_Tpc_Contracts_Prepend_Input = {
+  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
+  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** select columns of table "internal.tpc_contracts" */
+export enum Internal_Tpc_Contracts_Select_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  ContractId = 'contract_id',
+  /** column name */
+  ContractName = 'contract_name',
+  /** column name */
+  ContractObject = 'contract_object',
+  /** column name */
+  ContractUid = 'contract_uid',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EffectiveDate = 'effective_date',
+  /** column name */
+  EndDate = 'end_date',
+  /** column name */
+  ExternalId = 'external_id',
+  /** column name */
+  ExternalUrl = 'external_url',
+  /** column name */
+  Restrictions = 'restrictions',
+  /** column name */
+  SigningSide = 'signing_side',
+  /** column name */
+  Territory = 'territory',
+  /** column name */
+  UpdatedAt = 'updated_at'
+}
+
+/** input type for updating data in table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Set_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  contract_id?: InputMaybe<Scalars['Int']['input']>;
+  contract_name?: InputMaybe<Scalars['String']['input']>;
+  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
+  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  effective_date?: InputMaybe<Scalars['date']['input']>;
+  end_date?: InputMaybe<Scalars['date']['input']>;
+  external_id?: InputMaybe<Scalars['String']['input']>;
+  external_url?: InputMaybe<Scalars['String']['input']>;
+  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
+  signing_side?: InputMaybe<Scalars['String']['input']>;
+  territory?: InputMaybe<Scalars['String']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Internal_Tpc_Contracts_Stddev_Fields = {
+  __typename?: 'internal_tpc_contracts_stddev_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Stddev_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Internal_Tpc_Contracts_Stddev_Pop_Fields = {
+  __typename?: 'internal_tpc_contracts_stddev_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_pop() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Stddev_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Internal_Tpc_Contracts_Stddev_Samp_Fields = {
+  __typename?: 'internal_tpc_contracts_stddev_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_samp() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Stddev_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** Streaming cursor of the table "internal_tpc_contracts" */
+export type Internal_Tpc_Contracts_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Internal_Tpc_Contracts_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Internal_Tpc_Contracts_Stream_Cursor_Value_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  contract_id?: InputMaybe<Scalars['Int']['input']>;
+  contract_name?: InputMaybe<Scalars['String']['input']>;
+  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
+  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  effective_date?: InputMaybe<Scalars['date']['input']>;
+  end_date?: InputMaybe<Scalars['date']['input']>;
+  external_id?: InputMaybe<Scalars['String']['input']>;
+  external_url?: InputMaybe<Scalars['String']['input']>;
+  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
+  signing_side?: InputMaybe<Scalars['String']['input']>;
+  territory?: InputMaybe<Scalars['String']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Internal_Tpc_Contracts_Sum_Fields = {
+  __typename?: 'internal_tpc_contracts_sum_fields';
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  contract_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** order by sum() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Sum_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "internal.tpc_contracts" */
+export enum Internal_Tpc_Contracts_Update_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  ContractId = 'contract_id',
+  /** column name */
+  ContractName = 'contract_name',
+  /** column name */
+  ContractObject = 'contract_object',
+  /** column name */
+  ContractUid = 'contract_uid',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EffectiveDate = 'effective_date',
+  /** column name */
+  EndDate = 'end_date',
+  /** column name */
+  ExternalId = 'external_id',
+  /** column name */
+  ExternalUrl = 'external_url',
+  /** column name */
+  Restrictions = 'restrictions',
+  /** column name */
+  SigningSide = 'signing_side',
+  /** column name */
+  Territory = 'territory',
+  /** column name */
+  UpdatedAt = 'updated_at'
+}
+
+export type Internal_Tpc_Contracts_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Internal_Tpc_Contracts_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Internal_Tpc_Contracts_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Internal_Tpc_Contracts_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Internal_Tpc_Contracts_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Internal_Tpc_Contracts_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Internal_Tpc_Contracts_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Internal_Tpc_Contracts_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Internal_Tpc_Contracts_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Internal_Tpc_Contracts_Var_Pop_Fields = {
+  __typename?: 'internal_tpc_contracts_var_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_pop() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Var_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Internal_Tpc_Contracts_Var_Samp_Fields = {
+  __typename?: 'internal_tpc_contracts_var_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_samp() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Var_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Internal_Tpc_Contracts_Variance_Fields = {
+  __typename?: 'internal_tpc_contracts_variance_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  contract_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by variance() on columns of table "internal.tpc_contracts" */
+export type Internal_Tpc_Contracts_Variance_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  contract_id?: InputMaybe<Order_By>;
+};
+
 /** Boolean expression to compare columns of type "json". All fields are combined with logical 'AND'. */
 export type Json_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['json']['input']>;
@@ -4977,6 +5513,7 @@ export type Lessons = {
   description?: Maybe<Scalars['String']['output']>;
   equipment_and_resources?: Maybe<Scalars['json']['output']>;
   expiration_date?: Maybe<Scalars['date']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
   key_learning_points?: Maybe<Scalars['json']['output']>;
   keywords?: Maybe<Scalars['json']['output']>;
   lesson_id: Scalars['Int']['output'];
@@ -4986,6 +5523,7 @@ export type Lessons = {
   /** A computed field, executes function "function__lessons__media_clip_groups" */
   media_clips_groups?: Maybe<Array<Templates_Media_Clip_Groups>>;
   misconceptions_and_common_mistakes?: Maybe<Scalars['json']['output']>;
+  phonics_outcome?: Maybe<Scalars['String']['output']>;
   pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
   /** An object relationship */
   quiz_exit?: Maybe<Quizzes>;
@@ -5186,6 +5724,12 @@ export type LessonsDeprecated_FieldsArgs = {
 
 /** columns and relationships of "lessons" */
 export type LessonsEquipment_And_ResourcesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "lessons" */
+export type LessonsFeaturesArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -5511,6 +6055,7 @@ export type Lessons_Aggregate_Order_By = {
 export type Lessons_Append_Input = {
   additional_files?: InputMaybe<Scalars['jsonb']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_media_list?: InputMaybe<Scalars['jsonb']['input']>;
@@ -5596,6 +6141,7 @@ export type Lessons_Bool_Exp = {
   description?: InputMaybe<String_Comparison_Exp>;
   equipment_and_resources?: InputMaybe<Json_Comparison_Exp>;
   expiration_date?: InputMaybe<Date_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
   key_learning_points?: InputMaybe<Json_Comparison_Exp>;
   keywords?: InputMaybe<Json_Comparison_Exp>;
   lesson_id?: InputMaybe<Int_Comparison_Exp>;
@@ -5604,6 +6150,7 @@ export type Lessons_Bool_Exp = {
   media_clips?: InputMaybe<Jsonb_Comparison_Exp>;
   media_clips_groups?: InputMaybe<Templates_Media_Clip_Groups_Bool_Exp>;
   misconceptions_and_common_mistakes?: InputMaybe<Json_Comparison_Exp>;
+  phonics_outcome?: InputMaybe<String_Comparison_Exp>;
   pupil_lesson_outcome?: InputMaybe<String_Comparison_Exp>;
   quiz_exit?: InputMaybe<Quizzes_Bool_Exp>;
   quiz_exit_all_states?: InputMaybe<Quizzes_Bool_Exp>;
@@ -5653,6 +6200,7 @@ export enum Lessons_Constraint {
 export type Lessons_Delete_At_Path_Input = {
   additional_files?: InputMaybe<Array<Scalars['String']['input']>>;
   deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  features?: InputMaybe<Array<Scalars['String']['input']>>;
   media_clips?: InputMaybe<Array<Scalars['String']['input']>>;
   thirdpartycontent_list?: InputMaybe<Array<Scalars['String']['input']>>;
   tpc_media_list?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -5663,6 +6211,7 @@ export type Lessons_Delete_At_Path_Input = {
 export type Lessons_Delete_Elem_Input = {
   additional_files?: InputMaybe<Scalars['Int']['input']>;
   deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['Int']['input']>;
   media_clips?: InputMaybe<Scalars['Int']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['Int']['input']>;
   tpc_media_list?: InputMaybe<Scalars['Int']['input']>;
@@ -5673,6 +6222,7 @@ export type Lessons_Delete_Elem_Input = {
 export type Lessons_Delete_Key_Input = {
   additional_files?: InputMaybe<Scalars['String']['input']>;
   deprecated_fields?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['String']['input']>;
   media_clips?: InputMaybe<Scalars['String']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['String']['input']>;
   tpc_media_list?: InputMaybe<Scalars['String']['input']>;
@@ -5725,6 +6275,7 @@ export type Lessons_Insert_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   equipment_and_resources?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   key_learning_points?: InputMaybe<Scalars['json']['input']>;
   keywords?: InputMaybe<Scalars['json']['input']>;
   lesson_id?: InputMaybe<Scalars['Int']['input']>;
@@ -5732,6 +6283,7 @@ export type Lessons_Insert_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_exit?: InputMaybe<Quizzes_Obj_Rel_Insert_Input>;
   quiz_exit_all_states?: InputMaybe<Quizzes_Arr_Rel_Insert_Input>;
@@ -5777,6 +6329,7 @@ export type Lessons_Max_Fields = {
   expiration_date?: Maybe<Scalars['date']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
+  phonics_outcome?: Maybe<Scalars['String']['output']>;
   pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
   quiz_id_exit?: Maybe<Scalars['Int']['output']>;
   quiz_id_starter?: Maybe<Scalars['Int']['output']>;
@@ -5803,6 +6356,7 @@ export type Lessons_Max_Order_By = {
   expiration_date?: InputMaybe<Order_By>;
   lesson_id?: InputMaybe<Order_By>;
   lesson_uid?: InputMaybe<Order_By>;
+  phonics_outcome?: InputMaybe<Order_By>;
   pupil_lesson_outcome?: InputMaybe<Order_By>;
   quiz_id_exit?: InputMaybe<Order_By>;
   quiz_id_starter?: InputMaybe<Order_By>;
@@ -5830,6 +6384,7 @@ export type Lessons_Min_Fields = {
   expiration_date?: Maybe<Scalars['date']['output']>;
   lesson_id?: Maybe<Scalars['Int']['output']>;
   lesson_uid?: Maybe<Scalars['bpchar']['output']>;
+  phonics_outcome?: Maybe<Scalars['String']['output']>;
   pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
   quiz_id_exit?: Maybe<Scalars['Int']['output']>;
   quiz_id_starter?: Maybe<Scalars['Int']['output']>;
@@ -5856,6 +6411,7 @@ export type Lessons_Min_Order_By = {
   expiration_date?: InputMaybe<Order_By>;
   lesson_id?: InputMaybe<Order_By>;
   lesson_uid?: InputMaybe<Order_By>;
+  phonics_outcome?: InputMaybe<Order_By>;
   pupil_lesson_outcome?: InputMaybe<Order_By>;
   quiz_id_exit?: InputMaybe<Order_By>;
   quiz_id_starter?: InputMaybe<Order_By>;
@@ -5923,6 +6479,7 @@ export type Lessons_Order_By = {
   description?: InputMaybe<Order_By>;
   equipment_and_resources?: InputMaybe<Order_By>;
   expiration_date?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
   key_learning_points?: InputMaybe<Order_By>;
   keywords?: InputMaybe<Order_By>;
   lesson_id?: InputMaybe<Order_By>;
@@ -5931,6 +6488,7 @@ export type Lessons_Order_By = {
   media_clips?: InputMaybe<Order_By>;
   media_clips_groups_aggregate?: InputMaybe<Templates_Media_Clip_Groups_Aggregate_Order_By>;
   misconceptions_and_common_mistakes?: InputMaybe<Order_By>;
+  phonics_outcome?: InputMaybe<Order_By>;
   pupil_lesson_outcome?: InputMaybe<Order_By>;
   quiz_exit?: InputMaybe<Quizzes_Order_By>;
   quiz_exit_all_states_aggregate?: InputMaybe<Quizzes_Aggregate_Order_By>;
@@ -5973,6 +6531,7 @@ export type Lessons_Pk_Columns_Input = {
 export type Lessons_Prepend_Input = {
   additional_files?: InputMaybe<Scalars['jsonb']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_media_list?: InputMaybe<Scalars['jsonb']['input']>;
@@ -6020,6 +6579,8 @@ export enum Lessons_Select_Column {
   /** column name */
   ExpirationDate = 'expiration_date',
   /** column name */
+  Features = 'features',
+  /** column name */
   KeyLearningPoints = 'key_learning_points',
   /** column name */
   Keywords = 'keywords',
@@ -6033,6 +6594,8 @@ export enum Lessons_Select_Column {
   MediaClips = 'media_clips',
   /** column name */
   MisconceptionsAndCommonMistakes = 'misconceptions_and_common_mistakes',
+  /** column name */
+  PhonicsOutcome = 'phonics_outcome',
   /** column name */
   PupilLessonOutcome = 'pupil_lesson_outcome',
   /** column name */
@@ -6098,6 +6661,7 @@ export type Lessons_Set_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   equipment_and_resources?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   key_learning_points?: InputMaybe<Scalars['json']['input']>;
   keywords?: InputMaybe<Scalars['json']['input']>;
   lesson_id?: InputMaybe<Scalars['Int']['input']>;
@@ -6105,6 +6669,7 @@ export type Lessons_Set_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_id_exit?: InputMaybe<Scalars['Int']['input']>;
   quiz_id_starter?: InputMaybe<Scalars['Int']['input']>;
@@ -6244,6 +6809,7 @@ export type Lessons_Stream_Cursor_Value_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   equipment_and_resources?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   key_learning_points?: InputMaybe<Scalars['json']['input']>;
   keywords?: InputMaybe<Scalars['json']['input']>;
   lesson_id?: InputMaybe<Scalars['Int']['input']>;
@@ -6251,6 +6817,7 @@ export type Lessons_Stream_Cursor_Value_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_id_exit?: InputMaybe<Scalars['Int']['input']>;
   quiz_id_starter?: InputMaybe<Scalars['Int']['input']>;
@@ -6340,6 +6907,8 @@ export enum Lessons_Update_Column {
   /** column name */
   ExpirationDate = 'expiration_date',
   /** column name */
+  Features = 'features',
+  /** column name */
   KeyLearningPoints = 'key_learning_points',
   /** column name */
   Keywords = 'keywords',
@@ -6353,6 +6922,8 @@ export enum Lessons_Update_Column {
   MediaClips = 'media_clips',
   /** column name */
   MisconceptionsAndCommonMistakes = 'misconceptions_and_common_mistakes',
+  /** column name */
+  PhonicsOutcome = 'phonics_outcome',
   /** column name */
   PupilLessonOutcome = 'pupil_lesson_outcome',
   /** column name */
@@ -6540,6 +7111,10 @@ export type Mutation_Root = {
   delete_internal_review_lessons?: Maybe<Internal_Review_Lessons_Mutation_Response>;
   /** delete single row from the table: "internal.review_lessons" */
   delete_internal_review_lessons_by_pk?: Maybe<Internal_Review_Lessons>;
+  /** delete data from the table: "internal.tpc_contracts" */
+  delete_internal_tpc_contracts?: Maybe<Internal_Tpc_Contracts_Mutation_Response>;
+  /** delete single row from the table: "internal.tpc_contracts" */
+  delete_internal_tpc_contracts_by_pk?: Maybe<Internal_Tpc_Contracts>;
   /** delete data from the table: "lessons" */
   delete_lessons?: Maybe<Lessons_Mutation_Response>;
   /** delete single row from the table: "lessons" */
@@ -6584,6 +7159,10 @@ export type Mutation_Root = {
   delete_programme_units?: Maybe<Programme_Units_Mutation_Response>;
   /** delete single row from the table: "programme_units" */
   delete_programme_units_by_pk?: Maybe<Programme_Units>;
+  /** delete data from the table: "programmefeatures" */
+  delete_programmefeatures?: Maybe<Programmefeatures_Mutation_Response>;
+  /** delete single row from the table: "programmefeatures" */
+  delete_programmefeatures_by_pk?: Maybe<Programmefeatures>;
   /** delete data from the table: "programmes" */
   delete_programmes?: Maybe<Programmes_Mutation_Response>;
   /** delete single row from the table: "programmes" */
@@ -6626,10 +7205,6 @@ export type Mutation_Root = {
   delete_threads?: Maybe<Threads_Mutation_Response>;
   /** delete single row from the table: "threads" */
   delete_threads_by_pk?: Maybe<Threads>;
-  /** delete data from the table: "tpc_contracts" */
-  delete_tpc_contracts?: Maybe<Tpc_Contracts_Mutation_Response>;
-  /** delete single row from the table: "tpc_contracts" */
-  delete_tpc_contracts_by_pk?: Maybe<Tpc_Contracts>;
   /** delete data from the table: "tpc_media" */
   delete_tpc_media?: Maybe<Tpc_Media_Mutation_Response>;
   /** delete single row from the table: "tpc_media" */
@@ -6698,6 +7273,10 @@ export type Mutation_Root = {
   insert_internal_review_lessons?: Maybe<Internal_Review_Lessons_Mutation_Response>;
   /** insert a single row into the table: "internal.review_lessons" */
   insert_internal_review_lessons_one?: Maybe<Internal_Review_Lessons>;
+  /** insert data into the table: "internal.tpc_contracts" */
+  insert_internal_tpc_contracts?: Maybe<Internal_Tpc_Contracts_Mutation_Response>;
+  /** insert a single row into the table: "internal.tpc_contracts" */
+  insert_internal_tpc_contracts_one?: Maybe<Internal_Tpc_Contracts>;
   /** insert data into the table: "lessons" */
   insert_lessons?: Maybe<Lessons_Mutation_Response>;
   /** insert a single row into the table: "lessons" */
@@ -6742,6 +7321,10 @@ export type Mutation_Root = {
   insert_programme_units?: Maybe<Programme_Units_Mutation_Response>;
   /** insert a single row into the table: "programme_units" */
   insert_programme_units_one?: Maybe<Programme_Units>;
+  /** insert data into the table: "programmefeatures" */
+  insert_programmefeatures?: Maybe<Programmefeatures_Mutation_Response>;
+  /** insert a single row into the table: "programmefeatures" */
+  insert_programmefeatures_one?: Maybe<Programmefeatures>;
   /** insert data into the table: "programmes" */
   insert_programmes?: Maybe<Programmes_Mutation_Response>;
   /** insert a single row into the table: "programmes" */
@@ -6790,10 +7373,6 @@ export type Mutation_Root = {
   insert_threads?: Maybe<Threads_Mutation_Response>;
   /** insert a single row into the table: "threads" */
   insert_threads_one?: Maybe<Threads>;
-  /** insert data into the table: "tpc_contracts" */
-  insert_tpc_contracts?: Maybe<Tpc_Contracts_Mutation_Response>;
-  /** insert a single row into the table: "tpc_contracts" */
-  insert_tpc_contracts_one?: Maybe<Tpc_Contracts>;
   /** insert data into the table: "tpc_media" */
   insert_tpc_media?: Maybe<Tpc_Media_Mutation_Response>;
   /** insert a single row into the table: "tpc_media" */
@@ -6882,6 +7461,12 @@ export type Mutation_Root = {
   update_internal_review_lessons_by_pk?: Maybe<Internal_Review_Lessons>;
   /** update multiples rows of table: "internal.review_lessons" */
   update_internal_review_lessons_many?: Maybe<Array<Maybe<Internal_Review_Lessons_Mutation_Response>>>;
+  /** update data of the table: "internal.tpc_contracts" */
+  update_internal_tpc_contracts?: Maybe<Internal_Tpc_Contracts_Mutation_Response>;
+  /** update single row of the table: "internal.tpc_contracts" */
+  update_internal_tpc_contracts_by_pk?: Maybe<Internal_Tpc_Contracts>;
+  /** update multiples rows of table: "internal.tpc_contracts" */
+  update_internal_tpc_contracts_many?: Maybe<Array<Maybe<Internal_Tpc_Contracts_Mutation_Response>>>;
   /** update data of the table: "lessons" */
   update_lessons?: Maybe<Lessons_Mutation_Response>;
   /** update single row of the table: "lessons" */
@@ -6948,6 +7533,12 @@ export type Mutation_Root = {
   update_programme_units_by_pk?: Maybe<Programme_Units>;
   /** update multiples rows of table: "programme_units" */
   update_programme_units_many?: Maybe<Array<Maybe<Programme_Units_Mutation_Response>>>;
+  /** update data of the table: "programmefeatures" */
+  update_programmefeatures?: Maybe<Programmefeatures_Mutation_Response>;
+  /** update single row of the table: "programmefeatures" */
+  update_programmefeatures_by_pk?: Maybe<Programmefeatures>;
+  /** update multiples rows of table: "programmefeatures" */
+  update_programmefeatures_many?: Maybe<Array<Maybe<Programmefeatures_Mutation_Response>>>;
   /** update data of the table: "programmes" */
   update_programmes?: Maybe<Programmes_Mutation_Response>;
   /** update single row of the table: "programmes" */
@@ -7014,12 +7605,6 @@ export type Mutation_Root = {
   update_threads_by_pk?: Maybe<Threads>;
   /** update multiples rows of table: "threads" */
   update_threads_many?: Maybe<Array<Maybe<Threads_Mutation_Response>>>;
-  /** update data of the table: "tpc_contracts" */
-  update_tpc_contracts?: Maybe<Tpc_Contracts_Mutation_Response>;
-  /** update single row of the table: "tpc_contracts" */
-  update_tpc_contracts_by_pk?: Maybe<Tpc_Contracts>;
-  /** update multiples rows of table: "tpc_contracts" */
-  update_tpc_contracts_many?: Maybe<Array<Maybe<Tpc_Contracts_Mutation_Response>>>;
   /** update data of the table: "tpc_media" */
   update_tpc_media?: Maybe<Tpc_Media_Mutation_Response>;
   /** update single row of the table: "tpc_media" */
@@ -7196,6 +7781,19 @@ export type Mutation_RootDelete_Internal_Review_Lessons_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_Internal_Tpc_ContractsArgs = {
+  where: Internal_Tpc_Contracts_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Internal_Tpc_Contracts_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  contract_id: Scalars['Int']['input'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_LessonsArgs = {
   where: Lessons_Bool_Exp;
 };
@@ -7341,6 +7939,19 @@ export type Mutation_RootDelete_Programme_Units_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_ProgrammefeaturesArgs = {
+  where: Programmefeatures_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Programmefeatures_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  feature_id: Scalars['Int']['input'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_ProgrammesArgs = {
   where: Programmes_Bool_Exp;
 };
@@ -7472,19 +8083,6 @@ export type Mutation_RootDelete_ThreadsArgs = {
 export type Mutation_RootDelete_Threads_By_PkArgs = {
   _state: Scalars['String']['input'];
   thread_id: Scalars['Int']['input'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Tpc_ContractsArgs = {
-  where: Tpc_Contracts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Tpc_Contracts_By_PkArgs = {
-  _state: Scalars['String']['input'];
-  contract_id: Scalars['Int']['input'];
 };
 
 
@@ -7721,6 +8319,20 @@ export type Mutation_RootInsert_Internal_Review_Lessons_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_Internal_Tpc_ContractsArgs = {
+  objects: Array<Internal_Tpc_Contracts_Insert_Input>;
+  on_conflict?: InputMaybe<Internal_Tpc_Contracts_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Internal_Tpc_Contracts_OneArgs = {
+  object: Internal_Tpc_Contracts_Insert_Input;
+  on_conflict?: InputMaybe<Internal_Tpc_Contracts_On_Conflict>;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_LessonsArgs = {
   objects: Array<Lessons_Insert_Input>;
   on_conflict?: InputMaybe<Lessons_On_Conflict>;
@@ -7871,6 +8483,20 @@ export type Mutation_RootInsert_Programme_UnitsArgs = {
 export type Mutation_RootInsert_Programme_Units_OneArgs = {
   object: Programme_Units_Insert_Input;
   on_conflict?: InputMaybe<Programme_Units_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_ProgrammefeaturesArgs = {
+  objects: Array<Programmefeatures_Insert_Input>;
+  on_conflict?: InputMaybe<Programmefeatures_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Programmefeatures_OneArgs = {
+  object: Programmefeatures_Insert_Input;
+  on_conflict?: InputMaybe<Programmefeatures_On_Conflict>;
 };
 
 
@@ -8033,20 +8659,6 @@ export type Mutation_RootInsert_ThreadsArgs = {
 export type Mutation_RootInsert_Threads_OneArgs = {
   object: Threads_Insert_Input;
   on_conflict?: InputMaybe<Threads_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Tpc_ContractsArgs = {
-  objects: Array<Tpc_Contracts_Insert_Input>;
-  on_conflict?: InputMaybe<Tpc_Contracts_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Tpc_Contracts_OneArgs = {
-  object: Tpc_Contracts_Insert_Input;
-  on_conflict?: InputMaybe<Tpc_Contracts_On_Conflict>;
 };
 
 
@@ -8459,6 +9071,38 @@ export type Mutation_RootUpdate_Internal_Review_Lessons_ManyArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Internal_Tpc_ContractsArgs = {
+  _append?: InputMaybe<Internal_Tpc_Contracts_Append_Input>;
+  _delete_at_path?: InputMaybe<Internal_Tpc_Contracts_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Internal_Tpc_Contracts_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Internal_Tpc_Contracts_Delete_Key_Input>;
+  _inc?: InputMaybe<Internal_Tpc_Contracts_Inc_Input>;
+  _prepend?: InputMaybe<Internal_Tpc_Contracts_Prepend_Input>;
+  _set?: InputMaybe<Internal_Tpc_Contracts_Set_Input>;
+  where: Internal_Tpc_Contracts_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Internal_Tpc_Contracts_By_PkArgs = {
+  _append?: InputMaybe<Internal_Tpc_Contracts_Append_Input>;
+  _delete_at_path?: InputMaybe<Internal_Tpc_Contracts_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Internal_Tpc_Contracts_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Internal_Tpc_Contracts_Delete_Key_Input>;
+  _inc?: InputMaybe<Internal_Tpc_Contracts_Inc_Input>;
+  _prepend?: InputMaybe<Internal_Tpc_Contracts_Prepend_Input>;
+  _set?: InputMaybe<Internal_Tpc_Contracts_Set_Input>;
+  pk_columns: Internal_Tpc_Contracts_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Internal_Tpc_Contracts_ManyArgs = {
+  updates: Array<Internal_Tpc_Contracts_Updates>;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_LessonsArgs = {
   _append?: InputMaybe<Lessons_Append_Input>;
   _delete_at_path?: InputMaybe<Lessons_Delete_At_Path_Input>;
@@ -8811,6 +9455,38 @@ export type Mutation_RootUpdate_Programme_Units_ManyArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_ProgrammefeaturesArgs = {
+  _append?: InputMaybe<Programmefeatures_Append_Input>;
+  _delete_at_path?: InputMaybe<Programmefeatures_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Programmefeatures_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Programmefeatures_Delete_Key_Input>;
+  _inc?: InputMaybe<Programmefeatures_Inc_Input>;
+  _prepend?: InputMaybe<Programmefeatures_Prepend_Input>;
+  _set?: InputMaybe<Programmefeatures_Set_Input>;
+  where: Programmefeatures_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Programmefeatures_By_PkArgs = {
+  _append?: InputMaybe<Programmefeatures_Append_Input>;
+  _delete_at_path?: InputMaybe<Programmefeatures_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Programmefeatures_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Programmefeatures_Delete_Key_Input>;
+  _inc?: InputMaybe<Programmefeatures_Inc_Input>;
+  _prepend?: InputMaybe<Programmefeatures_Prepend_Input>;
+  _set?: InputMaybe<Programmefeatures_Set_Input>;
+  pk_columns: Programmefeatures_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Programmefeatures_ManyArgs = {
+  updates: Array<Programmefeatures_Updates>;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_ProgrammesArgs = {
   _append?: InputMaybe<Programmes_Append_Input>;
   _delete_at_path?: InputMaybe<Programmes_Delete_At_Path_Input>;
@@ -9126,38 +9802,6 @@ export type Mutation_RootUpdate_Threads_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_Threads_ManyArgs = {
   updates: Array<Threads_Updates>;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Tpc_ContractsArgs = {
-  _append?: InputMaybe<Tpc_Contracts_Append_Input>;
-  _delete_at_path?: InputMaybe<Tpc_Contracts_Delete_At_Path_Input>;
-  _delete_elem?: InputMaybe<Tpc_Contracts_Delete_Elem_Input>;
-  _delete_key?: InputMaybe<Tpc_Contracts_Delete_Key_Input>;
-  _inc?: InputMaybe<Tpc_Contracts_Inc_Input>;
-  _prepend?: InputMaybe<Tpc_Contracts_Prepend_Input>;
-  _set?: InputMaybe<Tpc_Contracts_Set_Input>;
-  where: Tpc_Contracts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Tpc_Contracts_By_PkArgs = {
-  _append?: InputMaybe<Tpc_Contracts_Append_Input>;
-  _delete_at_path?: InputMaybe<Tpc_Contracts_Delete_At_Path_Input>;
-  _delete_elem?: InputMaybe<Tpc_Contracts_Delete_Elem_Input>;
-  _delete_key?: InputMaybe<Tpc_Contracts_Delete_Key_Input>;
-  _inc?: InputMaybe<Tpc_Contracts_Inc_Input>;
-  _prepend?: InputMaybe<Tpc_Contracts_Prepend_Input>;
-  _set?: InputMaybe<Tpc_Contracts_Set_Input>;
-  pk_columns: Tpc_Contracts_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Tpc_Contracts_ManyArgs = {
-  updates: Array<Tpc_Contracts_Updates>;
 };
 
 
@@ -13705,6 +14349,461 @@ export type Programme_Units_Variance_Order_By = {
   unit_id?: InputMaybe<Order_By>;
 };
 
+/** columns and relationships of "programmefeatures" */
+export type Programmefeatures = {
+  __typename?: 'programmefeatures';
+  _cohort: Scalars['String']['output'];
+  _deleted: Scalars['Boolean']['output'];
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state: Scalars['String']['output'];
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  deprecated_fields?: Maybe<Scalars['jsonb']['output']>;
+  feature_id: Scalars['Int']['output'];
+  features: Scalars['jsonb']['output'];
+  programme_fields: Scalars['jsonb']['output'];
+  /** A computed field, executes function "function__programmefeatures__programmes" */
+  programmes?: Maybe<Array<Programmes>>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+
+/** columns and relationships of "programmefeatures" */
+export type ProgrammefeaturesDeprecated_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "programmefeatures" */
+export type ProgrammefeaturesFeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "programmefeatures" */
+export type ProgrammefeaturesProgramme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "programmefeatures" */
+export type ProgrammefeaturesProgrammesArgs = {
+  distinct_on?: InputMaybe<Array<Programmes_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmes_Order_By>>;
+  where?: InputMaybe<Programmes_Bool_Exp>;
+};
+
+/** aggregated selection of "programmefeatures" */
+export type Programmefeatures_Aggregate = {
+  __typename?: 'programmefeatures_aggregate';
+  aggregate?: Maybe<Programmefeatures_Aggregate_Fields>;
+  nodes: Array<Programmefeatures>;
+};
+
+/** aggregate fields of "programmefeatures" */
+export type Programmefeatures_Aggregate_Fields = {
+  __typename?: 'programmefeatures_aggregate_fields';
+  avg?: Maybe<Programmefeatures_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Programmefeatures_Max_Fields>;
+  min?: Maybe<Programmefeatures_Min_Fields>;
+  stddev?: Maybe<Programmefeatures_Stddev_Fields>;
+  stddev_pop?: Maybe<Programmefeatures_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Programmefeatures_Stddev_Samp_Fields>;
+  sum?: Maybe<Programmefeatures_Sum_Fields>;
+  var_pop?: Maybe<Programmefeatures_Var_Pop_Fields>;
+  var_samp?: Maybe<Programmefeatures_Var_Samp_Fields>;
+  variance?: Maybe<Programmefeatures_Variance_Fields>;
+};
+
+
+/** aggregate fields of "programmefeatures" */
+export type Programmefeatures_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** order by aggregate values of table "programmefeatures" */
+export type Programmefeatures_Aggregate_Order_By = {
+  avg?: InputMaybe<Programmefeatures_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Programmefeatures_Max_Order_By>;
+  min?: InputMaybe<Programmefeatures_Min_Order_By>;
+  stddev?: InputMaybe<Programmefeatures_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Programmefeatures_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Programmefeatures_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Programmefeatures_Sum_Order_By>;
+  var_pop?: InputMaybe<Programmefeatures_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Programmefeatures_Var_Samp_Order_By>;
+  variance?: InputMaybe<Programmefeatures_Variance_Order_By>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Programmefeatures_Append_Input = {
+  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Programmefeatures_Avg_Fields = {
+  __typename?: 'programmefeatures_avg_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by avg() on columns of table "programmefeatures" */
+export type Programmefeatures_Avg_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "programmefeatures". All fields are combined with a logical 'AND'. */
+export type Programmefeatures_Bool_Exp = {
+  _and?: InputMaybe<Array<Programmefeatures_Bool_Exp>>;
+  _cohort?: InputMaybe<String_Comparison_Exp>;
+  _deleted?: InputMaybe<Boolean_Comparison_Exp>;
+  _not?: InputMaybe<Programmefeatures_Bool_Exp>;
+  _or?: InputMaybe<Array<Programmefeatures_Bool_Exp>>;
+  _release_id?: InputMaybe<Int_Comparison_Exp>;
+  _state?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  deprecated_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  feature_id?: InputMaybe<Int_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programmes?: InputMaybe<Programmes_Bool_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "programmefeatures" */
+export enum Programmefeatures_Constraint {
+  /** unique or primary key constraint on columns "_state", "feature_id" */
+  ProgrammefeaturesPkey = 'programmefeatures_pkey'
+}
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Programmefeatures_Delete_At_Path_Input = {
+  deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  features?: InputMaybe<Array<Scalars['String']['input']>>;
+  programme_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Programmefeatures_Delete_Elem_Input = {
+  deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['Int']['input']>;
+  programme_fields?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Programmefeatures_Delete_Key_Input = {
+  deprecated_fields?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['String']['input']>;
+  programme_fields?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** input type for incrementing numeric columns in table "programmefeatures" */
+export type Programmefeatures_Inc_Input = {
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  feature_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "programmefeatures" */
+export type Programmefeatures_Insert_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  feature_id?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate max on columns */
+export type Programmefeatures_Max_Fields = {
+  __typename?: 'programmefeatures_max_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  feature_id?: Maybe<Scalars['Int']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by max() on columns of table "programmefeatures" */
+export type Programmefeatures_Max_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Programmefeatures_Min_Fields = {
+  __typename?: 'programmefeatures_min_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  feature_id?: Maybe<Scalars['Int']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by min() on columns of table "programmefeatures" */
+export type Programmefeatures_Min_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "programmefeatures" */
+export type Programmefeatures_Mutation_Response = {
+  __typename?: 'programmefeatures_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Programmefeatures>;
+};
+
+/** on_conflict condition type for table "programmefeatures" */
+export type Programmefeatures_On_Conflict = {
+  constraint: Programmefeatures_Constraint;
+  update_columns?: Array<Programmefeatures_Update_Column>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "programmefeatures". */
+export type Programmefeatures_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _deleted?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  deprecated_fields?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programmes_aggregate?: InputMaybe<Programmes_Aggregate_Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: programmefeatures */
+export type Programmefeatures_Pk_Columns_Input = {
+  _state: Scalars['String']['input'];
+  feature_id: Scalars['Int']['input'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Programmefeatures_Prepend_Input = {
+  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** select columns of table "programmefeatures" */
+export enum Programmefeatures_Select_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  DeprecatedFields = 'deprecated_fields',
+  /** column name */
+  FeatureId = 'feature_id',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  UpdatedAt = 'updated_at'
+}
+
+/** input type for updating data in table "programmefeatures" */
+export type Programmefeatures_Set_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  feature_id?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Programmefeatures_Stddev_Fields = {
+  __typename?: 'programmefeatures_stddev_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev() on columns of table "programmefeatures" */
+export type Programmefeatures_Stddev_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Programmefeatures_Stddev_Pop_Fields = {
+  __typename?: 'programmefeatures_stddev_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_pop() on columns of table "programmefeatures" */
+export type Programmefeatures_Stddev_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Programmefeatures_Stddev_Samp_Fields = {
+  __typename?: 'programmefeatures_stddev_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_samp() on columns of table "programmefeatures" */
+export type Programmefeatures_Stddev_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** Streaming cursor of the table "programmefeatures" */
+export type Programmefeatures_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Programmefeatures_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Programmefeatures_Stream_Cursor_Value_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  feature_id?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Programmefeatures_Sum_Fields = {
+  __typename?: 'programmefeatures_sum_fields';
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  feature_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** order by sum() on columns of table "programmefeatures" */
+export type Programmefeatures_Sum_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "programmefeatures" */
+export enum Programmefeatures_Update_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  DeprecatedFields = 'deprecated_fields',
+  /** column name */
+  FeatureId = 'feature_id',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  UpdatedAt = 'updated_at'
+}
+
+export type Programmefeatures_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Programmefeatures_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Programmefeatures_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Programmefeatures_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Programmefeatures_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Programmefeatures_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Programmefeatures_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Programmefeatures_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Programmefeatures_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Programmefeatures_Var_Pop_Fields = {
+  __typename?: 'programmefeatures_var_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_pop() on columns of table "programmefeatures" */
+export type Programmefeatures_Var_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Programmefeatures_Var_Samp_Fields = {
+  __typename?: 'programmefeatures_var_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_samp() on columns of table "programmefeatures" */
+export type Programmefeatures_Var_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Programmefeatures_Variance_Fields = {
+  __typename?: 'programmefeatures_variance_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  feature_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by variance() on columns of table "programmefeatures" */
+export type Programmefeatures_Variance_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  feature_id?: InputMaybe<Order_By>;
+};
+
 /** columns and relationships of "programmes" */
 export type Programmes = {
   __typename?: 'programmes';
@@ -13740,6 +14839,8 @@ export type Programmes = {
   programme_units_all_states: Array<Programme_Units>;
   /** An aggregate relationship */
   programme_units_all_states_aggregate: Programme_Units_Aggregate;
+  /** A computed field, executes function "function__programmes__programmefeatures" */
+  programmefeatures?: Maybe<Array<Programmefeatures>>;
   /** A computed field, executes function "function__programmes__computed_subject_phase_parent" */
   subject_phase_parent?: Maybe<Array<Programmes>>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -13853,6 +14954,16 @@ export type ProgrammesProgramme_Units_All_States_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Programme_Units_Order_By>>;
   where?: InputMaybe<Programme_Units_Bool_Exp>;
+};
+
+
+/** columns and relationships of "programmes" */
+export type ProgrammesProgrammefeaturesArgs = {
+  distinct_on?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmefeatures_Order_By>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
 };
 
 
@@ -13996,6 +15107,7 @@ export type Programmes_Bool_Exp = {
   programme_units_aggregate?: InputMaybe<Programme_Units_Aggregate_Bool_Exp>;
   programme_units_all_states?: InputMaybe<Programme_Units_Bool_Exp>;
   programme_units_all_states_aggregate?: InputMaybe<Programme_Units_Aggregate_Bool_Exp>;
+  programmefeatures?: InputMaybe<Programmefeatures_Bool_Exp>;
   subject_phase_parent?: InputMaybe<Programmes_Bool_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
 };
@@ -14162,6 +15274,7 @@ export type Programmes_Order_By = {
   programme_uid?: InputMaybe<Order_By>;
   programme_units_aggregate?: InputMaybe<Programme_Units_Aggregate_Order_By>;
   programme_units_all_states_aggregate?: InputMaybe<Programme_Units_Aggregate_Order_By>;
+  programmefeatures_aggregate?: InputMaybe<Programmefeatures_Aggregate_Order_By>;
   subject_phase_parent_aggregate?: InputMaybe<Programmes_Aggregate_Order_By>;
   updated_at?: InputMaybe<Order_By>;
 };
@@ -14700,6 +15813,142 @@ export type Published_Mv_Curriculum_Overview_0_3_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Published_Mv_Curriculum_Overview_0_3_Stream_Cursor_Value_Input = {
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  curriculum_intent?: InputMaybe<Scalars['String']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** columns and relationships of "published.mv_curriculum_overview_0_4" */
+export type Published_Mv_Curriculum_Overview_0_4 = {
+  __typename?: 'published_mv_curriculum_overview_0_4';
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  curriculum_intent?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** aggregated selection of "published.mv_curriculum_overview_0_4" */
+export type Published_Mv_Curriculum_Overview_0_4_Aggregate = {
+  __typename?: 'published_mv_curriculum_overview_0_4_aggregate';
+  aggregate?: Maybe<Published_Mv_Curriculum_Overview_0_4_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Curriculum_Overview_0_4>;
+};
+
+/** aggregate fields of "published.mv_curriculum_overview_0_4" */
+export type Published_Mv_Curriculum_Overview_0_4_Aggregate_Fields = {
+  __typename?: 'published_mv_curriculum_overview_0_4_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Curriculum_Overview_0_4_Max_Fields>;
+  min?: Maybe<Published_Mv_Curriculum_Overview_0_4_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_curriculum_overview_0_4" */
+export type Published_Mv_Curriculum_Overview_0_4_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_curriculum_overview_0_4". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Curriculum_Overview_0_4_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  curriculum_intent?: InputMaybe<String_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Curriculum_Overview_0_4_Max_Fields = {
+  __typename?: 'published_mv_curriculum_overview_0_4_max_fields';
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  curriculum_intent?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Curriculum_Overview_0_4_Min_Fields = {
+  __typename?: 'published_mv_curriculum_overview_0_4_min_fields';
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  curriculum_intent?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_curriculum_overview_0_4". */
+export type Published_Mv_Curriculum_Overview_0_4_Order_By = {
+  created_at?: InputMaybe<Order_By>;
+  curriculum_intent?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_curriculum_overview_0_4" */
+export enum Published_Mv_Curriculum_Overview_0_4_Select_Column {
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  CurriculumIntent = 'curriculum_intent',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  UpdatedAt = 'updated_at'
+}
+
+/** Streaming cursor of the table "published_mv_curriculum_overview_0_4" */
+export type Published_Mv_Curriculum_Overview_0_4_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Curriculum_Overview_0_4_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Curriculum_Overview_0_4_Stream_Cursor_Value_Input = {
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   curriculum_intent?: InputMaybe<Scalars['String']['input']>;
   examboard?: InputMaybe<Scalars['String']['input']>;
@@ -17062,6 +18311,378 @@ export type Published_Mv_Curriculum_Units_0_6_Var_Samp_Fields = {
 /** aggregate variance on columns */
 export type Published_Mv_Curriculum_Units_0_6_Variance_Fields = {
   __typename?: 'published_mv_curriculum_units_0_6_variance_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7 = {
+  __typename?: 'published_mv_curriculum_units_0_7';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  subjectcategories?: Maybe<Scalars['jsonb']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7SubjectcategoriesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7_Aggregate = {
+  __typename?: 'published_mv_curriculum_units_0_7_aggregate';
+  aggregate?: Maybe<Published_Mv_Curriculum_Units_0_7_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Curriculum_Units_0_7>;
+};
+
+/** aggregate fields of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7_Aggregate_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_aggregate_fields';
+  avg?: Maybe<Published_Mv_Curriculum_Units_0_7_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Curriculum_Units_0_7_Max_Fields>;
+  min?: Maybe<Published_Mv_Curriculum_Units_0_7_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Curriculum_Units_0_7_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Curriculum_Units_0_7_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Curriculum_Units_0_7_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Curriculum_Units_0_7_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Curriculum_Units_0_7_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Curriculum_Units_0_7_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Curriculum_Units_0_7_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Curriculum_Units_0_7_Avg_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_avg_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_curriculum_units_0_7". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Curriculum_Units_0_7_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Bool_Exp>>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<Int_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subjectcategories?: InputMaybe<Jsonb_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Curriculum_Units_0_7_Max_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Curriculum_Units_0_7_Min_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_curriculum_units_0_7". */
+export type Published_Mv_Curriculum_Units_0_7_Order_By = {
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subjectcategories?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_curriculum_units_0_7" */
+export enum Published_Mv_Curriculum_Units_0_7_Select_Column {
+  /** column name */
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
+  /** column name */
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
+  /** column name */
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
+  /** column name */
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
+  /** column name */
+  Domain = 'domain',
+  /** column name */
+  DomainId = 'domain_id',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  KeystageSlug = 'keystage_slug',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Subjectcategories = 'subjectcategories',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  Year = 'year'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Curriculum_Units_0_7_Stddev_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_stddev_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Curriculum_Units_0_7_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_stddev_pop_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Curriculum_Units_0_7_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_stddev_samp_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_curriculum_units_0_7" */
+export type Published_Mv_Curriculum_Units_0_7_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Curriculum_Units_0_7_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Curriculum_Units_0_7_Stream_Cursor_Value_Input = {
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['Int']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Curriculum_Units_0_7_Sum_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_sum_fields';
+  domain_id?: Maybe<Scalars['Int']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Curriculum_Units_0_7_Var_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_var_pop_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Curriculum_Units_0_7_Var_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_var_samp_fields';
+  domain_id?: Maybe<Scalars['Float']['output']>;
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Curriculum_Units_0_7_Variance_Fields = {
+  __typename?: 'published_mv_curriculum_units_0_7_variance_fields';
   domain_id?: Maybe<Scalars['Float']['output']>;
   order?: Maybe<Scalars['Float']['output']>;
   planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
@@ -30683,6 +32304,12 @@ export type Query_Root = {
   internal_review_lessons_aggregate: Internal_Review_Lessons_Aggregate;
   /** fetch data from the table: "internal.review_lessons" using primary key columns */
   internal_review_lessons_by_pk?: Maybe<Internal_Review_Lessons>;
+  /** fetch data from the table: "internal.tpc_contracts" */
+  internal_tpc_contracts: Array<Internal_Tpc_Contracts>;
+  /** fetch aggregated fields from the table: "internal.tpc_contracts" */
+  internal_tpc_contracts_aggregate: Internal_Tpc_Contracts_Aggregate;
+  /** fetch data from the table: "internal.tpc_contracts" using primary key columns */
+  internal_tpc_contracts_by_pk?: Maybe<Internal_Tpc_Contracts>;
   /** fetch data from the table: "lessons" */
   lessons: Array<Lessons>;
   /** fetch aggregated fields from the table: "lessons" */
@@ -30749,6 +32376,12 @@ export type Query_Root = {
   programme_units_aggregate: Programme_Units_Aggregate;
   /** fetch data from the table: "programme_units" using primary key columns */
   programme_units_by_pk?: Maybe<Programme_Units>;
+  /** fetch data from the table: "programmefeatures" */
+  programmefeatures: Array<Programmefeatures>;
+  /** fetch aggregated fields from the table: "programmefeatures" */
+  programmefeatures_aggregate: Programmefeatures_Aggregate;
+  /** fetch data from the table: "programmefeatures" using primary key columns */
+  programmefeatures_by_pk?: Maybe<Programmefeatures>;
   /** fetch data from the table: "programmes" */
   programmes: Array<Programmes>;
   /** fetch aggregated fields from the table: "programmes" */
@@ -30765,6 +32398,10 @@ export type Query_Root = {
   published_mv_curriculum_overview_0_3: Array<Published_Mv_Curriculum_Overview_0_3>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_overview_0_3" */
   published_mv_curriculum_overview_0_3_aggregate: Published_Mv_Curriculum_Overview_0_3_Aggregate;
+  /** fetch data from the table: "published.mv_curriculum_overview_0_4" */
+  published_mv_curriculum_overview_0_4: Array<Published_Mv_Curriculum_Overview_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_overview_0_4" */
+  published_mv_curriculum_overview_0_4_aggregate: Published_Mv_Curriculum_Overview_0_4_Aggregate;
   /** fetch data from the table: "published.mv_curriculum_overview_1" */
   published_mv_curriculum_overview_1: Array<Published_Mv_Curriculum_Overview_1>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_overview_1" */
@@ -30795,6 +32432,10 @@ export type Query_Root = {
   published_mv_curriculum_units_0_6: Array<Published_Mv_Curriculum_Units_0_6>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_6" */
   published_mv_curriculum_units_0_6_aggregate: Published_Mv_Curriculum_Units_0_6_Aggregate;
+  /** fetch data from the table: "published.mv_curriculum_units_0_7" */
+  published_mv_curriculum_units_0_7: Array<Published_Mv_Curriculum_Units_0_7>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_7" */
+  published_mv_curriculum_units_0_7_aggregate: Published_Mv_Curriculum_Units_0_7_Aggregate;
   /** fetch data from the table: "published.mv_curriculum_units_including_new_0_0_8" */
   published_mv_curriculum_units_including_new_0_0_8: Array<Published_Mv_Curriculum_Units_Including_New_0_0_8>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_units_including_new_0_0_8" */
@@ -31059,12 +32700,6 @@ export type Query_Root = {
   threads_aggregate: Threads_Aggregate;
   /** fetch data from the table: "threads" using primary key columns */
   threads_by_pk?: Maybe<Threads>;
-  /** fetch data from the table: "tpc_contracts" */
-  tpc_contracts: Array<Tpc_Contracts>;
-  /** fetch aggregated fields from the table: "tpc_contracts" */
-  tpc_contracts_aggregate: Tpc_Contracts_Aggregate;
-  /** fetch data from the table: "tpc_contracts" using primary key columns */
-  tpc_contracts_by_pk?: Maybe<Tpc_Contracts>;
   /** fetch data from the table: "tpc_media" */
   tpc_media: Array<Tpc_Media>;
   /** fetch aggregated fields from the table: "tpc_media" */
@@ -31350,6 +32985,30 @@ export type Query_RootInternal_Review_Lessons_By_PkArgs = {
 };
 
 
+export type Query_RootInternal_Tpc_ContractsArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+
+export type Query_RootInternal_Tpc_Contracts_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+
+export type Query_RootInternal_Tpc_Contracts_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  contract_id: Scalars['Int']['input'];
+};
+
+
 export type Query_RootLessonsArgs = {
   distinct_on?: InputMaybe<Array<Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -31616,6 +33275,30 @@ export type Query_RootProgramme_Units_By_PkArgs = {
 };
 
 
+export type Query_RootProgrammefeaturesArgs = {
+  distinct_on?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmefeatures_Order_By>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+
+export type Query_RootProgrammefeatures_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmefeatures_Order_By>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+
+export type Query_RootProgrammefeatures_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  feature_id: Scalars['Int']['input'];
+};
+
+
 export type Query_RootProgrammesArgs = {
   distinct_on?: InputMaybe<Array<Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -31682,6 +33365,24 @@ export type Query_RootPublished_Mv_Curriculum_Overview_0_3_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_3_Order_By>>;
   where?: InputMaybe<Published_Mv_Curriculum_Overview_0_3_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Overview_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Overview_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
 };
 
 
@@ -31817,6 +33518,24 @@ export type Query_RootPublished_Mv_Curriculum_Units_0_6_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_6_Order_By>>;
   where?: InputMaybe<Published_Mv_Curriculum_Units_0_6_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Units_0_7Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Units_0_7_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
 };
 
 
@@ -32981,30 +34700,6 @@ export type Query_RootThreads_AggregateArgs = {
 export type Query_RootThreads_By_PkArgs = {
   _state: Scalars['String']['input'];
   thread_id: Scalars['Int']['input'];
-};
-
-
-export type Query_RootTpc_ContractsArgs = {
-  distinct_on?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Tpc_Contracts_Order_By>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-};
-
-
-export type Query_RootTpc_Contracts_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Tpc_Contracts_Order_By>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-};
-
-
-export type Query_RootTpc_Contracts_By_PkArgs = {
-  _state: Scalars['String']['input'];
-  contract_id: Scalars['Int']['input'];
 };
 
 
@@ -35068,6 +36763,14 @@ export type Subscription_Root = {
   internal_review_lessons_by_pk?: Maybe<Internal_Review_Lessons>;
   /** fetch data from the table in a streaming manner: "internal.review_lessons" */
   internal_review_lessons_stream: Array<Internal_Review_Lessons>;
+  /** fetch data from the table: "internal.tpc_contracts" */
+  internal_tpc_contracts: Array<Internal_Tpc_Contracts>;
+  /** fetch aggregated fields from the table: "internal.tpc_contracts" */
+  internal_tpc_contracts_aggregate: Internal_Tpc_Contracts_Aggregate;
+  /** fetch data from the table: "internal.tpc_contracts" using primary key columns */
+  internal_tpc_contracts_by_pk?: Maybe<Internal_Tpc_Contracts>;
+  /** fetch data from the table in a streaming manner: "internal.tpc_contracts" */
+  internal_tpc_contracts_stream: Array<Internal_Tpc_Contracts>;
   /** fetch data from the table: "lessons" */
   lessons: Array<Lessons>;
   /** fetch aggregated fields from the table: "lessons" */
@@ -35156,6 +36859,14 @@ export type Subscription_Root = {
   programme_units_by_pk?: Maybe<Programme_Units>;
   /** fetch data from the table in a streaming manner: "programme_units" */
   programme_units_stream: Array<Programme_Units>;
+  /** fetch data from the table: "programmefeatures" */
+  programmefeatures: Array<Programmefeatures>;
+  /** fetch aggregated fields from the table: "programmefeatures" */
+  programmefeatures_aggregate: Programmefeatures_Aggregate;
+  /** fetch data from the table: "programmefeatures" using primary key columns */
+  programmefeatures_by_pk?: Maybe<Programmefeatures>;
+  /** fetch data from the table in a streaming manner: "programmefeatures" */
+  programmefeatures_stream: Array<Programmefeatures>;
   /** fetch data from the table: "programmes" */
   programmes: Array<Programmes>;
   /** fetch aggregated fields from the table: "programmes" */
@@ -35178,6 +36889,12 @@ export type Subscription_Root = {
   published_mv_curriculum_overview_0_3_aggregate: Published_Mv_Curriculum_Overview_0_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_curriculum_overview_0_3" */
   published_mv_curriculum_overview_0_3_stream: Array<Published_Mv_Curriculum_Overview_0_3>;
+  /** fetch data from the table: "published.mv_curriculum_overview_0_4" */
+  published_mv_curriculum_overview_0_4: Array<Published_Mv_Curriculum_Overview_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_overview_0_4" */
+  published_mv_curriculum_overview_0_4_aggregate: Published_Mv_Curriculum_Overview_0_4_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_curriculum_overview_0_4" */
+  published_mv_curriculum_overview_0_4_stream: Array<Published_Mv_Curriculum_Overview_0_4>;
   /** fetch data from the table: "published.mv_curriculum_overview_1" */
   published_mv_curriculum_overview_1: Array<Published_Mv_Curriculum_Overview_1>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_overview_1" */
@@ -35224,6 +36941,12 @@ export type Subscription_Root = {
   published_mv_curriculum_units_0_6_aggregate: Published_Mv_Curriculum_Units_0_6_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_curriculum_units_0_6" */
   published_mv_curriculum_units_0_6_stream: Array<Published_Mv_Curriculum_Units_0_6>;
+  /** fetch data from the table: "published.mv_curriculum_units_0_7" */
+  published_mv_curriculum_units_0_7: Array<Published_Mv_Curriculum_Units_0_7>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_units_0_7" */
+  published_mv_curriculum_units_0_7_aggregate: Published_Mv_Curriculum_Units_0_7_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_curriculum_units_0_7" */
+  published_mv_curriculum_units_0_7_stream: Array<Published_Mv_Curriculum_Units_0_7>;
   /** fetch data from the table: "published.mv_curriculum_units_including_new_0_0_8" */
   published_mv_curriculum_units_including_new_0_0_8: Array<Published_Mv_Curriculum_Units_Including_New_0_0_8>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_units_including_new_0_0_8" */
@@ -35612,14 +37335,6 @@ export type Subscription_Root = {
   threads_by_pk?: Maybe<Threads>;
   /** fetch data from the table in a streaming manner: "threads" */
   threads_stream: Array<Threads>;
-  /** fetch data from the table: "tpc_contracts" */
-  tpc_contracts: Array<Tpc_Contracts>;
-  /** fetch aggregated fields from the table: "tpc_contracts" */
-  tpc_contracts_aggregate: Tpc_Contracts_Aggregate;
-  /** fetch data from the table: "tpc_contracts" using primary key columns */
-  tpc_contracts_by_pk?: Maybe<Tpc_Contracts>;
-  /** fetch data from the table in a streaming manner: "tpc_contracts" */
-  tpc_contracts_stream: Array<Tpc_Contracts>;
   /** fetch data from the table: "tpc_media" */
   tpc_media: Array<Tpc_Media>;
   /** fetch aggregated fields from the table: "tpc_media" */
@@ -35989,6 +37704,37 @@ export type Subscription_RootInternal_Review_Lessons_StreamArgs = {
 };
 
 
+export type Subscription_RootInternal_Tpc_ContractsArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+
+export type Subscription_RootInternal_Tpc_Contracts_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+
+export type Subscription_RootInternal_Tpc_Contracts_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  contract_id: Scalars['Int']['input'];
+};
+
+
+export type Subscription_RootInternal_Tpc_Contracts_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Internal_Tpc_Contracts_Stream_Cursor_Input>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
+};
+
+
 export type Subscription_RootLessonsArgs = {
   distinct_on?: InputMaybe<Array<Lessons_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -36332,6 +38078,37 @@ export type Subscription_RootProgramme_Units_StreamArgs = {
 };
 
 
+export type Subscription_RootProgrammefeaturesArgs = {
+  distinct_on?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmefeatures_Order_By>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+
+export type Subscription_RootProgrammefeatures_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Programmefeatures_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmefeatures_Order_By>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+
+export type Subscription_RootProgrammefeatures_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  feature_id: Scalars['Int']['input'];
+};
+
+
+export type Subscription_RootProgrammefeatures_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Programmefeatures_Stream_Cursor_Input>>;
+  where?: InputMaybe<Programmefeatures_Bool_Exp>;
+};
+
+
 export type Subscription_RootProgrammesArgs = {
   distinct_on?: InputMaybe<Array<Programmes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -36419,6 +38196,31 @@ export type Subscription_RootPublished_Mv_Curriculum_Overview_0_3_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Curriculum_Overview_0_3_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Curriculum_Overview_0_3_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Overview_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Overview_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Overview_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Overview_0_4_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Curriculum_Overview_0_4_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Overview_0_4_Bool_Exp>;
 };
 
 
@@ -36610,6 +38412,31 @@ export type Subscription_RootPublished_Mv_Curriculum_Units_0_6_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Curriculum_Units_0_6_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Curriculum_Units_0_6_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_7Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_7_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Units_0_7_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Units_0_7_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Curriculum_Units_0_7_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
 };
 
 
@@ -38208,37 +40035,6 @@ export type Subscription_RootThreads_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Threads_Stream_Cursor_Input>>;
   where?: InputMaybe<Threads_Bool_Exp>;
-};
-
-
-export type Subscription_RootTpc_ContractsArgs = {
-  distinct_on?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Tpc_Contracts_Order_By>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-};
-
-
-export type Subscription_RootTpc_Contracts_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Tpc_Contracts_Order_By>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-};
-
-
-export type Subscription_RootTpc_Contracts_By_PkArgs = {
-  _state: Scalars['String']['input'];
-  contract_id: Scalars['Int']['input'];
-};
-
-
-export type Subscription_RootTpc_Contracts_StreamArgs = {
-  batch_size: Scalars['Int']['input'];
-  cursor: Array<InputMaybe<Tpc_Contracts_Stream_Cursor_Input>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
 };
 
 
@@ -40793,6 +42589,7 @@ export type Threads = {
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   deprecated_fields?: Maybe<Scalars['jsonb']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
   /** An object relationship */
   parent_thread?: Maybe<Threads>;
   parent_thread_id?: Maybe<Scalars['Int']['output']>;
@@ -40842,6 +42639,12 @@ export type ThreadsChild_Threads_AggregateArgs = {
 
 /** columns and relationships of "threads" */
 export type ThreadsDeprecated_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "threads" */
+export type ThreadsFeaturesArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -41000,6 +42803,7 @@ export type Threads_Aggregate_Order_By = {
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Threads_Append_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
 /** input type for inserting array relation for remote table "threads" */
@@ -41038,6 +42842,7 @@ export type Threads_Bool_Exp = {
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   deprecated_fields?: InputMaybe<Jsonb_Comparison_Exp>;
   description?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
   parent_thread?: InputMaybe<Threads_Bool_Exp>;
   parent_thread_id?: InputMaybe<Int_Comparison_Exp>;
   programme_threads?: InputMaybe<Programme_Threads_Bool_Exp>;
@@ -41064,16 +42869,19 @@ export enum Threads_Constraint {
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Threads_Delete_At_Path_Input = {
   deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  features?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Threads_Delete_Elem_Input = {
   deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Threads_Delete_Key_Input = {
   deprecated_fields?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** input type for incrementing numeric columns in table "threads" */
@@ -41093,6 +42901,7 @@ export type Threads_Insert_Input = {
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   parent_thread?: InputMaybe<Threads_Obj_Rel_Insert_Input>;
   parent_thread_id?: InputMaybe<Scalars['Int']['input']>;
   programme_threads?: InputMaybe<Programme_Threads_Arr_Rel_Insert_Input>;
@@ -41201,6 +43010,7 @@ export type Threads_Order_By = {
   created_at?: InputMaybe<Order_By>;
   deprecated_fields?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
   parent_thread?: InputMaybe<Threads_Order_By>;
   parent_thread_id?: InputMaybe<Order_By>;
   programme_threads_aggregate?: InputMaybe<Programme_Threads_Aggregate_Order_By>;
@@ -41223,6 +43033,7 @@ export type Threads_Pk_Columns_Input = {
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Threads_Prepend_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
 /** select columns of table "threads" */
@@ -41241,6 +43052,8 @@ export enum Threads_Select_Column {
   DeprecatedFields = 'deprecated_fields',
   /** column name */
   Description = 'description',
+  /** column name */
+  Features = 'features',
   /** column name */
   ParentThreadId = 'parent_thread_id',
   /** column name */
@@ -41276,6 +43089,7 @@ export type Threads_Set_Input = {
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   parent_thread_id?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   thread_id?: InputMaybe<Scalars['Int']['input']>;
@@ -41346,6 +43160,7 @@ export type Threads_Stream_Cursor_Value_Input = {
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   parent_thread_id?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   thread_id?: InputMaybe<Scalars['Int']['input']>;
@@ -41385,6 +43200,8 @@ export enum Threads_Update_Column {
   DeprecatedFields = 'deprecated_fields',
   /** column name */
   Description = 'description',
+  /** column name */
+  Features = 'features',
   /** column name */
   ParentThreadId = 'parent_thread_id',
   /** column name */
@@ -41489,542 +43306,6 @@ export type Timestamptz_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['timestamptz']['input']>>;
 };
 
-/** columns and relationships of "tpc_contracts" */
-export type Tpc_Contracts = {
-  __typename?: 'tpc_contracts';
-  _cohort: Scalars['String']['output'];
-  _deleted: Scalars['Boolean']['output'];
-  _release_id?: Maybe<Scalars['Int']['output']>;
-  _state: Scalars['String']['output'];
-  contract_id: Scalars['Int']['output'];
-  contract_name?: Maybe<Scalars['String']['output']>;
-  contract_object: Scalars['jsonb']['output'];
-  contract_uid?: Maybe<Scalars['bpchar']['output']>;
-  created_at?: Maybe<Scalars['timestamptz']['output']>;
-  effective_date?: Maybe<Scalars['date']['output']>;
-  end_date?: Maybe<Scalars['date']['output']>;
-  external_id?: Maybe<Scalars['String']['output']>;
-  external_url?: Maybe<Scalars['String']['output']>;
-  restrictions?: Maybe<Scalars['jsonb']['output']>;
-  signing_side?: Maybe<Scalars['String']['output']>;
-  territory?: Maybe<Scalars['String']['output']>;
-  updated_at?: Maybe<Scalars['timestamptz']['output']>;
-};
-
-
-/** columns and relationships of "tpc_contracts" */
-export type Tpc_ContractsContract_ObjectArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "tpc_contracts" */
-export type Tpc_ContractsRestrictionsArgs = {
-  path?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** aggregated selection of "tpc_contracts" */
-export type Tpc_Contracts_Aggregate = {
-  __typename?: 'tpc_contracts_aggregate';
-  aggregate?: Maybe<Tpc_Contracts_Aggregate_Fields>;
-  nodes: Array<Tpc_Contracts>;
-};
-
-/** aggregate fields of "tpc_contracts" */
-export type Tpc_Contracts_Aggregate_Fields = {
-  __typename?: 'tpc_contracts_aggregate_fields';
-  avg?: Maybe<Tpc_Contracts_Avg_Fields>;
-  count: Scalars['Int']['output'];
-  max?: Maybe<Tpc_Contracts_Max_Fields>;
-  min?: Maybe<Tpc_Contracts_Min_Fields>;
-  stddev?: Maybe<Tpc_Contracts_Stddev_Fields>;
-  stddev_pop?: Maybe<Tpc_Contracts_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Tpc_Contracts_Stddev_Samp_Fields>;
-  sum?: Maybe<Tpc_Contracts_Sum_Fields>;
-  var_pop?: Maybe<Tpc_Contracts_Var_Pop_Fields>;
-  var_samp?: Maybe<Tpc_Contracts_Var_Samp_Fields>;
-  variance?: Maybe<Tpc_Contracts_Variance_Fields>;
-};
-
-
-/** aggregate fields of "tpc_contracts" */
-export type Tpc_Contracts_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  distinct?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-/** order by aggregate values of table "tpc_contracts" */
-export type Tpc_Contracts_Aggregate_Order_By = {
-  avg?: InputMaybe<Tpc_Contracts_Avg_Order_By>;
-  count?: InputMaybe<Order_By>;
-  max?: InputMaybe<Tpc_Contracts_Max_Order_By>;
-  min?: InputMaybe<Tpc_Contracts_Min_Order_By>;
-  stddev?: InputMaybe<Tpc_Contracts_Stddev_Order_By>;
-  stddev_pop?: InputMaybe<Tpc_Contracts_Stddev_Pop_Order_By>;
-  stddev_samp?: InputMaybe<Tpc_Contracts_Stddev_Samp_Order_By>;
-  sum?: InputMaybe<Tpc_Contracts_Sum_Order_By>;
-  var_pop?: InputMaybe<Tpc_Contracts_Var_Pop_Order_By>;
-  var_samp?: InputMaybe<Tpc_Contracts_Var_Samp_Order_By>;
-  variance?: InputMaybe<Tpc_Contracts_Variance_Order_By>;
-};
-
-/** append existing jsonb value of filtered columns with new jsonb value */
-export type Tpc_Contracts_Append_Input = {
-  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
-  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
-};
-
-/** aggregate avg on columns */
-export type Tpc_Contracts_Avg_Fields = {
-  __typename?: 'tpc_contracts_avg_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by avg() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Avg_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "tpc_contracts". All fields are combined with a logical 'AND'. */
-export type Tpc_Contracts_Bool_Exp = {
-  _and?: InputMaybe<Array<Tpc_Contracts_Bool_Exp>>;
-  _cohort?: InputMaybe<String_Comparison_Exp>;
-  _deleted?: InputMaybe<Boolean_Comparison_Exp>;
-  _not?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-  _or?: InputMaybe<Array<Tpc_Contracts_Bool_Exp>>;
-  _release_id?: InputMaybe<Int_Comparison_Exp>;
-  _state?: InputMaybe<String_Comparison_Exp>;
-  contract_id?: InputMaybe<Int_Comparison_Exp>;
-  contract_name?: InputMaybe<String_Comparison_Exp>;
-  contract_object?: InputMaybe<Jsonb_Comparison_Exp>;
-  contract_uid?: InputMaybe<Bpchar_Comparison_Exp>;
-  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  effective_date?: InputMaybe<Date_Comparison_Exp>;
-  end_date?: InputMaybe<Date_Comparison_Exp>;
-  external_id?: InputMaybe<String_Comparison_Exp>;
-  external_url?: InputMaybe<String_Comparison_Exp>;
-  restrictions?: InputMaybe<Jsonb_Comparison_Exp>;
-  signing_side?: InputMaybe<String_Comparison_Exp>;
-  territory?: InputMaybe<String_Comparison_Exp>;
-  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "tpc_contracts" */
-export enum Tpc_Contracts_Constraint {
-  /** unique or primary key constraint on columns "_state", "external_id" */
-  TpcContractsExternalIdStateKey = 'tpc_contracts_external_id__state_key',
-  /** unique or primary key constraint on columns "external_url", "_state" */
-  TpcContractsExternalUrlStateKey = 'tpc_contracts_external_url__state_key',
-  /** unique or primary key constraint on columns "_state", "contract_id" */
-  TpcContractsPkey = 'tpc_contracts_pkey'
-}
-
-/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
-export type Tpc_Contracts_Delete_At_Path_Input = {
-  contract_object?: InputMaybe<Array<Scalars['String']['input']>>;
-  restrictions?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
-/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
-export type Tpc_Contracts_Delete_Elem_Input = {
-  contract_object?: InputMaybe<Scalars['Int']['input']>;
-  restrictions?: InputMaybe<Scalars['Int']['input']>;
-};
-
-/** delete key/value pair or string element. key/value pairs are matched based on their key value */
-export type Tpc_Contracts_Delete_Key_Input = {
-  contract_object?: InputMaybe<Scalars['String']['input']>;
-  restrictions?: InputMaybe<Scalars['String']['input']>;
-};
-
-/** input type for incrementing numeric columns in table "tpc_contracts" */
-export type Tpc_Contracts_Inc_Input = {
-  _release_id?: InputMaybe<Scalars['Int']['input']>;
-  contract_id?: InputMaybe<Scalars['Int']['input']>;
-};
-
-/** input type for inserting data into table "tpc_contracts" */
-export type Tpc_Contracts_Insert_Input = {
-  _cohort?: InputMaybe<Scalars['String']['input']>;
-  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
-  _release_id?: InputMaybe<Scalars['Int']['input']>;
-  _state?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['Int']['input']>;
-  contract_name?: InputMaybe<Scalars['String']['input']>;
-  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
-  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
-  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
-  effective_date?: InputMaybe<Scalars['date']['input']>;
-  end_date?: InputMaybe<Scalars['date']['input']>;
-  external_id?: InputMaybe<Scalars['String']['input']>;
-  external_url?: InputMaybe<Scalars['String']['input']>;
-  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
-  signing_side?: InputMaybe<Scalars['String']['input']>;
-  territory?: InputMaybe<Scalars['String']['input']>;
-  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
-};
-
-/** aggregate max on columns */
-export type Tpc_Contracts_Max_Fields = {
-  __typename?: 'tpc_contracts_max_fields';
-  _cohort?: Maybe<Scalars['String']['output']>;
-  _release_id?: Maybe<Scalars['Int']['output']>;
-  _state?: Maybe<Scalars['String']['output']>;
-  contract_id?: Maybe<Scalars['Int']['output']>;
-  contract_name?: Maybe<Scalars['String']['output']>;
-  contract_uid?: Maybe<Scalars['bpchar']['output']>;
-  created_at?: Maybe<Scalars['timestamptz']['output']>;
-  effective_date?: Maybe<Scalars['date']['output']>;
-  end_date?: Maybe<Scalars['date']['output']>;
-  external_id?: Maybe<Scalars['String']['output']>;
-  external_url?: Maybe<Scalars['String']['output']>;
-  signing_side?: Maybe<Scalars['String']['output']>;
-  territory?: Maybe<Scalars['String']['output']>;
-  updated_at?: Maybe<Scalars['timestamptz']['output']>;
-};
-
-/** order by max() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Max_Order_By = {
-  _cohort?: InputMaybe<Order_By>;
-  _release_id?: InputMaybe<Order_By>;
-  _state?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-  contract_name?: InputMaybe<Order_By>;
-  contract_uid?: InputMaybe<Order_By>;
-  created_at?: InputMaybe<Order_By>;
-  effective_date?: InputMaybe<Order_By>;
-  end_date?: InputMaybe<Order_By>;
-  external_id?: InputMaybe<Order_By>;
-  external_url?: InputMaybe<Order_By>;
-  signing_side?: InputMaybe<Order_By>;
-  territory?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Tpc_Contracts_Min_Fields = {
-  __typename?: 'tpc_contracts_min_fields';
-  _cohort?: Maybe<Scalars['String']['output']>;
-  _release_id?: Maybe<Scalars['Int']['output']>;
-  _state?: Maybe<Scalars['String']['output']>;
-  contract_id?: Maybe<Scalars['Int']['output']>;
-  contract_name?: Maybe<Scalars['String']['output']>;
-  contract_uid?: Maybe<Scalars['bpchar']['output']>;
-  created_at?: Maybe<Scalars['timestamptz']['output']>;
-  effective_date?: Maybe<Scalars['date']['output']>;
-  end_date?: Maybe<Scalars['date']['output']>;
-  external_id?: Maybe<Scalars['String']['output']>;
-  external_url?: Maybe<Scalars['String']['output']>;
-  signing_side?: Maybe<Scalars['String']['output']>;
-  territory?: Maybe<Scalars['String']['output']>;
-  updated_at?: Maybe<Scalars['timestamptz']['output']>;
-};
-
-/** order by min() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Min_Order_By = {
-  _cohort?: InputMaybe<Order_By>;
-  _release_id?: InputMaybe<Order_By>;
-  _state?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-  contract_name?: InputMaybe<Order_By>;
-  contract_uid?: InputMaybe<Order_By>;
-  created_at?: InputMaybe<Order_By>;
-  effective_date?: InputMaybe<Order_By>;
-  end_date?: InputMaybe<Order_By>;
-  external_id?: InputMaybe<Order_By>;
-  external_url?: InputMaybe<Order_By>;
-  signing_side?: InputMaybe<Order_By>;
-  territory?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
-};
-
-/** response of any mutation on the table "tpc_contracts" */
-export type Tpc_Contracts_Mutation_Response = {
-  __typename?: 'tpc_contracts_mutation_response';
-  /** number of rows affected by the mutation */
-  affected_rows: Scalars['Int']['output'];
-  /** data from the rows affected by the mutation */
-  returning: Array<Tpc_Contracts>;
-};
-
-/** on_conflict condition type for table "tpc_contracts" */
-export type Tpc_Contracts_On_Conflict = {
-  constraint: Tpc_Contracts_Constraint;
-  update_columns?: Array<Tpc_Contracts_Update_Column>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
-};
-
-/** Ordering options when selecting data from "tpc_contracts". */
-export type Tpc_Contracts_Order_By = {
-  _cohort?: InputMaybe<Order_By>;
-  _deleted?: InputMaybe<Order_By>;
-  _release_id?: InputMaybe<Order_By>;
-  _state?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-  contract_name?: InputMaybe<Order_By>;
-  contract_object?: InputMaybe<Order_By>;
-  contract_uid?: InputMaybe<Order_By>;
-  created_at?: InputMaybe<Order_By>;
-  effective_date?: InputMaybe<Order_By>;
-  end_date?: InputMaybe<Order_By>;
-  external_id?: InputMaybe<Order_By>;
-  external_url?: InputMaybe<Order_By>;
-  restrictions?: InputMaybe<Order_By>;
-  signing_side?: InputMaybe<Order_By>;
-  territory?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
-};
-
-/** primary key columns input for table: tpc_contracts */
-export type Tpc_Contracts_Pk_Columns_Input = {
-  _state: Scalars['String']['input'];
-  contract_id: Scalars['Int']['input'];
-};
-
-/** prepend existing jsonb value of filtered columns with new jsonb value */
-export type Tpc_Contracts_Prepend_Input = {
-  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
-  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
-};
-
-/** select columns of table "tpc_contracts" */
-export enum Tpc_Contracts_Select_Column {
-  /** column name */
-  Cohort = '_cohort',
-  /** column name */
-  Deleted = '_deleted',
-  /** column name */
-  ReleaseId = '_release_id',
-  /** column name */
-  State = '_state',
-  /** column name */
-  ContractId = 'contract_id',
-  /** column name */
-  ContractName = 'contract_name',
-  /** column name */
-  ContractObject = 'contract_object',
-  /** column name */
-  ContractUid = 'contract_uid',
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  EffectiveDate = 'effective_date',
-  /** column name */
-  EndDate = 'end_date',
-  /** column name */
-  ExternalId = 'external_id',
-  /** column name */
-  ExternalUrl = 'external_url',
-  /** column name */
-  Restrictions = 'restrictions',
-  /** column name */
-  SigningSide = 'signing_side',
-  /** column name */
-  Territory = 'territory',
-  /** column name */
-  UpdatedAt = 'updated_at'
-}
-
-/** input type for updating data in table "tpc_contracts" */
-export type Tpc_Contracts_Set_Input = {
-  _cohort?: InputMaybe<Scalars['String']['input']>;
-  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
-  _release_id?: InputMaybe<Scalars['Int']['input']>;
-  _state?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['Int']['input']>;
-  contract_name?: InputMaybe<Scalars['String']['input']>;
-  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
-  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
-  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
-  effective_date?: InputMaybe<Scalars['date']['input']>;
-  end_date?: InputMaybe<Scalars['date']['input']>;
-  external_id?: InputMaybe<Scalars['String']['input']>;
-  external_url?: InputMaybe<Scalars['String']['input']>;
-  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
-  signing_side?: InputMaybe<Scalars['String']['input']>;
-  territory?: InputMaybe<Scalars['String']['input']>;
-  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
-};
-
-/** aggregate stddev on columns */
-export type Tpc_Contracts_Stddev_Fields = {
-  __typename?: 'tpc_contracts_stddev_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by stddev() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Stddev_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Tpc_Contracts_Stddev_Pop_Fields = {
-  __typename?: 'tpc_contracts_stddev_pop_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by stddev_pop() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Stddev_Pop_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Tpc_Contracts_Stddev_Samp_Fields = {
-  __typename?: 'tpc_contracts_stddev_samp_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by stddev_samp() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Stddev_Samp_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** Streaming cursor of the table "tpc_contracts" */
-export type Tpc_Contracts_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: Tpc_Contracts_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type Tpc_Contracts_Stream_Cursor_Value_Input = {
-  _cohort?: InputMaybe<Scalars['String']['input']>;
-  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
-  _release_id?: InputMaybe<Scalars['Int']['input']>;
-  _state?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['Int']['input']>;
-  contract_name?: InputMaybe<Scalars['String']['input']>;
-  contract_object?: InputMaybe<Scalars['jsonb']['input']>;
-  contract_uid?: InputMaybe<Scalars['bpchar']['input']>;
-  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
-  effective_date?: InputMaybe<Scalars['date']['input']>;
-  end_date?: InputMaybe<Scalars['date']['input']>;
-  external_id?: InputMaybe<Scalars['String']['input']>;
-  external_url?: InputMaybe<Scalars['String']['input']>;
-  restrictions?: InputMaybe<Scalars['jsonb']['input']>;
-  signing_side?: InputMaybe<Scalars['String']['input']>;
-  territory?: InputMaybe<Scalars['String']['input']>;
-  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
-};
-
-/** aggregate sum on columns */
-export type Tpc_Contracts_Sum_Fields = {
-  __typename?: 'tpc_contracts_sum_fields';
-  _release_id?: Maybe<Scalars['Int']['output']>;
-  contract_id?: Maybe<Scalars['Int']['output']>;
-};
-
-/** order by sum() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Sum_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** update columns of table "tpc_contracts" */
-export enum Tpc_Contracts_Update_Column {
-  /** column name */
-  Cohort = '_cohort',
-  /** column name */
-  Deleted = '_deleted',
-  /** column name */
-  ReleaseId = '_release_id',
-  /** column name */
-  State = '_state',
-  /** column name */
-  ContractId = 'contract_id',
-  /** column name */
-  ContractName = 'contract_name',
-  /** column name */
-  ContractObject = 'contract_object',
-  /** column name */
-  ContractUid = 'contract_uid',
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  EffectiveDate = 'effective_date',
-  /** column name */
-  EndDate = 'end_date',
-  /** column name */
-  ExternalId = 'external_id',
-  /** column name */
-  ExternalUrl = 'external_url',
-  /** column name */
-  Restrictions = 'restrictions',
-  /** column name */
-  SigningSide = 'signing_side',
-  /** column name */
-  Territory = 'territory',
-  /** column name */
-  UpdatedAt = 'updated_at'
-}
-
-export type Tpc_Contracts_Updates = {
-  /** append existing jsonb value of filtered columns with new jsonb value */
-  _append?: InputMaybe<Tpc_Contracts_Append_Input>;
-  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
-  _delete_at_path?: InputMaybe<Tpc_Contracts_Delete_At_Path_Input>;
-  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
-  _delete_elem?: InputMaybe<Tpc_Contracts_Delete_Elem_Input>;
-  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
-  _delete_key?: InputMaybe<Tpc_Contracts_Delete_Key_Input>;
-  /** increments the numeric columns with given value of the filtered values */
-  _inc?: InputMaybe<Tpc_Contracts_Inc_Input>;
-  /** prepend existing jsonb value of filtered columns with new jsonb value */
-  _prepend?: InputMaybe<Tpc_Contracts_Prepend_Input>;
-  /** sets the columns of the filtered rows to the given values */
-  _set?: InputMaybe<Tpc_Contracts_Set_Input>;
-  /** filter the rows which have to be updated */
-  where: Tpc_Contracts_Bool_Exp;
-};
-
-/** aggregate var_pop on columns */
-export type Tpc_Contracts_Var_Pop_Fields = {
-  __typename?: 'tpc_contracts_var_pop_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by var_pop() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Var_Pop_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Tpc_Contracts_Var_Samp_Fields = {
-  __typename?: 'tpc_contracts_var_samp_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by var_samp() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Var_Samp_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Tpc_Contracts_Variance_Fields = {
-  __typename?: 'tpc_contracts_variance_fields';
-  _release_id?: Maybe<Scalars['Float']['output']>;
-  contract_id?: Maybe<Scalars['Float']['output']>;
-};
-
-/** order by variance() on columns of table "tpc_contracts" */
-export type Tpc_Contracts_Variance_Order_By = {
-  _release_id?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
-};
-
 /** columns and relationships of "tpc_media" */
 export type Tpc_Media = {
   __typename?: 'tpc_media';
@@ -42034,6 +43315,8 @@ export type Tpc_Media = {
   _state: Scalars['String']['output'];
   content_name?: Maybe<Scalars['String']['output']>;
   content_type?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__tpc_media__tpc_contracts" */
+  contracts?: Maybe<Array<Internal_Tpc_Contracts>>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   external_id?: Maybe<Scalars['String']['output']>;
   external_url?: Maybe<Scalars['String']['output']>;
@@ -42044,10 +43327,19 @@ export type Tpc_Media = {
   media_object: Scalars['jsonb']['output'];
   media_uid?: Maybe<Scalars['bpchar']['output']>;
   metadata?: Maybe<Scalars['jsonb']['output']>;
-  /** A computed field, executes function "function__tpc_media__tpc_contracts" */
-  tpc_contracts?: Maybe<Array<Tpc_Contracts>>;
+  thirdparty_id?: Maybe<Scalars['String']['output']>;
   tpc_contracts_list?: Maybe<Scalars['jsonb']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+
+/** columns and relationships of "tpc_media" */
+export type Tpc_MediaContractsArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
 };
 
 
@@ -42076,16 +43368,6 @@ export type Tpc_MediaMedia_ObjectArgs = {
 /** columns and relationships of "tpc_media" */
 export type Tpc_MediaMetadataArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/** columns and relationships of "tpc_media" */
-export type Tpc_MediaTpc_ContractsArgs = {
-  distinct_on?: InputMaybe<Array<Tpc_Contracts_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Tpc_Contracts_Order_By>>;
-  where?: InputMaybe<Tpc_Contracts_Bool_Exp>;
 };
 
 
@@ -42171,6 +43453,7 @@ export type Tpc_Media_Bool_Exp = {
   _state?: InputMaybe<String_Comparison_Exp>;
   content_name?: InputMaybe<String_Comparison_Exp>;
   content_type?: InputMaybe<String_Comparison_Exp>;
+  contracts?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   external_id?: InputMaybe<String_Comparison_Exp>;
   external_url?: InputMaybe<String_Comparison_Exp>;
@@ -42180,7 +43463,7 @@ export type Tpc_Media_Bool_Exp = {
   media_object?: InputMaybe<Jsonb_Comparison_Exp>;
   media_uid?: InputMaybe<Bpchar_Comparison_Exp>;
   metadata?: InputMaybe<Jsonb_Comparison_Exp>;
-  tpc_contracts?: InputMaybe<Tpc_Contracts_Bool_Exp>;
+  thirdparty_id?: InputMaybe<String_Comparison_Exp>;
   tpc_contracts_list?: InputMaybe<Jsonb_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
 };
@@ -42192,7 +43475,9 @@ export enum Tpc_Media_Constraint {
   /** unique or primary key constraint on columns "external_url", "_state" */
   TpcMediaExternalUrlStateKey = 'tpc_media_external_url__state_key',
   /** unique or primary key constraint on columns "_state", "media_id" */
-  TpcMediaPkey = 'tpc_media_pkey'
+  TpcMediaPkey = 'tpc_media_pkey',
+  /** unique or primary key constraint on columns "_state", "thirdparty_id" */
+  TpcMediaThirdpartyIdStateKey = 'tpc_media_thirdparty_id__state_key'
 }
 
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
@@ -42241,6 +43526,7 @@ export type Tpc_Media_Insert_Input = {
   media_object?: InputMaybe<Scalars['jsonb']['input']>;
   media_uid?: InputMaybe<Scalars['bpchar']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  thirdparty_id?: InputMaybe<Scalars['String']['input']>;
   tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
 };
@@ -42258,6 +43544,7 @@ export type Tpc_Media_Max_Fields = {
   external_url?: Maybe<Scalars['String']['output']>;
   media_id?: Maybe<Scalars['Int']['output']>;
   media_uid?: Maybe<Scalars['bpchar']['output']>;
+  thirdparty_id?: Maybe<Scalars['String']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -42273,6 +43560,7 @@ export type Tpc_Media_Max_Order_By = {
   external_url?: InputMaybe<Order_By>;
   media_id?: InputMaybe<Order_By>;
   media_uid?: InputMaybe<Order_By>;
+  thirdparty_id?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
 };
 
@@ -42289,6 +43577,7 @@ export type Tpc_Media_Min_Fields = {
   external_url?: Maybe<Scalars['String']['output']>;
   media_id?: Maybe<Scalars['Int']['output']>;
   media_uid?: Maybe<Scalars['bpchar']['output']>;
+  thirdparty_id?: Maybe<Scalars['String']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
 };
 
@@ -42304,6 +43593,7 @@ export type Tpc_Media_Min_Order_By = {
   external_url?: InputMaybe<Order_By>;
   media_id?: InputMaybe<Order_By>;
   media_uid?: InputMaybe<Order_By>;
+  thirdparty_id?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
 };
 
@@ -42338,6 +43628,7 @@ export type Tpc_Media_Order_By = {
   _state?: InputMaybe<Order_By>;
   content_name?: InputMaybe<Order_By>;
   content_type?: InputMaybe<Order_By>;
+  contracts_aggregate?: InputMaybe<Internal_Tpc_Contracts_Aggregate_Order_By>;
   created_at?: InputMaybe<Order_By>;
   external_id?: InputMaybe<Order_By>;
   external_url?: InputMaybe<Order_By>;
@@ -42347,7 +43638,7 @@ export type Tpc_Media_Order_By = {
   media_object?: InputMaybe<Order_By>;
   media_uid?: InputMaybe<Order_By>;
   metadata?: InputMaybe<Order_By>;
-  tpc_contracts_aggregate?: InputMaybe<Tpc_Contracts_Aggregate_Order_By>;
+  thirdparty_id?: InputMaybe<Order_By>;
   tpc_contracts_list?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
 };
@@ -42397,6 +43688,8 @@ export enum Tpc_Media_Select_Column {
   /** column name */
   Metadata = 'metadata',
   /** column name */
+  ThirdpartyId = 'thirdparty_id',
+  /** column name */
   TpcContractsList = 'tpc_contracts_list',
   /** column name */
   UpdatedAt = 'updated_at'
@@ -42418,6 +43711,7 @@ export type Tpc_Media_Set_Input = {
   media_object?: InputMaybe<Scalars['jsonb']['input']>;
   media_uid?: InputMaybe<Scalars['bpchar']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  thirdparty_id?: InputMaybe<Scalars['String']['input']>;
   tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
 };
@@ -42485,6 +43779,7 @@ export type Tpc_Media_Stream_Cursor_Value_Input = {
   media_object?: InputMaybe<Scalars['jsonb']['input']>;
   media_uid?: InputMaybe<Scalars['bpchar']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  thirdparty_id?: InputMaybe<Scalars['String']['input']>;
   tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
 };
@@ -42532,6 +43827,8 @@ export enum Tpc_Media_Update_Column {
   MediaUid = 'media_uid',
   /** column name */
   Metadata = 'metadata',
+  /** column name */
+  ThirdpartyId = 'thirdparty_id',
   /** column name */
   TpcContractsList = 'tpc_contracts_list',
   /** column name */
@@ -42604,15 +43901,27 @@ export type Tpc_Works = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
   author?: Maybe<Scalars['String']['output']>;
-  contract_id?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__tpc_works__tpc_contracts" */
+  contracts?: Maybe<Array<Internal_Tpc_Contracts>>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   /** A computed field, executes function "function__tpc_works__lessons" */
   lessons?: Maybe<Array<Lessons>>;
   title?: Maybe<Scalars['String']['output']>;
+  tpc_contracts_list?: Maybe<Scalars['jsonb']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
   works_id: Scalars['Int']['output'];
   works_object: Scalars['jsonb']['output'];
   works_uid?: Maybe<Scalars['bpchar']['output']>;
+};
+
+
+/** columns and relationships of "tpc_works" */
+export type Tpc_WorksContractsArgs = {
+  distinct_on?: InputMaybe<Array<Internal_Tpc_Contracts_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Internal_Tpc_Contracts_Order_By>>;
+  where?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
 };
 
 
@@ -42623,6 +43932,12 @@ export type Tpc_WorksLessonsArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Lessons_Order_By>>;
   where?: InputMaybe<Lessons_Bool_Exp>;
+};
+
+
+/** columns and relationships of "tpc_works" */
+export type Tpc_WorksTpc_Contracts_ListArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -42678,6 +43993,7 @@ export type Tpc_Works_Aggregate_Order_By = {
 
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Tpc_Works_Append_Input = {
+  tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   works_object?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -42704,10 +44020,11 @@ export type Tpc_Works_Bool_Exp = {
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
   author?: InputMaybe<String_Comparison_Exp>;
-  contract_id?: InputMaybe<String_Comparison_Exp>;
+  contracts?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   lessons?: InputMaybe<Lessons_Bool_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
+  tpc_contracts_list?: InputMaybe<Jsonb_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   works_id?: InputMaybe<Int_Comparison_Exp>;
   works_object?: InputMaybe<Jsonb_Comparison_Exp>;
@@ -42722,16 +44039,19 @@ export enum Tpc_Works_Constraint {
 
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Tpc_Works_Delete_At_Path_Input = {
+  tpc_contracts_list?: InputMaybe<Array<Scalars['String']['input']>>;
   works_object?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Tpc_Works_Delete_Elem_Input = {
+  tpc_contracts_list?: InputMaybe<Scalars['Int']['input']>;
   works_object?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Tpc_Works_Delete_Key_Input = {
+  tpc_contracts_list?: InputMaybe<Scalars['String']['input']>;
   works_object?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -42748,9 +44068,9 @@ export type Tpc_Works_Insert_Input = {
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   works_id?: InputMaybe<Scalars['Int']['input']>;
   works_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -42764,7 +44084,6 @@ export type Tpc_Works_Max_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   author?: Maybe<Scalars['String']['output']>;
-  contract_id?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   title?: Maybe<Scalars['String']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -42778,7 +44097,6 @@ export type Tpc_Works_Max_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
@@ -42793,7 +44111,6 @@ export type Tpc_Works_Min_Fields = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
   author?: Maybe<Scalars['String']['output']>;
-  contract_id?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   title?: Maybe<Scalars['String']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -42807,7 +44124,6 @@ export type Tpc_Works_Min_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
@@ -42838,10 +44154,11 @@ export type Tpc_Works_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
-  contract_id?: InputMaybe<Order_By>;
+  contracts_aggregate?: InputMaybe<Internal_Tpc_Contracts_Aggregate_Order_By>;
   created_at?: InputMaybe<Order_By>;
   lessons_aggregate?: InputMaybe<Lessons_Aggregate_Order_By>;
   title?: InputMaybe<Order_By>;
+  tpc_contracts_list?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
   works_id?: InputMaybe<Order_By>;
   works_object?: InputMaybe<Order_By>;
@@ -42856,6 +44173,7 @@ export type Tpc_Works_Pk_Columns_Input = {
 
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Tpc_Works_Prepend_Input = {
+  tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   works_object?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -42872,11 +44190,11 @@ export enum Tpc_Works_Select_Column {
   /** column name */
   Author = 'author',
   /** column name */
-  ContractId = 'contract_id',
-  /** column name */
   CreatedAt = 'created_at',
   /** column name */
   Title = 'title',
+  /** column name */
+  TpcContractsList = 'tpc_contracts_list',
   /** column name */
   UpdatedAt = 'updated_at',
   /** column name */
@@ -42894,9 +44212,9 @@ export type Tpc_Works_Set_Input = {
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   works_id?: InputMaybe<Scalars['Int']['input']>;
   works_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -42957,9 +44275,9 @@ export type Tpc_Works_Stream_Cursor_Value_Input = {
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
-  contract_id?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_contracts_list?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   works_id?: InputMaybe<Scalars['Int']['input']>;
   works_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -42992,11 +44310,11 @@ export enum Tpc_Works_Update_Column {
   /** column name */
   Author = 'author',
   /** column name */
-  ContractId = 'contract_id',
-  /** column name */
   CreatedAt = 'created_at',
   /** column name */
   Title = 'title',
+  /** column name */
+  TpcContractsList = 'tpc_contracts_list',
   /** column name */
   UpdatedAt = 'updated_at',
   /** column name */
@@ -43097,6 +44415,7 @@ export type Units = {
   description?: Maybe<Scalars['String']['output']>;
   exam_board_specification_content?: Maybe<Scalars['json']['output']>;
   expiration_date?: Maybe<Scalars['date']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
   intro_video_id?: Maybe<Scalars['Int']['output']>;
   /** A computed field, executes function "function__units__last_updated_lesson_review_date" */
   last_updated_lesson_review_date?: Maybe<Scalars['timestamptz']['output']>;
@@ -43213,6 +44532,12 @@ export type UnitsDeprecated_FieldsArgs = {
 
 /** columns and relationships of "units" */
 export type UnitsExam_Board_Specification_ContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "units" */
+export type UnitsFeaturesArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -43475,6 +44800,7 @@ export type Units_Aggregate_Order_By = {
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Units_Append_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -43534,6 +44860,7 @@ export type Units_Bool_Exp = {
   description?: InputMaybe<String_Comparison_Exp>;
   exam_board_specification_content?: InputMaybe<Json_Comparison_Exp>;
   expiration_date?: InputMaybe<Date_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
   intro_video_id?: InputMaybe<Int_Comparison_Exp>;
   last_updated_lesson_review_date?: InputMaybe<Timestamptz_Comparison_Exp>;
   national_curriculum_content?: InputMaybe<Json_Comparison_Exp>;
@@ -43575,18 +44902,21 @@ export enum Units_Constraint {
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Units_Delete_At_Path_Input = {
   deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  features?: InputMaybe<Array<Scalars['String']['input']>>;
   subjectcategories?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Units_Delete_Elem_Input = {
   deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
+  features?: InputMaybe<Scalars['Int']['input']>;
   subjectcategories?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Units_Delete_Key_Input = {
   deprecated_fields?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['String']['input']>;
   subjectcategories?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -43623,6 +44953,7 @@ export type Units_Insert_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   exam_board_specification_content?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   intro_video_id?: InputMaybe<Scalars['Int']['input']>;
   national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
   notes?: InputMaybe<Scalars['String']['input']>;
@@ -43789,6 +45120,7 @@ export type Units_Order_By = {
   description?: InputMaybe<Order_By>;
   exam_board_specification_content?: InputMaybe<Order_By>;
   expiration_date?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
   intro_video_id?: InputMaybe<Order_By>;
   last_updated_lesson_review_date?: InputMaybe<Order_By>;
   national_curriculum_content?: InputMaybe<Order_By>;
@@ -43823,6 +45155,7 @@ export type Units_Pk_Columns_Input = {
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Units_Prepend_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -43862,6 +45195,8 @@ export enum Units_Select_Column {
   ExamBoardSpecificationContent = 'exam_board_specification_content',
   /** column name */
   ExpirationDate = 'expiration_date',
+  /** column name */
+  Features = 'features',
   /** column name */
   IntroVideoId = 'intro_video_id',
   /** column name */
@@ -43925,6 +45260,7 @@ export type Units_Set_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   exam_board_specification_content?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   intro_video_id?: InputMaybe<Scalars['Int']['input']>;
   national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
   notes?: InputMaybe<Scalars['String']['input']>;
@@ -44030,6 +45366,7 @@ export type Units_Stream_Cursor_Value_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   exam_board_specification_content?: InputMaybe<Scalars['json']['input']>;
   expiration_date?: InputMaybe<Scalars['date']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
   intro_video_id?: InputMaybe<Scalars['Int']['input']>;
   national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
   notes?: InputMaybe<Scalars['String']['input']>;
@@ -44102,6 +45439,8 @@ export enum Units_Update_Column {
   ExamBoardSpecificationContent = 'exam_board_specification_content',
   /** column name */
   ExpirationDate = 'expiration_date',
+  /** column name */
+  Features = 'features',
   /** column name */
   IntroVideoId = 'intro_video_id',
   /** column name */
@@ -46764,21 +48103,21 @@ export type CurriculumOverviewQueryVariables = Exact<{
 }>;
 
 
-export type CurriculumOverviewQuery = { __typename?: 'query_root', curriculumOverview: Array<{ __typename?: 'published_mv_curriculum_overview_0_3', curriculaDesc?: string | null, subjectTitle?: string | null, phaseTitle?: string | null, examboardTitle?: string | null }> };
+export type CurriculumOverviewQuery = { __typename?: 'query_root', curriculumOverview: Array<{ __typename?: 'published_mv_curriculum_overview_0_4', curriculaDesc?: string | null, subjectTitle?: string | null, phaseTitle?: string | null, examboardTitle?: string | null }> };
 
 export type CurriculumUnitsQueryVariables = Exact<{
-  where?: InputMaybe<Published_Mv_Curriculum_Units_0_6_Bool_Exp>;
+  where?: InputMaybe<Published_Mv_Curriculum_Units_0_7_Bool_Exp>;
 }>;
 
 
-export type CurriculumUnitsQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_units_0_6', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: number | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, unit_options?: any | null, threads?: any | null, year?: string | null }> };
+export type CurriculumUnitsQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_units_0_7', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: number | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, unit_options?: any | null, threads?: any | null, year?: string | null }> };
 
 export type CurriculumUnitsIncludeNewQueryVariables = Exact<{
   where?: InputMaybe<Published_Mv_Curriculum_Units_Including_New_0_0_14_Bool_Exp>;
 }>;
 
 
-export type CurriculumUnitsIncludeNewQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_units_including_new_0_0_14', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, why_this_why_now?: string | null, cycle?: string | null, description?: string | null, domain?: string | null, domain_id?: number | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, state?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, pathway?: string | null, pathway_slug?: string | null, tags?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, unit_options?: any | null, threads?: any | null, year?: string | null }> };
+export type CurriculumUnitsIncludeNewQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_units_including_new_0_0_14', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, why_this_why_now?: string | null, cycle?: string | null, description?: string | null, domain?: string | null, domain_id?: number | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, state?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, pathway?: string | null, pathway_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, unit_options?: any | null, threads?: any | null, year?: string | null }> };
 
 export type LessonDownloadsQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -47033,7 +48372,7 @@ export type UnitListingQuery = { __typename?: 'query_root', units: Array<{ __typ
 
 export const CurriculumOverviewDocument = gql`
     query curriculumOverview($phaseSlug: String, $subjectSlug: String) {
-  curriculumOverview: published_mv_curriculum_overview_0_3(
+  curriculumOverview: published_mv_curriculum_overview_0_4(
     where: {phase_slug: {_eq: $phaseSlug}, subject_slug: {_eq: $subjectSlug}}
     limit: 1
   ) {
@@ -47045,8 +48384,8 @@ export const CurriculumOverviewDocument = gql`
 }
     `;
 export const CurriculumUnitsDocument = gql`
-    query curriculumUnits($where: published_mv_curriculum_units_0_6_bool_exp) {
-  units: published_mv_curriculum_units_0_6(where: $where) {
+    query curriculumUnits($where: published_mv_curriculum_units_0_7_bool_exp) {
+  units: published_mv_curriculum_units_0_7(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title

--- a/src/node-lib/curriculum-api-2023/queries/curriculumOverview/curriculumOverview.gql
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumOverview/curriculumOverview.gql
@@ -1,5 +1,5 @@
 query curriculumOverview($phaseSlug: String, $subjectSlug: String) {
-  curriculumOverview: published_mv_curriculum_overview_0_3(
+  curriculumOverview: published_mv_curriculum_overview_0_4(
     where: {
       phase_slug: { _eq: $phaseSlug }
       subject_slug: { _eq: $subjectSlug }

--- a/src/node-lib/curriculum-api-2023/queries/curriculumUnits/curriculumUnits.gql
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumUnits/curriculumUnits.gql
@@ -1,5 +1,5 @@
-query curriculumUnits($where: published_mv_curriculum_units_0_6_bool_exp) {
-  units: published_mv_curriculum_units_0_6(where: $where) {
+query curriculumUnits($where: published_mv_curriculum_units_0_7_bool_exp) {
+  units: published_mv_curriculum_units_0_7(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title

--- a/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.gql
+++ b/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.gql
@@ -1,8 +1,9 @@
 query subjectPhaseOptions {
-  options: published_mv_subject_phase_options_0_1 {
+  options: published_mv_subject_phase_options_0_3 {
     title
     slug
     phases
     examboards
+    state
   }
 }

--- a/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.query.ts
@@ -9,7 +9,10 @@ const subjectPhaseOptionsQuery = (sdk: Sdk) => async () => {
   if (subjectPhaseOptions.length === 0) {
     throw new OakError({ code: "curriculum-api/not-found" });
   }
-  return subjectPhaseOptionsSchema.parse(subjectPhaseOptions);
+  const results = subjectPhaseOptionsSchema.parse(subjectPhaseOptions);
+  return results.filter((result) => {
+    return result.state === "published";
+  });
 };
 
 export default subjectPhaseOptionsQuery;

--- a/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.schema.ts
@@ -16,6 +16,7 @@ const subjectPhaseOptionsSchema = z
     title: z.string(),
     phases: z.array(phaseSchema),
     examboards: z.array(examboard).optional().nullable(),
+    state: z.string().optional(),
   })
   .array();
 


### PR DESCRIPTION
## Description
Update the curriculum MVs which filter out cycle 2 programmes from curriculum visualiser until ready for launch.

## Issue(s)

Fixes `CUR-788`

## How to test
Test that there are no functional changes to the visualiser. Also @rightsaidjames are you able to find out if we can publish a programme on staging double check it all works correctly prior to production publish?

FYI: I can setup, a test env for staging locally and proxy it over to you.