### PR TITLE
Set max with of image to `600px` on homepage

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
@@ -86,6 +86,7 @@ const CurriculumTab: FC = () => {
                   $objectFit="contain"
                   priority
                   $ba={3}
+                  width={600}
                   $borderStyle={"solid"}
                   $borderColor={"black"}
                 />


### PR DESCRIPTION
## Description
Set max with of image to `600px` on homepage, reduces image size based on DPI, locally `3840px` width down to `1200px` width 

Before
<img width="1032" alt="Screenshot 2024-09-24 at 15 34 08" src="https://github.com/user-attachments/assets/7dba090d-b8ba-4690-9de8-becc1a31bea1">

After

<img width="1112" alt="Screenshot 2024-09-24 at 15 52 08" src="https://github.com/user-attachments/assets/257fbfa4-e7bb-4fad-86ef-43dbb1c1205f">


