### PR TITLE
chore(storybook): csf 2 to 3

### DIFF
--- a/src/components/AppComponents/AppHeaderBurgerMenuLink/AppHeaderBurgerMenuLink.stories.tsx
+++ b/src/components/AppComponents/AppHeaderBurgerMenuLink/AppHeaderBurgerMenuLink.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./AppHeaderBurgerMenuLink";
 
@@ -7,14 +6,13 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const AppHeaderBurgerMenuLink = Template.bind({});
-AppHeaderBurgerMenuLink.args = {
-  link: {
-    linkTo: { page: "home" },
-    text: "Home",
-    new: true,
-    external: false,
+export const AppHeaderBurgerMenuLink = {
+  args: {
+    link: {
+      linkTo: { page: "home" },
+      text: "Home",
+      new: true,
+      external: false,
+    },
   },
 };

--- a/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.stories.tsx
+++ b/src/components/AppComponents/AppHeaderBurgerMenuSections/AppHeaderBurgerMenuSections.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./AppHeaderBurgerMenuSections";
 
@@ -9,9 +8,8 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const NewMenuLinks = Template.bind({});
-NewMenuLinks.args = {
-  burgerMenuSections: burgerMenuSections,
+export const NewMenuLinks = {
+  args: {
+    burgerMenuSections: burgerMenuSections,
+  },
 };

--- a/src/components/AppComponents/AppHeaderMenu/AppHeaderMenu.stories.tsx
+++ b/src/components/AppComponents/AppHeaderMenu/AppHeaderMenu.stories.tsx
@@ -20,4 +20,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </MenuProvider>
 );
 
-export const Menu = Template.bind({});
+export const Menu = {
+  render: Template,
+};

--- a/src/components/AppComponents/LayoutFixedHeader/LayoutFixedHeader.stories.tsx
+++ b/src/components/AppComponents/LayoutFixedHeader/LayoutFixedHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./LayoutFixedHeader";
 
@@ -12,6 +12,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LayoutFixedHeader = Template.bind({});
+export const LayoutFixedHeader = {};

--- a/src/components/AppComponents/LayoutLandingPagesHeader/LayoutLandingPagesHeader.stories.tsx
+++ b/src/components/AppComponents/LayoutLandingPagesHeader/LayoutLandingPagesHeader.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./LayoutLandingPagesHeader";
 
@@ -8,13 +7,12 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LayoutLandingPagesHeader = Template.bind({});
-LayoutLandingPagesHeader.args = {
-  headerCta: {
-    linkType: "anchor",
-    anchor: "formBlock",
-    label: "Form CTA",
+export const LayoutLandingPagesHeader = {
+  args: {
+    headerCta: {
+      linkType: "anchor",
+      anchor: "formBlock",
+      label: "Form CTA",
+    },
   },
 };

--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.stories.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.stories.tsx
@@ -18,4 +18,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </div>
 );
 
-export const LayoutSiteFooter = Template.bind({});
+export const LayoutSiteFooter = {
+  render: Template,
+};

--- a/src/components/AppComponents/Logo/Logo.stories.tsx
+++ b/src/components/AppComponents/Logo/Logo.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from ".";
 
@@ -10,6 +9,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const Logo = Template.bind({});
+export const Logo = {};

--- a/src/components/ArchivedComponents/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/src/components/ArchivedComponents/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -43,4 +43,6 @@ const Template: StoryFn<typeof Component> = () => {
   );
 };
 
-export const CollapsibleSection = Template.bind({});
+export const CollapsibleSection = {
+  render: Template,
+};

--- a/src/components/ArchivedComponents/DynamicForm/DynamicForm.stories.tsx
+++ b/src/components/ArchivedComponents/DynamicForm/DynamicForm.stories.tsx
@@ -21,44 +21,47 @@ const Template: StoryFn<typeof Component> = (args) => (
   </OakGrid>
 );
 
-export const DynamicForm = Template.bind({});
-DynamicForm.args = {
-  form: {
-    formId: "abc-def",
-    portalId: 12345,
-    submitButtonLabel: "Submit label",
-    successMessage: "Success message",
-    fields: [
-      {
-        name: "name",
-        label: "Name",
-        type: "string",
-        required: true,
-      },
-      {
-        name: "user_type",
-        label: "User Type",
-        type: "select",
-        required: true,
-        options: [
-          { label: "Teacher", value: "Teacher" },
-          { label: "Pupil", value: "Pupil" },
-          { label: "Parent", value: "Parent" },
-        ],
-      },
-      {
-        name: "school",
-        label: "School",
-        type: "string",
-        required: false,
-        renderWhen: [
-          {
-            field: "user_type",
-            operator: "in",
-            value: ["Teacher"],
-          },
-        ],
-      },
-    ],
+export const DynamicForm = {
+  render: Template,
+
+  args: {
+    form: {
+      formId: "abc-def",
+      portalId: 12345,
+      submitButtonLabel: "Submit label",
+      successMessage: "Success message",
+      fields: [
+        {
+          name: "name",
+          label: "Name",
+          type: "string",
+          required: true,
+        },
+        {
+          name: "user_type",
+          label: "User Type",
+          type: "select",
+          required: true,
+          options: [
+            { label: "Teacher", value: "Teacher" },
+            { label: "Pupil", value: "Pupil" },
+            { label: "Parent", value: "Parent" },
+          ],
+        },
+        {
+          name: "school",
+          label: "School",
+          type: "string",
+          required: false,
+          renderWhen: [
+            {
+              field: "user_type",
+              operator: "in",
+              value: ["Teacher"],
+            },
+          ],
+        },
+      ],
+    },
   },
 };

--- a/src/components/ArchivedComponents/ImageBox/ImageBox.stories.tsx
+++ b/src/components/ArchivedComponents/ImageBox/ImageBox.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from ".";
 
@@ -20,6 +20,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const Box = Template.bind({});
+export const Box = {};

--- a/src/components/ArchivedComponents/KeyStagesNav/KeyStagesNav.stories.tsx
+++ b/src/components/ArchivedComponents/KeyStagesNav/KeyStagesNav.stories.tsx
@@ -13,4 +13,6 @@ const Template: StoryFn<typeof Component> = () => {
   return <Component keyStages={keyStagesNavData} />;
 };
 
-export const KeyStagesNav = Template.bind({});
+export const KeyStagesNav = {
+  render: Template,
+};

--- a/src/components/ArchivedComponents/LoadingSpinner/LoadingSpinner.stories.tsx
+++ b/src/components/ArchivedComponents/LoadingSpinner/LoadingSpinner.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./LoadingSpinner";
 
@@ -7,6 +6,4 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LoadingSpinner = Template.bind({});
+export const LoadingSpinner = {};

--- a/src/components/ArchivedComponents/SubjectCardList/SubjectCardList.stories.tsx
+++ b/src/components/ArchivedComponents/SubjectCardList/SubjectCardList.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import AnalyticsDecorator from "../../../storybook-decorators/AnalyticsDecorator";
 
@@ -9,10 +9,6 @@ export default {
   component: Component,
   argTypes: {},
 } as Meta<typeof Component>;
-
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const SubjectCardList = Template.bind({});
 
 const subjects = [
   [
@@ -26,14 +22,16 @@ const subjects = [
   ],
 ] as unknown as KeyStageSubject[];
 
-SubjectCardList.args = {
-  subjects: subjects,
-  isAvailable: true,
+export const SubjectCardList = {
+  args: {
+    subjects: subjects,
+    isAvailable: true,
+  },
 };
 
-export const SubjectCardListUnavailable = Template.bind({});
-
-SubjectCardListUnavailable.args = {
-  subjects: subjects,
-  isAvailable: false,
+export const SubjectCardListUnavailable = {
+  args: {
+    subjects: subjects,
+    isAvailable: false,
+  },
 };

--- a/src/components/ArchivedComponents/SubjectCardList/SubjectCardListItem.stories.tsx
+++ b/src/components/ArchivedComponents/SubjectCardList/SubjectCardListItem.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import AnalyticsDecorator from "../../../storybook-decorators/AnalyticsDecorator";
 
@@ -10,10 +10,6 @@ export default {
   component: Component,
   argTypes: {},
 } as Meta<typeof Component>;
-
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const SubjectCardListItem = Template.bind({});
 
 const subjects = [
   [
@@ -27,13 +23,15 @@ const subjects = [
   ],
 ] as unknown as KeyStageSubject[];
 
-SubjectCardListItem.args = {
-  subject: subjects[0],
+export const SubjectCardListItem = {
+  args: {
+    subject: subjects[0],
+  },
 };
 
-export const SubjectCardListItemUnavailable = Template.bind({});
-
-SubjectCardListItemUnavailable.args = {
-  subject: subjects[0],
-  isAvailable: true,
+export const SubjectCardListItemUnavailable = {
+  args: {
+    subject: subjects[0],
+    isAvailable: true,
+  },
 };

--- a/src/components/ArchivedComponents/Toast/Toast.stories.tsx
+++ b/src/components/ArchivedComponents/Toast/Toast.stories.tsx
@@ -21,4 +21,6 @@ const Template: StoryFn<typeof Component> = () => {
   );
 };
 
-export const Toast = Template.bind({});
+export const Toast = {
+  render: Template,
+};

--- a/src/components/ArchivedComponents/Toggle/Toggle.stories.tsx
+++ b/src/components/ArchivedComponents/Toggle/Toggle.stories.tsx
@@ -24,10 +24,14 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const Toggle = Template.bind({});
+export const Toggle = {
+  render: Template,
+};
 
-export const ToggleDisabled = Template.bind({});
+export const ToggleDisabled = {
+  render: Template,
 
-ToggleDisabled.args = {
-  disabled: true,
+  args: {
+    disabled: true,
+  },
 };

--- a/src/components/GenericPagesComponents/BioCardListItem/BioCardListItem.stories.tsx
+++ b/src/components/GenericPagesComponents/BioCardListItem/BioCardListItem.stories.tsx
@@ -10,8 +10,11 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const BioCardListItem = Template.bind({});
-BioCardListItem.args = {
-  name: "John Smith",
-  role: "Worker",
+export const BioCardListItem = {
+  render: Template,
+
+  args: {
+    name: "John Smith",
+    role: "Worker",
+  },
 };

--- a/src/components/GenericPagesComponents/BioCardListModal/BioCardListModal.stories.tsx
+++ b/src/components/GenericPagesComponents/BioCardListModal/BioCardListModal.stories.tsx
@@ -16,5 +16,7 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const BioCarsListModal = Template.bind({});
-BioCarsListModal.args = {};
+export const BioCardListModal = {
+  render: Template,
+  args: {},
+};

--- a/src/components/GenericPagesComponents/BioCardListModalDialog/BioCardListModalDialog.stories.tsx
+++ b/src/components/GenericPagesComponents/BioCardListModalDialog/BioCardListModalDialog.stories.tsx
@@ -40,7 +40,10 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const BioCardListModalDialog = Template.bind({});
-BioCardListModalDialog.args = {
-  size: "small",
+export const BioCardListModalDialog = {
+  render: Template,
+
+  args: {
+    size: "small",
+  },
 };

--- a/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.stories.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./CurriculumTab";
 
@@ -11,6 +10,4 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const CurriculumTab = Template.bind({});
+export const CurriculumTab = {};

--- a/src/components/GenericPagesComponents/CurriculumTabBadge/CurriculumTabBadge.stories.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTabBadge/CurriculumTabBadge.stories.tsx
@@ -10,11 +10,18 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const TextBadge = Template.bind({});
-TextBadge.args = {
-  text: "80%",
+export const TextBadge = {
+  render: Template,
+
+  args: {
+    text: "80%",
+  },
 };
-export const IconBadge = Template.bind({});
-IconBadge.args = {
-  icon: "share",
+
+export const IconBadge = {
+  render: Template,
+
+  args: {
+    icon: "share",
+  },
 };

--- a/src/components/GenericPagesComponents/DropdownSelect/DropdownSelect.stories.tsx
+++ b/src/components/GenericPagesComponents/DropdownSelect/DropdownSelect.stories.tsx
@@ -18,43 +18,49 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const DropdownSelect = Template.bind({});
+export const DropdownSelect = {
+  render: Template,
 
-DropdownSelect.args = {
-  listItems: [
-    { value: "1", label: "Teacher" },
-    { value: "2", label: "Parent" },
-    { value: "3", label: "Pupil" },
-    { value: "4", label: "Other" },
-  ],
-  name: "Role select dropdown",
-  placeholder: "What describes you best?",
-  label: "User type",
+  args: {
+    listItems: [
+      { value: "1", label: "Teacher" },
+      { value: "2", label: "Parent" },
+      { value: "3", label: "Pupil" },
+      { value: "4", label: "Other" },
+    ],
+    name: "Role select dropdown",
+    placeholder: "What describes you best?",
+    label: "User type",
+  },
 };
 
-export const DropdownSelectIcon = Template.bind({});
+export const DropdownSelectIcon = {
+  render: Template,
 
-DropdownSelectIcon.args = {
-  listItems: [
-    { value: "1", label: "Teacher" },
-    { value: "2", label: "Parent" },
-    { value: "3", label: "Pupil" },
-    { value: "4", label: "Other" },
-  ],
-  name: "Role select dropdown",
-  placeholder: "What describes you best?",
-  icon: "chevron-down",
+  args: {
+    listItems: [
+      { value: "1", label: "Teacher" },
+      { value: "2", label: "Parent" },
+      { value: "3", label: "Pupil" },
+      { value: "4", label: "Other" },
+    ],
+    name: "Role select dropdown",
+    placeholder: "What describes you best?",
+    icon: "chevron-down",
+  },
 };
 
-export const DropdownSelectLabel = Template.bind({});
+export const DropdownSelectLabel = {
+  render: Template,
 
-DropdownSelectLabel.args = {
-  listItems: [
-    { value: "1", label: "Teacher" },
-    { value: "2", label: "Parent" },
-    { value: "3", label: "Pupil" },
-    { value: "4", label: "Other" },
-  ],
-  name: "Role select dropdown",
-  label: "What describes you best?",
+  args: {
+    listItems: [
+      { value: "1", label: "Teacher" },
+      { value: "2", label: "Parent" },
+      { value: "3", label: "Pupil" },
+      { value: "4", label: "Other" },
+    ],
+    name: "Role select dropdown",
+    label: "What describes you best?",
+  },
 };

--- a/src/components/GenericPagesComponents/GenericSummaryCard/GenericSummaryCard.stories.tsx
+++ b/src/components/GenericPagesComponents/GenericSummaryCard/GenericSummaryCard.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./GenericSummaryCard";
 
@@ -9,14 +9,12 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const GenericSummaryCard = Template.bind({});
-
-GenericSummaryCard.args = {
-  title: "Title",
-  heading: "Heading",
-  summaryPortableText: portableTextFromString(
-    "We’re here to support great teaching. We’re an independent public body. We work in partnership to improve pupil outcomes and close the disadvantage gap by supporting teachers to teach, and enabling pupils to access a high-quality curriculum.",
-  ),
+export const GenericSummaryCard = {
+  args: {
+    title: "Title",
+    heading: "Heading",
+    summaryPortableText: portableTextFromString(
+      "We’re here to support great teaching. We’re an independent public body. We work in partnership to improve pupil outcomes and close the disadvantage gap by supporting teachers to teach, and enabling pupils to access a high-quality curriculum.",
+    ),
+  },
 };

--- a/src/components/GenericPagesComponents/GenericSummaryCardNavButton/GenericSummaryCardNavButton.stories.tsx
+++ b/src/components/GenericPagesComponents/GenericSummaryCardNavButton/GenericSummaryCardNavButton.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./GenericSummaryCardNavButton";
 
@@ -7,14 +7,12 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const GenericSummaryCardNavButton = Template.bind({});
-
-GenericSummaryCardNavButton.args = {
-  buttons: [
-    { label: "Who we are", href: "/first-one" },
-    { label: "Board", href: "/second-one" },
-    { label: "Leadership", href: "/third-one" },
-  ],
+export const GenericSummaryCardNavButton = {
+  args: {
+    buttons: [
+      { label: "Who we are", href: "/first-one" },
+      { label: "Board", href: "/second-one" },
+      { label: "Leadership", href: "/third-one" },
+    ],
+  },
 };

--- a/src/components/GenericPagesComponents/LandingPageHero/LandingPageHero.stories.tsx
+++ b/src/components/GenericPagesComponents/LandingPageHero/LandingPageHero.stories.tsx
@@ -15,28 +15,34 @@ const Template: StoryFn<typeof Component> = (args) => (
   </OakFlex>
 );
 
-export const LandingPagesHero = Template.bind({});
-LandingPagesHero.args = {
-  hero: {
-    title: "some-landing-page title",
-    heading: "landing page heading",
+export const LandingPagesHero = {
+  render: Template,
+
+  args: {
+    hero: {
+      title: "some-landing-page title",
+      heading: "landing page heading",
+    },
   },
 };
 
-export const LandingPagesHeroImageCta = Template.bind({});
-LandingPagesHeroImageCta.args = {
-  hero: {
-    title: "some-landing-page title",
-    heading: "landing page heading",
-    cta: {
-      linkType: "anchor",
-      label: "cta",
-      anchor: "formBlock",
-    },
-    image: {
-      asset: {
-        _id: `image-123-300x300-png`,
-        url: `https://cdn.sanity.io/images/p/d/123-300x300.png`,
+export const LandingPagesHeroImageCta = {
+  render: Template,
+
+  args: {
+    hero: {
+      title: "some-landing-page title",
+      heading: "landing page heading",
+      cta: {
+        linkType: "anchor",
+        label: "cta",
+        anchor: "formBlock",
+      },
+      image: {
+        asset: {
+          _id: `image-123-300x300-png`,
+          url: `https://cdn.sanity.io/images/p/d/123-300x300.png`,
+        },
       },
     },
   },

--- a/src/components/GenericPagesComponents/LandingPageQuote/LandingPageQuote.stories.tsx
+++ b/src/components/GenericPagesComponents/LandingPageQuote/LandingPageQuote.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { LandingPageQuote as Component } from "./LandingPageQuote";
 
@@ -8,10 +7,9 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LandingPagesQuote = Template.bind({});
-LandingPagesQuote.args = {
-  text: "This is an inspiring quote",
-  attribution: "I Wroteit",
+export const LandingPagesQuote = {
+  args: {
+    text: "This is an inspiring quote",
+    attribution: "I Wroteit",
+  },
 };

--- a/src/components/GenericPagesComponents/LandingPageSignupPrompt/LandingPageSignupPrompt.stories.tsx
+++ b/src/components/GenericPagesComponents/LandingPageSignupPrompt/LandingPageSignupPrompt.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { LandingPageSignupPrompt as Component } from "./LandingPageSignupPrompt";
 
@@ -11,28 +10,27 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LandingPageSignupPrompt = Template.bind({});
-LandingPageSignupPrompt.args = {
-  bodyPortableText: [
-    {
-      _key: "fba015024518",
-      _type: "block",
-      children: [
-        {
-          _key: "e55d6209321d0",
-          _type: "span",
-          marks: [],
-          text: "Our interim board oversees all of Oak’s work. They provide strategic direction, enable us to deliver on our plans, scrutinise our work and safeguard our independence. The interim board will be in place whilst a permanent board is chosen through a public appointments process.",
-        },
-      ],
-      markDefs: [],
-      style: "normal",
+export const LandingPageSignupPrompt = {
+  args: {
+    bodyPortableText: [
+      {
+        _key: "fba015024518",
+        _type: "block",
+        children: [
+          {
+            _key: "e55d6209321d0",
+            _type: "span",
+            marks: [],
+            text: "Our interim board oversees all of Oak’s work. They provide strategic direction, enable us to deliver on our plans, scrutinise our work and safeguard our independence. The interim board will be in place whilst a permanent board is chosen through a public appointments process.",
+          },
+        ],
+        markDefs: [],
+        style: "normal",
+      },
+    ],
+    title: "title",
+    form: {
+      title: "title of the form",
     },
-  ],
-  title: "title",
-  form: {
-    title: "title of the form",
   },
 };

--- a/src/components/GenericPagesComponents/LandingPageTextBlock/LandingPageTextBlock.stories.tsx
+++ b/src/components/GenericPagesComponents/LandingPageTextBlock/LandingPageTextBlock.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { LandingPageTextBlock as Component } from "./LandingPageTextBlock";
 
@@ -8,24 +7,23 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LandingPagesTextBlock = Template.bind({});
-LandingPagesTextBlock.args = {
-  bodyPortableText: [
-    {
-      _key: "fba015024518",
-      _type: "block",
-      children: [
-        {
-          _key: "e55d6209321d0",
-          _type: "span",
-          marks: [],
-          text: "Our interim board oversees all of Oak’s work. They provide strategic direction, enable us to deliver on our plans, scrutinise our work and safeguard our independence. The interim board will be in place whilst a permanent board is chosen through a public appointments process.",
-        },
-      ],
-      markDefs: [],
-      style: "normal",
-    },
-  ],
+export const LandingPagesTextBlock = {
+  args: {
+    bodyPortableText: [
+      {
+        _key: "fba015024518",
+        _type: "block",
+        children: [
+          {
+            _key: "e55d6209321d0",
+            _type: "span",
+            marks: [],
+            text: "Our interim board oversees all of Oak’s work. They provide strategic direction, enable us to deliver on our plans, scrutinise our work and safeguard our independence. The interim board will be in place whilst a permanent board is chosen through a public appointments process.",
+          },
+        ],
+        markDefs: [],
+        style: "normal",
+      },
+    ],
+  },
 };

--- a/src/components/GenericPagesComponents/NewsletterForm/NewsletterForm.stories.tsx
+++ b/src/components/GenericPagesComponents/NewsletterForm/NewsletterForm.stories.tsx
@@ -23,32 +23,39 @@ const Template: StoryFn<typeof Component> = (args) => (
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-export const NewsletterForm = Template.bind({});
-NewsletterForm.args = {
-  onSubmit: async () => {
-    await sleep(2000);
-  },
-};
+export const NewsletterForm = {
+  render: Template,
 
-export const WithError = Template.bind({});
-WithError.parameters = {
-  docs: {
-    description: {
-      story:
-        "Fill out this form correctly and press submit to see the submission error.",
+  args: {
+    onSubmit: async () => {
+      await sleep(2000);
     },
   },
 };
-WithError.args = {
-  onSubmit: async (data) => {
-    await sleep(2000);
-    if (data.email.includes("fishy")) {
+
+export const WithError = {
+  render: Template,
+
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fill out this form correctly and press submit to see the submission error.",
+      },
+    },
+  },
+
+  args: {
+    onSubmit: async (data: { email: string }) => {
+      await sleep(2000);
+      if (data.email.includes("fishy")) {
+        throw new Error(
+          "Thank you, that's been received, but please check as your email doesn't look quite right.",
+        );
+      }
       throw new Error(
-        "Thank you, that's been received, but please check as your email doesn't look quite right.",
+        "Sorry, we couldn't sign you up just now, try again later.",
       );
-    }
-    throw new Error(
-      "Sorry, we couldn't sign you up just now, try again later.",
-    );
+    },
   },
 };

--- a/src/components/GenericPagesComponents/PostPortableText/PostPortableText.stories.tsx
+++ b/src/components/GenericPagesComponents/PostPortableText/PostPortableText.stories.tsx
@@ -111,27 +111,42 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const PostSectionHeading = Template.bind({});
-PostSectionHeading.args = {
-  portableText: [sectionHeading],
+export const PostSectionHeading = {
+  render: Template,
+
+  args: {
+    portableText: [sectionHeading],
+  },
 };
 
-export const PostVideo = Template.bind({});
-PostVideo.args = {
-  portableText: [video],
+export const PostVideo = {
+  render: Template,
+
+  args: {
+    portableText: [video],
+  },
 };
 
-export const PostQuote = Template.bind({});
-PostQuote.args = {
-  portableText: [quote],
+export const PostQuote = {
+  render: Template,
+
+  args: {
+    portableText: [quote],
+  },
 };
 
-export const PostTextAndMedia = Template.bind({});
-PostTextAndMedia.args = {
-  portableText: [textAndMedia],
+export const PostTextAndMedia = {
+  render: Template,
+
+  args: {
+    portableText: [textAndMedia],
+  },
 };
 
-export const PostCallout = Template.bind({});
-PostCallout.args = {
-  portableText: [callout],
+export const PostCallout = {
+  render: Template,
+
+  args: {
+    portableText: [callout],
+  },
 };

--- a/src/components/GenericPagesComponents/PupilTab/PupilTab.stories.tsx
+++ b/src/components/GenericPagesComponents/PupilTab/PupilTab.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./PupilTab";
 
@@ -11,6 +10,4 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const PupilTab = Template.bind({});
+export const PupilTab = {};

--- a/src/components/GenericPagesComponents/SupportYourTeamBubbleMessage/SupportYourTeamBubbleMessage.stories.tsx
+++ b/src/components/GenericPagesComponents/SupportYourTeamBubbleMessage/SupportYourTeamBubbleMessage.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./SupportYourTeamBubbleMessage";
 
@@ -8,20 +7,20 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const BubbleMessage = Template.bind({});
-BubbleMessage.args = {
-  variant: "bubble-1",
-  outlineHeading: "3 hrs",
-  heading: "per week saved on lesson planning",
-  subHeading: "by nearly half of teachers using Oak",
+export const BubbleMessage = {
+  args: {
+    variant: "bubble-1",
+    outlineHeading: "3 hrs",
+    heading: "per week saved on lesson planning",
+    subHeading: "by nearly half of teachers using Oak",
+  },
 };
 
-export const BubbleMessage2 = Template.bind({});
-BubbleMessage2.args = {
-  variant: "bubble-2",
-  outlineHeading: "3 hrs",
-  heading: "per week saved on lesson planning",
-  subHeading: "by nearly half of teachers using Oak",
+export const BubbleMessage2 = {
+  args: {
+    variant: "bubble-2",
+    outlineHeading: "3 hrs",
+    heading: "per week saved on lesson planning",
+    subHeading: "by nearly half of teachers using Oak",
+  },
 };

--- a/src/components/GenericPagesComponents/SupportYourTeamTextBlockCard/SupportYourTeamTextBlockCard.stories.tsx
+++ b/src/components/GenericPagesComponents/SupportYourTeamTextBlockCard/SupportYourTeamTextBlockCard.stories.tsx
@@ -49,9 +49,12 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const SupportYourTeamTextBlockCard = Template.bind({});
-SupportYourTeamTextBlockCard.args = {
-  background: "lemon50",
-  title: "Card title",
-  bodyPortableText: bodyPortableText,
+export const SupportYourTeamTextBlockCard = {
+  render: Template,
+
+  args: {
+    background: "lemon50",
+    title: "Card title",
+    bodyPortableText: bodyPortableText,
+  },
 };

--- a/src/components/GenericPagesComponents/SupportYourTeamTextBlockCardULTick/SupportYourTeamTextBlockCardULTick.stories.tsx
+++ b/src/components/GenericPagesComponents/SupportYourTeamTextBlockCardULTick/SupportYourTeamTextBlockCardULTick.stories.tsx
@@ -41,5 +41,7 @@ const Template: StoryFn<typeof Card> = (args) => {
   );
 };
 
-export const SupportYourTeamTextBlockCardULTick = Template.bind({});
-SupportYourTeamTextBlockCardULTick.parameters = {};
+export const SupportYourTeamTextBlockCardULTick = {
+  render: Template,
+  parameters: {},
+};

--- a/src/components/GenericPagesComponents/TeachersTab/TeachersTab.stories.tsx
+++ b/src/components/GenericPagesComponents/TeachersTab/TeachersTab.stories.tsx
@@ -16,4 +16,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   <Component {...args} keyStages={keyStageKeypad.keyStages} />
 );
 
-export const TeachersTab = Template.bind({});
+export const TeachersTab = {
+  render: Template,
+};

--- a/src/components/GenericPagesComponents/TeachersTabResourceSelectorCard/TeachersTabResourceSelectorCard.stories.tsx
+++ b/src/components/GenericPagesComponents/TeachersTabResourceSelectorCard/TeachersTabResourceSelectorCard.stories.tsx
@@ -21,4 +21,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   />
 );
 
-export const TeachersTabResourceSelectorCard = Template.bind({});
+export const TeachersTabResourceSelectorCard = {
+  render: Template,
+};

--- a/src/components/GenericPagesComponents/UpcomingWebinarWall/UpcomingWebinarWall.stories.tsx
+++ b/src/components/GenericPagesComponents/UpcomingWebinarWall/UpcomingWebinarWall.stories.tsx
@@ -30,10 +30,13 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const UpcomingWebinarWall = Template.bind({});
-UpcomingWebinarWall.args = {
-  headingTag: "h3",
-  headingText: "Register to view",
-  buttonHref: "https://example.com",
-  buttonText: "Register",
+export const UpcomingWebinarWall = {
+  render: Template,
+
+  args: {
+    headingTag: "h3",
+    headingText: "Register to view",
+    buttonHref: "https://example.com",
+    buttonText: "Register",
+  },
 };

--- a/src/components/GenericPagesComponents/WebinarRegistration/WebinarRegistration.stories.tsx
+++ b/src/components/GenericPagesComponents/WebinarRegistration/WebinarRegistration.stories.tsx
@@ -24,7 +24,10 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const WebinarRegistration = Template.bind({});
-WebinarRegistration.args = {
-  headingTag: "h3",
+export const WebinarRegistration = {
+  render: Template,
+
+  args: {
+    headingTag: "h3",
+  },
 };

--- a/src/components/GenericPagesComponents/WebinarVideo/WebinarVideo.stories.tsx
+++ b/src/components/GenericPagesComponents/WebinarVideo/WebinarVideo.stories.tsx
@@ -25,14 +25,20 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const WebinarVideo = Template.bind({});
-WebinarVideo.args = {
-  webinar: mockWebinar(),
+export const WebinarVideo = {
+  render: Template,
+
+  args: {
+    webinar: mockWebinar(),
+  },
 };
 
-export const WebinarVideoUpcoming = Template.bind({});
-WebinarVideoUpcoming.args = {
-  webinar: mockWebinar({
-    date: "2053-04-14",
-  }),
+export const WebinarVideoUpcoming = {
+  render: Template,
+
+  args: {
+    webinar: mockWebinar({
+      date: "2053-04-14",
+    }),
+  },
 };

--- a/src/components/PupilComponents/PupilAnalyticsProvider/usePupilAnalytics.test.ts
+++ b/src/components/PupilComponents/PupilAnalyticsProvider/usePupilAnalytics.test.ts
@@ -1,0 +1,15 @@
+import { renderHook } from "@testing-library/react";
+
+import { usePupilAnalytics } from "./usePupilAnalytics";
+import { getMockPupilAnalytics } from "./getMockPupilAnalytics";
+
+describe("usePupilAnalytics", () => {
+  it("should return mock analytics when in Storybook environment", () => {
+    process.env.STORYBOOK = "true";
+    const { result } = renderHook(() => usePupilAnalytics());
+    expect(JSON.stringify(result.current)).toEqual(
+      JSON.stringify(getMockPupilAnalytics()),
+    );
+    delete process.env.STORYBOOK;
+  });
+});

--- a/src/components/SharedComponents/AspectRatio/AspectRatio.stories.tsx
+++ b/src/components/SharedComponents/AspectRatio/AspectRatio.stories.tsx
@@ -17,8 +17,10 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Box>
 );
 
-export const AspectRatio = Template.bind({});
+export const AspectRatio = {
+  render: Template,
 
-AspectRatio.args = {
-  ratio: "1:1",
+  args: {
+    ratio: "1:1",
+  },
 };

--- a/src/components/SharedComponents/AvatarImage/AvatarImage.stories.tsx
+++ b/src/components/SharedComponents/AvatarImage/AvatarImage.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from ".";
 
@@ -7,7 +6,6 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const AvatarImage = Template.bind({});
-AvatarImage.args = {};
+export const AvatarImage = {
+  args: {},
+};

--- a/src/components/SharedComponents/Box/Box.stories.tsx
+++ b/src/components/SharedComponents/Box/Box.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from ".";
 
@@ -20,6 +20,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const Box = Template.bind({});
+export const Box = {};

--- a/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./Breadcrumbs";
 
@@ -8,20 +7,19 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const Breadcrumbs = Template.bind({});
-Breadcrumbs.args = {
-  breadcrumbs: [
-    { oakLinkProps: { href: "/", page: null }, label: "Unit Quiz" },
-    { oakLinkProps: { href: "/", page: null }, label: "View In Classroom" },
-    {
-      oakLinkProps: { href: "/", page: null },
-      label: "Foundation Curriculum (PDF)",
-    },
-    {
-      oakLinkProps: { href: "/", page: null },
-      label: "Higher Curriculum (PDF)",
-    },
-  ],
+export const Breadcrumbs = {
+  args: {
+    breadcrumbs: [
+      { oakLinkProps: { href: "/", page: null }, label: "Unit Quiz" },
+      { oakLinkProps: { href: "/", page: null }, label: "View In Classroom" },
+      {
+        oakLinkProps: { href: "/", page: null },
+        label: "Foundation Curriculum (PDF)",
+      },
+      {
+        oakLinkProps: { href: "/", page: null },
+        label: "Higher Curriculum (PDF)",
+      },
+    ],
+  },
 };

--- a/src/components/SharedComponents/Button/Button.stories.tsx
+++ b/src/components/SharedComponents/Button/Button.stories.tsx
@@ -24,12 +24,17 @@ const Template: StoryFn<typeof Component> = (args) => (
   </>
 );
 
-export const Button = Template.bind({});
+export const Button = {
+  render: Template,
+};
 
-export const ButtonWithIcon = Template.bind({});
-ButtonWithIcon.args = {
-  icon: "save",
-  size: "large",
+export const ButtonWithIcon = {
+  render: Template,
+
+  args: {
+    icon: "save",
+    size: "large",
+  },
 };
 
 const MinimalButtonWithIconTemplate: StoryFn<typeof Component> = (args) => (
@@ -40,9 +45,12 @@ const MinimalButtonWithIconTemplate: StoryFn<typeof Component> = (args) => (
   </>
 );
 
-export const MinimalButtonWithIcon = MinimalButtonWithIconTemplate.bind({});
-MinimalButtonWithIcon.args = {
-  variant: "minimal",
-  icon: "save",
-  size: "large",
+export const MinimalButtonWithIcon = {
+  render: MinimalButtonWithIconTemplate,
+
+  args: {
+    variant: "minimal",
+    icon: "save",
+    size: "large",
+  },
 };

--- a/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.stories.tsx
+++ b/src/components/SharedComponents/Button/CopyLinkButton/CopyLinkButton.stories.tsx
@@ -15,4 +15,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </ToastProvider>
 );
 
-export const CopyLinkButton = Template.bind({});
+export const CopyLinkButton = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Button/IconButton/IconButton.stories.tsx
+++ b/src/components/SharedComponents/Button/IconButton/IconButton.stories.tsx
@@ -28,4 +28,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </OakFlex>
 );
 
-export const IconButton = Template.bind({});
+export const IconButton = {
+  render: Template,
+};

--- a/src/components/SharedComponents/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/SharedComponents/ButtonGroup/ButtonGroup.stories.tsx
@@ -28,4 +28,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const ButtonGroup = Template.bind({});
+export const ButtonGroup = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Card/Card.stories.tsx
+++ b/src/components/SharedComponents/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { StoryObj, StoryFn, Meta } from "@storybook/react";
 import { OakP, OakFlex } from "@oaknational/oak-components";
 
 import Component from ".";
@@ -26,77 +26,86 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const Card = Template.bind({});
+export const Card = {
+  render: Template,
+};
 
-export const CardIconButton: StoryFn<typeof Component> = (args) => (
-  <div style={{ width: "300px", height: "250px" }}>
-    <Component {...args}>
-      <CardTitle
-        icon={"download"}
-        $iconPosition={"leading"}
-        iconSize={32}
-        tag={"h4"}
-      >
-        Title
-      </CardTitle>
-      <OakP $font={"body-2"} $mb={"space-between-m"} $color={"grey50"}>
-        Short snappy description of what this card is about.
-      </OakP>
-      <ButtonAsLink $mt={"auto"} label={"Label"} $fullWidth page="home" />
-    </Component>
-  </div>
-);
-
-export const CardImageButton: StoryFn<typeof Component> = (args) => (
-  <div style={{ width: "300px" }}>
-    <Component {...args}>
-      <CardImage illustration="magic-carpet" />
-      <OakFlex $pa="inner-padding-xl" $flexDirection={"column"}>
-        <CardTitle tag={"h4"}>Title</CardTitle>
+export const CardIconButton: StoryObj<typeof Component> = {
+  render: (args) => (
+    <div style={{ width: "300px", height: "250px" }}>
+      <Component {...args}>
+        <CardTitle
+          icon={"download"}
+          $iconPosition={"leading"}
+          iconSize={32}
+          tag={"h4"}
+        >
+          Title
+        </CardTitle>
         <OakP $font={"body-2"} $mb={"space-between-m"} $color={"grey50"}>
           Short snappy description of what this card is about.
         </OakP>
+        <ButtonAsLink $mt={"auto"} label={"Label"} $fullWidth page="home" />
+      </Component>
+    </div>
+  ),
+};
+
+export const CardImageButton: StoryObj<typeof Component> = {
+  render: (args) => (
+    <div style={{ width: "300px" }}>
+      <Component {...args}>
+        <CardImage illustration="magic-carpet" />
+        <OakFlex $pa="inner-padding-xl" $flexDirection={"column"}>
+          <CardTitle tag={"h4"}>Title</CardTitle>
+          <OakP $font={"body-2"} $mb={"space-between-m"} $color={"grey50"}>
+            Short snappy description of what this card is about.
+          </OakP>
+          <ButtonAsLink
+            $mt={"auto"}
+            $mb={16}
+            label={"Label"}
+            $fullWidth
+            page={"home"}
+          />
+        </OakFlex>
+      </Component>
+    </div>
+  ),
+
+  args: {
+    pa: 0,
+  },
+};
+
+export const CardLargeIconCentered: StoryObj<typeof Component> = {
+  render: (args) => (
+    <div style={{ width: "300px", height: "336px" }}>
+      <Component {...args}>
+        <CardTitle
+          icon={"download"}
+          $iconPosition={"aboveTitle"}
+          iconSize={80}
+          tag={"h4"}
+        >
+          Title
+        </CardTitle>
+        <OakP
+          $textAlign="center"
+          $font={"body-2"}
+          $mb={"space-between-m"}
+          $color={"grey50"}
+        >
+          Short snappy description of what this card is about.
+        </OakP>
         <ButtonAsLink
-          $mt={"auto"}
           $mb={16}
+          $mt={"auto"}
           label={"Label"}
           $fullWidth
           page={"home"}
         />
-      </OakFlex>
-    </Component>
-  </div>
-);
-CardImageButton.args = {
-  pa: 0,
+      </Component>
+    </div>
+  ),
 };
-
-export const CardLargeIconCentered: StoryFn<typeof Component> = (args) => (
-  <div style={{ width: "300px", height: "336px" }}>
-    <Component {...args}>
-      <CardTitle
-        icon={"download"}
-        $iconPosition={"aboveTitle"}
-        iconSize={80}
-        tag={"h4"}
-      >
-        Title
-      </CardTitle>
-      <OakP
-        $textAlign="center"
-        $font={"body-2"}
-        $mb={"space-between-m"}
-        $color={"grey50"}
-      >
-        Short snappy description of what this card is about.
-      </OakP>
-      <ButtonAsLink
-        $mb={16}
-        $mt={"auto"}
-        label={"Label"}
-        $fullWidth
-        page={"home"}
-      />
-    </Component>
-  </div>
-);

--- a/src/components/SharedComponents/Card/DismissibleCard.stories.tsx
+++ b/src/components/SharedComponents/Card/DismissibleCard.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./DismissibleCard";
 
@@ -16,6 +16,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const DismissibleCard = Template.bind({});
+export const DismissibleCard = {};

--- a/src/components/SharedComponents/Card/SummaryCard.stories.tsx
+++ b/src/components/SharedComponents/Card/SummaryCard.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./SummaryCard";
 
@@ -7,31 +7,29 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const SummaryCard = Template.bind({});
-
-SummaryCard.args = {
-  title: "Title",
-  summaryPortableText: "A summary section.......",
-  background: "lemon50",
+export const SummaryCard = {
+  args: {
+    title: "Title",
+    summaryPortableText: "A summary section.......",
+    background: "lemon50",
+  },
 };
 
-export const SummaryCardImage = Template.bind({});
-
-SummaryCardImage.args = {
-  title: "Title",
-  summaryPortableText: "A summary section.......",
-  background: "lemon50",
+export const SummaryCardImage = {
+  args: {
+    title: "Title",
+    summaryPortableText: "A summary section.......",
+    background: "lemon50",
+  },
 };
 
-export const SummaryCardCustomImageContainer = Template.bind({});
-
-SummaryCardCustomImageContainer.args = {
-  title: "Title",
-  summaryPortableText: "A summary section.......",
-  background: "teal",
-  imageContainerProps: {
-    $minHeight: 160,
+export const SummaryCardCustomImageContainer = {
+  args: {
+    title: "Title",
+    summaryPortableText: "A summary section.......",
+    background: "teal",
+    imageContainerProps: {
+      $minHeight: 160,
+    },
   },
 };

--- a/src/components/SharedComponents/Checkbox/Checkbox.stories.tsx
+++ b/src/components/SharedComponents/Checkbox/Checkbox.stories.tsx
@@ -31,4 +31,6 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const Checkbox = Template.bind({});
+export const Checkbox = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Circle/Circle.stories.tsx
+++ b/src/components/SharedComponents/Circle/Circle.stories.tsx
@@ -18,8 +18,14 @@ const Template: StoryFn<typeof Component> = (props) => (
   <Component {...props}>Hi!</Component>
 );
 
-export const Circle = Template.bind({});
-export const CircleWithDropShadow = Template.bind({});
-CircleWithDropShadow.args = {
-  $dropShadow: "grey20",
+export const Circle = {
+  render: Template,
+};
+
+export const CircleWithDropShadow = {
+  render: Template,
+
+  args: {
+    $dropShadow: "grey20",
+  },
 };

--- a/src/components/SharedComponents/FieldError/FieldError.stories.tsx
+++ b/src/components/SharedComponents/FieldError/FieldError.stories.tsx
@@ -14,9 +14,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   </>
 );
 
-export const FieldError = Template.bind({});
+export const FieldError = {
+  render: Template,
 
-FieldError.args = {
-  id: "error id",
-  children: "Display error here",
+  args: {
+    id: "error id",
+    children: "Display error here",
+  },
 };

--- a/src/components/SharedComponents/Grid.deprecated/GridArea.deprecated.stories.tsx
+++ b/src/components/SharedComponents/Grid.deprecated/GridArea.deprecated.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./GridArea.deprecated";
 
@@ -24,6 +24,4 @@ export default {
   },
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const GridArea = Template.bind({});
+export const GridArea = {};

--- a/src/components/SharedComponents/Icon/Icon.stories.tsx
+++ b/src/components/SharedComponents/Icon/Icon.stories.tsx
@@ -22,9 +22,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   </>
 );
 
-export const Icon = Template.bind({});
+export const Icon = {
+  render: Template,
 
-Icon.args = {
-  name: "bell",
-  size: 48,
+  args: {
+    name: "bell",
+    size: 48,
+  },
 };

--- a/src/components/SharedComponents/Input/Input.stories.tsx
+++ b/src/components/SharedComponents/Input/Input.stories.tsx
@@ -23,10 +23,21 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const Input = Template.bind({});
-export const WithIcon = Template.bind({});
-WithIcon.args = { icon: "search" };
-export const WithLabel = Template.bind({});
-WithLabel.args = { label: "Password" };
-export const WithError = Template.bind({});
-WithError.args = { error: "Password should contain at least 8 characters" };
+export const Input = {
+  render: Template,
+};
+
+export const WithIcon = {
+  render: Template,
+  args: { icon: "search" },
+};
+
+export const WithLabel = {
+  render: Template,
+  args: { label: "Password" },
+};
+
+export const WithError = {
+  render: Template,
+  args: { error: "Password should contain at least 8 characters" },
+};

--- a/src/components/SharedComponents/LineClamp/LineClamp.stories.tsx
+++ b/src/components/SharedComponents/LineClamp/LineClamp.stories.tsx
@@ -23,4 +23,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const LineClamp = Template.bind({});
+export const LineClamp = {
+  render: Template,
+};

--- a/src/components/SharedComponents/OutlineHeading/OutlineHeading.stories.tsx
+++ b/src/components/SharedComponents/OutlineHeading/OutlineHeading.stories.tsx
@@ -11,8 +11,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   <Component {...args}>Outline heading</Component>
 );
 
-export const OutlineHeading = Template.bind({});
-OutlineHeading.args = {
-  tag: "h1",
-  $fontSize: 32,
+export const OutlineHeading = {
+  render: Template,
+
+  args: {
+    tag: "h1",
+    $fontSize: 32,
+  },
 };

--- a/src/components/SharedComponents/PostHeader/PostHeader.stories.tsx
+++ b/src/components/SharedComponents/PostHeader/PostHeader.stories.tsx
@@ -14,26 +14,29 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const PostHeader = Template.bind({});
-PostHeader.args = {
-  page: "blog-index",
-  post: {
-    title: "A blog",
-    id: "5",
-    date: "2025-01-01",
-    slug: "a-blog",
-    author: { id: "000", name: "Author McAuthorFace" },
-    mainImage: {
-      asset: {
-        _id: "",
-        url: "",
+export const PostHeader = {
+  render: Template,
+
+  args: {
+    page: "blog-index",
+    post: {
+      title: "A blog",
+      id: "5",
+      date: "2025-01-01",
+      slug: "a-blog",
+      author: { id: "000", name: "Author McAuthorFace" },
+      mainImage: {
+        asset: {
+          _id: "",
+          url: "",
+        },
       },
-    },
-    summaryPortableText: "Lorem ipsum",
-    contentPortableText: [],
-    category: {
-      title: "Lesson Plabning",
-      slug: "lesson-planning",
+      summaryPortableText: "Lorem ipsum",
+      contentPortableText: [],
+      category: {
+        title: "Lesson Plabning",
+        slug: "lesson-planning",
+      },
     },
   },
 };

--- a/src/components/SharedComponents/PostList/PostList.stories.tsx
+++ b/src/components/SharedComponents/PostList/PostList.stories.tsx
@@ -48,24 +48,30 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const PostList = Template.bind({});
-PostList.args = {
-  currentPageItems,
+export const PostList = {
+  render: Template,
+
+  args: {
+    currentPageItems,
+  },
 };
 
-export const PostListWithUpcomingWebinar = Template.bind({});
-PostListWithUpcomingWebinar.args = {
-  upcomingItem: {
-    titleTag: "h2",
-    title: "She came in through the bathroom window",
-    summary:
-      'Penny Lane, there is a barber showing photographs Of every head he\'s had the pleasure to know And all the people that come and go Stop and say, "Hello"',
-    slug: "long-road",
-    contentType: "webinar",
-    category: { title: "Curriculum Planning", slug: "curriculum-planning" },
-    date: new Date(2059, 7, 17).toISOString(),
+export const PostListWithUpcomingWebinar = {
+  render: Template,
+
+  args: {
+    upcomingItem: {
+      titleTag: "h2",
+      title: "She came in through the bathroom window",
+      summary:
+        'Penny Lane, there is a barber showing photographs Of every head he\'s had the pleasure to know And all the people that come and go Stop and say, "Hello"',
+      slug: "long-road",
+      contentType: "webinar",
+      category: { title: "Curriculum Planning", slug: "curriculum-planning" },
+      date: new Date(2059, 7, 17).toISOString(),
+    },
+    currentPageItems,
+    withContainingHrs: true,
+    withUpcomingItem: true,
   },
-  currentPageItems,
-  withContainingHrs: true,
-  withUpcomingItem: true,
 };

--- a/src/components/SharedComponents/RadioButtons/RadioGroup.stories.tsx
+++ b/src/components/SharedComponents/RadioButtons/RadioGroup.stories.tsx
@@ -19,11 +19,15 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const RadioGroup = Template.bind({});
+export const RadioGroup = {
+  render: Template,
+};
 
-export const RadioGroupError = Template.bind({});
+export const RadioGroupError = {
+  render: Template,
 
-RadioGroupError.args = {
-  hasError: true,
-  errorMessage: "Please select/search a school or an option from above",
+  args: {
+    hasError: true,
+    errorMessage: "Please select/search a school or an option from above",
+  },
 };

--- a/src/components/SharedComponents/ScreenReaderOnly/ScreenReaderOnly.stories.tsx
+++ b/src/components/SharedComponents/ScreenReaderOnly/ScreenReaderOnly.stories.tsx
@@ -14,6 +14,7 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const ScreenReaderOnly = Template.bind({});
-
-ScreenReaderOnly.args = {};
+export const ScreenReaderOnly = {
+  render: Template,
+  args: {},
+};

--- a/src/components/SharedComponents/SearchForm/SearchForm.stories.tsx
+++ b/src/components/SharedComponents/SearchForm/SearchForm.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./SearchForm";
 
@@ -10,9 +9,8 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const SearchInput = Template.bind({});
-SearchInput.args = {
-  placeholderText: "Search by keyword or topic",
+export const SearchInput = {
+  args: {
+    placeholderText: "Search by keyword or topic",
+  },
 };

--- a/src/components/SharedComponents/SocialButtons/SocialButtons.stories.tsx
+++ b/src/components/SharedComponents/SocialButtons/SocialButtons.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component, { OAK_SOCIALS } from "./SocialButtons";
 
@@ -8,9 +7,8 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const SocialButtons = Template.bind({});
-SocialButtons.args = {
-  ...OAK_SOCIALS,
+export const SocialButtons = {
+  args: {
+    ...OAK_SOCIALS,
+  },
 };

--- a/src/components/SharedComponents/SpriteSheet/BrushSvgs/BoxBorders/BoxBorders.stories.tsx
+++ b/src/components/SharedComponents/SpriteSheet/BrushSvgs/BoxBorders/BoxBorders.stories.tsx
@@ -22,4 +22,6 @@ const Template: StoryFn<typeof Component> = () => (
   </Card>
 );
 
-export const BoxBorders = Template.bind({});
+export const BoxBorders = {
+  render: Template,
+};

--- a/src/components/SharedComponents/SpriteSheet/BrushSvgs/BrushBorders/BrushBorders.stories.tsx
+++ b/src/components/SharedComponents/SpriteSheet/BrushSvgs/BrushBorders/BrushBorders.stories.tsx
@@ -22,4 +22,6 @@ const Template: StoryFn<typeof Component> = () => (
   </Card>
 );
 
-export const BrushBorders = Template.bind({});
+export const BrushBorders = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Svg/Svg.stories.tsx
+++ b/src/components/SharedComponents/Svg/Svg.stories.tsx
@@ -11,7 +11,10 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const Svg = Template.bind({});
-Svg.args = {
-  name: "looping-arrow-1",
+export const Svg = {
+  render: Template,
+
+  args: {
+    name: "looping-arrow-1",
+  },
 };

--- a/src/components/SharedComponents/TabularNav/TabularNav.stories.tsx
+++ b/src/components/SharedComponents/TabularNav/TabularNav.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./TabularNav";
 
@@ -7,22 +7,20 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const TabularNav = Template.bind({});
-
-TabularNav.args = {
-  label: "test label",
-  links: [
-    {
-      label: "Foundation",
-      page: null,
-      href: "https://www.example.com",
-    },
-    {
-      label: "Higher",
-      page: null,
-      href: "https://www.example.com",
-    },
-  ],
+export const TabularNav = {
+  args: {
+    label: "test label",
+    links: [
+      {
+        label: "Foundation",
+        page: null,
+        href: "https://www.example.com",
+      },
+      {
+        label: "Higher",
+        page: null,
+        href: "https://www.example.com",
+      },
+    ],
+  },
 };

--- a/src/components/SharedComponents/TagFunctional/TagFunctional.stories.tsx
+++ b/src/components/SharedComponents/TagFunctional/TagFunctional.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { TagFunctional as Component } from "./TagFunctional";
 
@@ -8,9 +7,8 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const TagFunctional = Template.bind({});
-TagFunctional.args = {
-  text: "AQA",
+export const TagFunctional = {
+  args: {
+    text: "AQA",
+  },
 };

--- a/src/components/SharedComponents/Typography/Blockquote.stories.tsx
+++ b/src/components/SharedComponents/Typography/Blockquote.stories.tsx
@@ -15,4 +15,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const Blockquote = Template.bind({});
+export const Blockquote = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Typography/Heading.deprecated.stories.tsx
+++ b/src/components/SharedComponents/Typography/Heading.deprecated.stories.tsx
@@ -16,7 +16,10 @@ const Template: StoryFn<typeof Component> = (args) => (
   <Component {...args}>Heading 1</Component>
 );
 
-export const Heading = Template.bind({});
-Heading.args = {
-  tag: "h1",
+export const Heading = {
+  render: Template,
+
+  args: {
+    tag: "h1",
+  },
 };

--- a/src/components/SharedComponents/Typography/Hr.stories.tsx
+++ b/src/components/SharedComponents/Typography/Hr.stories.tsx
@@ -16,4 +16,6 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Typography>
 );
 
-export const Hr = Template.bind({});
+export const Hr = {
+  render: Template,
+};

--- a/src/components/SharedComponents/Typography/P.deprecated.stories.tsx
+++ b/src/components/SharedComponents/Typography/P.deprecated.stories.tsx
@@ -26,8 +26,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const P = Template.bind({});
-P.args = {
-  fontSize: 16,
-  color: "grey70",
+export const P = {
+  render: Template,
+
+  args: {
+    fontSize: 16,
+    color: "grey70",
+  },
 };

--- a/src/components/SharedComponents/Typography/Span.deprecated.stories.tsx
+++ b/src/components/SharedComponents/Typography/Span.deprecated.stories.tsx
@@ -23,8 +23,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Typography>
 );
 
-export const Span = Template.bind({});
-Span.args = {
-  fontWeight: 600,
-  color: "inYourFace",
+export const Span = {
+  render: Template,
+
+  args: {
+    fontWeight: 600,
+    color: "inYourFace",
+  },
 };

--- a/src/components/SharedComponents/Typography/Typography.deprecated.stories.tsx
+++ b/src/components/SharedComponents/Typography/Typography.deprecated.stories.tsx
@@ -31,7 +31,10 @@ const Template: StoryFn<typeof Component> = (args) => (
   </Component>
 );
 
-export const Typography = Template.bind({});
-Typography.args = {
-  color: "grey70",
+export const Typography = {
+  render: Template,
+
+  args: {
+    color: "grey70",
+  },
 };

--- a/src/components/SharedComponents/Typography/UnderlinedHeading.stories.tsx
+++ b/src/components/SharedComponents/Typography/UnderlinedHeading.stories.tsx
@@ -11,8 +11,11 @@ const Template: StoryFn<typeof Component> = (args) => (
   <Component {...args}>A heading with an underline</Component>
 );
 
-export const UnderlinedHeading = Template.bind({});
-UnderlinedHeading.args = {
-  tag: "h2",
-  $font: "heading-6",
+export const UnderlinedHeading = {
+  render: Template,
+
+  args: {
+    tag: "h2",
+    $font: "heading-6",
+  },
 };

--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.stories.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.stories.tsx
@@ -27,5 +27,7 @@ const Template: StoryFn<typeof Component> = (args) => (
   </OakGrid>
 );
 
-export const VideoPlayer = Template.bind({});
-VideoPlayer.args = {};
+export const VideoPlayer = {
+  render: Template,
+  args: {},
+};

--- a/src/components/TeacherComponents/CopyrightNotice/CopyrightNotice.stories.tsx
+++ b/src/components/TeacherComponents/CopyrightNotice/CopyrightNotice.stories.tsx
@@ -1,6 +1,3 @@
-import React from "react";
-import { StoryFn } from "@storybook/react";
-
 import Component from ".";
 
 export default {
@@ -10,6 +7,4 @@ export default {
   },
 };
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const CopyrightNotice = Template.bind({});
+export const CopyrightNotice = {};

--- a/src/components/TeacherComponents/LessonAppearsIn/LessonAppearsIn.stories.tsx
+++ b/src/components/TeacherComponents/LessonAppearsIn/LessonAppearsIn.stories.tsx
@@ -19,144 +19,147 @@ const Template: StoryFn<typeof Component> = (args) => (
   </OakFlex>
 );
 
-export const LessonAppearsIn = Template.bind({});
-LessonAppearsIn.args = {
-  subjects: [
-    {
-      subjectTitle: "Combined Science",
-      subjectSlug: "combined-science",
-      units: [
-        {
-          unitTitle: "Measuring waves",
-          unitSlug: "measuring-waves",
-          examBoards: [
-            {
-              examBoardTitle: "AQA",
-              examBoardSlug: "aqa",
-              subjectTitle: "Combined Science",
-              subjectSlug: "combined-science",
-              tiers: [
-                {
-                  programmeSlug:
-                    "combined-science-secondary-ks4-foundation-aqa",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug: "combined-science-secondary-ks4-higher-aqa",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-            {
-              examBoardTitle: "Edexcel",
-              examBoardSlug: "edexcel",
-              subjectTitle: "Combined Science",
-              subjectSlug: "combined-science",
-              tiers: [
-                {
-                  programmeSlug:
-                    "combined-science-secondary-ks4-foundation-edexcel",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug:
-                    "combined-science-secondary-ks4-higher-edexcel",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-            {
-              examBoardTitle: "OCR",
-              examBoardSlug: "ocr",
-              subjectTitle: "Combined Science",
-              subjectSlug: "combined-science",
-              tiers: [
-                {
-                  programmeSlug:
-                    "combined-science-secondary-ks4-foundation-ocr",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug: "combined-science-secondary-ks4-higher-ocr",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      subjectTitle: "Physics",
-      subjectSlug: "physics",
-      units: [
-        {
-          unitTitle: "Measuring waves",
-          unitSlug: "measuring-waves",
-          examBoards: [
-            {
-              examBoardTitle: "AQA",
-              examBoardSlug: "aqa",
-              subjectTitle: "Physics",
-              subjectSlug: "physics",
-              tiers: [
-                {
-                  programmeSlug: "physics-secondary-ks4-foundation-aqa",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug: "physics-secondary-ks4-higher-aqa",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-            {
-              examBoardTitle: "Edexcel",
-              examBoardSlug: "edexcel",
-              subjectTitle: "Physics",
-              subjectSlug: "physics",
-              tiers: [
-                {
-                  programmeSlug: "physics-secondary-ks4-foundation-edexcel",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug: "physics-secondary-ks4-higher-edexcel",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-            {
-              examBoardTitle: "OCR",
-              examBoardSlug: "ocr",
-              subjectTitle: "Physics",
-              subjectSlug: "physics",
-              tiers: [
-                {
-                  programmeSlug: "physics-secondary-ks4-foundation-ocr",
-                  tierTitle: "foundation",
-                  tierSlug: null,
-                },
-                {
-                  programmeSlug: "physics-secondary-ks4-higher-ocr",
-                  tierTitle: "higher",
-                  tierSlug: null,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-  ],
+export const LessonAppearsIn = {
+  render: Template,
+
+  args: {
+    subjects: [
+      {
+        subjectTitle: "Combined Science",
+        subjectSlug: "combined-science",
+        units: [
+          {
+            unitTitle: "Measuring waves",
+            unitSlug: "measuring-waves",
+            examBoards: [
+              {
+                examBoardTitle: "AQA",
+                examBoardSlug: "aqa",
+                subjectTitle: "Combined Science",
+                subjectSlug: "combined-science",
+                tiers: [
+                  {
+                    programmeSlug:
+                      "combined-science-secondary-ks4-foundation-aqa",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug: "combined-science-secondary-ks4-higher-aqa",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+              {
+                examBoardTitle: "Edexcel",
+                examBoardSlug: "edexcel",
+                subjectTitle: "Combined Science",
+                subjectSlug: "combined-science",
+                tiers: [
+                  {
+                    programmeSlug:
+                      "combined-science-secondary-ks4-foundation-edexcel",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug:
+                      "combined-science-secondary-ks4-higher-edexcel",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+              {
+                examBoardTitle: "OCR",
+                examBoardSlug: "ocr",
+                subjectTitle: "Combined Science",
+                subjectSlug: "combined-science",
+                tiers: [
+                  {
+                    programmeSlug:
+                      "combined-science-secondary-ks4-foundation-ocr",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug: "combined-science-secondary-ks4-higher-ocr",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        subjectTitle: "Physics",
+        subjectSlug: "physics",
+        units: [
+          {
+            unitTitle: "Measuring waves",
+            unitSlug: "measuring-waves",
+            examBoards: [
+              {
+                examBoardTitle: "AQA",
+                examBoardSlug: "aqa",
+                subjectTitle: "Physics",
+                subjectSlug: "physics",
+                tiers: [
+                  {
+                    programmeSlug: "physics-secondary-ks4-foundation-aqa",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug: "physics-secondary-ks4-higher-aqa",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+              {
+                examBoardTitle: "Edexcel",
+                examBoardSlug: "edexcel",
+                subjectTitle: "Physics",
+                subjectSlug: "physics",
+                tiers: [
+                  {
+                    programmeSlug: "physics-secondary-ks4-foundation-edexcel",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug: "physics-secondary-ks4-higher-edexcel",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+              {
+                examBoardTitle: "OCR",
+                examBoardSlug: "ocr",
+                subjectTitle: "Physics",
+                subjectSlug: "physics",
+                tiers: [
+                  {
+                    programmeSlug: "physics-secondary-ks4-foundation-ocr",
+                    tierTitle: "foundation",
+                    tierSlug: null,
+                  },
+                  {
+                    programmeSlug: "physics-secondary-ks4-higher-ocr",
+                    tierTitle: "higher",
+                    tierSlug: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 };

--- a/src/components/TeacherComponents/LessonAppearsInPathwayCard/LessonAppearsInPathwayCard.stories.tsx
+++ b/src/components/TeacherComponents/LessonAppearsInPathwayCard/LessonAppearsInPathwayCard.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { LessonAppearsInPathwayCard as Component } from "./LessonAppearsInPathwayCard";
 
@@ -8,35 +7,35 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
+export const LessonAppearsInPathwayCard = {
+  args: {
+    unitSlug: "unit-slug",
+    examBoardTitle: "AQA",
+    examBoardSlug: "aqa",
+    subjectTitle: "Maths",
+    subjectSlug: "maths",
+    tiers: [
+      {
+        programmeSlug: "programme-slug",
+        tierTitle: "Foundation",
+        tierSlug: "foundation",
+      },
+      {
+        programmeSlug: "programme-slug",
+        tierTitle: "Core",
+        tierSlug: "core",
+      },
+      {
+        programmeSlug: "programme-slug",
+        tierTitle: "Higher",
+        tierSlug: "higher",
+      },
+    ],
+  },
 
-export const LessonAppearsInPathwayCard = Template.bind({});
-LessonAppearsInPathwayCard.args = {
-  unitSlug: "unit-slug",
-  examBoardTitle: "AQA",
-  examBoardSlug: "aqa",
-  subjectTitle: "Maths",
-  subjectSlug: "maths",
-  tiers: [
-    {
-      programmeSlug: "programme-slug",
-      tierTitle: "Foundation",
-      tierSlug: "foundation",
+  parameters: {
+    backgrounds: {
+      default: "dark",
     },
-    {
-      programmeSlug: "programme-slug",
-      tierTitle: "Core",
-      tierSlug: "core",
-    },
-    {
-      programmeSlug: "programme-slug",
-      tierTitle: "Higher",
-      tierSlug: "higher",
-    },
-  ],
-};
-LessonAppearsInPathwayCard.parameters = {
-  backgrounds: {
-    default: "dark",
   },
 };

--- a/src/components/TeacherComponents/LessonList/LessonList.stories.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.stories.tsx
@@ -47,6 +47,7 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const LessonList = Template.bind({});
-
-LessonList.args = currentPageItems;
+export const LessonList = {
+  render: Template,
+  args: currentPageItems,
+};

--- a/src/components/TeacherComponents/LessonOverviewHelper/LessonOverviewHelper.stories.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHelper/LessonOverviewHelper.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "@/components/TeacherComponents/LessonOverviewHelper/LessonOverviewHelper";
 
@@ -6,18 +6,16 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LessonOverviewHelper = Template.bind({});
-
-LessonOverviewHelper.args = {
-  supervisionLevel: "this is the helper description",
-  equipment: [{ equipment: "this is the equipment description" }],
-  contentGuidance: [
-    {
-      contentGuidanceLabel: "test label",
-      contentGuidanceArea: "test area",
-      contentGuidanceDescription: "test details",
-    },
-  ],
+export const LessonOverviewHelper = {
+  args: {
+    supervisionLevel: "this is the helper description",
+    equipment: [{ equipment: "this is the equipment description" }],
+    contentGuidance: [
+      {
+        contentGuidanceLabel: "test label",
+        contentGuidanceArea: "test area",
+        contentGuidanceDescription: "test details",
+      },
+    ],
+  },
 };

--- a/src/components/TeacherComponents/LessonPlanningElementLinks/LessonElementLinks.stories.tsx
+++ b/src/components/TeacherComponents/LessonPlanningElementLinks/LessonElementLinks.stories.tsx
@@ -17,4 +17,6 @@ const Template: StoryFn<typeof Component> = () => (
   />
 );
 
-export const LessonPlanningElementLinks = Template.bind({});
+export const LessonPlanningElementLinks = {
+  render: Template,
+};

--- a/src/components/TeacherComponents/LessonResourceGraphics/LessonResourceGraphics.stories.tsx
+++ b/src/components/TeacherComponents/LessonResourceGraphics/LessonResourceGraphics.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./LessonResourceGraphics";
 
@@ -6,54 +6,53 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const LessonResourceGraphic = Template.bind({});
-
-LessonResourceGraphic.args = {
-  items: [
-    {
-      titleSingular: "Slide deck",
-      titlePlural: "Slide decks",
-      icon: "slide-deck",
-      resourceCount: 1,
-    },
-    {
-      titleSingular: "Worksheet",
-      titlePlural: "Worksheets",
-      icon: "worksheet",
-      resourceCount: 2,
-    },
-    {
-      titleSingular: "Quiz",
-      titlePlural: "Quizzes",
-      icon: "quiz",
-      resourceCount: 3,
-    },
-    {
-      titleSingular: "Video",
-      titlePlural: "Videos",
-      icon: "video",
-      resourceCount: 2,
-    },
-  ],
+export const LessonResourceGraphic = {
+  args: {
+    items: [
+      {
+        titleSingular: "Slide deck",
+        titlePlural: "Slide decks",
+        icon: "slide-deck",
+        resourceCount: 1,
+      },
+      {
+        titleSingular: "Worksheet",
+        titlePlural: "Worksheets",
+        icon: "worksheet",
+        resourceCount: 2,
+      },
+      {
+        titleSingular: "Quiz",
+        titlePlural: "Quizzes",
+        icon: "quiz",
+        resourceCount: 3,
+      },
+      {
+        titleSingular: "Video",
+        titlePlural: "Videos",
+        icon: "video",
+        resourceCount: 2,
+      },
+    ],
+  },
 };
-export const LessonResourceGraphicMissing = Template.bind({});
 
-LessonResourceGraphicMissing.args = {
-  items: [
-    {
-      titleSingular: "Slide deck",
-      titlePlural: "Slide decks",
-      icon: "slide-deck",
-      resourceCount: 1,
-    },
+export const LessonResourceGraphicMissing = {
+  args: {
+    items: [
+      {
+        titleSingular: "Slide deck",
+        titlePlural: "Slide decks",
+        icon: "slide-deck",
+        resourceCount: 1,
+      },
 
-    {
-      titleSingular: "Quiz",
-      titlePlural: "Quizzes",
-      icon: "quiz",
-      resourceCount: 2,
-    },
-  ],
+      {
+        titleSingular: "Quiz",
+        titlePlural: "Quizzes",
+        icon: "quiz",
+        resourceCount: 2,
+      },
+    ],
+  },
 };

--- a/src/components/TeacherComponents/NoResourcesToDownload/NoResourcesToDownload.stories.tsx
+++ b/src/components/TeacherComponents/NoResourcesToDownload/NoResourcesToDownload.stories.tsx
@@ -11,4 +11,6 @@ const Template: StoryFn<typeof Component> = () => {
   return <Component />;
 };
 
-export const DetailsCompleted = Template.bind({});
+export const DetailsCompleted = {
+  render: Template,
+};

--- a/src/components/TeacherComponents/NoResourcesToShare/NoResourcesToShare.stories.tsx
+++ b/src/components/TeacherComponents/NoResourcesToShare/NoResourcesToShare.stories.tsx
@@ -11,4 +11,6 @@ const Template: StoryFn<typeof Component> = () => {
   return <Component />;
 };
 
-export const DetailsCompleted = Template.bind({});
+export const DetailsCompleted = {
+  render: Template,
+};

--- a/src/components/TeacherComponents/QuizQuestionsList/QuestionsList.stories.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsList/QuestionsList.stories.tsx
@@ -25,6 +25,7 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const LessonList = Template.bind({});
-
-LessonList.args = currentPageItems;
+export const LessonList = {
+  render: Template,
+  args: currentPageItems,
+};

--- a/src/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted.stories.tsx
+++ b/src/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted.stories.tsx
@@ -26,4 +26,6 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const ResourcePageDetailsCompleted = Template.bind({});
+export const ResourcePageDetailsCompleted = {
+  render: Template,
+};

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/ResourcePageSchoolPicker.stories.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/ResourcePageSchoolPicker.stories.tsx
@@ -70,15 +70,19 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const ResourcePageSchoolPicker = Template.bind({});
+export const ResourcePageSchoolPicker = {
+  render: Template,
 
-ResourcePageSchoolPicker.args = {
-  hasError: false,
+  args: {
+    hasError: false,
+  },
 };
 
-export const ResourcePageSchoolPickerError = Template.bind({});
+export const ResourcePageSchoolPickerError = {
+  render: Template,
 
-ResourcePageSchoolPickerError.args = {
-  hasError: true,
-  required: true,
+  args: {
+    hasError: true,
+    required: true,
+  },
 };

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.stories.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.stories.tsx
@@ -14,4 +14,6 @@ const Template: StoryFn<typeof Component> = (args) => {
   );
 };
 
-export const Checkbox = Template.bind({});
+export const Checkbox = {
+  render: Template,
+};

--- a/src/components/TeacherComponents/SearchResults/SearchResults.stories.tsx
+++ b/src/components/TeacherComponents/SearchResults/SearchResults.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./SearchResults";
 
@@ -14,12 +13,12 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
 const hits = searchResultsHitsSchema.parse(elasticResponseFixture.hits.hits);
 const allKeyStages = teachersHomePageFixture().keyStages;
-export const SearchResults = Template.bind({});
-SearchResults.args = {
-  hits,
-  allKeyStages,
+
+export const SearchResults = {
+  args: {
+    hits,
+    allKeyStages,
+  },
 };

--- a/src/components/TeacherComponents/SearchResultsItem/SearchResultsItem.stories.tsx
+++ b/src/components/TeacherComponents/SearchResultsItem/SearchResultsItem.stories.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from "./SearchResultsItem";
 
@@ -15,13 +14,13 @@ export default {
   argTypes: {},
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
 const hit = searchResultsHitSchema.parse(elasticResponseFixture.hits.hits[0]);
 
 const allKeyStages = teachersHomePageFixture().keyStages;
 const searchHitObject = getSearchHitObject(hit, allKeyStages);
-export const SearchResultsItem = Template.bind({});
-SearchResultsItem.args = {
-  ...searchHitObject,
+
+export const SearchResultsItem = {
+  args: {
+    ...searchHitObject,
+  },
 };

--- a/src/components/TeacherComponents/SubjectProgrammeList/SubjectProgrammeList.stories.tsx
+++ b/src/components/TeacherComponents/SubjectProgrammeList/SubjectProgrammeList.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import Component from ".";
 
@@ -10,10 +10,8 @@ export default {
   component: Component,
 } as Meta<typeof Component>;
 
-const Template: StoryFn<typeof Component> = (args) => <Component {...args} />;
-
-export const ProgrammeList = Template.bind({});
-
-ProgrammeList.args = {
-  ...programmeListingFixture(),
+export const ProgrammeList = {
+  args: {
+    ...programmeListingFixture(),
+  },
 };

--- a/src/components/TeacherComponents/UnitList/UnitList.stories.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.stories.tsx
@@ -38,9 +38,10 @@ const Template: StoryFn<typeof Component> = (args) => {
   return <Component {...args} />;
 };
 
-export const UnitList = Template.bind({});
-
-UnitList.args = currentPageItems;
+export const UnitList = {
+  render: Template,
+  args: currentPageItems,
+};
 
 const currentPageItemsWithTiers: UnitListProps = {
   ...unitListingWithTiers(),
@@ -62,6 +63,7 @@ const currentPageItemsWithTiers: UnitListProps = {
   },
 };
 
-export const UnitListTiers = Template.bind({});
-
-UnitListTiers.args = currentPageItemsWithTiers;
+export const UnitListTiers = {
+  render: Template,
+  args: currentPageItemsWithTiers,
+};

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -39,7 +39,6 @@ import HeaderLesson from "@/components/TeacherComponents/LessonOverviewHeader";
 import { useCurrentSection } from "@/components/TeacherComponents/helpers/lessonHelpers/useCurrentSection";
 import LessonOverviewAnchorLinks from "@/components/TeacherComponents/LessonOverviewAnchorLinks";
 import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
-import { GridArea } from "@/components/SharedComponents/Grid.deprecated/GridArea.deprecated.stories";
 import { LEGACY_COHORT, NEW_COHORT } from "@/config/cohort";
 import { keyLearningPoint } from "@/node-lib/curriculum-api-2023/shared.schema";
 import { LessonOverviewDownloads } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
@@ -48,6 +47,7 @@ import {
   getIsResourceDownloadable,
 } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/downloadsCopyright";
 import NewContentBanner from "@/components/TeacherComponents/NewContentBanner/NewContentBanner";
+import { GridArea } from "@/components/SharedComponents/Grid.deprecated";
 
 export type LessonOverviewProps = {
   lesson: LessonOverviewAll & { downloads: LessonOverviewDownloads };


### PR DESCRIPTION
## Description

Following the [upgrade to storybook 8](https://github.com/oaknational/Oak-Web-Application/pull/2831), this enables the [upgrade to CSF 3](https://storybook.js.org/blog/storybook-csf3-is-here/).

- [x] run `npx storybook@latest migrate csf-2-to-3 --glob="**/*.stories.tsx" --parser=tsx`
- [x] Update stories if required
- [x] Update tests where required