### PR TITLE
LESQ-1073: Remove restriction on manual school entry

### DIFF
--- a/src/components/TeacherComponents/ManualEntrySchoolDetails/ManualEntrySchoolDetails.tsx
+++ b/src/components/TeacherComponents/ManualEntrySchoolDetails/ManualEntrySchoolDetails.tsx
@@ -43,9 +43,7 @@ const ManualEntrySchoolDetails: FC<ManualEntrySchoolDetailsProps> = ({
         render={({ field: { onChange, onBlur, value } }) => {
           const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
             onChange(e.target.value);
-            if (e.target.value.length > 2) {
-              onManualSchoolInputChange(true, e.target.value);
-            }
+            onManualSchoolInputChange(true, e.target.value);
           };
           const onBlurHandler = () => {
             onBlur();
@@ -56,8 +54,9 @@ const ManualEntrySchoolDetails: FC<ManualEntrySchoolDetailsProps> = ({
             <Input
               label="School name"
               placeholder="Type school name"
-              value={value}
+              value={value ?? ""}
               isRequired
+              required
               id={"school-name"}
               onBlur={onBlurHandler}
               onChange={onChangeHandler}
@@ -78,9 +77,7 @@ const ManualEntrySchoolDetails: FC<ManualEntrySchoolDetailsProps> = ({
         render={({ field: { onChange, onBlur, value } }) => {
           const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
             onChange(e.target.value);
-            if (e.target.value.length > 2) {
-              onManualSchoolInputChange(false, e.target.value);
-            }
+            onManualSchoolInputChange(false, e.target.value);
           };
 
           const onBlurHandler = () => {
@@ -92,8 +89,9 @@ const ManualEntrySchoolDetails: FC<ManualEntrySchoolDetailsProps> = ({
             <Input
               label="School address"
               placeholder="Type school address"
-              value={value}
+              value={value ?? ""}
               isRequired
+              required
               id={"school-address"}
               onBlur={onBlurHandler}
               onChange={onChangeHandler}

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
@@ -32,13 +32,8 @@ const ukSchoolSchema = z.object({
 export type UkSchoolFormValues = z.infer<typeof ukSchoolSchema>;
 
 const manualSchoolSchema = z.object({
-  manualSchoolName: z
-    .string()
-    .min(3, "School name must be at least 3 characters long"),
-
-  schoolAddress: z
-    .string()
-    .min(3, "School address must be at least 3 characters long"),
+  manualSchoolName: z.string().trim().min(1),
+  schoolAddress: z.string().trim().min(1),
   ...baseSchema.shape,
 });
 export type ManualSchoolFormValues = z.infer<typeof manualSchoolSchema>;

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
@@ -4,15 +4,17 @@ const baseSchema = z.object({
   newsletterSignUp: z.boolean(),
 });
 
-export const roleSelectFormSchema = z.object({
-  ...baseSchema.shape,
-  role: z.string({
-    errorMap: () => ({
-      message: "Select a role",
-    }),
-  }),
-  other: z.string().optional(),
-});
+export const roleSelectFormSchema = z
+  .object({
+    ...baseSchema.shape,
+    role: z.string({ message: "Please select what describes you best" }),
+    other: z.string().trim().optional(),
+  })
+  .refine((input) => input.role === "Other" && !!input.other, {
+    message: "Please tell us what your role is",
+    path: ["other"],
+  });
+
 export type RoleSelectFormValues = z.infer<typeof roleSelectFormSchema>;
 export type RoleSelectFormProps = RoleSelectFormValues & {
   onSubmit: (values: RoleSelectFormValues) => Promise<void>;

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -167,6 +167,7 @@ const OnboardingForm = ({
         $borderRadius="border-radius-m2"
         $background={"white"}
         as="form"
+        noValidate
         onSubmit={
           (event) => void props.handleSubmit(onFormSubmit)(event) // https://github.com/orgs/react-hook-form/discussions/8622}
         }

--- a/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.test.tsx
+++ b/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.test.tsx
@@ -34,7 +34,7 @@ describe("RoleSelection", () => {
 
     const otherRadio = await screen.findByLabelText(/other/i);
 
-    userEvent.click(otherRadio);
+    await userEvent.click(otherRadio);
 
     const otherRoleInput = await screen.findByLabelText(/your role/i);
     expect(otherRoleInput).toBeDefined();

--- a/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.view.tsx
+++ b/src/components/TeacherViews/Onboarding/RoleSelection/RoleSelection.view.tsx
@@ -34,7 +34,6 @@ const RoleSelectionView = () => {
     setValue,
     handleSubmit,
     clearErrors,
-    setError,
     getValues,
     control,
     trigger,
@@ -64,17 +63,6 @@ const RoleSelectionView = () => {
           formState.errors.role === undefined &&
           formState.errors.other === undefined
         }
-        onSubmit={() => {
-          if (getValues().role === "Other" && !getValues().other) {
-            setError("other", {
-              message: "Please tell us what your role is",
-            });
-          } else if (!getValues().role) {
-            setError("role", {
-              message: "Please select what describes you best",
-            });
-          }
-        }}
         control={control as Control<OnboardingFormProps>}
         trigger={trigger as UseFormTrigger<OnboardingFormProps>}
       >

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
@@ -89,7 +89,7 @@ describe("Onboarding view", () => {
         name: "Enter manually",
       });
 
-      userEvent.click(manualButton);
+      await userEvent.click(manualButton);
 
       expect(await screen.findByText("School name")).toBeInTheDocument();
       expect(await screen.findByText("School address")).toBeInTheDocument();
@@ -102,10 +102,10 @@ describe("Onboarding view", () => {
       const manualButton = await screen.findByRole("button", {
         name: "Enter manually",
       });
-      userEvent.click(manualButton);
+      await userEvent.click(manualButton);
       const inputBox = await screen.findByPlaceholderText("Type school name");
-      user.type(inputBox, "  ");
-      user.tab();
+      await user.type(inputBox, "  ");
+      await user.tab();
 
       const schoolNameError = await screen.findByText("Enter school name");
       expect(schoolNameError).toBeInTheDocument();

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
@@ -95,7 +95,7 @@ describe("Onboarding view", () => {
       expect(await screen.findByText("School address")).toBeInTheDocument();
     });
 
-    it("shows error message when school name is not entered correctly", async () => {
+    it("shows error message when school name is empty", async () => {
       renderWithProviders()(<SchoolSelectionView />);
       const user = userEvent.setup();
 
@@ -104,24 +104,24 @@ describe("Onboarding view", () => {
       });
       userEvent.click(manualButton);
       const inputBox = await screen.findByPlaceholderText("Type school name");
-      await user.type(inputBox, "B");
-      await user.tab();
+      user.type(inputBox, "  ");
+      user.tab();
 
       const schoolNameError = await screen.findByText("Enter school name");
       expect(schoolNameError).toBeInTheDocument();
     });
-    it("shows error message when school address is not entered correctly", async () => {
+    it("shows error message when school address is empty", async () => {
       renderWithProviders()(<SchoolSelectionView />);
       const user = userEvent.setup();
 
       const manualButton = await screen.findByRole("button", {
         name: "Enter manually",
       });
-      userEvent.click(manualButton);
+      await userEvent.click(manualButton);
       const inputBox = await screen.findByPlaceholderText(
         "Type school address",
       );
-      await user.type(inputBox, "B");
+      await user.type(inputBox, "  ");
       await user.tab();
 
       const schoolAddressError = await screen.findByText(

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.view.tsx
@@ -124,6 +124,7 @@ export const SchoolSelectionView = () => {
               label={"School"}
               setSelectedSchool={setSelectedSchool}
               withHomeschool={false}
+              required
             />
             <OakFlex
               $mt={"space-between-s"}


### PR DESCRIPTION
## Description

Music year: 1971

Fixes #
1. Removes the minimum length requirement on the manually entered school name and address
2. Sets the manual school name, school address and school picker inputs as "required"
3. Fixes a regression in the role selection form caused by the above changes (this page should be retested 🙇🏻 )

## How to test

1. Go to https://deploy-preview-2798--oak-web-application.netlify.thenational.academy/onboarding
5. Select "Yes" when asked if you "Work in a school"
6. You should see a required field for the school picker
7. Click "Enter manually"
8. You should see required fields for "School name" and "School address"
9. You should be able to a enter a non-whitespace only string into both and proceed

## Screenshots

How it used to look

<img width="467" alt="Screenshot 2024-09-19 at 09 40 18" src="https://github.com/user-attachments/assets/58d6ed52-4e4b-4428-a4ba-2214f102a612">


How it should now look:

<img width="512" alt="Screenshot 2024-09-19 at 09 41 10" src="https://github.com/user-attachments/assets/58efe8a2-7c82-47be-83cb-f43b6d318a06">


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
