### PR TITLE
fix: tweak border radius of oak-inline banner

### DIFF
--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Fieldset render 1`] = `
 <body>
   <div>
     <div
-      class="sc-fqkvVR sc-gsFSXq hJncQr gXxntV"
+      class="sc-fqkvVR sc-gsFSXq cTKaen gXxntV"
       data-testid="oak-inline-banner"
       type="info"
     >
@@ -34,7 +34,7 @@ exports[`Fieldset render 1`] = `
       </div>
     </div>
     <div
-      class="sc-fqkvVR sc-gsFSXq bRmvpu gXxntV"
+      class="sc-fqkvVR sc-gsFSXq jmhHRi gXxntV"
       data-testid="oak-inline-banner"
       type="neutral"
     >
@@ -64,7 +64,7 @@ exports[`Fieldset render 1`] = `
       </div>
     </div>
     <div
-      class="sc-fqkvVR sc-gsFSXq dZGHts gXxntV"
+      class="sc-fqkvVR sc-gsFSXq bAhQYs gXxntV"
       data-testid="oak-inline-banner"
       type="success"
     >
@@ -94,7 +94,7 @@ exports[`Fieldset render 1`] = `
       </div>
     </div>
     <div
-      class="sc-fqkvVR sc-gsFSXq faIYJV gXxntV"
+      class="sc-fqkvVR sc-gsFSXq cnpfpZ gXxntV"
       data-testid="oak-inline-banner"
       type="alert"
     >
@@ -124,7 +124,7 @@ exports[`Fieldset render 1`] = `
       </div>
     </div>
     <div
-      class="sc-fqkvVR sc-gsFSXq igFOuh gXxntV"
+      class="sc-fqkvVR sc-gsFSXq eRnHFx gXxntV"
       data-testid="oak-inline-banner"
       type="error"
     >

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/index.tsx
@@ -55,7 +55,7 @@ export default function Alert(props: AlertProps) {
       data-testid="oak-inline-banner"
       $background={alertTypes[type]?.backgroundColour}
       $pa={"inner-padding-m"}
-      $borderRadius={"border-radius-m"}
+      $borderRadius={"border-radius-m2"}
       $borderStyle={"solid"}
       $borderColor={alertTypes[type]?.borderColour}
       $flexDirection={"row"}


### PR DESCRIPTION
## Description

Music year: 2016

- Change border radius of `oak-inline-banner` inside `<Alert />` component to `border-radius-m2` so that it comes out as 8px and is consistent with [the design](https://www.figma.com/design/3cz9fb0ObFDLv1c212OtJv/Final-designs---Curriculum-squad?node-id=5233-97372&m=dev).

## Issue(s)

Fixes #CUR-841

## How to test

Locally:

- Enable `SWIMMING_HACK` and `ENABLE_CYCLE_2`
- Check that blue info box has the correct border radius.

Storybook:

- Go to https://deploy-preview-2818--owa-storybook.netlify.thenational.academy/?path=/story/components-curriculumcomponents-oakcomponentskitchen-alert--alert
- Check border radius of alert components.

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2024-09-25 at 10 49 18](https://github.com/user-attachments/assets/5284685f-b4d7-4b3a-9458-9bb42dcbf89d)

How it should now look:
![Screenshot 2024-09-25 at 10 48 56](https://github.com/user-attachments/assets/36b05a9a-a430-46a7-a8ec-391575da3f31)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
