### PR TITLE
[CUR-827] Adding subject categories to units in docx

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/8_units/__snapshots__/8_units.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/__snapshots__/8_units.test.ts.snap
@@ -1638,6 +1638,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -3410,6 +3411,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -5112,6 +5114,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -6359,6 +6362,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -7851,6 +7855,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -9474,6 +9479,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[7]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -11918,6 +11924,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -13620,6 +13627,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -15287,6 +15295,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -16464,6 +16473,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -17702,6 +17712,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -18669,6 +18680,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -20511,6 +20523,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -21373,6 +21386,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[8]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -23504,6 +23518,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -25031,6 +25046,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -26663,6 +26679,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -27665,6 +27682,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -29157,6 +29175,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -30229,6 +30248,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -31756,6 +31776,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[9]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -34780,6 +34801,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -36561,6 +36583,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -38342,6 +38365,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -39974,6 +39998,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -41790,6 +41815,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -43606,6 +43632,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -45667,6 +45694,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -47728,6 +47756,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -49789,6 +49818,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -50931,6 +50961,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -52099,6 +52130,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -53300,6 +53332,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -54302,6 +54335,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[10]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -57765,6 +57799,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -58881,6 +58916,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -59997,6 +60033,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -60929,6 +60966,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -62080,6 +62118,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -63231,6 +63270,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -64592,6 +64632,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -65953,6 +65994,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -67314,6 +67356,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -68725,6 +68768,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -69830,6 +69874,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -70935,6 +70980,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -71891,6 +71937,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -73031,6 +73078,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -74171,6 +74219,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -75164,6 +75213,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -76446,6 +76496,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -77334,6 +77385,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>
@@ -78325,6 +78377,7 @@ exports[`8_units simple 1`] = `
         <w:t>
           Year <![CDATA[11]]>
         </w:t>
+        <w:t><![CDATA[, ]]></w:t>
       </w:r>
     </w:p>
     <w:p></w:p>

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -13,6 +13,7 @@ import {
 } from "../../docx";
 
 import { createProgrammeSlug } from "@/components/CurriculumComponents/UnitsTab/UnitsTab";
+import { SubjectCategory } from "@/components/CurriculumComponents/CurriculumVisualiser";
 
 const DISABLE_COLUMN_BREAKS = true;
 
@@ -433,6 +434,13 @@ export async function buildUnit(
     `;
   }
 
+  const getSubjectCategoriesAsString = (
+    subjectcategories: SubjectCategory[] | null | undefined,
+  ) =>
+    subjectcategories
+      ? `, ${subjectcategories.map(({ title }) => title).join(", ")}`
+      : "";
+
   const xml = safeXml`
     <XML_FRAGMENT>
       ${
@@ -487,6 +495,9 @@ export async function buildUnit(
             <w:color w:val="222222" />
           </w:rPr>
           <w:t>Year ${cdata(unit.year)}</w:t>
+          <w:t>
+            ${cdata(getSubjectCategoriesAsString(unit.subjectcategories))}
+          </w:t>
         </w:r>
       </w:p>
 

--- a/src/pages-helpers/curriculum/docx/index.ts
+++ b/src/pages-helpers/curriculum/docx/index.ts
@@ -81,19 +81,16 @@ export default async function docx(data: CombinedCurriculumData, slugs: Slugs) {
       <w:p>
         <w:pPr>
             <w:jc w:val="right"/>
-            <w:rPr/>
         </w:pPr>
         <w:r>
             <w:rPr>
-                <w:rtl w:val="0"/>
-                <w:rPr>
                   <w:rFonts
                     w:ascii="Arial"
                     w:eastAsia="Arial"
                     w:hAnsi="Arial"
                     w:cs="Arial"
                   />
-                </w:rPr>
+                  <w:rtl w:val="0"/>
             </w:rPr>
             <w:t xml:space="preserve">Exported ${format(
               new Date(),


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Added subject categories to docx as per design [here](https://docs.google.com/document/d/1PTD3RUuO9IbxLeFJz4qAeMp_u7Un-NA4vihdWaNNVz0/edit?pli=1#heading=h.6pqzmd1r1qx7)

## How to test

1. Go to {owa_deployment_url}
2. Go to Primary English / Science / any programme with subject categories
3. Download the docx
4. You should see the subject categories per unit 

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2024-09-04 at 12 20 01](https://github.com/user-attachments/assets/c5be3054-be4e-466a-8f76-5cb0152ad1f5)

How it should now look:
![Screenshot 2024-09-04 at 12 19 11](https://github.com/user-attachments/assets/e268dabe-525c-4d78-878e-5af920d00630)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
