### PR TITLE
LESQ 1042 & LESQ-1038 - clerk sign out button and form styles

### DIFF
--- a/src/app/(registration)/formAppearanceStyles.ts
+++ b/src/app/(registration)/formAppearanceStyles.ts
@@ -1,0 +1,103 @@
+export const formAppearanceStyles = {
+  elements: {
+    card: {
+      padding: "40px 40px 40px",
+    },
+    logoBox: {
+      height: "47px",
+      justifyContent: "flex-start",
+    },
+    headerTitle: {
+      fontSize: "20px",
+      textAlign: "start",
+      marginBottom: "8px",
+      color: "#222222",
+      fontWeight: "600",
+    },
+    headerSubtitle: {
+      fontSize: "16px",
+      textAlign: "start",
+      color: "#575757",
+      fontWeight: "300",
+    },
+    dividerText: {
+      fontSize: "16px",
+      color: "#575757",
+    },
+    dividerLine: {
+      height: "1px",
+      background: "#808080",
+    },
+    button__google: {
+      padding: "8px",
+      radius: "4px",
+      border: "1px solid #808080 !important",
+    },
+    button__microsoft: {
+      padding: "8px",
+      radius: "4px",
+      border: "1px solid #808080 !important",
+    },
+
+    socialButtonsBlockButtonText: {
+      fontSize: "16px",
+      color: "black",
+      fontWeight: "300",
+    },
+
+    formFieldLabel: {
+      fontSize: "16px",
+      fontWeight: "500",
+      color: "black",
+    },
+    button: {
+      padding: "14px",
+      fontSize: "16px",
+    },
+
+    formFieldInput: {
+      padding: "16px",
+      border: "1px solid #808080 !important",
+    },
+
+    input: {
+      border: "1px solid #808080 !important",
+    },
+    footer: {
+      padding: "0px",
+    },
+    footerAction: {
+      zIndex: "50",
+      margin: "0px 0px 24px 0px",
+      padding: "0px !important",
+      width: "100%",
+      paddingLeft: "40px  !important",
+    },
+    footerActionLink: {
+      color: "#0D24C4",
+      textAlign: "start !important",
+      fontSize: "16px",
+      "&:hover": {
+        color: "#0D24C4",
+      },
+    },
+    formResendCodeLink: {
+      fontWeight: "300",
+      fontSize: "16px",
+      color: "#575757",
+    },
+
+    footerActionText: {
+      color: "#000000",
+      fontWeight: "300",
+      fontSize: "16px",
+      display: "block",
+      textAlign: "start !important",
+    },
+    identityPreviewText: {
+      fontWeight: "300",
+      fontSize: "16px",
+      color: "#575757",
+    },
+  },
+};

--- a/src/app/(registration)/formAppearanceStyles.ts
+++ b/src/app/(registration)/formAppearanceStyles.ts
@@ -1,3 +1,31 @@
+import { oakColorTokens } from "@oaknational/oak-components";
+
+const formFocusStyles = {
+  "&:focus": {
+    boxShadow: `0px 0px 0px 2px ${oakColorTokens.lemon}, 0px 0px 0px 5px ${oakColorTokens.grey60} !important`,
+  },
+};
+
+const buttonStyles = {
+  padding: "8px",
+  radius: "4px",
+  border: `1px solid ${oakColorTokens.grey50} !important`,
+  ...formFocusStyles,
+};
+
+const headerTextStyles = {
+  textAlign: "start",
+  fontWeight: "300",
+  fontSize: "16px",
+  color: oakColorTokens.grey60,
+};
+
+const linkFocusStyles = {
+  borderRadius: "4px",
+  outline: "none",
+  boxShadow: `0px 0px 0px 2px ${oakColorTokens.lemon}, 0px 0px 0px 5px ${oakColorTokens.grey60}`,
+};
+
 export const formAppearanceStyles = {
   elements: {
     card: {
@@ -6,62 +34,52 @@ export const formAppearanceStyles = {
     logoBox: {
       height: "47px",
       justifyContent: "flex-start",
+      "a:focus": linkFocusStyles,
     },
     headerTitle: {
       fontSize: "20px",
       textAlign: "start",
       marginBottom: "8px",
-      color: "#222222",
+      color: oakColorTokens.black,
       fontWeight: "600",
     },
     headerSubtitle: {
-      fontSize: "16px",
-      textAlign: "start",
-      color: "#575757",
-      fontWeight: "300",
+      ...headerTextStyles,
     },
     dividerText: {
-      fontSize: "16px",
-      color: "#575757",
+      ...headerTextStyles,
     },
     dividerLine: {
       height: "1px",
-      background: "#808080",
+      background: oakColorTokens.grey50,
     },
     button__google: {
-      padding: "8px",
-      radius: "4px",
-      border: "1px solid #808080 !important",
+      ...buttonStyles,
     },
     button__microsoft: {
-      padding: "8px",
-      radius: "4px",
-      border: "1px solid #808080 !important",
+      ...buttonStyles,
     },
-
     socialButtonsBlockButtonText: {
-      fontSize: "16px",
-      color: "black",
-      fontWeight: "300",
+      ...headerTextStyles,
+      color: oakColorTokens.black,
     },
-
     formFieldLabel: {
       fontSize: "16px",
       fontWeight: "500",
-      color: "black",
+      color: oakColorTokens.black,
     },
     button: {
       padding: "14px",
       fontSize: "16px",
+      ...formFocusStyles,
     },
-
     formFieldInput: {
       padding: "16px",
-      border: "1px solid #808080 !important",
+      border: `1px solid ${oakColorTokens.grey50} !important`,
+      ...formFocusStyles,
     },
-
     input: {
-      border: "1px solid #808080 !important",
+      border: `1px solid ${oakColorTokens.grey50} !important`,
     },
     footer: {
       padding: "0px",
@@ -72,32 +90,31 @@ export const formAppearanceStyles = {
       padding: "0px !important",
       width: "100%",
       paddingLeft: "40px  !important",
+      "a:focus": linkFocusStyles,
     },
     footerActionLink: {
-      color: "#0D24C4",
+      color: oakColorTokens.navy,
       textAlign: "start !important",
       fontSize: "16px",
       "&:hover": {
-        color: "#0D24C4",
+        color: oakColorTokens.navy,
       },
     },
     formResendCodeLink: {
       fontWeight: "300",
       fontSize: "16px",
-      color: "#575757",
+      color: oakColorTokens.grey60,
+      ...formFocusStyles,
     },
-
     footerActionText: {
-      color: "#000000",
-      fontWeight: "300",
-      fontSize: "16px",
+      ...headerTextStyles,
+      color: oakColorTokens.black,
       display: "block",
       textAlign: "start !important",
+      ...formFocusStyles,
     },
     identityPreviewText: {
-      fontWeight: "300",
-      fontSize: "16px",
-      color: "#575757",
+      ...headerTextStyles,
     },
   },
 };

--- a/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
@@ -3,6 +3,8 @@
 
 import { SignIn } from "@clerk/nextjs";
 
+import { formAppearanceStyles } from "../../formAppearanceStyles";
+
 export default function SignInPage() {
-  return <SignIn />;
+  return <SignIn appearance={formAppearanceStyles} />;
 }

--- a/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
@@ -3,6 +3,8 @@
 
 import { SignUp } from "@clerk/nextjs";
 
+import { formAppearanceStyles } from "../../formAppearanceStyles";
+
 export default function SignUpPage() {
-  return <SignUp />;
+  return <SignUp appearance={formAppearanceStyles} />;
 }

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -18,6 +18,7 @@ import { burgerMenuSections } from "@/browser-lib/fixtures/burgerMenuSections";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import useSelectedArea from "@/hooks/useSelectedArea";
 import { useFeatureFlaggedClerk } from "@/context/FeatureFlaggedClerk/FeatureFlaggedClerk";
+import { getBreakpoint } from "@/styles/utils/responsive";
 
 export const siteAreas = {
   teachers: "TEACHERS",
@@ -71,7 +72,26 @@ const AppHeader: FC<HeaderProps> = () => {
             $font="heading-7"
           >
             {isSignedIn && authFlagEnabled && (
-              <UserButton data-testid="clerk-user-button" />
+              <UserButton
+                appearance={{
+                  elements: {
+                    userButtonAvatarBox: {
+                      [`@media (max-width: ${getBreakpoint("small")}px)`]: {
+                        width: "100%",
+                        maxWidth: "100%",
+                      },
+                    },
+                    userButtonPopoverCard: {
+                      [`@media (max-width: ${getBreakpoint("small")}px)`]: {
+                        width: "100%",
+                        maxWidth: "100%",
+                        marginLeft: "0",
+                      },
+                    },
+                  },
+                }}
+                data-testid="clerk-user-button"
+              />
             )}
             <OwaLink
               page={"home"}

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { FC, useRef } from "react";
-import { OakFlex } from "@oaknational/oak-components";
+import { oakColorTokens, OakFlex } from "@oaknational/oak-components";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { UserButton } from "@clerk/nextjs";
 
@@ -79,6 +79,11 @@ const AppHeader: FC<HeaderProps> = () => {
                       [`@media (max-width: ${getBreakpoint("small")}px)`]: {
                         width: "100%",
                         maxWidth: "100%",
+                      },
+                    },
+                    userButtonTrigger: {
+                      "&:focus": {
+                        boxShadow: `0px 0px 0px 2px ${oakColorTokens.lemon}, 0px 0px 0px 5px ${oakColorTokens.grey60} !important`,
                       },
                     },
                     userButtonPopoverCard: {

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -1,5 +1,7 @@
 import { FC, useRef } from "react";
 import { OakFlex } from "@oaknational/oak-components";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { UserButton } from "@clerk/nextjs";
 
 import Logo from "@/components/AppComponents/Logo";
 import { HeaderProps } from "@/components/AppComponents/Layout/Layout";
@@ -15,6 +17,7 @@ import { AppHeaderUnderline } from "@/components/AppComponents/AppHeaderUnderlin
 import { burgerMenuSections } from "@/browser-lib/fixtures/burgerMenuSections";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import useSelectedArea from "@/hooks/useSelectedArea";
+import { useFeatureFlaggedClerk } from "@/context/FeatureFlaggedClerk/FeatureFlaggedClerk";
 
 export const siteAreas = {
   teachers: "TEACHERS",
@@ -33,6 +36,9 @@ const AppHeader: FC<HeaderProps> = () => {
   const { openMenu, open } = useMenuContext();
   const { track } = useAnalytics();
   const selectedArea = useSelectedArea();
+  const { useUser } = useFeatureFlaggedClerk();
+  const authFlagEnabled = useFeatureFlagEnabled("use-auth-owa");
+  const { isSignedIn } = useUser();
 
   return (
     <header>
@@ -64,6 +70,9 @@ const AppHeader: FC<HeaderProps> = () => {
             $gap="all-spacing-6"
             $font="heading-7"
           >
+            {isSignedIn && authFlagEnabled && (
+              <UserButton data-testid="clerk-user-button" />
+            )}
             <OwaLink
               page={"home"}
               $focusStyles={["underline"]}

--- a/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.test.tsx
+++ b/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.test.tsx
@@ -1,6 +1,4 @@
 import { screen, within } from "@testing-library/react";
-import * as posthog from "posthog-js/react";
-import { PropsWithChildren } from "react";
 
 import AppHeaderBurgerMenuSections from "./AppHeaderBurgerMenuSections";
 
@@ -35,42 +33,5 @@ describe("AppHeaderBurgerburgerMenuSections", () => {
     expect(header).toBeInTheDocument();
     const list = within(firstSection!).getByRole("list");
     expect(list).toBeInTheDocument();
-  });
-
-  describe("when the `use-auth-owa` feature is enabled", () => {
-    function SignOutButton({ children }: PropsWithChildren) {
-      return <>{children}</>;
-    }
-    SignOutButton.displayName = "SignoutButton";
-
-    beforeEach(() => {
-      jest.spyOn(posthog, "useFeatureFlagEnabled").mockReturnValue(true);
-    });
-
-    it("does not render a sign out button when user is not logged in", () => {
-      enableMockClerk({ SignOutButton, SignedIn: () => null });
-
-      renderWithProviders()(
-        <AppHeaderBurgerMenuSections burgerMenuSections={burgerMenuSections} />,
-      );
-
-      const signOutButton = screen.queryByText("Sign out");
-      expect(signOutButton).not.toBeInTheDocument();
-    });
-
-    it("renders a sign out button when a user is logged in", async () => {
-      enableMockClerk({
-        SignOutButton,
-        SignedIn: ({ children }) => <>{children}</>,
-      });
-
-      renderWithProviders()(
-        <AppHeaderBurgerMenuSections burgerMenuSections={burgerMenuSections} />,
-      );
-      const signOutButton = await screen.findByRole("button", {
-        name: "Sign out",
-      });
-      expect(signOutButton).toBeInTheDocument();
-    });
   });
 });

--- a/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.tsx
+++ b/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.tsx
@@ -1,15 +1,9 @@
 import { FC } from "react";
-import {
-  OakHeading,
-  OakLI,
-  OakFlex,
-  OakSecondaryButton,
-} from "@oaknational/oak-components";
+import { OakHeading, OakLI, OakFlex } from "@oaknational/oak-components";
 
 import AppHeaderBurgerMenuLink, {
   BurgerMenuLink,
 } from "@/components/AppComponents/AppHeaderBurgerMenuLink";
-import { useFeatureFlaggedClerk } from "@/context/FeatureFlaggedClerk/FeatureFlaggedClerk";
 
 /**
  * New menu sections to be used in the hamburger menu for the beta site
@@ -28,15 +22,9 @@ const AppHeaderBurgerburgerMenuSections: FC<
   AppHeaderBurgerburgerMenuSectionsProps
 > = (props) => {
   const { burgerMenuSections } = props;
-  const clerk = useFeatureFlaggedClerk();
 
   return (
     <OakFlex $flexDirection="column" $gap="all-spacing-7">
-      <clerk.SignedIn>
-        <clerk.SignOutButton>
-          <OakSecondaryButton>Sign out</OakSecondaryButton>
-        </clerk.SignOutButton>
-      </clerk.SignedIn>
       {burgerMenuSections.map((section, i) => (
         <OakFlex
           $flexDirection="column"


### PR DESCRIPTION
## Description

- Replaces sign out in hamburger with clerk signout in app header
- Updates clerk style to match OWA (as much as possible considering limitations) 

## Acceptance Criteria:

- [ ]  Use the default style clerk sign out option (what AI squad currently has)
- [ ]  Should only be displayed if you are logged in with the feature flag enabed
- [ ] Logging out via the component should have the same behaviour as logging out currently does (logging the user out and redirecting them to the homepage)
- [ ]  remove log out button from hamburger

- [ ] Make sure sign in and sign up match Figma in terms of Font sizes, colours, spacing, border radius etc
- [ ]  Make name fields required

https://www.figma.com/design/fxWHjjNzvbbc0J38pM3Kti/Log-in?node-id=2343-5313&node-type=SECTION&m=dev

[[Ticket checklist (non-tester)](https://www.notion.so/Ticket-checklist-non-tester-5317535736fe47fb984a3591a1bd7616?pvs=21)](https://www.notion.so/Ticket-checklist-non-tester-5317535736fe47fb984a3591a1bd7616?pvs=21)

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2757--oak-web-application.netlify.thenational.academy
Go to lesson download and sign in, you should see avatar in app header, test criteria above. 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
