### PR TITLE
Remove order hack, now cooking and nutrition data has been fixed

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/curriculumUnits/curriculumUnits.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumUnits/curriculumUnits.query.ts
@@ -63,12 +63,7 @@ const curriculumUnitsQuery =
       where: where,
     });
 
-    const units = res.units.map((unit) => {
-      return {
-        ...unit,
-        order: unit.order ?? 0,
-      };
-    });
+    const { units } = res;
 
     if (!units || units.length === 0) {
       throw new OakError({ code: "curriculum-api/not-found" });


### PR DESCRIPTION
## Description
Previously cooking and nutrition was missing the `order` field. That has now been resolved upstream.

## Issue(s)
Fixes `CUR-924`

## How to test
Enable cycle 2 and check opening any of the sequences doesn't "error out" with errors regarding missing order field.

