### PR TITLE
LESQ-984: download button on lesson overview page is dynamic

### DIFF
--- a/src/__tests__/__helpers__/mockUser.ts
+++ b/src/__tests__/__helpers__/mockUser.ts
@@ -20,6 +20,7 @@ export const mockUserWithDownloadAccess: UserResource = {
   publicMetadata: {
     owa: {
       isRegionAuthorised: true,
+      isOnboarded: true,
     },
   },
 };

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -11,6 +11,14 @@ import LessonOverviewPage, {
   URLParams,
 } from "@/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]";
 import { LEGACY_COHORT, NEW_COHORT } from "@/config/cohort";
+import {
+  enableMockClerk,
+  setUseUserReturn,
+} from "@/__tests__/__helpers__/mockClerk";
+import {
+  mockLoggedIn,
+  mockUserWithDownloadAccess,
+} from "@/__tests__/__helpers__/mockUser";
 
 const props = {
   curriculumData: lessonOverviewFixture({
@@ -50,9 +58,18 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
   }),
 }));
 
+jest.mock("@/context/FeatureFlaggedClerk/FeatureFlaggedClerk");
+
 const render = renderWithProviders();
 
 describe("pages/teachers/lessons", () => {
+  beforeEach(() => {
+    enableMockClerk();
+    setUseUserReturn({
+      ...mockLoggedIn,
+      user: mockUserWithDownloadAccess,
+    });
+  });
   it("Renders title from the props", async () => {
     render(<LessonOverviewPage {...props} />);
 

--- a/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -10,6 +10,14 @@ import SpecialistLessonOverviewPage, {
   SpecialistLessonOverviewPageProps,
   URLParams,
 } from "@/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]";
+import {
+  enableMockClerk,
+  setUseUserReturn,
+} from "@/__tests__/__helpers__/mockClerk";
+import {
+  mockLoggedIn,
+  mockUserWithDownloadAccess,
+} from "@/__tests__/__helpers__/mockUser";
 
 const props = {
   curriculumData: specialistLessonOverviewFixture(),
@@ -29,9 +37,19 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
   }),
 }));
 
+jest.mock("@/context/FeatureFlaggedClerk/FeatureFlaggedClerk");
+
 const render = renderWithProviders();
 
 describe("pages/teachers/specialist/programmes/units/[unitSlug]/lessons/[lessonSlug]", () => {
+  beforeEach(() => {
+    enableMockClerk();
+    setUseUserReturn({
+      ...mockLoggedIn,
+      user: mockUserWithDownloadAccess,
+    });
+  });
+
   it("Renders title from the props", async () => {
     render(<SpecialistLessonOverviewPage {...props} />);
 

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -38,11 +38,10 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
     ? "downloads-auth"
     : "downloads";
 
-  const { user } = useFeatureFlaggedClerk().useUser();
-  let displaySignInMessage = false;
-  if (useFeatureFlagEnabled("use-auth-owa")) {
-    displaySignInMessage = !user || !user?.publicMetadata?.owa?.isOnboarded;
-  }
+  const { user, isLoaded } = useFeatureFlaggedClerk().useUser();
+
+  const displaySignInMessage =
+    isLoaded && !user?.publicMetadata?.owa?.isOnboarded;
 
   if (expired || !showDownloadAll) {
     return null;

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -9,6 +9,7 @@ import {
   SpecialistLessonDownloadsLinkProps,
 } from "@/common-lib/urls";
 import Box, { BoxProps } from "@/components/SharedComponents/Box";
+import { useFeatureFlaggedClerk } from "@/context/FeatureFlaggedClerk/FeatureFlaggedClerk";
 
 export const LessonOverviewHeaderDownloadAllButton: FC<
   LessonOverviewHeaderDownloadAllButtonProps & BoxProps
@@ -36,6 +37,10 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
   const downloads = useFeatureFlagEnabled("use-auth-owa")
     ? "downloads-auth"
     : "downloads";
+
+  const { user } = useFeatureFlaggedClerk().useUser();
+
+  const displaySignInMessage = !user || !user?.publicMetadata?.owa?.isOnboarded;
 
   if (expired || !showDownloadAll) {
     return null;
@@ -80,7 +85,11 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
         icon="arrow-right"
         size="large"
         $iconPosition="trailing"
-        label={`Download all resources`}
+        label={
+          displaySignInMessage
+            ? `Sign in to download all resources`
+            : `Download all resources`
+        }
         onClick={onClickDownloadAll}
       />
     </Box>

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -39,8 +39,10 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
     : "downloads";
 
   const { user } = useFeatureFlaggedClerk().useUser();
-
-  const displaySignInMessage = !user || !user?.publicMetadata?.owa?.isOnboarded;
+  let displaySignInMessage = false;
+  if (useFeatureFlagEnabled("use-auth-owa")) {
+    displaySignInMessage = !user || !user?.publicMetadata?.owa?.isOnboarded;
+  }
 
   if (expired || !showDownloadAll) {
     return null;

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -88,7 +88,7 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
         $iconPosition="trailing"
         label={
           displaySignInMessage
-            ? `Sign in to download all resources`
+            ? `Sign in to download`
             : `Download all resources`
         }
         onClick={onClickDownloadAll}


### PR DESCRIPTION
## Description

Music year: 1988

- Changes download button on lesson overview page based on if a use is signed in and onboarded or not
- Updates download test to have logged in user

## Issue(s)

Fixes #LESQ-984

## How to test

1. Go to https://deploy-preview-2845--oak-web-application.netlify.thenational.academy/teachers/programmes/combined-science-secondary-ks4-higher-edexcel/units/atomic-structure-and-the-periodic-table/lessons/atomic-structure-negligible-electron-mass#slide-deck 
(Or any lesson page)
2. You should see when feature flag is enabled, download all button say sign in to download all resources
3. After sign in, button says Download all resources

## Screenshots


How it should now look:
![Screenshot 2024-10-03 at 12 45 15](https://github.com/user-attachments/assets/c390b560-ac54-4568-a216-8ef223ed46d1)


![Screenshot 2024-10-03 at 14 30 03](https://github.com/user-attachments/assets/e42bce83-c556-4877-88e0-2a81e2ae32cc)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
