### PR TITLE
LESQ-1084: point the lesson downloads at the experiment feature flag

### DIFF
--- a/src/__tests__/pages/about-us/board.test.tsx
+++ b/src/__tests__/pages/about-us/board.test.tsx
@@ -10,6 +10,7 @@ import { mockSeoResult, portableTextFromString } from "../../__helpers__/cms";
 import { testAboutPageBaseData } from "./about-us.fixtures";
 
 jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
   useFeatureFlagEnabled: () => ({ enabled: {} }),
 }));
 jest.mock("../../../node-lib/cms");

--- a/src/__tests__/pages/onboarding/index.test.tsx
+++ b/src/__tests__/pages/onboarding/index.test.tsx
@@ -6,7 +6,7 @@ import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
 import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => true,
+  useFeatureFlagVariantKey: () => "with-login",
 }));
 
 jest.mock("next/navigation", () => require("next-router-mock"));

--- a/src/__tests__/pages/onboarding/role-selection.test.tsx
+++ b/src/__tests__/pages/onboarding/role-selection.test.tsx
@@ -6,7 +6,7 @@ import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
 import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => true,
+  useFeatureFlagVariantKey: () => "with-login",
 }));
 
 jest.mock("next/navigation", () => require("next-router-mock"));

--- a/src/__tests__/pages/onboarding/school-selection.test.tsx
+++ b/src/__tests__/pages/onboarding/school-selection.test.tsx
@@ -7,7 +7,7 @@ import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
 import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => true,
+  useFeatureFlagVariantKey: () => "with-login",
 }));
 
 jest.mock("next/navigation", () => require("next-router-mock"));

--- a/src/__tests__/pages/teachers/search.test.tsx
+++ b/src/__tests__/pages/teachers/search.test.tsx
@@ -13,6 +13,7 @@ const contentTypes = fixture.contentTypes;
 const examBoards = fixture.examBoards;
 
 jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
   useFeatureFlagEnabled: () => false,
 }));
 

--- a/src/app/(registration)/auth-layout.tsx
+++ b/src/app/(registration)/auth-layout.tsx
@@ -9,7 +9,6 @@ import {
 
 import { resolveOakHref } from "@/common-lib/urls";
 import { RegistrationLayout } from "@/components/TeacherComponents/RegistrationLayout/RegistrationLayout";
-import withFeatureFlag from "@/hocs/withFeatureFlag";
 import { OakBox, OakFlex, OakLink, OakP } from "@/styles/oakThemeApp";
 
 const TermsAndConditions = () => {
@@ -44,7 +43,7 @@ const TermsAndConditions = () => {
   );
 };
 
-function BaseAuthLayout({
+export function AuthLayout({
   children,
   asideSlot,
   headerSlot,
@@ -103,5 +102,3 @@ function BaseAuthLayout({
     </RegistrationLayout>
   );
 }
-
-export const AuthLayout = withFeatureFlag(BaseAuthLayout, "use-auth-owa");

--- a/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
@@ -9,8 +9,9 @@ import { AuthLayout } from "../../auth-layout";
 
 import { getIllustrationAsset } from "@/image-data";
 import CMSImage from "@/components/SharedComponents/CMSImage";
+import withFeatureFlag from "@/hocs/withFeatureFlag";
 
-export default function SignInPage() {
+function SignInPage() {
   return (
     <AuthLayout
       asideSlot={
@@ -27,3 +28,11 @@ export default function SignInPage() {
     </AuthLayout>
   );
 }
+
+const SigninPageWithFeatureFlag = withFeatureFlag(
+  SignInPage,
+  "teacher-download-auth",
+  "with-login",
+);
+
+export default SigninPageWithFeatureFlag;

--- a/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
@@ -18,6 +18,7 @@ import { AuthLayout } from "../../auth-layout";
 
 import { getIllustrationAsset } from "@/image-data";
 import CMSImage from "@/components/SharedComponents/CMSImage";
+import withFeatureFlag from "@/hocs/withFeatureFlag";
 
 function ListItem({ children }: PropsWithChildren) {
   return (
@@ -34,7 +35,7 @@ function ListItem({ children }: PropsWithChildren) {
   );
 }
 
-export default function SignUpPage() {
+function SignUpPage() {
   return (
     <AuthLayout
       headerSlot={
@@ -84,3 +85,11 @@ export default function SignUpPage() {
     </AuthLayout>
   );
 }
+
+const SignupPageWithFeatureFlag = withFeatureFlag(
+  SignUpPage,
+  "teacher-download-auth",
+  "with-login",
+);
+
+export default SignupPageWithFeatureFlag;

--- a/src/components/AppComponents/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.test.tsx
@@ -10,7 +10,7 @@ import { mockLoggedIn, mockLoggedOut } from "@/__tests__/__helpers__/mockUser";
 const render = renderWithProviders();
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: jest.fn(() => true),
+  useFeatureFlagVariantKey: jest.fn(() => "with-login"),
 }));
 
 describe("components/AppHeader", () => {
@@ -95,7 +95,7 @@ describe("components/AppHeader", () => {
     expect(signOutButton).not.toBeInTheDocument();
   });
 
-  it("renders a sign out button when a user is logged in and feature flag is on", async () => {
+  it("renders a sign out button when a user is logged in", async () => {
     setUseUserReturn(mockLoggedIn);
     renderWithProviders()(<AppHeader />);
 

--- a/src/components/TeacherComponents/LessonItemContainerLink/LessonItemContainerLink.tsx
+++ b/src/components/TeacherComponents/LessonItemContainerLink/LessonItemContainerLink.tsx
@@ -1,4 +1,4 @@
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import ButtonAsLink, {
   ButtonAsLinkProps,
@@ -86,9 +86,10 @@ export function LessonItemContainerLink({
               : undefined,
           };
 
-  const downloads = useFeatureFlagEnabled("use-auth-owa")
-    ? "downloads-auth"
-    : "downloads";
+  const downloads =
+    useFeatureFlagVariantKey("teacher-download-auth") === "with-login"
+      ? "downloads-auth"
+      : "downloads";
 
   const downloadLinkProps:
     | LessonDownloadsLinkProps

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useUser } from "@clerk/nextjs";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import { LessonOverviewHeaderProps as LessonOverviewHeaderDownloadAllButtonProps } from "@/components/TeacherComponents/LessonOverviewHeader";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
@@ -34,9 +34,10 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
   } = props;
 
   const preselected = "all";
-  const downloads = useFeatureFlagEnabled("use-auth-owa")
-    ? "downloads-auth"
-    : "downloads";
+  const downloads =
+    useFeatureFlagVariantKey("teacher-download-auth") === "with-login"
+      ? "downloads-auth"
+      : "downloads";
 
   const { user, isLoaded } = useUser();
 

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.test.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.test.tsx
@@ -30,7 +30,7 @@ const shareProps: UseResourceFormStateProps = {
 const useRouter = jest.spyOn(require("next/router"), "useRouter");
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: jest.fn(() => true),
+  useFeatureFlagVariantKey: jest.fn(() => "with-login"),
 }));
 
 jest.mock("../../helpers/downloadAndShareHelpers/fetchHubspotContactDetails");

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { useUser } from "@clerk/nextjs";
 
 import { fetchHubspotContactDetails } from "../../helpers/downloadAndShareHelpers/fetchHubspotContactDetails";
@@ -58,7 +58,8 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
   const [selectAllChecked, setSelectAllChecked] = useState(false);
   const [isLocalStorageLoading, setIsLocalStorageLoading] = useState(true);
   const [schoolUrn, setSchoolUrn] = useState(0);
-  const authFlagEnabled = useFeatureFlagEnabled("use-auth-owa");
+  const authFlagEnabled =
+    useFeatureFlagVariantKey("teacher-download-auth") === "with-login";
   const { isSignedIn, user } = useUser();
 
   const [hasOnboardingDownloadDetails, setHasOnboardingDownloadDetails] =

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
@@ -1,5 +1,5 @@
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useAuth } from "@clerk/nextjs";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import useLocalStorageForDownloads from "./useLocalStorageForDownloads";
 
@@ -21,7 +21,8 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
   } = useLocalStorageForDownloads();
 
   const auth = useAuth();
-  const authFlagEnabled = useFeatureFlagEnabled("use-auth-owa") || false;
+  const authFlagEnabled =
+    useFeatureFlagVariantKey("teacher-download-auth") === "with-login";
 
   const onSubmit = async (data: ResourceFormProps, slug: string) => {
     if (props.onSubmit) {

--- a/src/components/TeacherViews/LessonDownloads.view.test.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.test.tsx
@@ -16,7 +16,7 @@ const lesson = lessonDownloadsFixture({
 });
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: jest.fn(() => true),
+  useFeatureFlagVariantKey: jest.fn(() => "with-login"),
 }));
 
 describe("Hiding 'Your details", () => {

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -3,8 +3,8 @@ import {
   examboards,
   tierDescriptions,
 } from "@oaknational/oak-curriculum-schema";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useUser } from "@clerk/nextjs";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import { filterDownloadsByCopyright } from "../TeacherComponents/helpers/downloadAndShareHelpers/downloadsCopyright";
 import { LessonDownloadRegionBlocked } from "../TeacherComponents/LessonDownloadRegionBlocked/LessonDownloadRegionBlocked";
@@ -276,7 +276,8 @@ export function LessonDownloads(props: LessonDownloadsProps) {
 
   // TODO remove once we're confident that restrictions are being
   // applied correctly in production
-  const useAuthOwaEnabled = useFeatureFlagEnabled("use-auth-owa");
+  const useAuthOwaEnabled =
+    useFeatureFlagVariantKey("teacher-download-auth") === "with-login";
   useEffect(() => {
     if (useAuthOwaEnabled) {
       console.log("restrictions", {

--- a/src/components/TeacherViews/Onboarding/ONboarding.test.tsx
+++ b/src/components/TeacherViews/Onboarding/ONboarding.test.tsx
@@ -7,7 +7,7 @@ import OnboardingView from "./Onboarding.view";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => true,
+  useFeatureFlagVariantKey: () => "with-login",
 }));
 describe("Onboarding view", () => {
   it("renders a Continue button", async () => {

--- a/src/hocs/withFeatureFlag.test.tsx
+++ b/src/hocs/withFeatureFlag.test.tsx
@@ -1,0 +1,90 @@
+import { render } from "@testing-library/react";
+import * as posthog from "posthog-js/react";
+import mockRouter from "next-router-mock";
+
+import withFeatureFlag from "./withFeatureFlag";
+
+jest.mock("next/navigation", () => require("next-router-mock"));
+jest.mock("posthog-js/react");
+
+describe(withFeatureFlag, () => {
+  describe.each<
+    [variantValueType: string, variantValue: string | true | undefined]
+  >([
+    ["true", true],
+    ["a string", "test-variant"],
+  ])("when the variant value is %s", (__, variantValue) => {
+    const Subject = withFeatureFlag(
+      () => <div data-testid="canary" />,
+      "test-feature",
+      variantValue,
+    );
+
+    beforeEach(() => {
+      mockRouter.setCurrentUrl("/flagged-page");
+    });
+
+    describe("and the feature is enabled", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(posthog, "useFeatureFlagVariantKey")
+          .mockReturnValueOnce(variantValue);
+      });
+
+      it("renders the component", () => {
+        const { container, getByTestId } = render(<Subject />);
+
+        expect(posthog.useFeatureFlagVariantKey).toHaveBeenCalledWith(
+          "test-feature",
+        );
+        expect(container).toContainElement(getByTestId("canary"));
+      });
+
+      it("does not redirect", () => {
+        render(<Subject />);
+
+        expect(mockRouter.pathname).toEqual("/flagged-page");
+      });
+    });
+
+    describe("and flags are not loaded", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(posthog, "useFeatureFlagVariantKey")
+          .mockReturnValueOnce(undefined);
+      });
+
+      it("renders nothing", () => {
+        const { container } = render(<Subject />);
+
+        expect(container).toBeEmptyDOMElement();
+      });
+
+      it("does not redirect", () => {
+        render(<Subject />);
+
+        expect(mockRouter.pathname).toEqual("/flagged-page");
+      });
+    });
+
+    describe("and the feature is disabled", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(posthog, "useFeatureFlagVariantKey")
+          .mockReturnValueOnce(false);
+      });
+
+      it("renders nothing", () => {
+        const { container } = render(<Subject />);
+
+        expect(container).toBeEmptyDOMElement();
+      });
+
+      it("redirects to the 404 page", () => {
+        render(<Subject />);
+
+        expect(mockRouter.pathname).toEqual("/404");
+      });
+    });
+  });
+});

--- a/src/hocs/withFeatureFlag.tsx
+++ b/src/hocs/withFeatureFlag.tsx
@@ -1,23 +1,26 @@
 "use client";
 import React, { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 const withFeatureFlag = <P extends object>(
   WrappedComponent: React.ComponentType<P>,
   featureFlag: string,
+  featureFlagVariant: string | true = true,
 ) => {
   const WithFeatureFlag: React.FC<P> = (props) => {
-    const ffEnabled = useFeatureFlagEnabled(featureFlag);
+    const flagValue = useFeatureFlagVariantKey(featureFlag);
+    const flagLoaded = flagValue !== undefined;
+    const ffEnabled = flagValue === featureFlagVariant;
     const router = useRouter();
 
     useEffect(() => {
-      if (ffEnabled === false) {
+      if (flagLoaded && !ffEnabled) {
         router.replace("/404");
       }
-    }, [ffEnabled, router]);
+    }, [flagLoaded, ffEnabled, router]);
 
-    if (!ffEnabled) {
+    if (!flagLoaded || !ffEnabled) {
       return null;
     }
 

--- a/src/pages/onboarding/how-can-oak-support-you.tsx
+++ b/src/pages/onboarding/how-can-oak-support-you.tsx
@@ -15,7 +15,8 @@ const RoleSelectionComponent: NextPage = () => {
 
 const HowCanOakSupportPage = withFeatureFlag(
   withPageAuthRequired(RoleSelectionComponent),
-  "use-auth-owa",
+  "teacher-download-auth",
+  "with-login",
 );
 
 export default HowCanOakSupportPage;

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -15,7 +15,8 @@ const OnboardingComponent: NextPage = () => {
 
 const OnboardingPage = withFeatureFlag(
   withPageAuthRequired(OnboardingComponent),
-  "use-auth-owa",
+  "teacher-download-auth",
+  "with-login",
 );
 
 export default OnboardingPage;

--- a/src/pages/onboarding/role-selection.tsx
+++ b/src/pages/onboarding/role-selection.tsx
@@ -15,7 +15,8 @@ const RoleSelectionComponent: NextPage = () => {
 
 const RoleSelectionPage = withFeatureFlag(
   withPageAuthRequired(RoleSelectionComponent),
-  "use-auth-owa",
+  "teacher-download-auth",
+  "with-login",
 );
 
 export default RoleSelectionPage;

--- a/src/pages/onboarding/school-selection.tsx
+++ b/src/pages/onboarding/school-selection.tsx
@@ -15,7 +15,8 @@ const SchoolSelectionComponent: NextPage = () => {
 
 const SchoolSelectionPage = withFeatureFlag(
   withPageAuthRequired(SchoolSelectionComponent),
-  "use-auth-owa",
+  "teacher-download-auth",
+  "with-login",
 );
 
 export default SchoolSelectionPage;


### PR DESCRIPTION
## Description

This swaps out the original `use-auth-owa` feature flag for the new multi-variant flag required for our Posthog experiment

Development version of our experiment is here https://eu.posthog.com/project/124/experiments/21583

⚠️  We can merge this once we're happy with the experiment setup on production and all our events are in place.

Music year: [1992](https://www.youtube.com/watch?v=GLvohMXgcBo)

## How to test

1. In an incognito session / after clearing cookies
2. Go to https://deploy-preview-2844--oak-web-application.netlify.thenational.academy/teachers/programmes/citizenship-secondary-ks3-l/units/citizenship-whats-it-all-about-e038/lessons/what-is-citizenship-c4t38d
2. Click on "Download resources"
3. The odds are 🎲 :
    * 50% that you will be in the "with-login" group and asked to sign-in before downloading
    * 50% that you will be in the "control" group and sent directly to the download page
4. Welcome to the experiment

✋🏻 **The experiment is currently set to 100% of users for testing purposes. When we add it to production we can tune this down to 20%, so 10% of actual users will actually be in the "with-login" group**

👉🏻 **You can add yourself to the "with-login" group and skip the lottery by adding your Posthog distinct id to "Set 2" under the feature flag here https://eu.posthog.com/project/124/feature_flags/35482**

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
