### PR TITLE
fix: use optionality title for unit when available [LESQ-1063]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloads/constructCanonicalLessonDownloads.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloads/constructCanonicalLessonDownloads.ts
@@ -26,10 +26,12 @@ const constructCanonicalLessonDownloads = (
 
   return browseData.reduce(
     (acc, lesson) => {
+      const unitTitle =
+        lesson.programme_fields.optionality ?? lesson.unit_data.title;
       const pathwayLesson = {
         programmeSlug: lesson.programme_slug,
         unitSlug: lesson.unit_data.slug,
-        unitTitle: lesson.unit_data.title,
+        unitTitle,
         keyStageSlug: lesson.programme_fields.keystage_slug,
         keyStageTitle: toSentenceCase(
           lesson.programme_fields.keystage_description,

--- a/src/node-lib/curriculum-api-2023/queries/lessonDownloads/constructLessonDownloads.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonDownloads/constructLessonDownloads.ts
@@ -20,7 +20,9 @@ const constructLessonDownloads = (
 
   const parsedCurrentLesson =
     syntheticUnitvariantLessonsSchema.parse(currentLesson);
-
+  const unitTitle =
+    parsedCurrentLesson.programme_fields.optionality ??
+    parsedCurrentLesson.unit_data.title;
   const downloadsPageData = {
     downloads,
     programmeSlug: parsedCurrentLesson.programme_slug,
@@ -33,7 +35,7 @@ const constructLessonDownloads = (
     subjectSlug: parsedCurrentLesson.programme_fields.subject_slug,
     subjectTitle: parsedCurrentLesson.programme_fields.subject,
     unitSlug: parsedCurrentLesson.unit_slug,
-    unitTitle: parsedCurrentLesson.unit_data.title,
+    unitTitle,
     lessonCohort: parsedCurrentLesson.lesson_data._cohort,
     expired: expired ? expired : null,
     updatedAt: parsedCurrentLesson.lesson_data.updated_at,

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.test.ts
@@ -169,6 +169,36 @@ describe("lessonListing()", () => {
         yearSlug: "year-1",
       });
     });
+    test("getTransformedUnit returns the correct data for optionality units", () => {
+      const pfs = syntheticUnitvariantLessonsFixture().programme_fields;
+      const transformedLessons = getTransformedUnit(
+        syntheticUnitvariantLessonsFixture({
+          overrides: {
+            programme_fields: {
+              ...pfs,
+              optionality: "optional",
+            },
+          },
+        }),
+        [],
+      );
+      expect(transformedLessons).toEqual({
+        examBoardSlug: null,
+        examBoardTitle: null,
+        keyStageSlug: "ks1",
+        keyStageTitle: "Key stage 1",
+        lessons: [],
+        programmeSlug: "programme-slug",
+        subjectSlug: "maths",
+        subjectTitle: "Maths",
+        tierSlug: null,
+        tierTitle: null,
+        unitSlug: "unit-slug",
+        unitTitle: "optional",
+        yearTitle: "Year 1",
+        yearSlug: "year-1",
+      });
+    });
     test("getTransformedLessons returns the correct data", async () => {
       const transformedLessons = getTransformedLessons({
         unit: [syntheticUnitvariantLessonsFixture()],

--- a/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonListing/lessonListing.query.ts
@@ -50,6 +50,7 @@ export const getTransformedUnit = (
   unit: SyntheticUnitvariantLessons,
   parsedLessons: LessonListingPageData["lessons"],
 ): LessonListingPageData => {
+  const unitTitle = unit.programme_fields.optionality ?? unit.unit_data.title;
   return {
     programmeSlug: unit.programme_slug,
     keyStageSlug: unit.programme_fields.keystage_slug,
@@ -57,7 +58,7 @@ export const getTransformedUnit = (
     subjectSlug: unit.programme_fields.subject_slug,
     subjectTitle: unit.programme_fields.subject,
     unitSlug: unit.unit_slug,
-    unitTitle: unit.unit_data.title,
+    unitTitle,
     tierSlug: unit.programme_fields.tier_slug,
     tierTitle: unit.programme_fields.tier_description,
     examBoardSlug: unit.programme_fields.examboard_slug,

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -152,10 +152,12 @@ const transformedLessonOverviewData = (
 ): LessonOverviewPageData => {
   const starterQuiz = lessonOverviewQuizData.parse(content.starterQuiz);
   const exitQuiz = lessonOverviewQuizData.parse(content.exitQuiz);
+  const unitTitle =
+    browseData.programmeFields.optionality ?? browseData.unitData.title;
   return {
     programmeSlug: browseData.programmeSlug,
     unitSlug: browseData.unitSlug,
-    unitTitle: browseData.unitData.title,
+    unitTitle,
     keyStageSlug: browseData.programmeFields.keystageSlug,
     keyStageTitle: toSentenceCase(
       browseData.programmeFields.keystageDescription,

--- a/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.query.ts
@@ -126,10 +126,12 @@ export function getCopyrightContent(
 const getPathways = (res: LessonOverviewQuery): LessonPathway[] => {
   const pathways = res.browseData.map((l) => {
     const lesson = lessonBrowseDataSchema.parse(l);
+    const unitTitle =
+      lesson.programme_fields.optionality ?? lesson.unit_data.title;
     const pathway = {
       programmeSlug: lesson.programme_slug,
       unitSlug: lesson.unit_slug,
-      unitTitle: lesson.unit_data.title,
+      unitTitle,
       keyStageSlug: lesson.programme_fields.keystage_slug,
       keyStageTitle: lesson.programme_fields.keystage_description,
       subjectSlug: lesson.programme_fields.subject_slug,

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.query.ts
@@ -86,7 +86,9 @@ const lessonShareQuery =
       lessonSlug: args.lessonSlug,
       lessonTitle: parsedRawLesson.lesson_title,
       unitSlug: args.unitSlug,
-      unitTitle: parsedRawBrowseData.unit_title,
+      unitTitle:
+        parsedRawBrowseData.programme_fields.optionality ??
+        parsedRawBrowseData.unit_title,
       subjectSlug: parsedRawBrowseData.programme_fields.subject_slug,
       subjectTitle: parsedRawBrowseData.programme_fields.subject,
       examBoardSlug: parsedRawBrowseData.programme_fields.examboard_slug,


### PR DESCRIPTION
## Description

Music year: 2018

- update lessonListing, lessonOverview, and lessonDownload queries to use optionality title for the unit title when present
- add test for this

## Issue(s)

Fixes #
Null unitvariant title being used on optionality units

## How to test

1. Go to https://deploy-preview-2765--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks4-aqa/units/modern-text-first-study-152/lessons
3. You should see the optionality title 'Animal Farm: the pigs and power' as the heading and in breadcrumbs
4. Continue the journey to lesson overview and downloads/share and it should continue to use the optionality title in breadcrumbs
5. Clicking on the breadcrumbs should work
6. Canonical lesson page breadcrumbs should also be using optionality unit title

## Screenshots

How it used to look (delete if n/a):

<img width="600" alt="Screenshot 2024-09-10 at 14 07 39" src="https://github.com/user-attachments/assets/d5516100-a875-4a1a-9aca-941b7b01516c">

How it should now look:

<img width="600" alt="Screenshot 2024-09-10 at 14 07 21" src="https://github.com/user-attachments/assets/58d92c03-0437-4d11-8c57-f086d88727ca">

