### PR TITLE
[CUR-950] Add new exam board Edexcel B for cycle 2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
         "@oaknational/oak-components": "^1.33.0",
         "@oaknational/oak-consent-client": "^2.1.0",
-        "@oaknational/oak-curriculum-schema": "^1.22.0",
+        "@oaknational/oak-curriculum-schema": "^1.24.0",
         "@oaknational/oak-pupil-client": "^2.12.0",
         "@portabletext/react": "^3.0.11",
         "@react-aria/aria-modal-polyfill": "^3.7.8",
@@ -7717,9 +7717,9 @@
       }
     },
     "node_modules/@oaknational/oak-curriculum-schema": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-curriculum-schema/-/oak-curriculum-schema-1.22.0.tgz",
-      "integrity": "sha512-12nJYsOFkNnBh17gp9Vanrfxuv4wGvfqVNvtbNyCC8GdhTJG2lze29f1OnFvWp0Bnyg/JwB54S63oQ3/oMFJXQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-curriculum-schema/-/oak-curriculum-schema-1.24.0.tgz",
+      "integrity": "sha512-ziIRpQ9moZYGi5+/vBTsL5F4Bz75chWiBP7CZOpxJEhASQT3X1ps+WidQAs9SDSSyU4+g5xBfCgXLZBUviJ2FA==",
       "peerDependencies": {
         "zod": "^3.22.4"
       }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
     "@oaknational/oak-components": "^1.33.0",
     "@oaknational/oak-consent-client": "^2.1.0",
-    "@oaknational/oak-curriculum-schema": "^1.22.0",
+    "@oaknational/oak-curriculum-schema": "^1.24.0",
     "@oaknational/oak-pupil-client": "^2.12.0",
     "@portabletext/react": "^3.0.11",
     "@react-aria/aria-modal-polyfill": "^3.7.8",

--- a/src/browser-lib/avo/Avo.ts
+++ b/src/browser-lib/avo/Avo.ts
@@ -1121,6 +1121,7 @@ export const ExamBoard = {
   'EDUQAS': 'Eduqas',
   'OCR': 'OCR',
   'WJEC': 'WJEC',
+  'EDEXCELB': 'Edexcel B',
 } as const;
 export type ExamBoardType = typeof ExamBoard;
 export type ExamBoardValueType = ExamBoardType[keyof ExamBoardType];


### PR DESCRIPTION
## Description

Music year: 1953

Adding new exam board for cycle 2 support (Edexcel B).

This change did also require an update to the Avo types in order to pass type checking. I think I'll get Tash to check that addition as it seems she edited that area last.

## Issue(s)

Fixes # CUR-950

## How to test

1. Go to https://deploy-preview-2838--oak-web-application.netlify.thenational.academy
2. Check there are no issues with the visualiser functionality
3. Pull the branch down, set the cycle 2 to true
4. Check the correct results are shown in Geography KS4 - Edexcel B

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
