### PR TITLE
LESQ-1088: Updated sign up page copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.0.1",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-        "@oaknational/oak-components": "^1.38.0",
+        "@oaknational/oak-components": "^1.38.2",
         "@oaknational/oak-consent-client": "^2.1.0",
         "@oaknational/oak-curriculum-schema": "^1.25.1",
         "@oaknational/oak-pupil-client": "^2.12.1",
@@ -7062,9 +7062,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.38.0.tgz",
-      "integrity": "sha512-ky6LtzIxOf1FE/RrqyovoHohxfYSkWCsmF3sqsombVlcOuadYb8srm7JoyF5dt0vnu7DimQ6Mpz3NoLImRxEyA==",
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.38.2.tgz",
+      "integrity": "sha512-sstoqG8sYN4orG8QoMGjM1kmREs6sbu6mGQZiA7No5vKJBOEGbDFG+Rq1eF0I9ksXV7iLU+//Ekusi8x5tg9jw==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@mdx-js/loader": "^3.0.1",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-    "@oaknational/oak-components": "^1.38.0",
+    "@oaknational/oak-components": "^1.38.2",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "^1.25.1",
     "@oaknational/oak-pupil-client": "^2.12.1",

--- a/src/app/(registration)/auth-layout.tsx
+++ b/src/app/(registration)/auth-layout.tsx
@@ -47,9 +47,11 @@ const TermsAndConditions = () => {
 function BaseAuthLayout({
   children,
   asideSlot,
+  headerSlot,
 }: {
   children: React.ReactNode;
   asideSlot: React.ReactNode;
+  headerSlot?: React.ReactNode;
 }) {
   const clerkRef = useRef<null | HTMLDivElement>(null);
   const [clerkRendered, setClerkRendered] = useState(false);
@@ -80,6 +82,7 @@ function BaseAuthLayout({
 
   return (
     <RegistrationLayout asideSlot={asideSlot}>
+      {headerSlot}
       <OakFlex
         $flexDirection="column"
         $alignItems="center"

--- a/src/app/(registration)/auth-layout.tsx
+++ b/src/app/(registration)/auth-layout.tsx
@@ -8,10 +8,8 @@ import {
 } from "react";
 
 import { resolveOakHref } from "@/common-lib/urls";
-import CMSImage from "@/components/SharedComponents/CMSImage";
 import { RegistrationLayout } from "@/components/TeacherComponents/RegistrationLayout/RegistrationLayout";
 import withFeatureFlag from "@/hocs/withFeatureFlag";
-import { getIllustrationAsset } from "@/image-data";
 import { OakBox, OakFlex, OakLink, OakP } from "@/styles/oakThemeApp";
 
 const TermsAndConditions = () => {
@@ -46,7 +44,13 @@ const TermsAndConditions = () => {
   );
 };
 
-function Layout({ children }: { children: React.ReactNode }) {
+function BaseAuthLayout({
+  children,
+  asideSlot,
+}: {
+  children: React.ReactNode;
+  asideSlot: React.ReactNode;
+}) {
   const clerkRef = useRef<null | HTMLDivElement>(null);
   const [clerkRendered, setClerkRendered] = useState(false);
 
@@ -75,17 +79,7 @@ function Layout({ children }: { children: React.ReactNode }) {
   }, [clerkRef, checkForClerkElement]);
 
   return (
-    <RegistrationLayout
-      asideSlot={
-        <OakBox $maxWidth="all-spacing-21">
-          <CMSImage
-            image={getIllustrationAsset("auth-acorn")}
-            $width="100%"
-            $objectFit="contain"
-          />
-        </OakBox>
-      }
-    >
+    <RegistrationLayout asideSlot={asideSlot}>
       <OakFlex
         $flexDirection="column"
         $alignItems="center"
@@ -107,6 +101,4 @@ function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-const LayoutWithFF = withFeatureFlag(Layout, "use-auth-owa");
-
-export default LayoutWithFF;
+export const AuthLayout = withFeatureFlag(BaseAuthLayout, "use-auth-owa");

--- a/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
@@ -2,9 +2,28 @@
 "use client";
 
 import { SignIn } from "@clerk/nextjs";
+import { OakBox } from "@oaknational/oak-components";
 
 import { formAppearanceStyles } from "../../formAppearanceStyles";
+import { AuthLayout } from "../../auth-layout";
+
+import { getIllustrationAsset } from "@/image-data";
+import CMSImage from "@/components/SharedComponents/CMSImage";
 
 export default function SignInPage() {
-  return <SignIn appearance={formAppearanceStyles} />;
+  return (
+    <AuthLayout
+      asideSlot={
+        <OakBox $maxWidth="all-spacing-21">
+          <CMSImage
+            image={getIllustrationAsset("auth-acorn")}
+            $width="100%"
+            $objectFit="contain"
+          />
+        </OakBox>
+      }
+    >
+      <SignIn appearance={formAppearanceStyles} />
+    </AuthLayout>
+  );
 }

--- a/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
@@ -2,9 +2,70 @@
 "use client";
 
 import { SignUp } from "@clerk/nextjs";
+import {
+  OakBox,
+  OakFlex,
+  OakHeading,
+  OakIcon,
+  OakLI,
+  OakUL,
+} from "@oaknational/oak-components";
+import { PropsWithChildren } from "react";
 
 import { formAppearanceStyles } from "../../formAppearanceStyles";
+import { AuthLayout } from "../../auth-layout";
+
+import { getIllustrationAsset } from "@/image-data";
+import CMSImage from "@/components/SharedComponents/CMSImage";
+
+
+function ListItem({ children }: PropsWithChildren) {
+  return (
+    <OakLI
+      $display="flex"
+      $flexDirection="row"
+      $alignItems="center"
+      $gap="space-between-s"
+      $mb="space-between-xs"
+    >
+      <OakIcon iconName="tick" $height="all-spacing-7" $width="all-spacing-7" />
+      {children}
+    </OakLI>
+  );
+}
 
 export default function SignUpPage() {
-  return <SignUp appearance={formAppearanceStyles} />;
+  return (
+    <AuthLayout
+      asideSlot={
+        <OakBox
+          $width="min-content"
+          $minWidth="all-spacing-21"
+          $mb="space-between-xl"
+        >
+          <OakFlex $mb="space-between-m2" $maxHeight="all-spacing-19">
+            <CMSImage
+              image={getIllustrationAsset("auth-acorn")}
+              $objectFit="contain"
+            />
+          </OakFlex>
+          <OakHeading
+            tag="h1"
+            $font="heading-5"
+            $mb="space-between-l"
+            $textAlign="center"
+          >
+            Our resources will always be free. Creating an account gives you:
+          </OakHeading>
+          <OakUL $font="heading-light-7" $reset $mh="space-between-xl">
+            <ListItem>Unlimited downloads</ListItem>
+            <ListItem>Instant access to Aila, our AI lesson assistant</ListItem>
+            <ListItem>Priority access to new products and features</ListItem>
+          </OakUL>
+        </OakBox>
+      }
+    >
+      <SignUp appearance={formAppearanceStyles} />
+    </AuthLayout>
+  );
 }

--- a/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
@@ -7,6 +7,7 @@ import {
   OakFlex,
   OakHeading,
   OakIcon,
+  OakInlineBanner,
   OakLI,
   OakUL,
 } from "@oaknational/oak-components";
@@ -17,7 +18,6 @@ import { AuthLayout } from "../../auth-layout";
 
 import { getIllustrationAsset } from "@/image-data";
 import CMSImage from "@/components/SharedComponents/CMSImage";
-
 
 function ListItem({ children }: PropsWithChildren) {
   return (
@@ -37,6 +37,18 @@ function ListItem({ children }: PropsWithChildren) {
 export default function SignUpPage() {
   return (
     <AuthLayout
+      headerSlot={
+        <OakInlineBanner
+          isOpen
+          message={
+            <>
+              No <strong>pupil accounts</strong>, sorry.
+            </>
+          }
+          $mt={["space-between-m", "space-between-none"]}
+          $mb={["space-between-none", "space-between-m"]}
+        />
+      }
       asideSlot={
         <OakBox
           $width="min-content"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,14 @@ export default function RootLayout({
             <OakThemeProvider theme={oakDefaultTheme}>
               <CookieConsentProvider>
                 <ClerkProvider
+                  localization={{
+                    signUp: {
+                      start: {
+                        subtitle: "Sign up to Oak to continue",
+                        title: "Create a free account",
+                      },
+                    },
+                  }}
                   appearance={{
                     variables: {
                       colorPrimary: "#222222",

--- a/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
@@ -68,12 +68,10 @@ describe("Component - Curriculum Download Tab", () => {
     test("user can see the tier selector for secondary maths", async () => {
       // NOTE: This is only active during testing.
       mockPrerelease("curriculum.downloads");
-      const { findByText, findByTestId } = renderComponent({
+      const { findByTestId } = renderComponent({
         tiers: tiersMock,
       });
-      const formHeading = await findByText("Download");
       const tierSelector = await findByTestId("tier-selector");
-      expect(formHeading).toBeInTheDocument();
       expect(tierSelector).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Description

Music year: 1971

Figma: https://www.figma.com/design/fxWHjjNzvbbc0J38pM3Kti/Log-in?node-id=3330-8406&m=dev
Design: 

![Step 1 (choose sign up option)](https://github.com/user-attachments/assets/18eb8005-83bd-44a9-b12e-7b0f293e863e)

🎨  I diverged from the design in a few places:

* The copy colour is #222 or `text-primary` — _i think the use of #000 in Figma was a bug_
* ~~The "No pupils" banner has a border — _this is consistent with the design kit and storybook components_~~
* The "No pupils" banner uses the "info" icon from the design kit and storybook — _looks like the one in the design is from an obsolete design file?_

⚠️ We have limited control over the login box itself so this PR is only intended to update the heading and subheading copy of that component, everything else is out of scope

- [x] change title to ‘Create a free account”
- [x] change subheading to: ‘Sign up to Oak to continue’
- [x] Add "No pupil accounts, sorry" banner
- [x] Add copy under the acorn

## How to test

1. Go to https://deploy-preview-2851--oak-web-application.netlify.thenational.academy/sign-up
2. You should see the new copy changes

## Screenshots

How it used to look (delete if n/a):
![www thenational academy_sign-up](https://github.com/user-attachments/assets/bb8bc58c-b73c-4d20-ae18-59a85346670c)
![www thenational academy_sign-up(iPad Mini)](https://github.com/user-attachments/assets/d472b1df-10d2-4d99-9ecf-7886edd6eac8)
![www thenational academy_sign-up(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/33af5296-d118-4a3d-b8f9-33083b33b540)

How it should now look:

![localhost_3000_sign-up](https://github.com/user-attachments/assets/870bf5e6-7faf-48af-a6bd-562328d66c56)
![localhost_3000_sign-up(iPad Mini)](https://github.com/user-attachments/assets/91b5073d-1200-4ef5-9856-6aa43cb4e564)
![localhost_3000_sign-up(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/edf3208d-a76e-47e2-a03d-3d6bb361f5ea)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
