### PR TITLE
fix(LESQ-1066): set the sign-in and sign-up routes on ClerkProvider

### DIFF
--- a/src/context/FeatureFlaggedClerk/FeatureFlaggedClerk.tsx
+++ b/src/context/FeatureFlaggedClerk/FeatureFlaggedClerk.tsx
@@ -70,7 +70,11 @@ export function useFeatureFlaggedClerk() {
 export function FeatureFlaggedClerkProvider({ children }: PropsWithChildren) {
   if (useFeatureFlagEnabled("use-auth-owa")) {
     return (
-      <ClerkProvider>
+      <ClerkProvider
+        signInUrl="/sign-in"
+        signUpUrl="/sign-up"
+        afterSignOutUrl="/"
+      >
         <clerkApiContext.Provider value={realClerkApi}>
           {children}
         </clerkApiContext.Provider>


### PR DESCRIPTION
## Description

Music year: 1978

the production Clerk environment is misconfigured and both the sign-in and sign-up routes point to labs.thenational.academy. It makes sense to have these paths under version control so i'm setting them in code instead of doing it through the Clerk UI to avoid causing any issues with the AI project. Clerk themselves say you should do this and it keeps OWA decoupled from other projects.

🚨 **This will only have an impact in production where the environment is currently misconfigured in Clerk. That is also the only environment in which we can properly test that login sessions are shared between labs and OWA.** 

👇🏻 Production these are quite clearly wrong for both labs and OWA — in labs the environment variables are set to override these values so there is currently no issue in Aila
<img width="923" alt="Screenshot 2024-09-16 at 09 28 03" src="https://github.com/user-attachments/assets/b198a1c2-80a3-47c5-90f3-046e15899e1a">

👇🏻 Development these are correct for both labs and OWA
<img width="930" alt="Screenshot 2024-09-16 at 09 28 17" src="https://github.com/user-attachments/assets/5f1c0edc-eadb-4f4e-b339-0860f22fa261">


## How to test

1. Go to https://deploy-preview-2783--oak-web-application.netlify.thenational.academy/onboarding
2. You should see the sign-up page
3. Click on "Sign in"
4. You should see the sign-in page
5. Sign-in
6. Sign-out
7. You should be redirected to the OWA homepage

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
