### PR TITLE
Fix/pupil/unit listing page to throw better error

### DIFF
--- a/src/__tests__/pages/pupils/programmes/[programmesSlug]/units.test.tsx
+++ b/src/__tests__/pages/pupils/programmes/[programmesSlug]/units.test.tsx
@@ -142,15 +142,14 @@ describe("pages/pupils/programmes/[programmeSlug]/units", () => {
           }),
         ]);
 
-        expect.assertions(2);
-        try {
-          await getStaticProps({
-            params: { programmeSlug: "english-secondary-year-11" },
-          });
-        } catch (error) {
-          expect(error).toBeInstanceOf(Error);
-          expect(error).toMatchObject({ message: "No curriculum data" });
-        }
+        expect.assertions(1);
+
+        const res = await getStaticProps({
+          params: { programmeSlug: "english-secondary-year-11" },
+        });
+        expect(res).toEqual({
+          notFound: true,
+        });
       });
       it("should throw error is phase is foundation", async () => {
         const programmeFieldsSnake = programmeFieldsFixture({

--- a/src/pages/pupils/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units.tsx
@@ -121,7 +121,7 @@ export const getStaticProps: GetStaticProps<
         (unit) => unit.programmeSlug === programmeSlug,
       );
       if (!selectedProgramme) {
-        throw new Error("No curriculum data");
+        throw new OakError({ code: "curriculum-api/not-found" });
       }
 
       const { programmeFields, isLegacy } = selectedProgramme;


### PR DESCRIPTION
## Description

Music year: 1961

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-2856--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
