### PR TITLE
Feat/lesq 1054/hubspot checkbox conditional [LESQ-1054]

### DIFF
--- a/scripts/build/write_env_file/index.js
+++ b/scripts/build/write_env_file/index.js
@@ -101,6 +101,9 @@ async function main() {
     HUBSPOT_FORMS_ACCESS_TOKEN:
       process.env.HUBSPOT_FORMS_ACCESS_TOKEN ||
       secretsFromNetwork.HUBSPOT_FORMS_ACCESS_TOKEN,
+    HUBSPOT_OWA_ACCESS_TOKEN:
+      process.env.HUBSPOT_OWA_ACCESS_TOKEN ||
+      secretsFromNetwork.HUBSPOT_OWA_ACCESS_TOKEN,
 
     // Oak
     // App hosting URL, needed for accurate sitemaps (and canonical URLs in the metadata?).

--- a/src/__tests__/__helpers__/mockUser.ts
+++ b/src/__tests__/__helpers__/mockUser.ts
@@ -12,6 +12,7 @@ export const mockUser = {
   id: "user-123",
   publicMetadata: {},
   reload: jest.fn(),
+  emailAddresses: [{ emailAddress: "test-email" }],
 } as unknown as UserResource;
 
 export const mockUserWithDownloadAccess: UserResource = {

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
@@ -55,7 +55,7 @@ describe("Onboarding form", () => {
     renderForm({}, false);
 
     expect(
-      screen.getByLabelText(
+      await screen.findByLabelText(
         "Sign up for our latest resources and updates by email. Unsubscribe at any time",
       ),
     ).toBeInTheDocument();

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
@@ -3,6 +3,7 @@ import { DefaultValues, useForm } from "react-hook-form";
 import { renderHook } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
+import fetchMock from "jest-fetch-mock";
 
 import OnboardingForm from "./OnboardingForm";
 import { OnboardingFormProps } from "./OnboardingForm.schema";
@@ -13,7 +14,13 @@ import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
 import type { OnboardingSchema } from "@/common-lib/schemas/onboarding";
 
 jest.mock("@/browser-lib/hubspot/forms");
-jest.mock("./onboardingActions");
+jest.mock("./onboardingActions", () => {
+  const actual = jest.requireActual("./onboardingActions");
+  return {
+    ...actual,
+    onboardUser: jest.fn(),
+  };
+});
 jest.mock("@clerk/nextjs", () => {
   return {
     useUser() {
@@ -25,6 +32,13 @@ jest.mock("@clerk/nextjs", () => {
 type OnboardingFormState = DefaultValues<OnboardingFormProps>;
 
 describe("Onboarding form", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
   it("should render the onboarding form with fieldset and legend", async () => {
     renderForm();
 
@@ -36,26 +50,28 @@ describe("Onboarding form", () => {
     expect(fieldset).toContainElement(legend);
   });
 
-  it.skip("renders newsletter signup checkbox", () => {
-    renderForm();
+  it("renders newsletter signup checkbox", async () => {
+    fetchMock.mockResponse(JSON.stringify(false));
+    renderForm({}, false);
 
     expect(
-      screen.getByLabelText(
+      await screen.findByLabelText(
         "Sign up to receive helpful content via email. Unsubscribe at any time.",
       ),
     ).toBeInTheDocument();
   });
-  it.skip("should render the Controller component and handle checkbox change", async () => {
-    renderForm();
+  it("should render the Controller component and handle checkbox change", async () => {
+    fetchMock.mockResponse(JSON.stringify(false));
+    renderForm({}, false);
 
     const checkbox = await screen.findByRole("checkbox", {
       name: /Sign up to receive helpful content via email. Unsubscribe at any time./i,
     });
-    expect(checkbox).toBeChecked();
+    expect(checkbox).not.toBeChecked();
 
     fireEvent.click(checkbox);
 
-    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeChecked();
   });
 
   it.each<[string, string, boolean]>([
@@ -126,6 +142,7 @@ describe("Onboarding form", () => {
 
 function renderForm(
   formState: OnboardingFormState = { newsletterSignUp: true },
+  forceHideNewsletterSignUp: boolean = true,
 ) {
   const { result } = renderHook(() =>
     useForm<OnboardingFormProps>({
@@ -141,7 +158,7 @@ function renderForm(
       canSubmit={true}
       trigger={result.current.trigger}
       control={result.current.control}
-      forceHideNewsletterSignUp={true}
+      forceHideNewsletterSignUp={forceHideNewsletterSignUp}
     >
       <div />
     </OnboardingForm>,

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.test.tsx
@@ -36,7 +36,7 @@ describe("Onboarding form", () => {
     expect(fieldset).toContainElement(legend);
   });
 
-  it("renders newsletter signup checkbox", () => {
+  it.skip("renders newsletter signup checkbox", () => {
     renderForm();
 
     expect(
@@ -45,7 +45,7 @@ describe("Onboarding form", () => {
       ),
     ).toBeInTheDocument();
   });
-  it("should render the Controller component and handle checkbox change", async () => {
+  it.skip("should render the Controller component and handle checkbox change", async () => {
     renderForm();
 
     const checkbox = await screen.findByRole("checkbox", {
@@ -141,6 +141,7 @@ function renderForm(
       canSubmit={true}
       trigger={result.current.trigger}
       control={result.current.control}
+      forceHideNewsletterSignUp={true}
     >
       <div />
     </OnboardingForm>,

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -67,7 +67,7 @@ const OnboardingForm = ({
     }
   }, [user, forceHideNewsletterSignUp]);
 
-  const showHubspotSignUp =
+  const showNewsletterSignUp =
     userRegisteredInHubspot === false && forceHideNewsletterSignUp !== true;
 
   const onFormSubmit = async (data: OnboardingFormProps) => {
@@ -184,7 +184,7 @@ const OnboardingForm = ({
           >
             Continue
           </OakPrimaryButton>
-          {showHubspotSignUp && (
+          {showNewsletterSignUp && (
             <Controller
               control={props.control}
               name="newsletterSignUp"

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -67,6 +67,9 @@ const OnboardingForm = ({
     }
   }, [user, forceHideNewsletterSignUp]);
 
+  const showHubspotSignUp =
+    userRegisteredInHubspot === false && forceHideNewsletterSignUp !== true;
+
   const onFormSubmit = async (data: OnboardingFormProps) => {
     if ("worksInSchool" in data) {
       router.push({
@@ -181,32 +184,29 @@ const OnboardingForm = ({
           >
             Continue
           </OakPrimaryButton>
-          {userRegisteredInHubspot === false &&
-            forceHideNewsletterSignUp !== true && (
-              <Controller
-                control={props.control}
-                name="newsletterSignUp"
-                render={({ field: { value, onChange, name, onBlur } }) => {
-                  const onChangeHandler = (
-                    e: ChangeEvent<HTMLInputElement>,
-                  ) => {
-                    onChange(e.target.checked);
-                    props.trigger("newsletterSignUp");
-                  };
-                  return (
-                    <OakCheckBox
-                      checked={value}
-                      name={name}
-                      onBlur={onBlur}
-                      onChange={onChangeHandler}
-                      value="Sign up to receive helpful content via email. Unsubscribe at any
+          {showHubspotSignUp && (
+            <Controller
+              control={props.control}
+              name="newsletterSignUp"
+              render={({ field: { value, onChange, name, onBlur } }) => {
+                const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+                  onChange(e.target.checked);
+                  props.trigger("newsletterSignUp");
+                };
+                return (
+                  <OakCheckBox
+                    checked={value}
+                    name={name}
+                    onBlur={onBlur}
+                    onChange={onChangeHandler}
+                    value="Sign up to receive helpful content via email. Unsubscribe at any
                     time."
-                      id="newsletterSignUp"
-                    />
-                  );
-                }}
-              />
-            )}
+                    id="newsletterSignUp"
+                  />
+                );
+              }}
+            />
+          )}
         </OakFlex>
       </OakFlex>
 

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -19,7 +19,7 @@ import {
 } from "@oaknational/oak-components";
 
 import { OnboardingFormProps } from "./OnboardingForm.schema";
-import { onboardUser } from "./onboardingActions";
+import { getSubscriptionStatus, onboardUser } from "./onboardingActions";
 
 import Logo from "@/components/AppComponents/Logo";
 import { resolveOakHref } from "@/common-lib/urls";
@@ -31,7 +31,6 @@ import { getHubspotOnboardingFormPayload } from "@/browser-lib/hubspot/forms/get
 import { hubspotSubmitForm } from "@/browser-lib/hubspot/forms";
 import OakError from "@/errors/OakError";
 import toSafeRedirect from "@/common-lib/urls/toSafeRedirect";
-import { subscriptionResponseSchema } from "@/pages/api/hubspot/subscription";
 
 const OnboardingForm = ({
   forceHideNewsletterSignUp,
@@ -59,37 +58,12 @@ const OnboardingForm = ({
   >(undefined);
 
   useEffect(() => {
-    const fetchData = async (email: string) => {
-      try {
-        const response = await fetch("/api/hubspot/subscription", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            email,
-            subscriptionName: "School support",
-          }),
-        });
-
-        const result = subscriptionResponseSchema.parse(await response.json());
-        setUserRegisteredinHubspot(result);
-      } catch (err) {
-        if (err instanceof OakError) {
-          throw err;
-        }
-        throw new OakError({
-          code: "hubspot/unknown",
-          originalError: err,
-        });
-      }
-    };
     if (forceHideNewsletterSignUp) {
       return;
     }
     if (user?.emailAddresses[0]) {
       const email = String(user.emailAddresses[0].emailAddress);
-      fetchData(email);
+      getSubscriptionStatus(email, setUserRegisteredinHubspot);
     }
   }, [user, forceHideNewsletterSignUp]);
 

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from "jest-fetch-mock";
 
-import { onboardUser } from "./onboardingActions";
+import { getSubscriptionStatus, onboardUser } from "./onboardingActions";
 
 import OakError from "@/errors/OakError";
 
@@ -53,5 +53,42 @@ describe(onboardUser, () => {
         expect.any(OakError),
       );
     });
+  });
+});
+
+describe("getSubscriptionStatus", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
+  it("makes a request to get the subscription status", async () => {
+    fetchMock.mockResponse(JSON.stringify(true));
+    await getSubscriptionStatus("fakeEmail.com", jest.fn);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching("/api/hubspot/subscription"),
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "fakeEmail.com",
+          subscriptionName: "School support",
+        }),
+      }),
+    );
+  });
+  it("calls the callback with the response JSON", async () => {
+    fetchMock.mockResponse(JSON.stringify(true));
+    const callback = jest.fn();
+    await getSubscriptionStatus("fakeEmail.com", callback);
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+  it("throws an error if the response is not valid", async () => {
+    fetchMock.mockResponse(JSON.stringify({}));
+    await expect(
+      getSubscriptionStatus("fakeEmail.com", jest.fn),
+    ).rejects.toEqual(expect.any(OakError));
   });
 });

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.test.ts
@@ -74,7 +74,7 @@ describe("getSubscriptionStatus", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: "fakeEmail.com",
-          subscriptionName: "School support",
+          subscriptionName: "School Support",
         }),
       }),
     );

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
@@ -59,7 +59,7 @@ export async function getSubscriptionStatus(
       },
       body: JSON.stringify({
         email,
-        subscriptionName: "School support",
+        subscriptionName: "School Support",
       }),
     });
     const result = subscriptionResponseSchema.parse(await response.json());

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions.ts
@@ -1,8 +1,9 @@
 import errorReporter from "@/common-lib/error-reporter";
 import type { OnboardingSchema } from "@/common-lib/schemas/onboarding";
 import OakError from "@/errors/OakError";
+import { subscriptionResponseSchema } from "@/pages/api/hubspot/subscription";
 
-const apiRoute = "/api/auth/onboarding";
+const onboardingApiRoute = "/api/auth/onboarding";
 
 const reportError = errorReporter("onboardingActions");
 
@@ -13,7 +14,7 @@ export async function onboardUser(
   data: OnboardingSchema,
 ): Promise<UserPublicMetadata> {
   try {
-    const response = await fetch(apiRoute, {
+    const response = await fetch(onboardingApiRoute, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -24,7 +25,7 @@ export async function onboardUser(
       throw new OakError({
         code: "onboarding/request-error",
         meta: {
-          url: apiRoute,
+          url: onboardingApiRoute,
           status: response.status,
         },
       });
@@ -36,12 +37,40 @@ export async function onboardUser(
       finalError = new OakError({
         code: "misc/network-error",
         originalError: error,
-        meta: { route: apiRoute },
+        meta: { route: onboardingApiRoute },
       });
     }
 
     reportError(finalError);
 
     throw error;
+  }
+}
+
+export async function getSubscriptionStatus(
+  email: string,
+  callback: (status: boolean) => void,
+) {
+  try {
+    const response = await fetch("/api/hubspot/subscription", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email,
+        subscriptionName: "School support",
+      }),
+    });
+    const result = subscriptionResponseSchema.parse(await response.json());
+    callback(result);
+  } catch (err) {
+    if (err instanceof OakError) {
+      throw err;
+    }
+    throw new OakError({
+      code: "hubspot/unknown",
+      originalError: err,
+    });
   }
 }

--- a/src/components/TeacherViews/Onboarding/Onboarding.view.tsx
+++ b/src/components/TeacherViews/Onboarding/Onboarding.view.tsx
@@ -45,7 +45,7 @@ export const OnboardingView = () => {
         heading="Do you work in a school?"
         handleSubmit={handleSubmit}
         canSubmit={!formState.errors.worksInSchool}
-        showNewsletterSignUp={false}
+        forceHideNewsletterSignUp={true}
       >
         <OakBox>
           <FieldError id={"onboarding-error"}>

--- a/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.view.tsx
+++ b/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.view.tsx
@@ -41,9 +41,6 @@ const RoleSelectionView = () => {
   } = useForm<RoleSelectFormProps>({
     resolver: zodResolver(roleSelectFormSchema),
     mode: "onBlur",
-    defaultValues: {
-      newsletterSignUp: true,
-    },
   });
 
   const handleChange = (role: "other" | "role", value: string) => {

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
@@ -23,9 +23,6 @@ export const SchoolSelectionView = () => {
     useForm<SchoolSelectFormProps>({
       resolver: zodResolver(schoolSelectFormSchema),
       mode: "onBlur",
-      defaultValues: {
-        newsletterSignUp: true,
-      },
     });
 
   const setSchoolDetailsInManualForm = useCallback(

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
@@ -100,7 +100,16 @@ export const SchoolSelectionView = () => {
         handleSubmit={handleSubmit}
         canSubmit={!formState.isSubmitted || formState.isValid}
       >
-        {!renderManualSchoolInput && (
+        {renderManualSchoolInput ? (
+          <ManualEntrySchoolDetails
+            hasErrors={formState.errors}
+            onManualSchoolInputChange={setSchoolDetailsInManualForm}
+            setValue={setValue}
+            control={control}
+            setRenderManualSchoolInput={setRenderManualSchoolInput}
+            reset={reset}
+          />
+        ) : (
           <OakBox $mt="space-between-m">
             <FieldError id="onboarding-school-error">
               {"school" in formState.errors && formState.errors.school?.message}
@@ -137,17 +146,6 @@ export const SchoolSelectionView = () => {
               </OakLink>
             </OakFlex>
           </OakBox>
-        )}
-
-        {renderManualSchoolInput && (
-          <ManualEntrySchoolDetails
-            hasErrors={formState.errors}
-            onManualSchoolInputChange={setSchoolDetailsInManualForm}
-            setValue={setValue}
-            control={control}
-            setRenderManualSchoolInput={setRenderManualSchoolInput}
-            reset={reset}
-          />
         )}
       </OnboardingForm>
     </OnboardingLayout>

--- a/src/node-lib/getServerConfig.ts
+++ b/src/node-lib/getServerConfig.ts
@@ -108,6 +108,13 @@ const envVars = satisfies<Record<string, EnvVar>>()({
     availableInBrowser: false,
     default: null,
   },
+  hubspotOwaAccessToken: {
+    value: process.env.HUBSPOT_OWA_ACCESS_TOKEN,
+    envName: "HUBSPOT_OWA_ACCESS_TOKEN",
+    required: true,
+    availableInBrowser: false,
+    default: null,
+  },
   curriculumApiUrl: {
     value: process.env.CURRICULUM_API_URL,
     envName: "CURRICULUM_API_URL",

--- a/src/pages/api/hubspot/subscription/index.test.ts
+++ b/src/pages/api/hubspot/subscription/index.test.ts
@@ -1,0 +1,41 @@
+import {
+  PublicSubscriptionStatusSourceOfStatusEnum,
+  PublicSubscriptionStatusStatusEnum,
+} from "@hubspot/api-client/lib/codegen/communication_preferences";
+
+import { getisSubscribed } from "./index";
+
+describe("getIsSubscribed", () => {
+  it("should return true when subscription status is set", async () => {
+    const result = getisSubscribed(
+      [
+        {
+          name: "School Support",
+          status: PublicSubscriptionStatusStatusEnum.Subscribed,
+          description: "",
+          id: "1",
+          sourceOfStatus:
+            PublicSubscriptionStatusSourceOfStatusEnum.SubscriptionStatus,
+        },
+      ],
+      "School Support",
+    );
+    expect(result).toBe(true);
+  });
+  it("should return false when subscription status is not set", async () => {
+    const result = getisSubscribed(
+      [
+        {
+          name: "School Support",
+          status: PublicSubscriptionStatusStatusEnum.NotSubscribed,
+          description: "",
+          id: "1",
+          sourceOfStatus:
+            PublicSubscriptionStatusSourceOfStatusEnum.SubscriptionStatus,
+        },
+      ],
+      "School Support",
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/src/pages/api/hubspot/subscription/index.ts
+++ b/src/pages/api/hubspot/subscription/index.ts
@@ -1,6 +1,7 @@
 import { Client as HubspotClient } from "@hubspot/api-client";
 import { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { PublicSubscriptionStatus } from "@hubspot/api-client/lib/codegen/communication_preferences";
 
 import getServerConfig from "@/node-lib/getServerConfig";
 
@@ -14,6 +15,15 @@ const subscriptionRequestSchema = z.object({
 });
 export const subscriptionResponseSchema = z.boolean();
 
+export const getisSubscribed = (
+  statuses: PublicSubscriptionStatus[],
+  subscriptionName: string,
+) => {
+  const subscription = statuses.find((s) => s.name === subscriptionName);
+  const isSubscribed = subscription?.status === "SUBSCRIBED";
+  return isSubscribed;
+};
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -23,10 +33,10 @@ export default async function handler(
     const apiResponse =
       await hubspot.communicationPreferences.statusApi.getEmailStatus(email);
 
-    const subscription = apiResponse.subscriptionStatuses.find(
-      (s) => s.name === subscriptionName,
+    const isSubscribed = getisSubscribed(
+      apiResponse.subscriptionStatuses,
+      subscriptionName,
     );
-    const isSubscribed = subscription?.status === "SUBSCRIBED";
 
     return res.status(200).json(isSubscribed);
   } catch (error) {

--- a/src/pages/api/hubspot/subscription/index.ts
+++ b/src/pages/api/hubspot/subscription/index.ts
@@ -1,0 +1,35 @@
+import { Client as HubspotClient } from "@hubspot/api-client";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import getServerConfig from "@/node-lib/getServerConfig";
+
+const hubspot = new HubspotClient({
+  accessToken: getServerConfig("hubspotOwaAccessToken"),
+});
+
+const subscriptionRequestSchema = z.object({
+  email: z.string(),
+  subscriptionName: z.string(),
+});
+export const subscriptionResponseSchema = z.boolean();
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { email, subscriptionName } = subscriptionRequestSchema.parse(req.body);
+  try {
+    const apiResponse =
+      await hubspot.communicationPreferences.statusApi.getEmailStatus(email);
+
+    const subscription = apiResponse.subscriptionStatuses.find(
+      (s) => s.name === subscriptionName,
+    );
+    const isSubscribed = subscription?.status === "SUBSCRIBED";
+
+    return res.status(200).json(isSubscribed);
+  } catch (error) {
+    return res.status(500).json({ error: JSON.stringify(error) });
+  }
+}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Add an api route to get a user's subscription status
- Make the hubspot sign up checkbox conditional on subscription status

## How to test

1. Go to https://deploy-preview-2756--oak-web-application.netlify.thenational.academy/onboarding **while logged in**
2. You should not see the sign up checkbox
3. Go to school selection
4. You should see an unchecked checkbox on the page (if you haven't already set up a subscription)
5. Go to the contact for your email in hubspot ([example](https://app-eu1.hubspot.com/contacts/24947711/record/0-1/33730277100)) and on the left under 'communication subscriptions` update the School Support subscription to subscribed 
6. Go back to the school selection page and refresh
7. You should not see the checkbox

## Screenshots

How it used to look (d
<img width="448" alt="Screenshot 2024-09-05 at 16 04 41" src="https://github.com/user-attachments/assets/40800b52-463c-4ad7-b115-35bf1cf49e19">
elete if n/a):


How it should now look:
Not subscribed:
<img width="569" alt="Screenshot 2024-09-05 at 15 32 07" src="https://github.com/user-attachments/assets/c3e58c03-68e0-469b-a690-06cb5ad28e86">
Already subscribed:
<img width="509" alt="Screenshot 2024-09-05 at 16 03 45" src="https://github.com/user-attachments/assets/a3bd9407-df93-4b3a-9de7-74c9ec46f007">

## Checklist
- [ ]  When user has already opted in to hubspot marketing (via their email) they will not see a checkbox during onboarding
- [ ]  When a user has no record of signing up in hubspot they will see an unchecked check box during onboarding
