### PR TITLE
Feat skip button on unit page  - LESQ-1048

### DIFF
--- a/src/components/TeacherComponents/UnitList/UnitList.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.tsx
@@ -5,6 +5,7 @@ import {
   OakUnitListItem,
   OakUnitListOptionalityItem,
   OakPagination,
+  OakAnchorTarget,
 } from "@oaknational/oak-components";
 import { NextRouter, useRouter } from "next/router";
 
@@ -260,6 +261,7 @@ const UnitList: FC<UnitListProps> = (props) => {
 
   return (
     <OakFlex $flexDirection="column">
+      <OakAnchorTarget id="unit-list" />
       {currentPageItems.length ? (
         isUnitListData(props) ? (
           <OakFlex $flexDirection="column" $gap="space-between-xxl">

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
@@ -84,7 +84,7 @@ describe("UnitsLearningThemeFilters", () => {
       activeFilters: { keyStage: ["ks3"], subject: ["english"] },
     });
   });
-  test("skip units button becomes visible when focussed", async () => {
+  test("skip filters button becomes visible when focussed", async () => {
     const { getByText } = renderWithTheme(
       <UnitsLearningThemeFilters
         labelledBy={"Learning Theme Filter"}

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
+import { oakDefaultTheme, OakThemeProvider } from "@oaknational/oak-components";
 
 import UnitsLearningThemeFilters from "./UnitsLearningThemeFilters";
 
@@ -19,26 +20,29 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
 describe("UnitsLearningThemeFilters", () => {
   test("should render links to lessons", () => {
     const { getByRole } = renderWithTheme(
-      <UnitsLearningThemeFilters
-        labelledBy={"Learning Theme Filter"}
-        learningThemes={[
-          {
-            themeTitle: "Grammar",
-            themeSlug: "grammar",
-          },
-        ]}
-        selectedThemeSlug={"all"}
-        linkProps={{
-          page: "unit-index",
-          programmeSlug: "maths-secondary-ks3",
-        }}
-        trackingProps={{
-          keyStageSlug: "ks3",
-          keyStageTitle: "Key stage 3",
-          subjectSlug: "english",
-          subjectTitle: "English",
-        }}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <UnitsLearningThemeFilters
+          labelledBy={"Learning Theme Filter"}
+          learningThemes={[
+            {
+              themeTitle: "Grammar",
+              themeSlug: "grammar",
+            },
+          ]}
+          selectedThemeSlug={"all"}
+          linkProps={{
+            page: "unit-index",
+            programmeSlug: "maths-secondary-ks3",
+          }}
+          trackingProps={{
+            keyStageSlug: "ks3",
+            keyStageTitle: "Key stage 3",
+            subjectSlug: "english",
+            subjectTitle: "English",
+          }}
+        />
+        ,
+      </OakThemeProvider>,
     );
     expect(getByRole("link", { name: "Grammar" })).toHaveAttribute(
       "href",
@@ -47,26 +51,29 @@ describe("UnitsLearningThemeFilters", () => {
   });
   test("should call tracking browse refined with correct args", async () => {
     renderWithTheme(
-      <UnitsLearningThemeFilters
-        labelledBy={"Learning Theme Filter"}
-        learningThemes={[
-          {
-            themeTitle: "Grammar",
-            themeSlug: "grammar",
-          },
-        ]}
-        selectedThemeSlug={"all"}
-        linkProps={{
-          page: "unit-index",
-          programmeSlug: "maths-secondary-ks3",
-        }}
-        trackingProps={{
-          keyStageSlug: "ks3",
-          keyStageTitle: "Key stage 3",
-          subjectSlug: "english",
-          subjectTitle: "English",
-        }}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <UnitsLearningThemeFilters
+          labelledBy={"Learning Theme Filter"}
+          learningThemes={[
+            {
+              themeTitle: "Grammar",
+              themeSlug: "grammar",
+            },
+          ]}
+          selectedThemeSlug={"all"}
+          linkProps={{
+            page: "unit-index",
+            programmeSlug: "maths-secondary-ks3",
+          }}
+          trackingProps={{
+            keyStageSlug: "ks3",
+            keyStageTitle: "Key stage 3",
+            subjectSlug: "english",
+            subjectTitle: "English",
+          }}
+        />
+        ,
+      </OakThemeProvider>,
     );
 
     const grammarThread = screen.getByRole("link", { name: "Grammar" });
@@ -86,26 +93,29 @@ describe("UnitsLearningThemeFilters", () => {
   });
   test("skip filters button becomes visible when focussed", async () => {
     const { getByText } = renderWithTheme(
-      <UnitsLearningThemeFilters
-        labelledBy={"Learning Theme Filter"}
-        learningThemes={[
-          {
-            themeTitle: "Grammar",
-            themeSlug: "grammar",
-          },
-        ]}
-        selectedThemeSlug={"all"}
-        linkProps={{
-          page: "unit-index",
-          programmeSlug: "maths-secondary-ks3",
-        }}
-        trackingProps={{
-          keyStageSlug: "ks3",
-          keyStageTitle: "Key stage 3",
-          subjectSlug: "english",
-          subjectTitle: "English",
-        }}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <UnitsLearningThemeFilters
+          labelledBy={"Learning Theme Filter"}
+          learningThemes={[
+            {
+              themeTitle: "Grammar",
+              themeSlug: "grammar",
+            },
+          ]}
+          selectedThemeSlug={"all"}
+          linkProps={{
+            page: "unit-index",
+            programmeSlug: "maths-secondary-ks3",
+          }}
+          trackingProps={{
+            keyStageSlug: "ks3",
+            keyStageTitle: "Key stage 3",
+            subjectSlug: "english",
+            subjectTitle: "English",
+          }}
+        />
+        ,
+      </OakThemeProvider>,
     );
 
     const skipUnits = getByText("Skip to units").closest("a");

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
 
 import UnitsLearningThemeFilters from "./UnitsLearningThemeFilters";
 
@@ -82,5 +83,46 @@ describe("UnitsLearningThemeFilters", () => {
       filterValue: "Grammar",
       activeFilters: { keyStage: ["ks3"], subject: ["english"] },
     });
+  });
+  test("skip units button becomes visible when focussed", async () => {
+    const { getByText } = renderWithTheme(
+      <UnitsLearningThemeFilters
+        labelledBy={"Learning Theme Filter"}
+        learningThemes={[
+          {
+            themeTitle: "Grammar",
+            themeSlug: "grammar",
+          },
+        ]}
+        selectedThemeSlug={"all"}
+        linkProps={{
+          page: "unit-index",
+          programmeSlug: "maths-secondary-ks3",
+        }}
+        trackingProps={{
+          keyStageSlug: "ks3",
+          keyStageTitle: "Key stage 3",
+          subjectSlug: "english",
+          subjectTitle: "English",
+        }}
+      />,
+    );
+
+    const skipUnits = getByText("Skip to units").closest("a");
+
+    if (!skipUnits) {
+      throw new Error("Could not find filter button");
+    }
+
+    act(() => {
+      skipUnits.focus();
+    });
+    expect(skipUnits).toHaveFocus();
+    expect(skipUnits).not.toHaveStyle("position: absolute");
+
+    act(() => {
+      skipUnits.blur();
+    });
+    expect(skipUnits).not.toHaveFocus();
   });
 });

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
@@ -35,7 +35,7 @@ const UnitsLearningThemeFilters = ({
   linkProps,
   trackingProps,
 }: UnitsLearningThemeFiltersProps) => {
-  const [SkipUnitsFocusButton, setSkipUnitsFocusButton] = useState(false);
+  const [skipFiltersButton, setSkipFiltersButton] = useState(false);
   const listStateProps = useCategoryFilterList({
     selectedKey: selectedThemeSlug,
     getKey: (
@@ -84,16 +84,14 @@ const UnitsLearningThemeFilters = ({
         $position={"relative"}
         $flexDirection={"column"}
       >
-        <OakBox $mb={SkipUnitsFocusButton ? "space-between-xs" : "auto"}>
+        <OakBox $mb={skipFiltersButton ? "space-between-xs" : "auto"}>
           <OakSecondaryButton
             element="a"
             href="#unit-list"
-            onFocus={() => setSkipUnitsFocusButton(true)}
-            onBlur={() => setSkipUnitsFocusButton(false)}
+            onFocus={() => setSkipFiltersButton(true)}
+            onBlur={() => setSkipFiltersButton(false)}
             style={
-              SkipUnitsFocusButton
-                ? {}
-                : { position: "absolute", top: "-600px" }
+              skipFiltersButton ? {} : { position: "absolute", top: "-600px" }
             }
           >
             Skip to units

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
@@ -1,4 +1,11 @@
-import { OakFlex } from "@oaknational/oak-components";
+import {
+  OakBox,
+  oakDefaultTheme,
+  OakFlex,
+  OakSecondaryButton,
+  OakThemeProvider,
+} from "@oaknational/oak-components";
+import { useState } from "react";
 
 import {
   SpecialistUnitListingLinkProps,
@@ -28,6 +35,7 @@ const UnitsLearningThemeFilters = ({
   linkProps,
   trackingProps,
 }: UnitsLearningThemeFiltersProps) => {
+  const [SkipUnitsFocusButton, setSkipUnitsFocusButton] = useState(false);
   const listStateProps = useCategoryFilterList({
     selectedKey: selectedThemeSlug,
     getKey: (
@@ -70,29 +78,50 @@ const UnitsLearningThemeFilters = ({
     : [];
 
   return (
-    <OakFlex $flexDirection={"column"}>
-      <CategoryFilterList
-        {...listStateProps}
-        labelledBy={labelledBy}
-        categories={[
-          {
-            label: "All in suggested order",
-            linkProps: {
-              ...linkProps,
-              search: { ...linkProps.search, ["learning-theme"]: undefined },
+    <OakThemeProvider theme={oakDefaultTheme}>
+      <OakFlex
+        $mb={"space-between-xl"}
+        $position={"relative"}
+        $flexDirection={"column"}
+      >
+        <OakBox $mb={SkipUnitsFocusButton ? "space-between-xs" : "auto"}>
+          <OakSecondaryButton
+            element="a"
+            href="#unit-list"
+            onFocus={() => setSkipUnitsFocusButton(true)}
+            onBlur={() => setSkipUnitsFocusButton(false)}
+            style={
+              SkipUnitsFocusButton
+                ? {}
+                : { position: "absolute", top: "-600px" }
+            }
+          >
+            Skip to units
+          </OakSecondaryButton>
+        </OakBox>
+        <CategoryFilterList
+          {...listStateProps}
+          labelledBy={labelledBy}
+          categories={[
+            {
+              label: "All in suggested order",
+              linkProps: {
+                ...linkProps,
+                search: { ...linkProps.search, ["learning-theme"]: undefined },
+              },
             },
-          },
-          ...learningThemesMapped.map(({ label, slug }) => ({
-            label: label ? label : "",
-            linkProps: {
-              ...linkProps,
-              search: { ...linkProps.search, ["learning-theme"]: slug },
-            },
-          })),
-        ]}
-        themeTrackingProps={trackingProps}
-      />
-    </OakFlex>
+            ...learningThemesMapped.map(({ label, slug }) => ({
+              label: label ? label : "",
+              linkProps: {
+                ...linkProps,
+                search: { ...linkProps.search, ["learning-theme"]: slug },
+              },
+            })),
+          ]}
+          themeTrackingProps={trackingProps}
+        />
+      </OakFlex>
+    </OakThemeProvider>
   );
 };
 

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
@@ -79,11 +79,7 @@ const UnitsLearningThemeFilters = ({
 
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
-      <OakFlex
-        $mb={"space-between-xl"}
-        $position={"relative"}
-        $flexDirection={"column"}
-      >
+      <OakFlex $flexDirection={"column"}>
         <OakBox $mb={skipFiltersButton ? "space-between-xs" : "auto"}>
           <OakSecondaryButton
             element="a"
@@ -97,6 +93,7 @@ const UnitsLearningThemeFilters = ({
             Skip to units
           </OakSecondaryButton>
         </OakBox>
+
         <CategoryFilterList
           {...listStateProps}
           labelledBy={labelledBy}

--- a/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
+++ b/src/components/TeacherComponents/UnitsLearningThemeFilters/UnitsLearningThemeFilters.tsx
@@ -1,9 +1,7 @@
 import {
   OakBox,
-  oakDefaultTheme,
   OakFlex,
   OakSecondaryButton,
-  OakThemeProvider,
 } from "@oaknational/oak-components";
 import { useState } from "react";
 
@@ -78,45 +76,44 @@ const UnitsLearningThemeFilters = ({
     : [];
 
   return (
-    <OakThemeProvider theme={oakDefaultTheme}>
-      <OakFlex $flexDirection={"column"}>
-        <OakBox $mb={skipFiltersButton ? "space-between-xs" : "auto"}>
-          <OakSecondaryButton
-            element="a"
-            href="#unit-list"
-            onFocus={() => setSkipFiltersButton(true)}
-            onBlur={() => setSkipFiltersButton(false)}
-            style={
-              skipFiltersButton ? {} : { position: "absolute", top: "-600px" }
-            }
-          >
-            Skip to units
-          </OakSecondaryButton>
-        </OakBox>
+    <OakFlex $flexDirection={"column"}>
+      <OakBox $mb={skipFiltersButton ? "space-between-xs" : "auto"}>
+        <OakSecondaryButton
+          element="a"
+          aria-label="Skip to units"
+          href="#unit-list"
+          onFocus={() => setSkipFiltersButton(true)}
+          onBlur={() => setSkipFiltersButton(false)}
+          style={
+            skipFiltersButton ? {} : { position: "absolute", top: "-600px" }
+          }
+        >
+          Skip to units
+        </OakSecondaryButton>
+      </OakBox>
 
-        <CategoryFilterList
-          {...listStateProps}
-          labelledBy={labelledBy}
-          categories={[
-            {
-              label: "All in suggested order",
-              linkProps: {
-                ...linkProps,
-                search: { ...linkProps.search, ["learning-theme"]: undefined },
-              },
+      <CategoryFilterList
+        {...listStateProps}
+        labelledBy={labelledBy}
+        categories={[
+          {
+            label: "All in suggested order",
+            linkProps: {
+              ...linkProps,
+              search: { ...linkProps.search, ["learning-theme"]: undefined },
             },
-            ...learningThemesMapped.map(({ label, slug }) => ({
-              label: label ? label : "",
-              linkProps: {
-                ...linkProps,
-                search: { ...linkProps.search, ["learning-theme"]: slug },
-              },
-            })),
-          ]}
-          themeTrackingProps={trackingProps}
-        />
-      </OakFlex>
-    </OakThemeProvider>
+          },
+          ...learningThemesMapped.map(({ label, slug }) => ({
+            label: label ? label : "",
+            linkProps: {
+              ...linkProps,
+              search: { ...linkProps.search, ["learning-theme"]: slug },
+            },
+          })),
+        ]}
+        themeTrackingProps={trackingProps}
+      />
+    </OakFlex>
   );
 };
 


### PR DESCRIPTION
## Description

Music year: 2011

- Adds skip button to threads on unit page

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2769--oak-web-application.netlify.thenational.academy
Got to unit and specialist unit page - tab through page, you should see a skip to units button that will skip thread filters


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
