### PR TITLE
Key stage text derived from list of available key stages

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -30,6 +30,14 @@ import { CurriculumTab } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[t
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
 import FocusIndicator from "@/components/CurriculumComponents/OakComponentsKitchen/FocusIndicator";
+import { getPhaseText } from "@/utils/curriculum/formatting";
+
+const DEFAULT_KEYSTAGES = [
+  { slug: "ks1" },
+  { slug: "ks2" },
+  { slug: "ks3" },
+  { slug: "ks4" },
+];
 
 /**
  * Interface to pick a subject, phase, and if applicable, an exam board.
@@ -312,16 +320,6 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
   const getIconName = (slug: string) => {
     const iconName = `subject-${slug}`;
     return isValidIconName(iconName) ? iconName : undefined;
-  };
-
-  const getPhaseText = (phase: Phase) => {
-    if (phase.slug === "primary") {
-      return "Key stage 1 and 2";
-    }
-    if (phase.slug === "secondary") {
-      return "Key stage 3 and 4";
-    }
-    return "";
   };
 
   return (
@@ -695,7 +693,12 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                             hoverShadow={null}
                           >
                             {phase.title}
-                            <OakP $font={"body-2"}>{getPhaseText(phase)}</OakP>
+                            <OakP $font={"body-2"}>
+                              {getPhaseText(
+                                phase,
+                                selectedSubject?.keystages ?? DEFAULT_KEYSTAGES,
+                              )}
+                            </OakP>
                           </OakSecondaryButton>
                         </ButtonContainer>
                       ))}

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -235,7 +235,7 @@ export type Assets_Bool_Exp = {
 
 /** unique or primary key constraints on table "assets" */
 export enum Assets_Constraint {
-  /** unique or primary key constraint on columns "asset_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "asset_id" */
   AssetsPkey = 'assets_pkey'
 }
 
@@ -804,7 +804,7 @@ export type Cat_Contentguidance_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_contentguidance" */
 export enum Cat_Contentguidance_Constraint {
-  /** unique or primary key constraint on columns "_state", "contentguidance_id" */
+  /** unique or primary key constraint on columns "contentguidance_id", "_state" */
   CatContentguidancePkey = 'cat_contentguidance_pkey'
 }
 
@@ -1670,7 +1670,7 @@ export type Cat_Nationalcurriculum_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_nationalcurriculum" */
 export enum Cat_Nationalcurriculum_Constraint {
-  /** unique or primary key constraint on columns "nationalcurriculum_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "nationalcurriculum_id" */
   CatNationalcurriculumPkey = 'cat_nationalcurriculum_pkey'
 }
 
@@ -2104,7 +2104,7 @@ export type Cat_Subjectcategories_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_subjectcategories" */
 export enum Cat_Subjectcategories_Constraint {
-  /** unique or primary key constraint on columns "_state", "subjectcategory_id" */
+  /** unique or primary key constraint on columns "subjectcategory_id", "_state" */
   CatSubjectcategoriesPkey = 'cat_subjectcategories_pkey'
 }
 
@@ -3013,7 +3013,7 @@ export type Cat_Tags_Bool_Exp = {
 
 /** unique or primary key constraints on table "cat_tags" */
 export enum Cat_Tags_Constraint {
-  /** unique or primary key constraint on columns "_state", "tag_id" */
+  /** unique or primary key constraint on columns "tag_id", "_state" */
   CatTagsPkey = 'cat_tags_pkey'
 }
 
@@ -3400,6 +3400,517 @@ export type Cat_Tags_Variance_Fields = {
 export type Cat_Tags_Variance_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   tag_id?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "cat_vocabulary" */
+export type Cat_Vocabulary = {
+  __typename?: 'cat_vocabulary';
+  _cohort: Scalars['String']['output'];
+  _deleted: Scalars['Boolean']['output'];
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state: Scalars['String']['output'];
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  english_translation?: Maybe<Scalars['String']['output']>;
+  frequency?: Maybe<Scalars['String']['output']>;
+  headword?: Maybe<Scalars['String']['output']>;
+  /** A computed field, executes function "function__cat_vocabulary__lessons" */
+  lessons?: Maybe<Array<Lessons>>;
+  part_of_speech?: Maybe<Scalars['String']['output']>;
+  programme_fields: Scalars['jsonb']['output'];
+  /** A computed field, executes function "function__cat_vocabulary__programmes" */
+  programmes?: Maybe<Array<Programmes>>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+  vocabulary_id: Scalars['Int']['output'];
+  vocabulary_uid?: Maybe<Scalars['bpchar']['output']>;
+  word?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "cat_vocabulary" */
+export type Cat_VocabularyLessonsArgs = {
+  distinct_on?: InputMaybe<Array<Lessons_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Lessons_Order_By>>;
+  where?: InputMaybe<Lessons_Bool_Exp>;
+};
+
+
+/** columns and relationships of "cat_vocabulary" */
+export type Cat_VocabularyProgramme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "cat_vocabulary" */
+export type Cat_VocabularyProgrammesArgs = {
+  distinct_on?: InputMaybe<Array<Programmes_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Programmes_Order_By>>;
+  where?: InputMaybe<Programmes_Bool_Exp>;
+};
+
+/** aggregated selection of "cat_vocabulary" */
+export type Cat_Vocabulary_Aggregate = {
+  __typename?: 'cat_vocabulary_aggregate';
+  aggregate?: Maybe<Cat_Vocabulary_Aggregate_Fields>;
+  nodes: Array<Cat_Vocabulary>;
+};
+
+/** aggregate fields of "cat_vocabulary" */
+export type Cat_Vocabulary_Aggregate_Fields = {
+  __typename?: 'cat_vocabulary_aggregate_fields';
+  avg?: Maybe<Cat_Vocabulary_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Cat_Vocabulary_Max_Fields>;
+  min?: Maybe<Cat_Vocabulary_Min_Fields>;
+  stddev?: Maybe<Cat_Vocabulary_Stddev_Fields>;
+  stddev_pop?: Maybe<Cat_Vocabulary_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Cat_Vocabulary_Stddev_Samp_Fields>;
+  sum?: Maybe<Cat_Vocabulary_Sum_Fields>;
+  var_pop?: Maybe<Cat_Vocabulary_Var_Pop_Fields>;
+  var_samp?: Maybe<Cat_Vocabulary_Var_Samp_Fields>;
+  variance?: Maybe<Cat_Vocabulary_Variance_Fields>;
+};
+
+
+/** aggregate fields of "cat_vocabulary" */
+export type Cat_Vocabulary_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** order by aggregate values of table "cat_vocabulary" */
+export type Cat_Vocabulary_Aggregate_Order_By = {
+  avg?: InputMaybe<Cat_Vocabulary_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Cat_Vocabulary_Max_Order_By>;
+  min?: InputMaybe<Cat_Vocabulary_Min_Order_By>;
+  stddev?: InputMaybe<Cat_Vocabulary_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Cat_Vocabulary_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Cat_Vocabulary_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Cat_Vocabulary_Sum_Order_By>;
+  var_pop?: InputMaybe<Cat_Vocabulary_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Cat_Vocabulary_Var_Samp_Order_By>;
+  variance?: InputMaybe<Cat_Vocabulary_Variance_Order_By>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Cat_Vocabulary_Append_Input = {
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Cat_Vocabulary_Avg_Fields = {
+  __typename?: 'cat_vocabulary_avg_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by avg() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Avg_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "cat_vocabulary". All fields are combined with a logical 'AND'. */
+export type Cat_Vocabulary_Bool_Exp = {
+  _and?: InputMaybe<Array<Cat_Vocabulary_Bool_Exp>>;
+  _cohort?: InputMaybe<String_Comparison_Exp>;
+  _deleted?: InputMaybe<Boolean_Comparison_Exp>;
+  _not?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+  _or?: InputMaybe<Array<Cat_Vocabulary_Bool_Exp>>;
+  _release_id?: InputMaybe<Int_Comparison_Exp>;
+  _state?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  english_translation?: InputMaybe<String_Comparison_Exp>;
+  frequency?: InputMaybe<String_Comparison_Exp>;
+  headword?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Lessons_Bool_Exp>;
+  part_of_speech?: InputMaybe<String_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programmes?: InputMaybe<Programmes_Bool_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  vocabulary_id?: InputMaybe<Int_Comparison_Exp>;
+  vocabulary_uid?: InputMaybe<Bpchar_Comparison_Exp>;
+  word?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "cat_vocabulary" */
+export enum Cat_Vocabulary_Constraint {
+  /** unique or primary key constraint on columns "vocabulary_id", "_state" */
+  CatVocabularyPkey = 'cat_vocabulary_pkey'
+}
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Cat_Vocabulary_Delete_At_Path_Input = {
+  programme_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Cat_Vocabulary_Delete_Elem_Input = {
+  programme_fields?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Cat_Vocabulary_Delete_Key_Input = {
+  programme_fields?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** input type for incrementing numeric columns in table "cat_vocabulary" */
+export type Cat_Vocabulary_Inc_Input = {
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  vocabulary_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "cat_vocabulary" */
+export type Cat_Vocabulary_Insert_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  english_translation?: InputMaybe<Scalars['String']['input']>;
+  frequency?: InputMaybe<Scalars['String']['input']>;
+  headword?: InputMaybe<Scalars['String']['input']>;
+  part_of_speech?: InputMaybe<Scalars['String']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  vocabulary_id?: InputMaybe<Scalars['Int']['input']>;
+  vocabulary_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  word?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate max on columns */
+export type Cat_Vocabulary_Max_Fields = {
+  __typename?: 'cat_vocabulary_max_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  english_translation?: Maybe<Scalars['String']['output']>;
+  frequency?: Maybe<Scalars['String']['output']>;
+  headword?: Maybe<Scalars['String']['output']>;
+  part_of_speech?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+  vocabulary_id?: Maybe<Scalars['Int']['output']>;
+  vocabulary_uid?: Maybe<Scalars['bpchar']['output']>;
+  word?: Maybe<Scalars['String']['output']>;
+};
+
+/** order by max() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Max_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  english_translation?: InputMaybe<Order_By>;
+  frequency?: InputMaybe<Order_By>;
+  headword?: InputMaybe<Order_By>;
+  part_of_speech?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+  vocabulary_uid?: InputMaybe<Order_By>;
+  word?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Cat_Vocabulary_Min_Fields = {
+  __typename?: 'cat_vocabulary_min_fields';
+  _cohort?: Maybe<Scalars['String']['output']>;
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  _state?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  english_translation?: Maybe<Scalars['String']['output']>;
+  frequency?: Maybe<Scalars['String']['output']>;
+  headword?: Maybe<Scalars['String']['output']>;
+  part_of_speech?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+  vocabulary_id?: Maybe<Scalars['Int']['output']>;
+  vocabulary_uid?: Maybe<Scalars['bpchar']['output']>;
+  word?: Maybe<Scalars['String']['output']>;
+};
+
+/** order by min() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Min_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  english_translation?: InputMaybe<Order_By>;
+  frequency?: InputMaybe<Order_By>;
+  headword?: InputMaybe<Order_By>;
+  part_of_speech?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+  vocabulary_uid?: InputMaybe<Order_By>;
+  word?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "cat_vocabulary" */
+export type Cat_Vocabulary_Mutation_Response = {
+  __typename?: 'cat_vocabulary_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Cat_Vocabulary>;
+};
+
+/** on_conflict condition type for table "cat_vocabulary" */
+export type Cat_Vocabulary_On_Conflict = {
+  constraint: Cat_Vocabulary_Constraint;
+  update_columns?: Array<Cat_Vocabulary_Update_Column>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "cat_vocabulary". */
+export type Cat_Vocabulary_Order_By = {
+  _cohort?: InputMaybe<Order_By>;
+  _deleted?: InputMaybe<Order_By>;
+  _release_id?: InputMaybe<Order_By>;
+  _state?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  english_translation?: InputMaybe<Order_By>;
+  frequency?: InputMaybe<Order_By>;
+  headword?: InputMaybe<Order_By>;
+  lessons_aggregate?: InputMaybe<Lessons_Aggregate_Order_By>;
+  part_of_speech?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programmes_aggregate?: InputMaybe<Programmes_Aggregate_Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+  vocabulary_uid?: InputMaybe<Order_By>;
+  word?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: cat_vocabulary */
+export type Cat_Vocabulary_Pk_Columns_Input = {
+  _state: Scalars['String']['input'];
+  vocabulary_id: Scalars['Int']['input'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Cat_Vocabulary_Prepend_Input = {
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** select columns of table "cat_vocabulary" */
+export enum Cat_Vocabulary_Select_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EnglishTranslation = 'english_translation',
+  /** column name */
+  Frequency = 'frequency',
+  /** column name */
+  Headword = 'headword',
+  /** column name */
+  PartOfSpeech = 'part_of_speech',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  UpdatedAt = 'updated_at',
+  /** column name */
+  VocabularyId = 'vocabulary_id',
+  /** column name */
+  VocabularyUid = 'vocabulary_uid',
+  /** column name */
+  Word = 'word'
+}
+
+/** input type for updating data in table "cat_vocabulary" */
+export type Cat_Vocabulary_Set_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  english_translation?: InputMaybe<Scalars['String']['input']>;
+  frequency?: InputMaybe<Scalars['String']['input']>;
+  headword?: InputMaybe<Scalars['String']['input']>;
+  part_of_speech?: InputMaybe<Scalars['String']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  vocabulary_id?: InputMaybe<Scalars['Int']['input']>;
+  vocabulary_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  word?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Cat_Vocabulary_Stddev_Fields = {
+  __typename?: 'cat_vocabulary_stddev_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Stddev_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Cat_Vocabulary_Stddev_Pop_Fields = {
+  __typename?: 'cat_vocabulary_stddev_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_pop() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Stddev_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Cat_Vocabulary_Stddev_Samp_Fields = {
+  __typename?: 'cat_vocabulary_stddev_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_samp() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Stddev_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** Streaming cursor of the table "cat_vocabulary" */
+export type Cat_Vocabulary_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Cat_Vocabulary_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Cat_Vocabulary_Stream_Cursor_Value_Input = {
+  _cohort?: InputMaybe<Scalars['String']['input']>;
+  _deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  _release_id?: InputMaybe<Scalars['Int']['input']>;
+  _state?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  english_translation?: InputMaybe<Scalars['String']['input']>;
+  frequency?: InputMaybe<Scalars['String']['input']>;
+  headword?: InputMaybe<Scalars['String']['input']>;
+  part_of_speech?: InputMaybe<Scalars['String']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  vocabulary_id?: InputMaybe<Scalars['Int']['input']>;
+  vocabulary_uid?: InputMaybe<Scalars['bpchar']['input']>;
+  word?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Cat_Vocabulary_Sum_Fields = {
+  __typename?: 'cat_vocabulary_sum_fields';
+  _release_id?: Maybe<Scalars['Int']['output']>;
+  vocabulary_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** order by sum() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Sum_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "cat_vocabulary" */
+export enum Cat_Vocabulary_Update_Column {
+  /** column name */
+  Cohort = '_cohort',
+  /** column name */
+  Deleted = '_deleted',
+  /** column name */
+  ReleaseId = '_release_id',
+  /** column name */
+  State = '_state',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EnglishTranslation = 'english_translation',
+  /** column name */
+  Frequency = 'frequency',
+  /** column name */
+  Headword = 'headword',
+  /** column name */
+  PartOfSpeech = 'part_of_speech',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  UpdatedAt = 'updated_at',
+  /** column name */
+  VocabularyId = 'vocabulary_id',
+  /** column name */
+  VocabularyUid = 'vocabulary_uid',
+  /** column name */
+  Word = 'word'
+}
+
+export type Cat_Vocabulary_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Cat_Vocabulary_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Cat_Vocabulary_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Cat_Vocabulary_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Cat_Vocabulary_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Cat_Vocabulary_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Cat_Vocabulary_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Cat_Vocabulary_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Cat_Vocabulary_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Cat_Vocabulary_Var_Pop_Fields = {
+  __typename?: 'cat_vocabulary_var_pop_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_pop() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Var_Pop_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Cat_Vocabulary_Var_Samp_Fields = {
+  __typename?: 'cat_vocabulary_var_samp_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_samp() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Var_Samp_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Cat_Vocabulary_Variance_Fields = {
+  __typename?: 'cat_vocabulary_variance_fields';
+  _release_id?: Maybe<Scalars['Float']['output']>;
+  vocabulary_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by variance() on columns of table "cat_vocabulary" */
+export type Cat_Vocabulary_Variance_Order_By = {
+  _release_id?: InputMaybe<Order_By>;
+  vocabulary_id?: InputMaybe<Order_By>;
 };
 
 /** ordering argument of a cursor */
@@ -3875,7 +4386,7 @@ export type Internal_Releases_Bool_Exp = {
 
 /** unique or primary key constraints on table "internal.releases" */
 export enum Internal_Releases_Constraint {
-  /** unique or primary key constraint on columns "_state", "release_id" */
+  /** unique or primary key constraint on columns "release_id", "_state" */
   ReleasesPkey = 'releases_pkey'
 }
 
@@ -4355,7 +4866,7 @@ export type Internal_Review_Lessons_Bool_Exp = {
 
 /** unique or primary key constraints on table "internal.review_lessons" */
 export enum Internal_Review_Lessons_Constraint {
-  /** unique or primary key constraint on columns "lesson_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "lesson_id" */
   ReviewLessonsPkey = 'review_lessons_pkey'
 }
 
@@ -4887,6 +5398,7 @@ export type Internal_Tpc_Contracts = {
   _deleted: Scalars['Boolean']['output'];
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
+  attribution_template?: Maybe<Scalars['String']['output']>;
   contract_id: Scalars['Int']['output'];
   contract_name?: Maybe<Scalars['String']['output']>;
   contract_object: Scalars['jsonb']['output'];
@@ -4987,6 +5499,7 @@ export type Internal_Tpc_Contracts_Bool_Exp = {
   _or?: InputMaybe<Array<Internal_Tpc_Contracts_Bool_Exp>>;
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
+  attribution_template?: InputMaybe<String_Comparison_Exp>;
   contract_id?: InputMaybe<Int_Comparison_Exp>;
   contract_name?: InputMaybe<String_Comparison_Exp>;
   contract_object?: InputMaybe<Jsonb_Comparison_Exp>;
@@ -5004,7 +5517,7 @@ export type Internal_Tpc_Contracts_Bool_Exp = {
 
 /** unique or primary key constraints on table "internal.tpc_contracts" */
 export enum Internal_Tpc_Contracts_Constraint {
-  /** unique or primary key constraint on columns "_state", "external_id" */
+  /** unique or primary key constraint on columns "external_id", "_state" */
   TpcContractsExternalIdStateKey = 'tpc_contracts_external_id__state_key',
   /** unique or primary key constraint on columns "external_url", "_state" */
   TpcContractsExternalUrlStateKey = 'tpc_contracts_external_url__state_key',
@@ -5042,6 +5555,7 @@ export type Internal_Tpc_Contracts_Insert_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution_template?: InputMaybe<Scalars['String']['input']>;
   contract_id?: InputMaybe<Scalars['Int']['input']>;
   contract_name?: InputMaybe<Scalars['String']['input']>;
   contract_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -5063,6 +5577,7 @@ export type Internal_Tpc_Contracts_Max_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution_template?: Maybe<Scalars['String']['output']>;
   contract_id?: Maybe<Scalars['Int']['output']>;
   contract_name?: Maybe<Scalars['String']['output']>;
   contract_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -5081,6 +5596,7 @@ export type Internal_Tpc_Contracts_Max_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution_template?: InputMaybe<Order_By>;
   contract_id?: InputMaybe<Order_By>;
   contract_name?: InputMaybe<Order_By>;
   contract_uid?: InputMaybe<Order_By>;
@@ -5100,6 +5616,7 @@ export type Internal_Tpc_Contracts_Min_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution_template?: Maybe<Scalars['String']['output']>;
   contract_id?: Maybe<Scalars['Int']['output']>;
   contract_name?: Maybe<Scalars['String']['output']>;
   contract_uid?: Maybe<Scalars['bpchar']['output']>;
@@ -5118,6 +5635,7 @@ export type Internal_Tpc_Contracts_Min_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution_template?: InputMaybe<Order_By>;
   contract_id?: InputMaybe<Order_By>;
   contract_name?: InputMaybe<Order_By>;
   contract_uid?: InputMaybe<Order_By>;
@@ -5153,6 +5671,7 @@ export type Internal_Tpc_Contracts_Order_By = {
   _deleted?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution_template?: InputMaybe<Order_By>;
   contract_id?: InputMaybe<Order_By>;
   contract_name?: InputMaybe<Order_By>;
   contract_object?: InputMaybe<Order_By>;
@@ -5191,6 +5710,8 @@ export enum Internal_Tpc_Contracts_Select_Column {
   /** column name */
   State = '_state',
   /** column name */
+  AttributionTemplate = 'attribution_template',
+  /** column name */
   ContractId = 'contract_id',
   /** column name */
   ContractName = 'contract_name',
@@ -5224,6 +5745,7 @@ export type Internal_Tpc_Contracts_Set_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution_template?: InputMaybe<Scalars['String']['input']>;
   contract_id?: InputMaybe<Scalars['Int']['input']>;
   contract_name?: InputMaybe<Scalars['String']['input']>;
   contract_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -5292,6 +5814,7 @@ export type Internal_Tpc_Contracts_Stream_Cursor_Value_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution_template?: InputMaybe<Scalars['String']['input']>;
   contract_id?: InputMaybe<Scalars['Int']['input']>;
   contract_name?: InputMaybe<Scalars['String']['input']>;
   contract_object?: InputMaybe<Scalars['jsonb']['input']>;
@@ -5330,6 +5853,8 @@ export enum Internal_Tpc_Contracts_Update_Column {
   ReleaseId = '_release_id',
   /** column name */
   State = '_state',
+  /** column name */
+  AttributionTemplate = 'attribution_template',
   /** column name */
   ContractId = 'contract_id',
   /** column name */
@@ -5523,6 +6048,9 @@ export type Lessons = {
   /** A computed field, executes function "function__lessons__media_clip_groups" */
   media_clips_groups?: Maybe<Array<Templates_Media_Clip_Groups>>;
   misconceptions_and_common_mistakes?: Maybe<Scalars['json']['output']>;
+  /** A computed field, executes function "function__lessons__new_vocabulary" */
+  new_vocabulary?: Maybe<Array<Cat_Vocabulary>>;
+  new_vocabulary_list?: Maybe<Scalars['jsonb']['output']>;
   phonics_outcome?: Maybe<Scalars['String']['output']>;
   pupil_lesson_outcome?: Maybe<Scalars['String']['output']>;
   /** An object relationship */
@@ -5545,6 +6073,9 @@ export type Lessons = {
   review_lesson_all_states: Array<Internal_Review_Lessons>;
   /** An aggregate relationship */
   review_lesson_all_states_aggregate: Internal_Review_Lessons_Aggregate;
+  /** A computed field, executes function "function__lessons__revisited_vocabulary" */
+  revisited_vocabulary?: Maybe<Array<Cat_Vocabulary>>;
+  revisited_vocabulary_list?: Maybe<Scalars['jsonb']['output']>;
   sign_language_video_id?: Maybe<Scalars['Int']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   supervision_level?: Maybe<Scalars['String']['output']>;
@@ -5775,6 +6306,22 @@ export type LessonsMisconceptions_And_Common_MistakesArgs = {
 
 
 /** columns and relationships of "lessons" */
+export type LessonsNew_VocabularyArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+/** columns and relationships of "lessons" */
+export type LessonsNew_Vocabulary_ListArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "lessons" */
 export type LessonsQuiz_Exit_All_StatesArgs = {
   distinct_on?: InputMaybe<Array<Quizzes_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -5831,6 +6378,22 @@ export type LessonsReview_Lesson_All_States_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Internal_Review_Lessons_Order_By>>;
   where?: InputMaybe<Internal_Review_Lessons_Bool_Exp>;
+};
+
+
+/** columns and relationships of "lessons" */
+export type LessonsRevisited_VocabularyArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+/** columns and relationships of "lessons" */
+export type LessonsRevisited_Vocabulary_ListArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -6057,6 +6620,8 @@ export type Lessons_Append_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   features?: InputMaybe<Scalars['jsonb']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_media_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_works_list?: InputMaybe<Scalars['jsonb']['input']>;
@@ -6150,6 +6715,8 @@ export type Lessons_Bool_Exp = {
   media_clips?: InputMaybe<Jsonb_Comparison_Exp>;
   media_clips_groups?: InputMaybe<Templates_Media_Clip_Groups_Bool_Exp>;
   misconceptions_and_common_mistakes?: InputMaybe<Json_Comparison_Exp>;
+  new_vocabulary?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+  new_vocabulary_list?: InputMaybe<Jsonb_Comparison_Exp>;
   phonics_outcome?: InputMaybe<String_Comparison_Exp>;
   pupil_lesson_outcome?: InputMaybe<String_Comparison_Exp>;
   quiz_exit?: InputMaybe<Quizzes_Bool_Exp>;
@@ -6163,6 +6730,8 @@ export type Lessons_Bool_Exp = {
   review_lesson?: InputMaybe<Internal_Review_Lessons_Bool_Exp>;
   review_lesson_all_states?: InputMaybe<Internal_Review_Lessons_Bool_Exp>;
   review_lesson_all_states_aggregate?: InputMaybe<Internal_Review_Lessons_Aggregate_Bool_Exp>;
+  revisited_vocabulary?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+  revisited_vocabulary_list?: InputMaybe<Jsonb_Comparison_Exp>;
   sign_language_video_id?: InputMaybe<Int_Comparison_Exp>;
   slug?: InputMaybe<String_Comparison_Exp>;
   supervision_level?: InputMaybe<String_Comparison_Exp>;
@@ -6192,7 +6761,7 @@ export type Lessons_Bool_Exp = {
 
 /** unique or primary key constraints on table "lessons" */
 export enum Lessons_Constraint {
-  /** unique or primary key constraint on columns "lesson_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "lesson_id" */
   LessonsPkey = 'lessons_pkey'
 }
 
@@ -6202,6 +6771,8 @@ export type Lessons_Delete_At_Path_Input = {
   deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
   features?: InputMaybe<Array<Scalars['String']['input']>>;
   media_clips?: InputMaybe<Array<Scalars['String']['input']>>;
+  new_vocabulary_list?: InputMaybe<Array<Scalars['String']['input']>>;
+  revisited_vocabulary_list?: InputMaybe<Array<Scalars['String']['input']>>;
   thirdpartycontent_list?: InputMaybe<Array<Scalars['String']['input']>>;
   tpc_media_list?: InputMaybe<Array<Scalars['String']['input']>>;
   tpc_works_list?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -6213,6 +6784,8 @@ export type Lessons_Delete_Elem_Input = {
   deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
   features?: InputMaybe<Scalars['Int']['input']>;
   media_clips?: InputMaybe<Scalars['Int']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['Int']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['Int']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['Int']['input']>;
   tpc_media_list?: InputMaybe<Scalars['Int']['input']>;
   tpc_works_list?: InputMaybe<Scalars['Int']['input']>;
@@ -6224,6 +6797,8 @@ export type Lessons_Delete_Key_Input = {
   deprecated_fields?: InputMaybe<Scalars['String']['input']>;
   features?: InputMaybe<Scalars['String']['input']>;
   media_clips?: InputMaybe<Scalars['String']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['String']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['String']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['String']['input']>;
   tpc_media_list?: InputMaybe<Scalars['String']['input']>;
   tpc_works_list?: InputMaybe<Scalars['String']['input']>;
@@ -6283,6 +6858,7 @@ export type Lessons_Insert_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_exit?: InputMaybe<Quizzes_Obj_Rel_Insert_Input>;
@@ -6293,6 +6869,7 @@ export type Lessons_Insert_Input = {
   quiz_starter_all_states?: InputMaybe<Quizzes_Arr_Rel_Insert_Input>;
   review_lesson?: InputMaybe<Internal_Review_Lessons_Obj_Rel_Insert_Input>;
   review_lesson_all_states?: InputMaybe<Internal_Review_Lessons_Arr_Rel_Insert_Input>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   sign_language_video_id?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   supervision_level?: InputMaybe<Scalars['String']['input']>;
@@ -6488,6 +7065,8 @@ export type Lessons_Order_By = {
   media_clips?: InputMaybe<Order_By>;
   media_clips_groups_aggregate?: InputMaybe<Templates_Media_Clip_Groups_Aggregate_Order_By>;
   misconceptions_and_common_mistakes?: InputMaybe<Order_By>;
+  new_vocabulary_aggregate?: InputMaybe<Cat_Vocabulary_Aggregate_Order_By>;
+  new_vocabulary_list?: InputMaybe<Order_By>;
   phonics_outcome?: InputMaybe<Order_By>;
   pupil_lesson_outcome?: InputMaybe<Order_By>;
   quiz_exit?: InputMaybe<Quizzes_Order_By>;
@@ -6498,6 +7077,8 @@ export type Lessons_Order_By = {
   quiz_starter_all_states_aggregate?: InputMaybe<Quizzes_Aggregate_Order_By>;
   review_lesson?: InputMaybe<Internal_Review_Lessons_Order_By>;
   review_lesson_all_states_aggregate?: InputMaybe<Internal_Review_Lessons_Aggregate_Order_By>;
+  revisited_vocabulary_aggregate?: InputMaybe<Cat_Vocabulary_Aggregate_Order_By>;
+  revisited_vocabulary_list?: InputMaybe<Order_By>;
   sign_language_video_id?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   supervision_level?: InputMaybe<Order_By>;
@@ -6533,6 +7114,8 @@ export type Lessons_Prepend_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   features?: InputMaybe<Scalars['jsonb']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   thirdpartycontent_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_media_list?: InputMaybe<Scalars['jsonb']['input']>;
   tpc_works_list?: InputMaybe<Scalars['jsonb']['input']>;
@@ -6595,6 +7178,8 @@ export enum Lessons_Select_Column {
   /** column name */
   MisconceptionsAndCommonMistakes = 'misconceptions_and_common_mistakes',
   /** column name */
+  NewVocabularyList = 'new_vocabulary_list',
+  /** column name */
   PhonicsOutcome = 'phonics_outcome',
   /** column name */
   PupilLessonOutcome = 'pupil_lesson_outcome',
@@ -6602,6 +7187,8 @@ export enum Lessons_Select_Column {
   QuizIdExit = 'quiz_id_exit',
   /** column name */
   QuizIdStarter = 'quiz_id_starter',
+  /** column name */
+  RevisitedVocabularyList = 'revisited_vocabulary_list',
   /** column name */
   SignLanguageVideoId = 'sign_language_video_id',
   /** column name */
@@ -6669,10 +7256,12 @@ export type Lessons_Set_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_id_exit?: InputMaybe<Scalars['Int']['input']>;
   quiz_id_starter?: InputMaybe<Scalars['Int']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   sign_language_video_id?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   supervision_level?: InputMaybe<Scalars['String']['input']>;
@@ -6817,10 +7406,12 @@ export type Lessons_Stream_Cursor_Value_Input = {
   lesson_uid?: InputMaybe<Scalars['bpchar']['input']>;
   media_clips?: InputMaybe<Scalars['jsonb']['input']>;
   misconceptions_and_common_mistakes?: InputMaybe<Scalars['json']['input']>;
+  new_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   phonics_outcome?: InputMaybe<Scalars['String']['input']>;
   pupil_lesson_outcome?: InputMaybe<Scalars['String']['input']>;
   quiz_id_exit?: InputMaybe<Scalars['Int']['input']>;
   quiz_id_starter?: InputMaybe<Scalars['Int']['input']>;
+  revisited_vocabulary_list?: InputMaybe<Scalars['jsonb']['input']>;
   sign_language_video_id?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   supervision_level?: InputMaybe<Scalars['String']['input']>;
@@ -6923,6 +7514,8 @@ export enum Lessons_Update_Column {
   /** column name */
   MisconceptionsAndCommonMistakes = 'misconceptions_and_common_mistakes',
   /** column name */
+  NewVocabularyList = 'new_vocabulary_list',
+  /** column name */
   PhonicsOutcome = 'phonics_outcome',
   /** column name */
   PupilLessonOutcome = 'pupil_lesson_outcome',
@@ -6930,6 +7523,8 @@ export enum Lessons_Update_Column {
   QuizIdExit = 'quiz_id_exit',
   /** column name */
   QuizIdStarter = 'quiz_id_starter',
+  /** column name */
+  RevisitedVocabularyList = 'revisited_vocabulary_list',
   /** column name */
   SignLanguageVideoId = 'sign_language_video_id',
   /** column name */
@@ -7099,6 +7694,10 @@ export type Mutation_Root = {
   delete_cat_tags?: Maybe<Cat_Tags_Mutation_Response>;
   /** delete single row from the table: "cat_tags" */
   delete_cat_tags_by_pk?: Maybe<Cat_Tags>;
+  /** delete data from the table: "cat_vocabulary" */
+  delete_cat_vocabulary?: Maybe<Cat_Vocabulary_Mutation_Response>;
+  /** delete single row from the table: "cat_vocabulary" */
+  delete_cat_vocabulary_by_pk?: Maybe<Cat_Vocabulary>;
   /** delete data from the table: "internal.archives" */
   delete_internal_archives?: Maybe<Internal_Archives_Mutation_Response>;
   /** delete single row from the table: "internal.archives" */
@@ -7261,6 +7860,10 @@ export type Mutation_Root = {
   insert_cat_tags?: Maybe<Cat_Tags_Mutation_Response>;
   /** insert a single row into the table: "cat_tags" */
   insert_cat_tags_one?: Maybe<Cat_Tags>;
+  /** insert data into the table: "cat_vocabulary" */
+  insert_cat_vocabulary?: Maybe<Cat_Vocabulary_Mutation_Response>;
+  /** insert a single row into the table: "cat_vocabulary" */
+  insert_cat_vocabulary_one?: Maybe<Cat_Vocabulary>;
   /** insert data into the table: "internal.archives" */
   insert_internal_archives?: Maybe<Internal_Archives_Mutation_Response>;
   /** insert a single row into the table: "internal.archives" */
@@ -7443,6 +8046,12 @@ export type Mutation_Root = {
   update_cat_tags_by_pk?: Maybe<Cat_Tags>;
   /** update multiples rows of table: "cat_tags" */
   update_cat_tags_many?: Maybe<Array<Maybe<Cat_Tags_Mutation_Response>>>;
+  /** update data of the table: "cat_vocabulary" */
+  update_cat_vocabulary?: Maybe<Cat_Vocabulary_Mutation_Response>;
+  /** update single row of the table: "cat_vocabulary" */
+  update_cat_vocabulary_by_pk?: Maybe<Cat_Vocabulary>;
+  /** update multiples rows of table: "cat_vocabulary" */
+  update_cat_vocabulary_many?: Maybe<Array<Maybe<Cat_Vocabulary_Mutation_Response>>>;
   /** update data of the table: "internal.archives" */
   update_internal_archives?: Maybe<Internal_Archives_Mutation_Response>;
   /** update single row of the table: "internal.archives" */
@@ -7738,6 +8347,19 @@ export type Mutation_RootDelete_Cat_TagsArgs = {
 export type Mutation_RootDelete_Cat_Tags_By_PkArgs = {
   _state: Scalars['String']['input'];
   tag_id: Scalars['Int']['input'];
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Cat_VocabularyArgs = {
+  where: Cat_Vocabulary_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Cat_Vocabulary_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  vocabulary_id: Scalars['Int']['input'];
 };
 
 
@@ -8273,6 +8895,20 @@ export type Mutation_RootInsert_Cat_TagsArgs = {
 export type Mutation_RootInsert_Cat_Tags_OneArgs = {
   object: Cat_Tags_Insert_Input;
   on_conflict?: InputMaybe<Cat_Tags_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Cat_VocabularyArgs = {
+  objects: Array<Cat_Vocabulary_Insert_Input>;
+  on_conflict?: InputMaybe<Cat_Vocabulary_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Cat_Vocabulary_OneArgs = {
+  object: Cat_Vocabulary_Insert_Input;
+  on_conflict?: InputMaybe<Cat_Vocabulary_On_Conflict>;
 };
 
 
@@ -8981,6 +9617,38 @@ export type Mutation_RootUpdate_Cat_Tags_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_Cat_Tags_ManyArgs = {
   updates: Array<Cat_Tags_Updates>;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Cat_VocabularyArgs = {
+  _append?: InputMaybe<Cat_Vocabulary_Append_Input>;
+  _delete_at_path?: InputMaybe<Cat_Vocabulary_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Cat_Vocabulary_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Cat_Vocabulary_Delete_Key_Input>;
+  _inc?: InputMaybe<Cat_Vocabulary_Inc_Input>;
+  _prepend?: InputMaybe<Cat_Vocabulary_Prepend_Input>;
+  _set?: InputMaybe<Cat_Vocabulary_Set_Input>;
+  where: Cat_Vocabulary_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Cat_Vocabulary_By_PkArgs = {
+  _append?: InputMaybe<Cat_Vocabulary_Append_Input>;
+  _delete_at_path?: InputMaybe<Cat_Vocabulary_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Cat_Vocabulary_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Cat_Vocabulary_Delete_Key_Input>;
+  _inc?: InputMaybe<Cat_Vocabulary_Inc_Input>;
+  _prepend?: InputMaybe<Cat_Vocabulary_Prepend_Input>;
+  _set?: InputMaybe<Cat_Vocabulary_Set_Input>;
+  pk_columns: Cat_Vocabulary_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Cat_Vocabulary_ManyArgs = {
+  updates: Array<Cat_Vocabulary_Updates>;
 };
 
 
@@ -10133,7 +10801,7 @@ export type Pf_Developmentstages_Bool_Exp = {
 export enum Pf_Developmentstages_Constraint {
   /** unique or primary key constraint on columns "_state", "developmentstage_id" */
   PfDevelopmentstagesPkey = 'pf_developmentstages_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfDevelopmentstagesSlugStateCohortKey = 'pf_developmentstages_slug__state__cohort_key'
 }
 
@@ -10513,9 +11181,9 @@ export type Pf_Examboards_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_examboards" */
 export enum Pf_Examboards_Constraint {
-  /** unique or primary key constraint on columns "examboard_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "examboard_id" */
   PfExamboardsPkey = 'pf_examboards_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfExamboardsSlugStateCohortKey = 'pf_examboards_slug__state__cohort_key'
 }
 
@@ -10895,9 +11563,9 @@ export type Pf_Keystages_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_keystages" */
 export enum Pf_Keystages_Constraint {
-  /** unique or primary key constraint on columns "_state", "keystage_id" */
+  /** unique or primary key constraint on columns "keystage_id", "_state" */
   PfKeystagesPkey = 'pf_keystages_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfKeystagesSlugStateCohortKey = 'pf_keystages_slug__state__cohort_key'
 }
 
@@ -11277,9 +11945,9 @@ export type Pf_Pathways_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_pathways" */
 export enum Pf_Pathways_Constraint {
-  /** unique or primary key constraint on columns "_state", "pathway_id" */
+  /** unique or primary key constraint on columns "pathway_id", "_state" */
   PfPathwaysPkey = 'pf_pathways_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfPathwaysSlugStateCohortKey = 'pf_pathways_slug__state__cohort_key'
 }
 
@@ -11661,7 +12329,7 @@ export type Pf_Phases_Bool_Exp = {
 export enum Pf_Phases_Constraint {
   /** unique or primary key constraint on columns "_state", "phase_id" */
   PfPhasesPkey = 'pf_phases_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfPhasesSlugStateCohortKey = 'pf_phases_slug__state__cohort_key'
 }
 
@@ -12064,7 +12732,7 @@ export type Pf_Subjects_Bool_Exp = {
 export enum Pf_Subjects_Constraint {
   /** unique or primary key constraint on columns "subject_id", "_state" */
   PfSubjectsPkey = 'pf_subjects_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfSubjectsSlugStateCohortKey = 'pf_subjects_slug__state__cohort_key'
 }
 
@@ -12482,9 +13150,9 @@ export type Pf_Tiers_Bool_Exp = {
 
 /** unique or primary key constraints on table "pf_tiers" */
 export enum Pf_Tiers_Constraint {
-  /** unique or primary key constraint on columns "_state", "tier_id" */
+  /** unique or primary key constraint on columns "tier_id", "_state" */
   PfTiersPkey = 'pf_tiers_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfTiersSlugStateCohortKey = 'pf_tiers_slug__state__cohort_key'
 }
 
@@ -12866,7 +13534,7 @@ export type Pf_Years_Bool_Exp = {
 export enum Pf_Years_Constraint {
   /** unique or primary key constraint on columns "_state", "year_id" */
   PfYearsPkey = 'pf_years_pkey',
-  /** unique or primary key constraint on columns "slug", "_cohort", "_state" */
+  /** unique or primary key constraint on columns "_cohort", "_state", "slug" */
   PfYearsSlugStateCohortKey = 'pf_years_slug__state__cohort_key'
 }
 
@@ -13367,7 +14035,7 @@ export type Programme_Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "programme_threads" */
 export enum Programme_Threads_Constraint {
-  /** unique or primary key constraint on columns "thread_id", "_state", "programme_id" */
+  /** unique or primary key constraint on columns "programme_id", "_state", "thread_id" */
   ProgrammeThreadsPkey = 'programme_threads_pkey'
 }
 
@@ -13962,7 +14630,7 @@ export type Programme_Units_Bool_Exp = {
 
 /** unique or primary key constraints on table "programme_units" */
 export enum Programme_Units_Constraint {
-  /** unique or primary key constraint on columns "unit_id", "_state", "programme_id" */
+  /** unique or primary key constraint on columns "unit_id", "programme_id", "_state" */
   ProgrammeUnitsPkey = 'programme_units_pkey'
 }
 
@@ -14479,7 +15147,7 @@ export type Programmefeatures_Bool_Exp = {
 
 /** unique or primary key constraints on table "programmefeatures" */
 export enum Programmefeatures_Constraint {
-  /** unique or primary key constraint on columns "_state", "feature_id" */
+  /** unique or primary key constraint on columns "feature_id", "_state" */
   ProgrammefeaturesPkey = 'programmefeatures_pkey'
 }
 
@@ -14813,6 +15481,8 @@ export type Programmes = {
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
   adapt_video_id?: Maybe<Scalars['Int']['output']>;
+  /** A computed field, executes function "function__programmes__cat_vocabulary" */
+  cat_vocabulary?: Maybe<Array<Cat_Vocabulary>>;
   /** A computed field, executes function "function__programmes__computed_features" */
   computed_features?: Maybe<Scalars['jsonb']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -14850,6 +15520,16 @@ export type Programmes = {
 /** columns and relationships of "programmes" */
 export type Programmes_MetadataArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "programmes" */
+export type ProgrammesCat_VocabularyArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
 };
 
 
@@ -15090,6 +15770,7 @@ export type Programmes_Bool_Exp = {
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
   adapt_video_id?: InputMaybe<Int_Comparison_Exp>;
+  cat_vocabulary?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
   computed_features?: InputMaybe<Jsonb_Comparison_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   curriculum_intent?: InputMaybe<String_Comparison_Exp>;
@@ -15114,7 +15795,7 @@ export type Programmes_Bool_Exp = {
 
 /** unique or primary key constraints on table "programmes" */
 export enum Programmes_Constraint {
-  /** unique or primary key constraint on columns "_state", "programme_id" */
+  /** unique or primary key constraint on columns "programme_id", "_state" */
   ProgrammesPkey = 'programmes_pkey',
   /** unique or primary key constraint on columns "programme_fields", "_state" */
   ProgrammesProgrammeFieldsStateKey = 'programmes_programme_fields__state_key'
@@ -15261,6 +15942,7 @@ export type Programmes_Order_By = {
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
   adapt_video_id?: InputMaybe<Order_By>;
+  cat_vocabulary_aggregate?: InputMaybe<Cat_Vocabulary_Aggregate_Order_By>;
   computed_features?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   curriculum_intent?: InputMaybe<Order_By>;
@@ -26926,6 +27608,546 @@ export type Published_Mv_Subject_Phase_Options_0_3_Variance_Fields = {
   display_order?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4 = {
+  __typename?: 'published_mv_subject_phase_options_0_4';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  examboards?: Maybe<Scalars['jsonb']['output']>;
+  phases?: Maybe<Scalars['jsonb']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4ExamboardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4PhasesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4_Aggregate = {
+  __typename?: 'published_mv_subject_phase_options_0_4_aggregate';
+  aggregate?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Subject_Phase_Options_0_4>;
+};
+
+/** aggregate fields of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4_Aggregate_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_aggregate_fields';
+  avg?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Max_Fields>;
+  min?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Subject_Phase_Options_0_4_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Avg_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_avg_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_subject_phase_options_0_4". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Subject_Phase_Options_0_4_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>>;
+  display_order?: InputMaybe<Int_Comparison_Exp>;
+  examboards?: InputMaybe<Jsonb_Comparison_Exp>;
+  phases?: InputMaybe<Jsonb_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Max_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_max_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Min_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_min_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_subject_phase_options_0_4". */
+export type Published_Mv_Subject_Phase_Options_0_4_Order_By = {
+  display_order?: InputMaybe<Order_By>;
+  examboards?: InputMaybe<Order_By>;
+  phases?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_subject_phase_options_0_4" */
+export enum Published_Mv_Subject_Phase_Options_0_4_Select_Column {
+  /** column name */
+  DisplayOrder = 'display_order',
+  /** column name */
+  Examboards = 'examboards',
+  /** column name */
+  Phases = 'phases',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Title = 'title'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Stddev_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_stddev_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_stddev_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_stddev_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_subject_phase_options_0_4" */
+export type Published_Mv_Subject_Phase_Options_0_4_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Subject_Phase_Options_0_4_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Subject_Phase_Options_0_4_Stream_Cursor_Value_Input = {
+  display_order?: InputMaybe<Scalars['Int']['input']>;
+  examboards?: InputMaybe<Scalars['jsonb']['input']>;
+  phases?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Sum_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_sum_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Var_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_var_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Var_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_var_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Subject_Phase_Options_0_4_Variance_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_4_variance_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5 = {
+  __typename?: 'published_mv_subject_phase_options_0_5';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  examboards?: Maybe<Scalars['jsonb']['output']>;
+  phases?: Maybe<Scalars['jsonb']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5ExamboardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5PhasesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5_Aggregate = {
+  __typename?: 'published_mv_subject_phase_options_0_5_aggregate';
+  aggregate?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Subject_Phase_Options_0_5>;
+};
+
+/** aggregate fields of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5_Aggregate_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_aggregate_fields';
+  avg?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Max_Fields>;
+  min?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Subject_Phase_Options_0_5_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Avg_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_avg_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_subject_phase_options_0_5". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Subject_Phase_Options_0_5_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>>;
+  display_order?: InputMaybe<Int_Comparison_Exp>;
+  examboards?: InputMaybe<Jsonb_Comparison_Exp>;
+  phases?: InputMaybe<Jsonb_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Max_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_max_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Min_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_min_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_subject_phase_options_0_5". */
+export type Published_Mv_Subject_Phase_Options_0_5_Order_By = {
+  display_order?: InputMaybe<Order_By>;
+  examboards?: InputMaybe<Order_By>;
+  phases?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_subject_phase_options_0_5" */
+export enum Published_Mv_Subject_Phase_Options_0_5_Select_Column {
+  /** column name */
+  DisplayOrder = 'display_order',
+  /** column name */
+  Examboards = 'examboards',
+  /** column name */
+  Phases = 'phases',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Title = 'title'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Stddev_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_stddev_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_stddev_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_stddev_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_subject_phase_options_0_5" */
+export type Published_Mv_Subject_Phase_Options_0_5_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Subject_Phase_Options_0_5_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Subject_Phase_Options_0_5_Stream_Cursor_Value_Input = {
+  display_order?: InputMaybe<Scalars['Int']['input']>;
+  examboards?: InputMaybe<Scalars['jsonb']['input']>;
+  phases?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Sum_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_sum_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Var_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_var_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Var_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_var_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Subject_Phase_Options_0_5_Variance_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_5_variance_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6 = {
+  __typename?: 'published_mv_subject_phase_options_0_6';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  examboards?: Maybe<Scalars['jsonb']['output']>;
+  keystages?: Maybe<Scalars['jsonb']['output']>;
+  phases?: Maybe<Scalars['jsonb']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6ExamboardsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6KeystagesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6PhasesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6_Aggregate = {
+  __typename?: 'published_mv_subject_phase_options_0_6_aggregate';
+  aggregate?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Subject_Phase_Options_0_6>;
+};
+
+/** aggregate fields of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6_Aggregate_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_aggregate_fields';
+  avg?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Max_Fields>;
+  min?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Subject_Phase_Options_0_6_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Avg_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_avg_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_subject_phase_options_0_6". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Subject_Phase_Options_0_6_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>>;
+  display_order?: InputMaybe<Int_Comparison_Exp>;
+  examboards?: InputMaybe<Jsonb_Comparison_Exp>;
+  keystages?: InputMaybe<Jsonb_Comparison_Exp>;
+  phases?: InputMaybe<Jsonb_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Max_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_max_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Min_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_min_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_subject_phase_options_0_6". */
+export type Published_Mv_Subject_Phase_Options_0_6_Order_By = {
+  display_order?: InputMaybe<Order_By>;
+  examboards?: InputMaybe<Order_By>;
+  keystages?: InputMaybe<Order_By>;
+  phases?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_subject_phase_options_0_6" */
+export enum Published_Mv_Subject_Phase_Options_0_6_Select_Column {
+  /** column name */
+  DisplayOrder = 'display_order',
+  /** column name */
+  Examboards = 'examboards',
+  /** column name */
+  Keystages = 'keystages',
+  /** column name */
+  Phases = 'phases',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Title = 'title'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Stddev_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_stddev_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_stddev_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_stddev_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_subject_phase_options_0_6" */
+export type Published_Mv_Subject_Phase_Options_0_6_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Subject_Phase_Options_0_6_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Subject_Phase_Options_0_6_Stream_Cursor_Value_Input = {
+  display_order?: InputMaybe<Scalars['Int']['input']>;
+  examboards?: InputMaybe<Scalars['jsonb']['input']>;
+  keystages?: InputMaybe<Scalars['jsonb']['input']>;
+  phases?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Sum_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_sum_fields';
+  display_order?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Var_Pop_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_var_pop_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Var_Samp_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_var_samp_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Subject_Phase_Options_0_6_Variance_Fields = {
+  __typename?: 'published_mv_subject_phase_options_0_6_variance_fields';
+  display_order?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_subject_phase_options_1" */
 export type Published_Mv_Subject_Phase_Options_1 = {
   __typename?: 'published_mv_subject_phase_options_1';
@@ -28193,6 +29415,224 @@ export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Var_Sa
 /** aggregate variance on columns */
 export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Variance_Fields = {
   __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_0_0_variance_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0 = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0';
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  lesson_data?: Maybe<Scalars['jsonb']['output']>;
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  null_unitvariant?: Maybe<Scalars['jsonb']['output']>;
+  programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  supplementary_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_data?: Maybe<Scalars['jsonb']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Lesson_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Null_UnitvariantArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Supplementary_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Unit_DataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0>;
+};
+
+/** aggregate fields of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_aggregate_fields';
+  avg?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Avg_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_avg_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  lesson_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  lesson_slug?: InputMaybe<String_Comparison_Exp>;
+  null_unitvariant?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  supplementary_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_data?: InputMaybe<Jsonb_Comparison_Exp>;
+  unit_slug?: InputMaybe<String_Comparison_Exp>;
+  unitvariant_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Max_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_max_fields';
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Min_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_min_fields';
+  lesson_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  unit_slug?: Maybe<Scalars['String']['output']>;
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0". */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Order_By = {
+  is_legacy?: InputMaybe<Order_By>;
+  lesson_data?: InputMaybe<Order_By>;
+  lesson_slug?: InputMaybe<Order_By>;
+  null_unitvariant?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  supplementary_data?: InputMaybe<Order_By>;
+  unit_data?: InputMaybe<Order_By>;
+  unit_slug?: InputMaybe<Order_By>;
+  unitvariant_id?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export enum Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column {
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  LessonData = 'lesson_data',
+  /** column name */
+  LessonSlug = 'lesson_slug',
+  /** column name */
+  NullUnitvariant = 'null_unitvariant',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  SupplementaryData = 'supplementary_data',
+  /** column name */
+  UnitData = 'unit_data',
+  /** column name */
+  UnitSlug = 'unit_slug',
+  /** column name */
+  UnitvariantId = 'unitvariant_id'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_stddev_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_stddev_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_stddev_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stream_Cursor_Value_Input = {
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  lesson_data?: InputMaybe<Scalars['jsonb']['input']>;
+  lesson_slug?: InputMaybe<Scalars['String']['input']>;
+  null_unitvariant?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_slug?: InputMaybe<Scalars['String']['input']>;
+  supplementary_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_data?: InputMaybe<Scalars['jsonb']['input']>;
+  unit_slug?: InputMaybe<Scalars['String']['input']>;
+  unitvariant_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Sum_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_sum_fields';
+  unitvariant_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Var_Pop_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_var_pop_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Var_Samp_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_var_samp_fields';
+  unitvariant_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Variance_Fields = {
+  __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_variance_fields';
   unitvariant_id?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -32462,6 +33902,12 @@ export type Query_Root = {
   cat_tags_aggregate: Cat_Tags_Aggregate;
   /** fetch data from the table: "cat_tags" using primary key columns */
   cat_tags_by_pk?: Maybe<Cat_Tags>;
+  /** fetch data from the table: "cat_vocabulary" */
+  cat_vocabulary: Array<Cat_Vocabulary>;
+  /** fetch aggregated fields from the table: "cat_vocabulary" */
+  cat_vocabulary_aggregate: Cat_Vocabulary_Aggregate;
+  /** fetch data from the table: "cat_vocabulary" using primary key columns */
+  cat_vocabulary_by_pk?: Maybe<Cat_Vocabulary>;
   /** fetch data from the table: "internal.archives" */
   internal_archives: Array<Internal_Archives>;
   /** fetch aggregated fields from the table: "internal.archives" */
@@ -32716,6 +34162,18 @@ export type Query_Root = {
   published_mv_subject_phase_options_0_3: Array<Published_Mv_Subject_Phase_Options_0_3>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_3" */
   published_mv_subject_phase_options_0_3_aggregate: Published_Mv_Subject_Phase_Options_0_3_Aggregate;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_4" */
+  published_mv_subject_phase_options_0_4: Array<Published_Mv_Subject_Phase_Options_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_4" */
+  published_mv_subject_phase_options_0_4_aggregate: Published_Mv_Subject_Phase_Options_0_4_Aggregate;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_5" */
+  published_mv_subject_phase_options_0_5: Array<Published_Mv_Subject_Phase_Options_0_5>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_5" */
+  published_mv_subject_phase_options_0_5_aggregate: Published_Mv_Subject_Phase_Options_0_5_Aggregate;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_6" */
+  published_mv_subject_phase_options_0_6: Array<Published_Mv_Subject_Phase_Options_0_6>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_6" */
+  published_mv_subject_phase_options_0_6_aggregate: Published_Mv_Subject_Phase_Options_0_6_Aggregate;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -32748,6 +34206,10 @@ export type Query_Root = {
   published_mv_synthetic_unitvariant_lessons_by_keystage_10_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_keystage_10_0_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_year_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
@@ -33090,6 +34552,30 @@ export type Query_RootCat_Tags_AggregateArgs = {
 export type Query_RootCat_Tags_By_PkArgs = {
   _state: Scalars['String']['input'];
   tag_id: Scalars['Int']['input'];
+};
+
+
+export type Query_RootCat_VocabularyArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+export type Query_RootCat_Vocabulary_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+export type Query_RootCat_Vocabulary_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  vocabulary_id: Scalars['Int']['input'];
 };
 
 
@@ -34187,6 +35673,60 @@ export type Query_RootPublished_Mv_Subject_Phase_Options_0_3_AggregateArgs = {
 };
 
 
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_5Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_6Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Subject_Phase_Options_0_6_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Subject_Phase_Options_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -34328,6 +35868,24 @@ export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
 };
 
 
@@ -35907,7 +37465,7 @@ export type Quiz_Questions_Bool_Exp = {
 
 /** unique or primary key constraints on table "quiz_questions" */
 export enum Quiz_Questions_Constraint {
-  /** unique or primary key constraint on columns "quiz_id", "question_id", "_state" */
+  /** unique or primary key constraint on columns "question_id", "quiz_id", "_state" */
   QuizQuestionsPkey = 'quiz_questions_pkey'
 }
 
@@ -36937,6 +38495,14 @@ export type Subscription_Root = {
   cat_tags_by_pk?: Maybe<Cat_Tags>;
   /** fetch data from the table in a streaming manner: "cat_tags" */
   cat_tags_stream: Array<Cat_Tags>;
+  /** fetch data from the table: "cat_vocabulary" */
+  cat_vocabulary: Array<Cat_Vocabulary>;
+  /** fetch aggregated fields from the table: "cat_vocabulary" */
+  cat_vocabulary_aggregate: Cat_Vocabulary_Aggregate;
+  /** fetch data from the table: "cat_vocabulary" using primary key columns */
+  cat_vocabulary_by_pk?: Maybe<Cat_Vocabulary>;
+  /** fetch data from the table in a streaming manner: "cat_vocabulary" */
+  cat_vocabulary_stream: Array<Cat_Vocabulary>;
   /** fetch data from the table: "internal.archives" */
   internal_archives: Array<Internal_Archives>;
   /** fetch aggregated fields from the table: "internal.archives" */
@@ -37301,6 +38867,24 @@ export type Subscription_Root = {
   published_mv_subject_phase_options_0_3_aggregate: Published_Mv_Subject_Phase_Options_0_3_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_3" */
   published_mv_subject_phase_options_0_3_stream: Array<Published_Mv_Subject_Phase_Options_0_3>;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_4" */
+  published_mv_subject_phase_options_0_4: Array<Published_Mv_Subject_Phase_Options_0_4>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_4" */
+  published_mv_subject_phase_options_0_4_aggregate: Published_Mv_Subject_Phase_Options_0_4_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_4" */
+  published_mv_subject_phase_options_0_4_stream: Array<Published_Mv_Subject_Phase_Options_0_4>;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_5" */
+  published_mv_subject_phase_options_0_5: Array<Published_Mv_Subject_Phase_Options_0_5>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_5" */
+  published_mv_subject_phase_options_0_5_aggregate: Published_Mv_Subject_Phase_Options_0_5_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_5" */
+  published_mv_subject_phase_options_0_5_stream: Array<Published_Mv_Subject_Phase_Options_0_5>;
+  /** fetch data from the table: "published.mv_subject_phase_options_0_6" */
+  published_mv_subject_phase_options_0_6: Array<Published_Mv_Subject_Phase_Options_0_6>;
+  /** fetch aggregated fields from the table: "published.mv_subject_phase_options_0_6" */
+  published_mv_subject_phase_options_0_6_aggregate: Published_Mv_Subject_Phase_Options_0_6_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_subject_phase_options_0_6" */
+  published_mv_subject_phase_options_0_6_stream: Array<Published_Mv_Subject_Phase_Options_0_6>;
   /** fetch data from the table: "published.mv_subject_phase_options_1" */
   published_mv_subject_phase_options_1: Array<Published_Mv_Subject_Phase_Options_1>;
   /** fetch aggregated fields from the table: "published.mv_subject_phase_options_1" */
@@ -37349,6 +38933,12 @@ export type Subscription_Root = {
   published_mv_synthetic_unitvariant_lessons_by_keystage_10_0_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_keystage_10_0_0_stream: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0>;
+  /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_aggregate: Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_synthetic_unitvariant_lessons_by_keystage_10_1_0" */
+  published_mv_synthetic_unitvariant_lessons_by_keystage_10_1_0_stream: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0>;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
   published_mv_synthetic_unitvariant_lessons_by_year_6_0_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Year_6_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_year_6_0_0" */
@@ -37812,6 +39402,37 @@ export type Subscription_RootCat_Tags_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Cat_Tags_Stream_Cursor_Input>>;
   where?: InputMaybe<Cat_Tags_Bool_Exp>;
+};
+
+
+export type Subscription_RootCat_VocabularyArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+export type Subscription_RootCat_Vocabulary_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Cat_Vocabulary_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Cat_Vocabulary_Order_By>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
+};
+
+
+export type Subscription_RootCat_Vocabulary_By_PkArgs = {
+  _state: Scalars['String']['input'];
+  vocabulary_id: Scalars['Int']['input'];
+};
+
+
+export type Subscription_RootCat_Vocabulary_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Cat_Vocabulary_Stream_Cursor_Input>>;
+  where?: InputMaybe<Cat_Vocabulary_Bool_Exp>;
 };
 
 
@@ -39294,6 +40915,81 @@ export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_3_StreamArgs =
 };
 
 
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_4Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_4_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_4_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_4_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_4_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_5Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_5_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_5_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_5_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_5_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_6Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_6_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_0_6_Order_By>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Subject_Phase_Options_0_6_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Subject_Phase_Options_0_6_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Subject_Phase_Options_1Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Subject_Phase_Options_1_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -39491,6 +41187,31 @@ export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keyst
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_10_1_0_Bool_Exp>;
 };
 
 
@@ -42429,7 +44150,7 @@ export type Thread_Units_Bool_Exp = {
 
 /** unique or primary key constraints on table "thread_units" */
 export enum Thread_Units_Constraint {
-  /** unique or primary key constraint on columns "unit_id", "thread_id", "_state" */
+  /** unique or primary key constraint on columns "unit_id", "_state", "thread_id" */
   ThreadUnitsPkey = 'thread_units_pkey'
 }
 
@@ -43091,7 +44812,7 @@ export type Threads_Bool_Exp = {
 
 /** unique or primary key constraints on table "threads" */
 export enum Threads_Constraint {
-  /** unique or primary key constraint on columns "thread_id", "_state" */
+  /** unique or primary key constraint on columns "_state", "thread_id" */
   ThreadsPkey = 'threads_pkey'
 }
 
@@ -43542,6 +45263,7 @@ export type Tpc_Media = {
   _deleted: Scalars['Boolean']['output'];
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
+  attribution?: Maybe<Scalars['String']['output']>;
   content_name?: Maybe<Scalars['String']['output']>;
   content_type?: Maybe<Scalars['String']['output']>;
   /** A computed field, executes function "function__tpc_media__tpc_contracts" */
@@ -43680,6 +45402,7 @@ export type Tpc_Media_Bool_Exp = {
   _or?: InputMaybe<Array<Tpc_Media_Bool_Exp>>;
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
+  attribution?: InputMaybe<String_Comparison_Exp>;
   content_name?: InputMaybe<String_Comparison_Exp>;
   content_type?: InputMaybe<String_Comparison_Exp>;
   contracts?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
@@ -43699,13 +45422,13 @@ export type Tpc_Media_Bool_Exp = {
 
 /** unique or primary key constraints on table "tpc_media" */
 export enum Tpc_Media_Constraint {
-  /** unique or primary key constraint on columns "_state", "external_id" */
+  /** unique or primary key constraint on columns "external_id", "_state" */
   TpcMediaExternalIdStateKey = 'tpc_media_external_id__state_key',
   /** unique or primary key constraint on columns "external_url", "_state" */
   TpcMediaExternalUrlStateKey = 'tpc_media_external_url__state_key',
-  /** unique or primary key constraint on columns "_state", "media_id" */
+  /** unique or primary key constraint on columns "media_id", "_state" */
   TpcMediaPkey = 'tpc_media_pkey',
-  /** unique or primary key constraint on columns "_state", "thirdparty_id" */
+  /** unique or primary key constraint on columns "thirdparty_id", "_state" */
   TpcMediaThirdpartyIdStateKey = 'tpc_media_thirdparty_id__state_key'
 }
 
@@ -43745,6 +45468,7 @@ export type Tpc_Media_Insert_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   content_name?: InputMaybe<Scalars['String']['input']>;
   content_type?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -43766,6 +45490,7 @@ export type Tpc_Media_Max_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution?: Maybe<Scalars['String']['output']>;
   content_name?: Maybe<Scalars['String']['output']>;
   content_type?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -43782,6 +45507,7 @@ export type Tpc_Media_Max_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   content_name?: InputMaybe<Order_By>;
   content_type?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -43799,6 +45525,7 @@ export type Tpc_Media_Min_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution?: Maybe<Scalars['String']['output']>;
   content_name?: Maybe<Scalars['String']['output']>;
   content_type?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
@@ -43815,6 +45542,7 @@ export type Tpc_Media_Min_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   content_name?: InputMaybe<Order_By>;
   content_type?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -43855,6 +45583,7 @@ export type Tpc_Media_Order_By = {
   _deleted?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   content_name?: InputMaybe<Order_By>;
   content_type?: InputMaybe<Order_By>;
   contracts_aggregate?: InputMaybe<Internal_Tpc_Contracts_Aggregate_Order_By>;
@@ -43897,6 +45626,8 @@ export enum Tpc_Media_Select_Column {
   /** column name */
   State = '_state',
   /** column name */
+  Attribution = 'attribution',
+  /** column name */
   ContentName = 'content_name',
   /** column name */
   ContentType = 'content_type',
@@ -43930,6 +45661,7 @@ export type Tpc_Media_Set_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   content_name?: InputMaybe<Scalars['String']['input']>;
   content_type?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -43998,6 +45730,7 @@ export type Tpc_Media_Stream_Cursor_Value_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   content_name?: InputMaybe<Scalars['String']['input']>;
   content_type?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -44036,6 +45769,8 @@ export enum Tpc_Media_Update_Column {
   ReleaseId = '_release_id',
   /** column name */
   State = '_state',
+  /** column name */
+  Attribution = 'attribution',
   /** column name */
   ContentName = 'content_name',
   /** column name */
@@ -44129,6 +45864,7 @@ export type Tpc_Works = {
   _deleted: Scalars['Boolean']['output'];
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state: Scalars['String']['output'];
+  attribution?: Maybe<Scalars['String']['output']>;
   author?: Maybe<Scalars['String']['output']>;
   /** A computed field, executes function "function__tpc_works__tpc_contracts" */
   contracts?: Maybe<Array<Internal_Tpc_Contracts>>;
@@ -44248,6 +45984,7 @@ export type Tpc_Works_Bool_Exp = {
   _or?: InputMaybe<Array<Tpc_Works_Bool_Exp>>;
   _release_id?: InputMaybe<Int_Comparison_Exp>;
   _state?: InputMaybe<String_Comparison_Exp>;
+  attribution?: InputMaybe<String_Comparison_Exp>;
   author?: InputMaybe<String_Comparison_Exp>;
   contracts?: InputMaybe<Internal_Tpc_Contracts_Bool_Exp>;
   created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
@@ -44296,6 +46033,7 @@ export type Tpc_Works_Insert_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -44312,6 +46050,7 @@ export type Tpc_Works_Max_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution?: Maybe<Scalars['String']['output']>;
   author?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   title?: Maybe<Scalars['String']['output']>;
@@ -44325,6 +46064,7 @@ export type Tpc_Works_Max_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -44339,6 +46079,7 @@ export type Tpc_Works_Min_Fields = {
   _cohort?: Maybe<Scalars['String']['output']>;
   _release_id?: Maybe<Scalars['Int']['output']>;
   _state?: Maybe<Scalars['String']['output']>;
+  attribution?: Maybe<Scalars['String']['output']>;
   author?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   title?: Maybe<Scalars['String']['output']>;
@@ -44352,6 +46093,7 @@ export type Tpc_Works_Min_Order_By = {
   _cohort?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -44382,6 +46124,7 @@ export type Tpc_Works_Order_By = {
   _deleted?: InputMaybe<Order_By>;
   _release_id?: InputMaybe<Order_By>;
   _state?: InputMaybe<Order_By>;
+  attribution?: InputMaybe<Order_By>;
   author?: InputMaybe<Order_By>;
   contracts_aggregate?: InputMaybe<Internal_Tpc_Contracts_Aggregate_Order_By>;
   created_at?: InputMaybe<Order_By>;
@@ -44417,6 +46160,8 @@ export enum Tpc_Works_Select_Column {
   /** column name */
   State = '_state',
   /** column name */
+  Attribution = 'attribution',
+  /** column name */
   Author = 'author',
   /** column name */
   CreatedAt = 'created_at',
@@ -44440,6 +46185,7 @@ export type Tpc_Works_Set_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -44503,6 +46249,7 @@ export type Tpc_Works_Stream_Cursor_Value_Input = {
   _deleted?: InputMaybe<Scalars['Boolean']['input']>;
   _release_id?: InputMaybe<Scalars['Int']['input']>;
   _state?: InputMaybe<Scalars['String']['input']>;
+  attribution?: InputMaybe<Scalars['String']['input']>;
   author?: InputMaybe<Scalars['String']['input']>;
   created_at?: InputMaybe<Scalars['timestamptz']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -44536,6 +46283,8 @@ export enum Tpc_Works_Update_Column {
   ReleaseId = '_release_id',
   /** column name */
   State = '_state',
+  /** column name */
+  Attribution = 'attribution',
   /** column name */
   Author = 'author',
   /** column name */
@@ -45988,7 +47737,7 @@ export type Unitvariant_Lessons_Bool_Exp = {
 
 /** unique or primary key constraints on table "unitvariant_lessons" */
 export enum Unitvariant_Lessons_Constraint {
-  /** unique or primary key constraint on columns "lesson_id", "unitvariant_id", "_state" */
+  /** unique or primary key constraint on columns "unitvariant_id", "_state", "lesson_id" */
   UnitvariantLessonsPkey = 'unitvariant_lessons_pkey'
 }
 
@@ -46628,7 +48377,7 @@ export type Unitvariants_Bool_Exp = {
 export enum Unitvariants_Constraint {
   /** unique or primary key constraint on columns "unitvariant_id", "_state" */
   UnitvariantsPkey = 'unitvariants_pkey',
-  /** unique or primary key constraint on columns "programme_fields", "unit_id", "_state" */
+  /** unique or primary key constraint on columns "unit_id", "programme_fields", "_state" */
   UnitvariantsUnitIdProgrammeFieldsStateKey = 'unitvariants_unit_id_programme_fields__state_key'
 }
 
@@ -47844,7 +49593,7 @@ export type Videos_Bool_Exp = {
 
 /** unique or primary key constraints on table "videos" */
 export enum Videos_Constraint {
-  /** unique or primary key constraint on columns "_state", "video_id" */
+  /** unique or primary key constraint on columns "video_id", "_state" */
   VideosPkey = 'videos_pkey'
 }
 
@@ -48559,7 +50308,7 @@ export type SubjectListingQuery = { __typename?: 'query_root', subjectLessons: A
 export type SubjectPhaseOptionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SubjectPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_subject_phase_options_0_3', title?: string | null, slug?: string | null, phases?: any | null, examboards?: any | null, state?: string | null }> };
+export type SubjectPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_subject_phase_options_0_6', title?: string | null, slug?: string | null, phases?: any | null, examboards?: any | null, state?: string | null }> };
 
 export type SubjectPhaseOptionsIncludeNewQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -49284,11 +51033,12 @@ export const SubjectListingDocument = gql`
     `;
 export const SubjectPhaseOptionsDocument = gql`
     query subjectPhaseOptions {
-  options: published_mv_subject_phase_options_0_3 {
+  options: published_mv_subject_phase_options_0_6 {
     title
     slug
     phases
     examboards
+    keystages
     state
   }
 }

--- a/src/node-lib/curriculum-api-2023/index.ts
+++ b/src/node-lib/curriculum-api-2023/index.ts
@@ -63,6 +63,11 @@ export const examboardSchema = z.object({
   slug: z.string(),
   displayOrder: z.number().optional(),
 });
+export const keystagesSchema = z.object({
+  title: z.string(),
+  slug: z.string(),
+  displayOrder: z.number().optional(),
+});
 
 const contentTypesSchema = z.object({
   slug: z.union([z.literal("unit"), z.literal("lesson")]),
@@ -79,6 +84,7 @@ export const searchPageSchema = z.object({
 export const subjectPhaseOptionSchema = subjectSchema.extend({
   phases: z.array(phaseSchema),
   examboards: z.array(examboardSchema).optional().nullable(),
+  keystages: z.array(keystagesSchema).optional().nullable(),
 });
 
 const curriculumHeaderData = z.object({

--- a/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.gql
+++ b/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.gql
@@ -1,5 +1,5 @@
 query subjectPhaseOptions {
-  options: published_mv_subject_phase_options_0_3 {
+  options: published_mv_subject_phase_options_0_6 {
     title
     slug
     phases

--- a/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/subjectPhaseOptions/subjectPhaseOptions.schema.ts
@@ -10,12 +10,18 @@ const examboard = z.object({
   title: z.string(),
 });
 
+const keystage = z.object({
+  slug: z.string(),
+  title: z.string(),
+});
+
 const subjectPhaseOptionsSchema = z
   .object({
     slug: z.string(),
     title: z.string(),
     phases: z.array(phaseSchema),
     examboards: z.array(examboard).optional().nullable(),
+    keystages: z.array(keystage).optional().nullable(),
     state: z.string().optional(),
   })
   .array();

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -1,0 +1,54 @@
+import { getPhaseText } from "./formatting";
+
+describe("getPhaseText", () => {
+  it("ks1", () => {
+    expect(getPhaseText({ slug: "primary" }, [{ slug: "ks1" }])).toEqual(
+      "Key stage 1",
+    );
+    expect(getPhaseText({ slug: "secondary" }, [{ slug: "ks1" }])).toEqual("");
+  });
+
+  it("ks2", () => {
+    expect(getPhaseText({ slug: "primary" }, [{ slug: "ks2" }])).toEqual(
+      "Key stage 2",
+    );
+    expect(getPhaseText({ slug: "secondary" }, [{ slug: "ks2" }])).toEqual("");
+  });
+
+  it("ks1 & ks2", () => {
+    expect(
+      getPhaseText({ slug: "primary" }, [{ slug: "ks1" }, { slug: "ks2" }]),
+    ).toEqual("Key stage 1 and 2");
+    expect(
+      getPhaseText({ slug: "secondary" }, [{ slug: "ks1" }, { slug: "ks2" }]),
+    ).toEqual("");
+  });
+
+  it("ks3", () => {
+    expect(getPhaseText({ slug: "primary" }, [{ slug: "ks3" }])).toEqual("");
+    expect(getPhaseText({ slug: "secondary" }, [{ slug: "ks3" }])).toEqual(
+      "Key stage 3",
+    );
+  });
+
+  it("ks4", () => {
+    expect(getPhaseText({ slug: "primary" }, [{ slug: "ks4" }])).toEqual("");
+    expect(getPhaseText({ slug: "secondary" }, [{ slug: "ks4" }])).toEqual(
+      "Key stage 4",
+    );
+  });
+
+  it("ks3 & ks4", () => {
+    expect(
+      getPhaseText({ slug: "primary" }, [{ slug: "ks3" }, { slug: "ks4" }]),
+    ).toEqual("");
+    expect(
+      getPhaseText({ slug: "secondary" }, [{ slug: "ks3" }, { slug: "ks4" }]),
+    ).toEqual("Key stage 3 and 4");
+  });
+
+  it("missing", () => {
+    expect(getPhaseText({ slug: "secondary" }, [])).toEqual("");
+    expect(getPhaseText({ slug: "primary" }, [])).toEqual("");
+  });
+});

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -1,0 +1,30 @@
+import { Phase } from "@/node-lib/curriculum-api-2023";
+
+export function getPhaseText(
+  phase: Pick<Phase, "slug">,
+  keystages: { slug: string }[],
+) {
+  if (phase.slug === "primary") {
+    const hasKs1 = keystages.find((k) => k.slug === "ks1");
+    const hasKs2 = keystages.find((k) => k.slug === "ks2");
+    if (hasKs1 && hasKs2) {
+      return "Key stage 1 and 2";
+    } else if (hasKs1) {
+      return "Key stage 1";
+    } else if (hasKs2) {
+      return "Key stage 2";
+    }
+  }
+  if (phase.slug === "secondary") {
+    const hasKs3 = keystages.find((k) => k.slug === "ks3");
+    const hasKs4 = keystages.find((k) => k.slug === "ks4");
+    if (hasKs3 && hasKs4) {
+      return "Key stage 3 and 4";
+    } else if (hasKs3) {
+      return "Key stage 3";
+    } else if (hasKs4) {
+      return "Key stage 4";
+    }
+  }
+  return "";
+}


### PR DESCRIPTION
## Description
The text "Key stage 1 and 2" and  "Key stage 3 and 4" will now be generated from the key stages available.  

<img width="1003" alt="Screenshot 2024-09-12 at 15 42 30" src="https://github.com/user-attachments/assets/7b2e85a4-1bda-47a9-8ee4-1c033d7ad9b1">

Although we haven't got any it also now supports single key stages, such as "Key stage 1" or "Key stage 3"

## Issue(s)

Fixes `CUR-857`

## How to test
Test for regressions in the above UI. There should be no functional changes until we enable cycle 2.
