### PR TITLE
LESQ-1076: Individual download buttons require onboarding

### DIFF
--- a/src/components/TeacherComponents/LessonItemContainerLink/LessonItemContainerLink.tsx
+++ b/src/components/TeacherComponents/LessonItemContainerLink/LessonItemContainerLink.tsx
@@ -1,3 +1,5 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
 import ButtonAsLink, {
   ButtonAsLinkProps,
 } from "@/components/SharedComponents/Button/ButtonAsLink";
@@ -84,6 +86,10 @@ export function LessonItemContainerLink({
               : undefined,
           };
 
+  const downloads = useFeatureFlagEnabled("use-auth-owa")
+    ? "downloads-auth"
+    : "downloads";
+
   const downloadLinkProps:
     | LessonDownloadsLinkProps
     | LessonDownloadsCanonicalLinkProps
@@ -94,7 +100,7 @@ export function LessonItemContainerLink({
           lessonSlug,
           unitSlug,
           programmeSlug,
-          downloads: "downloads",
+          downloads,
           query: isPreselectedDownloadType(preselected)
             ? { preselected }
             : undefined,
@@ -105,7 +111,7 @@ export function LessonItemContainerLink({
             lessonSlug,
             unitSlug,
             programmeSlug,
-            downloads: "downloads",
+            downloads,
             query: isPreselectedDownloadType(preselected)
               ? { preselected }
               : undefined,
@@ -113,7 +119,7 @@ export function LessonItemContainerLink({
         : {
             page: "lesson-downloads-canonical",
             lessonSlug,
-            downloads: "downloads",
+            downloads,
             query: isPreselectedDownloadType(preselected)
               ? { preselected }
               : undefined,


### PR DESCRIPTION
## Description

Music year: 1963

- Each download button on the download page should navigate un-onboarded users / non-logged in users to onboarding page

## ACs:

- [ ] Clicking on any download link on the lesson page allows the user to complete the required steps of the sign in journey

## Issue(s)

Fixes #LESQ-1076

## How to test

1. Go to https://deploy-preview-2809--oak-web-application.netlify.thenational.academy
2. Navigate to any lesson page, all download buttons should navigate you to the onboarding journey when not signed in

## Screenshots

How it should now look:


https://github.com/user-attachments/assets/7cb88833-4950-4c36-84b9-1eb675f042b9


## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
