### PR TITLE
fix: render optionality units when there are 2 of them

### DIFF
--- a/src/components/PupilComponents/PupilUnitsSection/PupilUnitsSection.tsx
+++ b/src/components/PupilComponents/PupilUnitsSection/PupilUnitsSection.tsx
@@ -156,13 +156,6 @@ export const PupilUnitsSection = ({
                   optionalityUnit[0],
                   optionalityUnit[0].supplementaryData.unitOrder,
                 );
-            } else if (optionalityUnit.length === 2) {
-              // 2 optionalities, doesn't need sublistings but the unit with optionality should be used for the title.
-              const unit = optionalityUnit.find(
-                (unit) => unit.programmeFields.optionality,
-              );
-              if (unit)
-                return renderListItem(unit, unit.supplementaryData.unitOrder);
             } else {
               // More than 2 optionalities and therefore needs sublistings
               if (optionalityUnit[0])


### PR DESCRIPTION

## Issue(s)

Pupil area is not showing optionality units when there are only two units to display (showing more than two remains unaffected)

Eg.https://www.thenational.academy/pupils/programmes/english-secondary-year-10-edexcel/units

Fixes #

This was because the backend was changed to stop serving null unitvariants alongside their optionality counterparts. I removed the condition which filtered for this situation and allowed arrays of two unitvariants to be rendered.

## How to test

1. Go to https://deploy-preview-2782--oak-web-application.netlify.thenational.academy/pupils/programmes/english-secondary-year-10-edexcel/units

Confirm that you can see the same optionality units as in the teacher journey

https://www.thenational.academy/teachers/programmes/english-secondary-ks4-edexcel/units


## Checklist

- [x]  Bother optionality units should be displayed when there only 2
- [x]  test coverage
- [x]  documentation where relevant
- [x]  pa11y and percy
