### PR TITLE
Added `<Alert/>` component and initial swimming functionality for cycle 2 curriculum

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -882,6 +882,8 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
               year: "10",
             },
           ],
+          groupAs: null,
+          labels: [],
         },
         "11": {
           childSubjects: [
@@ -1232,6 +1234,8 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
               year: "11",
             },
           ],
+          groupAs: null,
+          labels: [],
         },
         "7": {
           childSubjects: [],
@@ -1335,6 +1339,8 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
               year: "7",
             },
           ],
+          groupAs: null,
+          labels: [],
         },
       };
       expect(createUnitsListingByYear(unitData)).toEqual(unitListingByYear);

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -125,6 +125,8 @@ const curriculumVisualiserFixture = {
       childSubjects: [],
       tiers: [],
       subjectCategories: [],
+      labels: [],
+      groupAs: null,
     },
   },
   mobileHeaderScrollOffset: 148,

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -17,6 +17,7 @@ import UnitModal, {
 import { TagFunctional } from "@/components/SharedComponents/TagFunctional";
 import UnitsTabSidebar from "@/components/CurriculumComponents/UnitsTabSidebar";
 import AnchorTarget from "@/components/SharedComponents/AnchorTarget";
+import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 
 export type YearData = {
   [key: string]: {
@@ -256,14 +257,8 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
             return 0;
           })
           .map((year, index) => {
-            const {
-              units,
-              childSubjects,
-              tiers,
-              subjectCategories,
-              labels,
-              groupAs,
-            } = yearData[year] as YearData[string];
+            const { units, childSubjects, tiers, subjectCategories, labels } =
+              yearData[year] as YearData[string];
 
             const ref = (element: HTMLDivElement) => {
               itemEls.current[index] = element;
@@ -273,12 +268,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
             );
             const dedupedUnits = dedupUnits(filteredUnits);
 
-            let yearTitle: string;
-            if (groupAs && year === "all") {
-              yearTitle = `${groupAs} (all years)`;
-            } else {
-              yearTitle = `Year ${year}`;
-            }
+            const yearTitle = getYearGroupTitle(yearData, year);
 
             return (
               <Box

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -3,6 +3,7 @@ import { VisuallyHidden } from "react-aria";
 import { OakGridArea, OakHeading, OakFlex } from "@oaknational/oak-components";
 
 import { createProgrammeSlug } from "../UnitsTab/UnitsTab";
+import Alert from "../OakComponentsKitchen/Alert";
 
 import Box from "@/components/SharedComponents/Box";
 import Card from "@/components/SharedComponents/Card/Card";
@@ -23,6 +24,8 @@ export type YearData = {
     childSubjects: Subject[];
     tiers: Tier[];
     subjectCategories: SubjectCategory[];
+    labels: string[];
+    groupAs: string | null;
   };
 };
 
@@ -244,10 +247,23 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
       {yearData &&
         Object.keys(yearData)
           .filter((year) => !selectedYear || selectedYear === year)
+          .sort((a, b) => {
+            if (a === "all-years") {
+              return -1;
+            }
+            if (a < b) return -1;
+            if (a > b) return 1;
+            return 0;
+          })
           .map((year, index) => {
-            const { units, childSubjects, tiers, subjectCategories } = yearData[
-              year
-            ] as YearData[string];
+            const {
+              units,
+              childSubjects,
+              tiers,
+              subjectCategories,
+              labels,
+              groupAs,
+            } = yearData[year] as YearData[string];
 
             const ref = (element: HTMLDivElement) => {
               itemEls.current[index] = element;
@@ -256,6 +272,13 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
               isVisibleUnit(yearSelection, year, unit),
             );
             const dedupedUnits = dedupUnits(filteredUnits);
+
+            let yearTitle: string;
+            if (groupAs && year === "all") {
+              yearTitle = `${groupAs} (all years)`;
+            } else {
+              yearTitle = `Year ${year}`;
+            }
 
             return (
               <Box
@@ -278,11 +301,19 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
                 <OakHeading
                   tag="h3"
                   $font={["heading-6", "heading-5"]}
-                  $mb="space-between-m2"
+                  $mb="space-between-s"
                   data-testid="year-heading"
                 >
-                  Year {year}
+                  {yearTitle}
                 </OakHeading>
+                {labels.includes("swimming") && (
+                  <Alert
+                    $mb="space-between-s"
+                    $mr="space-between-m2"
+                    type="info"
+                    message="Swimming units should be selected based on the ability and experience of your pupils."
+                  />
+                )}
                 {childSubjects.length < 1 && subjectCategories?.length > 1 && (
                   <Box role="group" aria-label="Categories">
                     {subjectCategories.map((subjectCategory, index) => {
@@ -366,7 +397,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
                 )}
                 <OakFlex
                   $flexWrap={"wrap"}
-                  $mt="space-between-xs"
+                  $pt="inner-padding-s"
                   data-testid="unit-cards"
                 >
                   {dedupedUnits.map((unit: Unit, index: number) => {

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -252,9 +252,9 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
             if (a === "all-years") {
               return -1;
             }
-            if (a < b) return -1;
-            if (a > b) return 1;
-            return 0;
+            const aNum = parseInt(a);
+            const bNum = parseInt(b);
+            return aNum - bNum;
           })
           .map((year, index) => {
             const { units, childSubjects, tiers, subjectCategories, labels } =

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.stories.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.stories.tsx
@@ -1,0 +1,28 @@
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import { Meta, StoryObj } from "@storybook/react";
+
+import Component from ".";
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Component>;
+
+const TestComponent = () => {
+  return (
+    <OakThemeProvider theme={oakDefaultTheme}>
+      <Component type="info" message="Info example" />
+      <Component type="neutral" message="Neutral example" />
+      <Component type="success" message="Success example" />
+      <Component type="alert" message="Alert example" />
+      <Component type="error" message="Error example" />
+    </OakThemeProvider>
+  );
+};
+
+export const SkipLink: Story = {
+  render: TestComponent,
+};

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.stories.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.stories.tsx
@@ -23,6 +23,6 @@ const TestComponent = () => {
   );
 };
 
-export const SkipLink: Story = {
+export const Alert: Story = {
   render: TestComponent,
 };

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.test.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/Alert.test.tsx
@@ -1,0 +1,19 @@
+import Alert from ".";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+describe("Fieldset", () => {
+  test("render", async () => {
+    const { baseElement } = renderWithTheme(
+      <>
+        <Alert type="info" message="Info example" />
+        <Alert type="neutral" message="Neutral example" />
+        <Alert type="success" message="Success example" />
+        <Alert type="alert" message="Alert example" />
+        <Alert type="error" message="Error example" />
+      </>,
+    );
+
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fieldset render 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-fqkvVR sc-gsFSXq hJncQr gXxntV"
+      data-testid="oak-inline-banner"
+      type="info"
+    >
+      <div
+        class="sc-fqkvVR bjeqlm"
+      >
+        <div
+          class="sc-fqkvVR cTLAoS"
+          data-testid="inline-banner-icon"
+        >
+          <img
+            alt="info"
+            class="sc-dcJsrY dAhYsf"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1709052869/icons/Icon_Info_vsx3xi.svg"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR ipjbBR"
+        data-testid="inline-banner-message"
+      >
+        Info example
+      </div>
+    </div>
+    <div
+      class="sc-fqkvVR sc-gsFSXq bRmvpu gXxntV"
+      data-testid="oak-inline-banner"
+      type="neutral"
+    >
+      <div
+        class="sc-fqkvVR bjeqlm"
+      >
+        <div
+          class="sc-fqkvVR cTLAoS"
+          data-testid="inline-banner-icon"
+        >
+          <img
+            alt="info"
+            class="sc-dcJsrY dAhYsf"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1709052869/icons/Icon_Info_vsx3xi.svg"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR ipjbBR"
+        data-testid="inline-banner-message"
+      >
+        Neutral example
+      </div>
+    </div>
+    <div
+      class="sc-fqkvVR sc-gsFSXq dZGHts gXxntV"
+      data-testid="oak-inline-banner"
+      type="success"
+    >
+      <div
+        class="sc-fqkvVR bjeqlm"
+      >
+        <div
+          class="sc-fqkvVR cTLAoS"
+          data-testid="inline-banner-icon"
+        >
+          <img
+            alt="success"
+            class="sc-dcJsrY dAhYsf"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699895534/icons/Icon-Success_aiiprx"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR ipjbBR"
+        data-testid="inline-banner-message"
+      >
+        Success example
+      </div>
+    </div>
+    <div
+      class="sc-fqkvVR sc-gsFSXq faIYJV gXxntV"
+      data-testid="oak-inline-banner"
+      type="alert"
+    >
+      <div
+        class="sc-fqkvVR bjeqlm"
+      >
+        <div
+          class="sc-fqkvVR cTLAoS"
+          data-testid="inline-banner-icon"
+        >
+          <img
+            alt="warning"
+            class="sc-dcJsrY dAhYsf"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1704901279/icons/zzszodmk7fvxm9xzzg9s.svg"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR ipjbBR"
+        data-testid="inline-banner-message"
+      >
+        Alert example
+      </div>
+    </div>
+    <div
+      class="sc-fqkvVR sc-gsFSXq igFOuh gXxntV"
+      data-testid="oak-inline-banner"
+      type="error"
+    >
+      <div
+        class="sc-fqkvVR bjeqlm"
+      >
+        <div
+          class="sc-fqkvVR cTLAoS"
+          data-testid="inline-banner-icon"
+        >
+          <img
+            alt="error"
+            class="sc-dcJsrY dYJCWu"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699895534/icons/Icon-Error_r25aza.svg"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR ipjbBR"
+        data-testid="inline-banner-message"
+      >
+        Error example
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/index.tsx
@@ -1,0 +1,80 @@
+import {
+  OakBox,
+  OakFlex,
+  OakFlexProps,
+  OakIcon,
+  OakIconName,
+} from "@oaknational/oak-components";
+
+export const alertTypes = {
+  info: {
+    icon: "info",
+    iconColorFilter: "black",
+    backgroundColour: "lavender30",
+    borderColour: "lavender",
+  },
+  neutral: {
+    icon: "info",
+    iconColorFilter: "black",
+    backgroundColour: "grey20",
+    borderColour: "grey40",
+  },
+  success: {
+    icon: "success",
+    iconColorFilter: "black",
+    backgroundColour: "mint30",
+    borderColour: "mint110",
+  },
+  alert: {
+    icon: "warning",
+    iconColorFilter: "black",
+    backgroundColour: "lemon30",
+    borderColour: "lemon50",
+  },
+  error: {
+    icon: "error",
+    iconColorFilter: "red",
+    backgroundColour: "red30",
+    borderColour: "red",
+  },
+} as const;
+
+type AlertProps = {
+  icon?: OakIconName;
+  type?: "info" | "neutral" | "success" | "alert" | "error";
+  message: string;
+} & OakFlexProps;
+
+export default function Alert(props: AlertProps) {
+  const { type = "info", icon, message } = props;
+  const iconResult = icon || alertTypes[type]?.icon;
+  const iconColorFilterResult = alertTypes[type]?.iconColorFilter;
+
+  return (
+    <OakFlex
+      data-testid="oak-inline-banner"
+      $background={alertTypes[type]?.backgroundColour}
+      $pa={"inner-padding-m"}
+      $borderRadius={"border-radius-m"}
+      $borderStyle={"solid"}
+      $borderColor={alertTypes[type]?.borderColour}
+      $flexDirection={"row"}
+      $gap="space-between-xs"
+      $alignItems={"center"}
+      {...props}
+    >
+      <OakBox>
+        <OakIcon
+          iconName={iconResult || "info"}
+          $colorFilter={iconColorFilterResult}
+          $width="all-spacing-7"
+          $height="all-spacing-7"
+          data-testid="inline-banner-icon"
+        />
+      </OakBox>
+      <OakBox $font={"body-2"} data-testid="inline-banner-message">
+        {message}
+      </OakBox>
+    </OakFlex>
+  );
+}

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -29,6 +29,7 @@ import {
   CurriculumUnitsFormattedData,
   CurriculumUnitsTrackingData,
 } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[tab]";
+import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 
 // Types and interfaces
 
@@ -314,13 +315,18 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
                     All
                   </RadioButton>
                 </Box>
-                {yearOptions.map((yearOption) => (
-                  <Box key={yearOption} $mb={16}>
-                    <RadioButton value={yearOption} data-testid={"year-radio"}>
-                      Year {yearOption}
-                    </RadioButton>
-                  </Box>
-                ))}
+                {yearOptions.map((yearOption) => {
+                  return (
+                    <Box key={yearOption} $mb={16}>
+                      <RadioButton
+                        value={yearOption}
+                        data-testid={"year-radio"}
+                      >
+                        {getYearGroupTitle(yearData, yearOption)}
+                      </RadioButton>
+                    </Box>
+                  );
+                })}
               </RadioGroup>
             </Fieldset>
           </OakGridArea>

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -315,18 +315,13 @@ const UnitsTab: FC<UnitsTabProps> = ({ trackingData, formattedData }) => {
                     All
                   </RadioButton>
                 </Box>
-                {yearOptions.map((yearOption) => {
-                  return (
-                    <Box key={yearOption} $mb={16}>
-                      <RadioButton
-                        value={yearOption}
-                        data-testid={"year-radio"}
-                      >
-                        {getYearGroupTitle(yearData, yearOption)}
-                      </RadioButton>
-                    </Box>
-                  );
-                })}
+                {yearOptions.map((yearOption) => (
+                  <Box key={yearOption} $mb={16}>
+                    <RadioButton value={yearOption} data-testid={"year-radio"}>
+                      {getYearGroupTitle(yearData, yearOption)}
+                    </RadioButton>
+                  </Box>
+                ))}
               </RadioGroup>
             </Fieldset>
           </OakGridArea>

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -7,7 +7,7 @@ import {
 import React, { MutableRefObject } from "react";
 import { useRouter } from "next/router";
 import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
-import { uniq } from "lodash";
+import { isEqual, uniq } from "lodash";
 
 import CMSClient from "@/node-lib/cms";
 import { CurriculumOverviewSanityData } from "@/common-lib/cms-types";
@@ -41,6 +41,7 @@ import {
 } from "@/components/CurriculumComponents/CurriculumVisualiser";
 import { YearSelection } from "@/components/CurriculumComponents/UnitsTab/UnitsTab";
 import { getMvRefreshTime } from "@/pages-helpers/curriculum/docx/getMvRefreshTime";
+import { getUnitFeatures } from "@/utils/curriculum/features";
 
 export type CurriculumSelectionSlugs = {
   phaseSlug: string;
@@ -68,6 +69,8 @@ export type CurriculumUnitsYearData<T = Unit> = {
     subjectCategories: SubjectCategory[];
     tiers: Tier[];
     pathways: Pathway[];
+    labels: string[];
+    groupAs: string | null;
     ref?: MutableRefObject<HTMLDivElement>;
   };
 };
@@ -281,8 +284,10 @@ export function createYearOptions(units: Unit[]): string[] {
 
   units.forEach((unit: Unit) => {
     // Populate years object
-    if (yearOptions.every((yo) => yo !== unit.year)) {
-      yearOptions.push(unit.year);
+    const year =
+      getUnitFeatures(unit)?.programmes_fields_overrides.year ?? unit.year;
+    if (yearOptions.every((yo) => yo !== year)) {
+      yearOptions.push(year);
     }
   });
   // Sort year data
@@ -332,7 +337,10 @@ export function createUnitsListingByYear(
     // Check if the yearData object has an entry for the unit's year
     // If not, initialize it with default values
 
-    let currentYearData = yearData[unit.year];
+    const year =
+      getUnitFeatures(unit)?.programmes_fields_overrides?.year ?? unit.year;
+
+    let currentYearData = yearData[year];
     if (!currentYearData) {
       currentYearData = {
         units: [],
@@ -340,8 +348,10 @@ export function createUnitsListingByYear(
         subjectCategories: [],
         tiers: [],
         pathways: [],
+        labels: [],
+        groupAs: null,
       };
-      yearData[unit.year] = currentYearData;
+      yearData[year] = currentYearData;
     }
 
     // Add the current unit
@@ -402,6 +412,33 @@ export function createUnitsListingByYear(
       }
     });
   });
+
+  for (const year of Object.keys(yearData)) {
+    const data = yearData[year]!;
+    if (data.units.length > 0) {
+      const labels = getUnitFeatures(data.units[0]!)?.labels ?? [];
+      if (
+        data.units.every((unit) =>
+          isEqual(getUnitFeatures(unit)?.labels, labels),
+        )
+      ) {
+        data.labels = data.labels.concat(labels);
+      }
+    }
+
+    if (data.units.length > 0) {
+      const groupAs = getUnitFeatures(data.units[0]!)?.group_as;
+      if (groupAs) {
+        if (
+          data.units.every(
+            (unit) => getUnitFeatures(unit)?.group_as === groupAs,
+          )
+        ) {
+          data.groupAs = groupAs;
+        }
+      }
+    }
+  }
 
   return yearData;
 }

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,1 +1,5 @@
 export const ENABLE_CYCLE_2 = false;
+
+// Due to swimming primary not get being published, we have added a hack to
+// define some physical-education as "all-years" swimming.
+export const SWIMMING_HACK = false;

--- a/src/utils/curriculum/features.test.ts
+++ b/src/utils/curriculum/features.test.ts
@@ -1,0 +1,92 @@
+import {
+  isCycleTwoEnabled,
+  useCycleTwoEnabled,
+  isSwimmingHackEnabled,
+  getUnitFeatures,
+} from "./features";
+
+import { Unit } from "@/components/CurriculumComponents/CurriculumVisualiser";
+
+const MOCK_ENABLE_CYCLE_2 = jest.fn();
+const MOCK_SWIMMING_HACK = jest.fn();
+jest.mock("./constants", () => ({
+  __esModule: true,
+  get ENABLE_CYCLE_2() {
+    return MOCK_ENABLE_CYCLE_2() ?? false;
+  },
+  get SWIMMING_HACK() {
+    return MOCK_SWIMMING_HACK() ?? false;
+  },
+  default: {},
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.clearAllMocks();
+});
+
+describe("isCycleTwoEnabled", () => {
+  it("true when ENABLE_CYCLE_2 true", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    expect(isCycleTwoEnabled()).toEqual(true);
+  });
+
+  it("false when ENABLE_CYCLE_2 false", () => {
+    expect(isCycleTwoEnabled()).toEqual(false);
+  });
+});
+
+describe("useCycleTwoEnabled", () => {
+  it("true when ENABLE_CYCLE_2 true", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    expect(useCycleTwoEnabled()).toEqual(true);
+  });
+
+  it("false when ENABLE_CYCLE_2 false", () => {
+    expect(useCycleTwoEnabled()).toEqual(false);
+  });
+});
+
+describe("isSwimmingHackEnabled", () => {
+  it("true when ENABLE_CYCLE_2 & SWIMMING_HACK is true", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    MOCK_SWIMMING_HACK.mockReturnValue(true);
+    expect(isSwimmingHackEnabled()).toEqual(true);
+  });
+
+  it("false when neither true", () => {
+    expect(isSwimmingHackEnabled()).toEqual(false);
+  });
+
+  it("false when only SWIMMING_HACK is true", () => {
+    MOCK_SWIMMING_HACK.mockReturnValue(true);
+    expect(isSwimmingHackEnabled()).toEqual(false);
+  });
+});
+
+describe("getUnitFeatures", () => {
+  it("returns rules when hack enabled and matching unit", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    MOCK_SWIMMING_HACK.mockReturnValue(true);
+    expect(
+      getUnitFeatures({ slug: "sport-psychology-skill-and-ability" } as Unit),
+    ).toEqual({
+      labels: ["swimming"],
+      exclusions: ["pupils"],
+      group_as: "Swimming",
+      programmes_fields_overrides: {
+        year: "all-years",
+        keystage: "All keystages",
+      },
+    });
+  });
+
+  it("returns nothing when hack disabled", () => {
+    expect(getUnitFeatures({ slug: "test" } as Unit)).toEqual(undefined);
+  });
+
+  it("returns nothing when hack enabled but not a matching unit", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    expect(getUnitFeatures({ slug: "test" } as Unit)).toEqual(undefined);
+  });
+});

--- a/src/utils/curriculum/features.ts
+++ b/src/utils/curriculum/features.ts
@@ -1,4 +1,6 @@
-import { ENABLE_CYCLE_2 } from "./constants";
+import { ENABLE_CYCLE_2, SWIMMING_HACK } from "./constants";
+
+import { Unit } from "@/components/CurriculumComponents/CurriculumVisualiser";
 
 export function isCycleTwoEnabled() {
   return ENABLE_CYCLE_2;
@@ -6,4 +8,29 @@ export function isCycleTwoEnabled() {
 
 export function useCycleTwoEnabled() {
   return ENABLE_CYCLE_2;
+}
+
+export function isSwimmingHackEnabled() {
+  return ENABLE_CYCLE_2 && SWIMMING_HACK;
+}
+
+export function getUnitFeatures(unit: Unit) {
+  // HACK: Swimming primary isn't yet published so we're hacking in some secondary units and giving them the overrides
+  if (
+    isSwimmingHackEnabled() &&
+    [
+      "health-and-wellbeing-hiit-and-couch-to-5k-team-challenges-to-develop-fitness",
+      "sport-psychology-skill-and-ability",
+    ].includes(unit.slug)
+  ) {
+    return {
+      labels: ["swimming"],
+      exclusions: ["pupils"],
+      group_as: "Swimming",
+      programmes_fields_overrides: {
+        year: "all-years",
+        keystage: "All keystages",
+      },
+    };
+  }
 }

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -1,0 +1,39 @@
+import { getYearGroupTitle } from "./formatting";
+
+describe("getYearGroupTitle", () => {
+  it("support all-years", () => {
+    expect(
+      getYearGroupTitle(
+        {
+          ["all-years"]: {
+            units: [],
+            childSubjects: [],
+            tiers: [],
+            subjectCategories: [],
+            labels: [],
+            groupAs: "Swimming",
+          },
+        },
+        "all-years",
+      ),
+    ).toEqual("Swimming (all years)");
+  });
+
+  it("support years", () => {
+    expect(
+      getYearGroupTitle(
+        {
+          ["7"]: {
+            units: [],
+            childSubjects: [],
+            tiers: [],
+            subjectCategories: [],
+            labels: [],
+            groupAs: null,
+          },
+        },
+        "7",
+      ),
+    ).toEqual("Year 7");
+  });
+});

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -1,0 +1,13 @@
+import { YearData } from "@/components/CurriculumComponents/CurriculumVisualiser";
+
+export function getYearGroupTitle(yearData: YearData, year: string) {
+  if (year in yearData) {
+    const { groupAs } = yearData[year]!;
+    if (groupAs && year === "all-years") {
+      return `${groupAs} (all years)`;
+    } else {
+      return `Year ${year}`;
+    }
+  }
+  return `Year ${year}`;
+}


### PR DESCRIPTION
## Description
Added `<Alert/>` component and initial swimming functionality for cycle 2 curriculum all behind a flag.

Because we haven't got a published primary PE with "all-years", I've added a constant `SWIMMING_HACK`, which when enabled turns some PE secondary into "swimming units".

`<Alert/>`  in the curriculum kitchen

<img width="1311" alt="Screenshot 2024-09-24 at 08 28 45" src="https://github.com/user-attachments/assets/e57e7908-9ee5-4958-9b04-12189ad20bbd">

Swimming "all years" hacked into PE secondary when `SWIMMING_HACK` and `ENABLE_CYCLE_2` is enabled

<img width="1311" alt="Screenshot 2024-09-24 at 08 38 22" src="https://github.com/user-attachments/assets/c65a9530-54f6-413f-a63f-0ab3bf55f134">


## Issue(s)
Completes `CUR-843` & `CUR-841`

## How to test
Cycle 1 regressions

1. Go to https://deploy-preview-2813--oak-web-application.netlify.thenational.academy
2. Check for regressions in the curriculum visualiser

Cycle 2 testing

1. Enable `SWIMMING_HACK` and `ENABLE_CYCLE_2`
2. Check that blue info box appears and is correct
3. Check that filtering works, year is at the top of the visualiser and titles are correct for "all years"

