### PR TITLE
Added new curriculum explainer styling in overview tab

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -17,6 +17,7 @@ import {
   CurriculumTab,
 } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[tab]";
 import { ButtonAsLinkProps } from "@/components/SharedComponents/Button/ButtonAsLink";
+import { isCycleTwoEnabled } from "@/utils/curriculum/features";
 
 export type CurriculumHeaderPageProps = {
   subjectPhaseOptions: SubjectPhasePickerData;
@@ -33,6 +34,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   subjectPhaseOptions,
   keyStages,
 }) => {
+  const cycleTwoEnabled = isCycleTwoEnabled();
   const router = useRouter();
   const tab = router.query.tab as CurriculumTab;
   const subject = subjectPhaseOptions.subjects.find(
@@ -134,13 +136,13 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
           />
         </Box>
       </Flex>
-      <Box $background={color2}>
+      <Box $background={cycleTwoEnabled ? color1 : color2}>
         {/* @todo replace with OakFlex - work out padding as max padding in oak-components is 24px */}
         <Flex $pv={32}>
           <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
             <OakFlex>
               <Box
-                $background={color1}
+                $background={cycleTwoEnabled ? color2 : color1}
                 $borderRadius={6}
                 $minWidth={56}
                 $mr={12}

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.test.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.test.tsx
@@ -2,6 +2,7 @@ import OverviewTab from "./OverviewTab";
 
 import curriculumOverviewTabFixture from "@/node-lib/curriculum-api-2023/fixtures/curriculumOverview.fixture";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 const useCycleTwoEnabled = jest.fn(() => false);
 jest.mock("@/utils/curriculum/features", () => ({
@@ -51,7 +52,8 @@ describe("Component - Overview Tab", () => {
     fixture.curriculumCMSInfo.subjectPrinciples = [
       "Sequences learning over time which: • Builds musical knowledge, techniques and specialist language • Promotes the understanding of a diverse range of genres, traditions and styles • Develops pupils analytical skills in responding to different types of music",
     ];
-    const { getByTestId } = renderWithTheme(<OverviewTab data={fixture} />);
+    const render = renderWithProviders();
+    const { getByTestId } = render(<OverviewTab data={fixture} />);
     const explainer = getByTestId("explainer");
     expect(explainer).toHaveTextContent("Aims and purpose");
   });

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.test.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.test.tsx
@@ -8,6 +8,7 @@ const useCycleTwoEnabled = jest.fn(() => false);
 jest.mock("@/utils/curriculum/features", () => ({
   __esModule: true,
   useCycleTwoEnabled: (...args: []) => useCycleTwoEnabled(...args),
+  isCurricPartnerHackEnabled: () => false,
   default: {},
 }));
 

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -29,7 +29,10 @@ import CMSImage from "@/components/SharedComponents/CMSImage";
 import CMSVideo from "@/components/SharedComponents/CMSVideo";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
 import { basePortableTextComponents } from "@/components/SharedComponents/PortableText";
-import { useCycleTwoEnabled } from "@/utils/curriculum/features";
+import {
+  isCurricPartnerHackEnabled,
+  useCycleTwoEnabled,
+} from "@/utils/curriculum/features";
 
 export type OverviewTabProps = {
   data: {
@@ -174,7 +177,9 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
   };
 
   // TODO: Add multiple curriculum partners here, see <https://www.notion.so/oaknationalacademy/New-curriculum-partner-design-in-overview-tab-10326cc4e1b180098542eb3b70ba270d>
-  const curriculumPartners = [curriculumPartner];
+  const curriculumPartners = isCurricPartnerHackEnabled()
+    ? [curriculumPartner, curriculumPartner]
+    : [curriculumPartner];
 
   const h1Headings = (curriculumExplainer.explainerRaw ?? []).filter(
     (block) => {

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -191,6 +191,10 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
     document.querySelector(`#header-${selector}`)?.scrollIntoView();
   };
 
+  const partnerTitle = `Our curriculum partner${
+    curriculumPartners.length > 1 ? "s" : ""
+  }`;
+
   const contents = (
     <OakFlex $gap={"space-between-m"} $flexDirection={"column"}>
       <OakP>Contents</OakP>
@@ -433,7 +437,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
                   $font={["heading-6", "heading-5"]}
                   $mb="space-between-s"
                 >
-                  Our curriculum partner
+                  {partnerTitle}
                 </OakHeading>
                 <OakTypography $font={"body-1"}>{partnerBio}</OakTypography>
               </Box>
@@ -451,7 +455,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
             >
               <OakBox $display={["block", "none"]}>
                 <OakHeading tag="h3" $font={["heading-5"]}>
-                  Our curriculum partner
+                  {partnerTitle}
                 </OakHeading>
               </OakBox>
               <OakFlex
@@ -493,7 +497,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
                           {curriculumPartnerIndex === 0 && (
                             <OakBox $display={["none", "block"]}>
                               <OakHeading tag="h3" $font={["heading-5"]}>
-                                Our curriculum partner
+                                {partnerTitle}
                               </OakHeading>
                             </OakBox>
                           )}

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -6,12 +6,15 @@ import {
   OakLI,
   OakTypography,
   OakFlex,
+  OakBox,
+  OakTertiaryButton,
 } from "@oaknational/oak-components";
 import {
   PortableText,
   PortableTextBlockComponent,
   PortableTextComponents,
 } from "@portabletext/react";
+import styled from "styled-components";
 
 import Box from "@/components/SharedComponents/Box";
 import Flex from "@/components/SharedComponents/Flex.deprecated";
@@ -35,6 +38,54 @@ export type OverviewTabProps = {
     curriculumSelectionSlugs: CurriculumSelectionSlugs;
   };
 };
+
+const ExplainerStyles = styled("div")`
+  h3:first-child {
+    margin-top: 0;
+  }
+  h3 {
+    font-weight: 600;
+    margin-top: 1rem;
+    font-size: 2rem;
+  }
+  h4 {
+    font-weight: 600;
+    margin-top: 1rem;
+    font-size: 1.25rem;
+  }
+  h5 {
+    font-weight: 600;
+    margin-top: 0.5rem;
+    font-size: 1rem;
+  }
+  h6 {
+    font-weight: 600;
+    margin-top: 0.5rem;
+    font-size: 1rem;
+  }
+  p + h3 {
+    margin-top: 4.5rem;
+  }
+  p + h4 {
+    margin-top: 1.5 em;
+  }
+  p + h5 {
+    margin-top: 3.5rem;
+  }
+  p + h6 {
+    margin-top: 0.5rem;
+  }
+
+  h3 + h4 {
+    margin-top: 1.5rem;
+  }
+  h4 + h5 {
+    margin-top: 1.5rem;
+  }
+  h5 + h6 {
+    margin-top: 1.5rem;
+  }
+`;
 
 const PrincipleBullet = ({
   bulletText,
@@ -61,9 +112,12 @@ const PrincipleBullet = ({
 );
 
 const blockHeadingComponents: PortableTextComponents["block"] = {
-  heading2: (props) => <OakHeading tag="h2">{props.children}</OakHeading>,
-  heading3: (props) => <OakHeading tag="h3">{props.children}</OakHeading>,
-  heading4: (props) => <OakHeading tag="h4">{props.children}</OakHeading>,
+  heading1: (props) => (
+    <h3 id={`header-${props.value._key}`}>{props.children}</h3>
+  ),
+  heading2: (props) => <h4>{props.children}</h4>,
+  heading3: (props) => <h5>{props.children}</h5>,
+  heading4: (props) => <h6>{props.children}</h6>,
 };
 
 const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
@@ -118,196 +172,343 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
       </PrincipleBullet>
     );
   };
-  return (
-    <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
-      {isCycleTwoEnabled && (
-        <OakFlex $mb="space-between-ssx">
-          <Box
-            $mr={16}
-            $pb={48}
-            $maxWidth={["100%", "100%", "65%"]}
-            $textAlign={"left"}
-          >
-            <OakHeading
-              tag="h2"
-              $font={["heading-5", "heading-4"]}
-              $mb="space-between-m"
+
+  // TODO: Add multiple curriculum partners here, see <https://www.notion.so/oaknationalacademy/New-curriculum-partner-design-in-overview-tab-10326cc4e1b180098542eb3b70ba270d>
+  const curriculumPartners = [curriculumPartner];
+
+  const h1Headings = (curriculumExplainer.explainerRaw ?? []).filter(
+    (block) => {
+      return block.style === "heading1";
+    },
+  );
+
+  const goToAnchor = (selector: string) => {
+    document.querySelector(`#header-${selector}`)?.scrollIntoView();
+  };
+
+  const contents = (
+    <OakFlex $gap={"space-between-m"} $flexDirection={"column"}>
+      <OakP>Contents</OakP>
+      <OakFlex $gap={"space-between-xs"} $flexDirection={"column"}>
+        {h1Headings.map((heading, headingIndex) => {
+          return (
+            <OakFlex
+              key={heading._key}
+              $gap={"space-between-xs"}
+              $alignItems="center"
             >
-              Overview
-            </OakHeading>
-            <OakP data-testid="explainer">
-              <PortableText
-                value={curriculumExplainer.explainerRaw}
-                components={{
-                  ...basePortableTextComponents.list,
-                  ...basePortableTextComponents.listItem,
-                  block: {
-                    ...basePortableTextComponents.block,
-                    ...blockHeadingComponents,
-                  } as PortableTextBlockComponent,
-                  types: {},
-                  marks: {
-                    strong: basePortableTextComponents.marks!.strong,
-                    em: basePortableTextComponents.marks!.em,
-                  },
+              <OakFlex
+                $alignItems="center"
+                $justifyContent="center"
+                $minWidth="all-spacing-7"
+                $minHeight="all-spacing-7"
+                $borderRadius="border-radius-circle"
+                $background={"black"}
+                $color={"white"}
+              >
+                {headingIndex + 1}
+              </OakFlex>
+              <OakTertiaryButton onClick={() => goToAnchor(heading._key)}>
+                {heading.children[0].text}
+              </OakTertiaryButton>
+            </OakFlex>
+          );
+        })}
+      </OakFlex>
+    </OakFlex>
+  );
+
+  return (
+    <>
+      {isCycleTwoEnabled && (
+        <Box
+          $minWidth={"100%"}
+          style={{ marginTop: -40 }}
+          $display={["block", "block", "none"]}
+        >
+          <OakBox
+            $background={"bg-decorative1-very-subdued"}
+            $ph="inner-padding-m"
+            $pv="inner-padding-l"
+          >
+            {contents}
+          </OakBox>
+        </Box>
+      )}
+      <Box $maxWidth={1280} $mh={"auto"} $ph={16} $width={"100%"}>
+        {isCycleTwoEnabled && (
+          <OakFlex $gap={"all-spacing-16"} $alignItems={"flex-start"}>
+            <Box
+              $minWidth={300}
+              $position={["static", "static", "sticky"]}
+              $top={20}
+              $pb={40}
+              $display={["none", "none", "block"]}
+            >
+              {contents}
+            </Box>
+            <OakFlex
+              $mb="space-between-ssx"
+              $mt={["space-between-m", "space-between-m", "space-between-none"]}
+            >
+              <Box
+                $pb={48}
+                $maxWidth={["100%", "65%", "65%"]}
+                $mh={["auto", "auto", 0]}
+                $textAlign={"left"}
+              >
+                <OakBox data-testid="explainer">
+                  <ExplainerStyles>
+                    <PortableText
+                      value={curriculumExplainer.explainerRaw}
+                      components={{
+                        ...basePortableTextComponents.list,
+                        ...basePortableTextComponents.listItem,
+                        block: {
+                          ...basePortableTextComponents.block,
+                          ...blockHeadingComponents,
+                        } as PortableTextBlockComponent,
+                        types: {},
+                        marks: {
+                          strong: basePortableTextComponents.marks!.strong,
+                          em: basePortableTextComponents.marks!.em,
+                        },
+                      }}
+                    />
+                  </ExplainerStyles>
+                </OakBox>
+              </Box>
+            </OakFlex>
+          </OakFlex>
+        )}
+        {!isCycleTwoEnabled && (
+          <>
+            <OakFlex $mb="space-between-ssx">
+              <Box
+                $mr={16}
+                $pb={48}
+                $maxWidth={["100%", "100%", "65%"]}
+                $textAlign={"left"}
+              >
+                <OakHeading
+                  tag="h2"
+                  $font={["heading-5", "heading-4"]}
+                  $mb="space-between-m"
+                >
+                  Overview
+                </OakHeading>
+                <OakHeading
+                  tag="h3"
+                  $font={["heading-6", "heading-5"]}
+                  data-testid="intent-heading"
+                  $mb="space-between-s"
+                  line-height={48}
+                >
+                  Curriculum explainer
+                </OakHeading>
+                <OakTypography
+                  $font={["body-2", "body-1"]}
+                  style={{ fontWeight: "light" }}
+                  $mt="space-between-ssx"
+                  $mr="space-between-xs"
+                  $whiteSpace={"break-spaces"}
+                >
+                  {curriculaDesc}
+                </OakTypography>
+              </Box>
+
+              <Card
+                $ml={40}
+                $maxHeight={200}
+                $maxWidth={[0, 0, 200]}
+                $ma={"auto"}
+                $zIndex={"inFront"}
+                $transform={[
+                  "rotate(-2.179deg) scale(1.5, 1.5) translate(15%,40%)",
+                ]}
+                $display={["none", "none", "flex"]}
+                $background={"lemon50"}
+              >
+                <BrushBorders color="lemon50" />
+                <SubjectIcon
+                  subjectSlug={subjectSlug}
+                  $maxHeight={200}
+                  $maxWidth={200}
+                  $transform={["rotate(-2.179deg)", "scale(1.25, 1.25)"]}
+                  $background={"lemon50"}
+                />
+              </Card>
+            </OakFlex>
+            <Card
+              $maxWidth={"100%"}
+              $background={"mint30"}
+              $zIndex={"neutral"}
+              $mb={80}
+            >
+              <BrushBorders color={"mint30"} />
+              <Box $ma={16}>
+                <OakHeading tag="h3" $font={["heading-6", "heading-5"]}>
+                  Subject principles
+                </OakHeading>
+                <OakUL
+                  $font={["body-2", "body-1"]}
+                  $mt="space-between-m"
+                  $reset={true}
+                >
+                  {subjectPrinciples.map((item, i) =>
+                    itemiseSubjectPrinciples(item, i),
+                  )}
+                </OakUL>
+              </Box>
+            </Card>
+          </>
+        )}
+        {video && videoExplainer && (
+          <OakFlex
+            $alignItems={"center"}
+            $justifyContent={"flex-start"}
+            $flexDirection={["column-reverse", "row"]}
+            $gap={["all-spacing-6", "all-spacing-16"]}
+            $mb={["space-between-l", "space-between-xxxl"]}
+          >
+            <Box $minWidth={["100%", "50%"]} $maxWidth={["100%", "50%"]}>
+              <CMSVideo video={video} location="lesson" />
+            </Box>
+            {/* @todo replace with OakFlex - work out $maxWidth */}
+            <Flex
+              $flexDirection={"column"}
+              $maxWidth={["100%", "30%"]}
+              $alignItems={"flex-start"}
+              $gap={[16, 24]}
+            >
+              <OakHeading tag="h3" $font={["heading-6", "heading-5"]}>
+                Video guide
+              </OakHeading>
+              <OakP $font={"body-1"}>{videoExplainer}</OakP>
+              <ButtonAsLink
+                variant="buttonStyledAsLink"
+                label="Read more about our new curriculum"
+                page={"blog-single"}
+                blogSlug="our-approach-to-curriculum"
+                icon="chevron-right"
+                background={"white"}
+                $iconPosition="trailing"
+                iconBackground="white"
+                $textAlign={"start"}
+              />
+            </Flex>
+          </OakFlex>
+        )}
+
+        {!isCycleTwoEnabled && (
+          <Card $background={"lemon30"} $width={"100%"} $mb={[36, 48]}>
+            <BrushBorders color="lemon30" />
+            <OakFlex
+              $justifyContent={"center"}
+              $alignItems={"center"}
+              $pa="inner-padding-m"
+              $flexDirection={["column", "row"]}
+              $gap={["all-spacing-4", "all-spacing-7"]}
+            >
+              <CMSImage
+                $background={"grey20"}
+                $ma={"auto"}
+                $ml={20}
+                $mr={32}
+                $height={180}
+                $width={180}
+                image={{
+                  ...curriculumPartner.image,
+                  altText: `Logo for ${curriculumPartner.name}`,
                 }}
               />
-            </OakP>
-          </Box>
-        </OakFlex>
-      )}
-      {!isCycleTwoEnabled && (
-        <>
-          <OakFlex $mb="space-between-ssx">
-            <Box
-              $mr={16}
-              $pb={48}
-              $maxWidth={["100%", "100%", "65%"]}
-              $textAlign={"left"}
-            >
-              <OakHeading
-                tag="h2"
-                $font={["heading-5", "heading-4"]}
-                $mb="space-between-m"
-              >
-                Overview
-              </OakHeading>
-              <OakHeading
-                tag="h3"
-                $font={["heading-6", "heading-5"]}
-                data-testid="intent-heading"
-                $mb="space-between-s"
-                line-height={48}
-              >
-                Curriculum explainer
-              </OakHeading>
-              <OakTypography
-                $font={["body-2", "body-1"]}
-                style={{ fontWeight: "light" }}
-                $mt="space-between-ssx"
-                $mr="space-between-xs"
-                $whiteSpace={"break-spaces"}
-              >
-                {curriculaDesc}
-              </OakTypography>
-            </Box>
-
-            <Card
-              $ml={40}
-              $maxHeight={200}
-              $maxWidth={[0, 0, 200]}
-              $ma={"auto"}
-              $zIndex={"inFront"}
-              $transform={[
-                "rotate(-2.179deg) scale(1.5, 1.5) translate(15%,40%)",
-              ]}
-              $display={["none", "none", "flex"]}
-              $background={"lemon50"}
-            >
-              <BrushBorders color="lemon50" />
-              <SubjectIcon
-                subjectSlug={subjectSlug}
-                $maxHeight={200}
-                $maxWidth={200}
-                $transform={["rotate(-2.179deg)", "scale(1.25, 1.25)"]}
-                $background={"lemon50"}
-              />
-            </Card>
-          </OakFlex>
-          <Card
-            $maxWidth={"100%"}
-            $background={"mint30"}
-            $zIndex={"neutral"}
-            $mb={80}
-          >
-            <BrushBorders color={"mint30"} />
-            <Box $ma={16}>
-              <OakHeading tag="h3" $font={["heading-6", "heading-5"]}>
-                Subject principles
-              </OakHeading>
-              <OakUL
-                $font={["body-2", "body-1"]}
-                $mt="space-between-m"
-                $reset={true}
-              >
-                {subjectPrinciples.map((item, i) =>
-                  itemiseSubjectPrinciples(item, i),
-                )}
-              </OakUL>
-            </Box>
+              <Box>
+                <OakHeading
+                  tag="h3"
+                  $font={["heading-6", "heading-5"]}
+                  $mb="space-between-s"
+                >
+                  Our curriculum partner
+                </OakHeading>
+                <OakTypography $font={"body-1"}>{partnerBio}</OakTypography>
+              </Box>
+            </OakFlex>
           </Card>
-        </>
-      )}
-      {video && videoExplainer && (
-        <OakFlex
-          $alignItems={"center"}
-          $justifyContent={"flex-start"}
-          $flexDirection={["column-reverse", "row"]}
-          $gap={["all-spacing-6", "all-spacing-16"]}
-          $mb={["space-between-l", "space-between-xxxl"]}
-        >
-          <Box $minWidth={["100%", "50%"]} $maxWidth={["100%", "50%"]}>
-            <CMSVideo video={video} location="lesson" />
-          </Box>
-          {/* @todo replace with OakFlex - work out $maxWidth */}
-          <Flex
-            $flexDirection={"column"}
-            $maxWidth={["100%", "30%"]}
-            $alignItems={"flex-start"}
-            $gap={[16, 24]}
-          >
-            <OakHeading tag="h3" $font={["heading-6", "heading-5"]}>
-              Video guide
-            </OakHeading>
-            <OakP $font={"body-1"}>{videoExplainer}</OakP>
-            <ButtonAsLink
-              variant="buttonStyledAsLink"
-              label="Read more about our new curriculum"
-              page={"blog-single"}
-              blogSlug="our-approach-to-curriculum"
-              icon="chevron-right"
-              background={"white"}
-              $iconPosition="trailing"
-              iconBackground="white"
-              $textAlign={"start"}
-            />
-          </Flex>
-        </OakFlex>
-      )}
-      <Card $background={"lemon30"} $width={"100%"} $mb={[36, 48]}>
-        <BrushBorders color="lemon30" />
-        <OakFlex
-          $justifyContent={"center"}
-          $alignItems={"center"}
-          $pa="inner-padding-m"
-          $flexDirection={["column", "row"]}
-          $gap={["all-spacing-4", "all-spacing-7"]}
-        >
-          <CMSImage
-            $background={"grey20"}
-            $ma={"auto"}
-            $ml={20}
-            $mr={32}
-            $height={180}
-            $width={180}
-            image={{
-              ...curriculumPartner.image,
-              altText: `Logo for ${curriculumPartner.name}`,
-            }}
-          />
-          <Box>
-            <OakHeading
-              tag="h3"
-              $font={["heading-6", "heading-5"]}
-              $mb="space-between-s"
+        )}
+      </Box>
+
+      {isCycleTwoEnabled && (
+        <OakBox $background={"bg-decorative1-subdued"} $pv="inner-padding-xl4">
+          <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
+            <OakFlex
+              $gap={["space-between-m", "space-between-m2"]}
+              $flexDirection={"column"}
             >
-              Our curriculum partner
-            </OakHeading>
-            <OakTypography $font={"body-1"}>{partnerBio}</OakTypography>
+              <OakBox $display={["block", "none"]}>
+                <OakHeading tag="h3" $font={["heading-5"]}>
+                  Our curriculum partner
+                </OakHeading>
+              </OakBox>
+              <OakFlex
+                $gap={["space-between-l", "space-between-m2"]}
+                $flexDirection={"column"}
+              >
+                {curriculumPartners.map(
+                  (curriculumPartner, curriculumPartnerIndex) => {
+                    return (
+                      <OakFlex
+                        $justifyContent={"center"}
+                        $alignContent={"start"}
+                        $gap={["space-between-s", "space-between-m2"]}
+                        $flexDirection={["column", "row"]}
+                      >
+                        <OakBox
+                          $borderRadius="border-radius-s"
+                          $overflow={"hidden"}
+                          $borderColor="border-neutral-lighter"
+                          $borderStyle={"solid"}
+                          $maxHeight={["all-spacing-18", "all-spacing-19"]}
+                          $maxWidth={["all-spacing-18", "all-spacing-19"]}
+                          $minHeight={["all-spacing-18", "all-spacing-19"]}
+                          $minWidth={["all-spacing-18", "all-spacing-19"]}
+                        >
+                          <CMSImage
+                            image={{
+                              ...curriculumPartner.image,
+                              altText: `Logo for ${curriculumPartner.name}`,
+                            }}
+                          />
+                        </OakBox>
+                        <OakFlex
+                          $flexGrow={1}
+                          $flexDirection={"column"}
+                          $gap={"space-between-s"}
+                          $justifyContent={"center"}
+                        >
+                          {curriculumPartnerIndex === 0 && (
+                            <OakBox $display={["none", "block"]}>
+                              <OakHeading tag="h3" $font={["heading-5"]}>
+                                Our curriculum partner
+                              </OakHeading>
+                            </OakBox>
+                          )}
+                          <OakHeading tag="h4" $font={["heading-6"]}>
+                            {curriculumPartner.name}
+                          </OakHeading>
+                          <OakTypography $font={"body-1"}>
+                            {partnerBio}
+                          </OakTypography>
+                        </OakFlex>
+                      </OakFlex>
+                    );
+                  },
+                )}
+              </OakFlex>
+            </OakFlex>
           </Box>
-        </OakFlex>
-      </Card>
-    </Box>
+        </OakBox>
+      )}
+    </>
   );
 };
 export default OverviewTab;

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -3,3 +3,5 @@ export const ENABLE_CYCLE_2 = false;
 // Due to swimming primary not get being published, we have added a hack to
 // define some physical-education as "all-years" swimming.
 export const SWIMMING_HACK = false;
+
+export const CURRIC_PARTNER_HACK = false;

--- a/src/utils/curriculum/features.test.ts
+++ b/src/utils/curriculum/features.test.ts
@@ -3,12 +3,14 @@ import {
   useCycleTwoEnabled,
   isSwimmingHackEnabled,
   getUnitFeatures,
+  isCurricPartnerHackEnabled,
 } from "./features";
 
 import { Unit } from "@/components/CurriculumComponents/CurriculumVisualiser";
 
 const MOCK_ENABLE_CYCLE_2 = jest.fn();
 const MOCK_SWIMMING_HACK = jest.fn();
+const MOCK_CURRIC_PARTNER_HACK = jest.fn();
 jest.mock("./constants", () => ({
   __esModule: true,
   get ENABLE_CYCLE_2() {
@@ -16,6 +18,9 @@ jest.mock("./constants", () => ({
   },
   get SWIMMING_HACK() {
     return MOCK_SWIMMING_HACK() ?? false;
+  },
+  get CURRIC_PARTNER_HACK() {
+    return MOCK_CURRIC_PARTNER_HACK() ?? false;
   },
   default: {},
 }));
@@ -61,6 +66,23 @@ describe("isSwimmingHackEnabled", () => {
   it("false when only SWIMMING_HACK is true", () => {
     MOCK_SWIMMING_HACK.mockReturnValue(true);
     expect(isSwimmingHackEnabled()).toEqual(false);
+  });
+});
+
+describe("isCurricPartnerHackEnabled", () => {
+  it("true when ENABLE_CYCLE_2 & CURRIC_PARTNER_HACK is true", () => {
+    MOCK_ENABLE_CYCLE_2.mockReturnValue(true);
+    MOCK_CURRIC_PARTNER_HACK.mockReturnValue(true);
+    expect(isCurricPartnerHackEnabled()).toEqual(true);
+  });
+
+  it("false when neither true", () => {
+    expect(isCurricPartnerHackEnabled()).toEqual(false);
+  });
+
+  it("false when only CURRIC_PARTNER_HACK is true", () => {
+    MOCK_CURRIC_PARTNER_HACK.mockReturnValue(true);
+    expect(isCurricPartnerHackEnabled()).toEqual(false);
   });
 });
 

--- a/src/utils/curriculum/features.ts
+++ b/src/utils/curriculum/features.ts
@@ -1,4 +1,8 @@
-import { ENABLE_CYCLE_2, SWIMMING_HACK } from "./constants";
+import {
+  CURRIC_PARTNER_HACK,
+  ENABLE_CYCLE_2,
+  SWIMMING_HACK,
+} from "./constants";
 
 import { Unit } from "@/components/CurriculumComponents/CurriculumVisualiser";
 
@@ -12,6 +16,10 @@ export function useCycleTwoEnabled() {
 
 export function isSwimmingHackEnabled() {
   return ENABLE_CYCLE_2 && SWIMMING_HACK;
+}
+
+export function isCurricPartnerHackEnabled() {
+  return ENABLE_CYCLE_2 && CURRIC_PARTNER_HACK;
 }
 
 export function getUnitFeatures(unit: Unit) {


### PR DESCRIPTION
## Description
Added new curriculum explainer styling sticky contents and new partners footer in overview tab

 - Added new partner styling
 - Curriculum explainer typography styles
 - Sticky contents pane
 - Color changes to header

## Issue(s)

 - `CUR-892`
 - `CUR-895` (only UI part)
 - `CUR-893`

## How to test
 - Check for regressions in cycle 1
 - Test tickets linked above with `ENABLE_CYCLE_2` enabled

## Screenshots

https://github.com/user-attachments/assets/8d8b981b-8c94-4298-a1da-e08ba3f24753


<img width="1559" alt="Screenshot 2024-09-26 at 08 56 45" src="https://github.com/user-attachments/assets/384534c7-1265-4477-8e41-911b0c673beb">

