### PR TITLE
LESQ-1097: Prevent multiple submissions of onboarding form

### DIFF
--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
@@ -87,11 +87,14 @@ const HowCanOakSupport = () => {
         trigger={trigger as UseFormTrigger<OnboardingFormProps>}
         forceHideNewsletterSignUp={true}
         subheading="Select all that apply"
-        secondaryButton={
-          <OakSecondaryButton width="100%" disabled={hasMissingFormData}>
+        secondaryButton={(isSubmitting) => (
+          <OakSecondaryButton
+            width="100%"
+            disabled={hasMissingFormData || isSubmitting}
+          >
             Skip
           </OakSecondaryButton>
-        }
+        )}
       >
         <OakFlex $flexDirection="column" $gap="space-between-s">
           {Object.entries(oakSupportMap).map(([key, value]) => (


### PR DESCRIPTION
## Description

Music year: 1977

- Disables the onboarding form (by setting the buttons to disabled) while the user is being onboarded to Clerk and Hubspot

## How to test

1. Go to https://deploy-preview-2840--oak-web-application.netlify.thenational.academy/onboarding
2. Onboard as usual
3. On the last step the "Continue" and "Skip" buttons should switch to a disabled state while submission is taking place 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
