### PR TITLE
LESQ-1096: fix confirmation email sent twice

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -75,6 +75,7 @@ sonar.coverage.exclusions=\
   src/node-lib/posthog/**, \
   src/app/(registration)/**, \
   src/app/layout.tsx, \
+  src/app/styles-registry.tsx, \
   src/styles/oakThemeApp.ts, \
   src/app/providers.tsx
 

--- a/src/app/(registration)/layout.tsx
+++ b/src/app/(registration)/layout.tsx
@@ -86,25 +86,21 @@ function Layout({ children }: { children: React.ReactNode }) {
         </OakBox>
       }
     >
-      <OakBox $display={["none", "block"]}>
+      <OakFlex
+        $flexDirection="column"
+        $alignItems="center"
+        $gap="space-between-m"
+        $display={["flex", "block"]}
+      >
         <OakBox
-          $dropShadow="drop-shadow-standard"
+          $dropShadow={[null, "drop-shadow-standard"]}
           $borderRadius="border-radius-m2"
-          $width="max-content"
-          $mb="space-between-m"
+          $width={["auto", "max-content"]}
+          $mb={["space-between-none", "space-between-m"]}
           ref={clerkRef}
         >
           {children}
         </OakBox>
-        {clerkRendered && <TermsAndConditions />}
-      </OakBox>
-      <OakFlex
-        $flexDirection="column"
-        $alignItems="center"
-        $display={["flex", "none"]}
-        $gap="space-between-m"
-      >
-        {children}
         {clerkRendered && <TermsAndConditions />}
       </OakFlex>
     </RegistrationLayout>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Lexend } from "next/font/google";
 
 import { PHProvider } from "./providers";
+import StyledComponentsRegistry from "./styles-registry";
 
 import {
   OakGlobalStyle,
@@ -27,38 +28,40 @@ export default function RootLayout({
     <html lang="en" className={lexend.className}>
       <OakGlobalStyle />
       <body style={{ margin: "0px" }}>
-        <PHProvider>
-          <OakThemeProvider theme={oakDefaultTheme}>
-            <CookieConsentProvider>
-              <ClerkProvider
-                appearance={{
-                  variables: {
-                    colorPrimary: "#222222",
-                    fontFamily: lexend.style.fontFamily,
-                    borderRadius: "4px",
-                  },
-                  elements: {
-                    cardBox: {
-                      boxShadow: "none",
-                      overflow: "auto",
-                      borderRadius: "8px",
+        <StyledComponentsRegistry>
+          <PHProvider>
+            <OakThemeProvider theme={oakDefaultTheme}>
+              <CookieConsentProvider>
+                <ClerkProvider
+                  appearance={{
+                    variables: {
+                      colorPrimary: "#222222",
+                      fontFamily: lexend.style.fontFamily,
+                      borderRadius: "4px",
                     },
-                    card: {
-                      paddingBlock: "40px",
-                      boxShadow: "none",
-                      borderRadius: "8px",
+                    elements: {
+                      cardBox: {
+                        boxShadow: "none",
+                        overflow: "auto",
+                        borderRadius: "8px",
+                      },
+                      card: {
+                        paddingBlock: "40px",
+                        boxShadow: "none",
+                        borderRadius: "8px",
+                      },
+                      footer: {
+                        background: "#ffffff",
+                      },
                     },
-                    footer: {
-                      background: "#ffffff",
-                    },
-                  },
-                }}
-              >
-                {children}
-              </ClerkProvider>
-            </CookieConsentProvider>
-          </OakThemeProvider>
-        </PHProvider>
+                  }}
+                >
+                  {children}
+                </ClerkProvider>
+              </CookieConsentProvider>
+            </OakThemeProvider>
+          </PHProvider>
+        </StyledComponentsRegistry>
       </body>
     </html>
   );

--- a/src/app/styles-registry.tsx
+++ b/src/app/styles-registry.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+
+export default function StyledComponentsRegistry({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  );
+}

--- a/src/app/styles-registry.tsx
+++ b/src/app/styles-registry.tsx
@@ -1,9 +1,11 @@
+/* istanbul ignore file */
 "use client";
 
 import React, { useState } from "react";
 import { useServerInsertedHTML } from "next/navigation";
 import { ServerStyleSheet, StyleSheetManager } from "styled-components";
 
+// https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components
 export default function StyledComponentsRegistry({
   children,
 }: {


### PR DESCRIPTION
## Description

Music year: 1988

rendering two sign-up/sign-in forms was causing the email confirmation
to be sent twice. I believe this was intended to make it easier to
present an alternative mobile view of the sign-up UI.

it appears to ultimately be an implementation bug in Clerk, because this
only happens with the confirmation link flow and not with the confirmation
code flow. Also if you refresh the page it will send another link which
is not great.

## How to test

1. Go to https://deploy-preview-2834--oak-web-application.netlify.thenational.academy/sign-up
2. Sign up with an email address
3. You should see the "Verify your email" screen
4. Check your email
5. You should have received one confirmation email

🚨 **I had to make some tweaks to the way the responsive layout was implemented to fix this. Definitely worth checking that I haven't caused a regression in the page layout (I tested and it all looked correct)** 

🤦🏻‍♂️ 😮‍💨  **Reloading the "Verify your email" screen will also cause another email to be sent. This appears to be a bug in Clerk because these emails should be throttled to the countdown you can see on screen.**

**Also, it will continue to send 2 emails in development owing to strict mode which causes the component to double render. In fact I was getting 4 emails in development because of strict mode and the double form bug combined. Fun.**

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
