### PR TITLE
chore: bump oak components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.0.1",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-        "@oaknational/oak-components": "^1.38.2",
+        "@oaknational/oak-components": "^1.40.0",
         "@oaknational/oak-consent-client": "^2.1.0",
         "@oaknational/oak-curriculum-schema": "^1.27.1",
         "@oaknational/oak-pupil-client": "^2.12.1",
@@ -7062,9 +7062,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.38.2",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.38.2.tgz",
-      "integrity": "sha512-sstoqG8sYN4orG8QoMGjM1kmREs6sbu6mGQZiA7No5vKJBOEGbDFG+Rq1eF0I9ksXV7iLU+//Ekusi8x5tg9jw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.40.0.tgz",
+      "integrity": "sha512-mdWBSUqeZb0lOjcMyNTmrrwwcJBnVnWT0JPq2X4o1PgsMr2+PHq6MkWR2rTOCZkf4KtcfBjgBDqezYfBhLN74w==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@mdx-js/loader": "^3.0.1",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "2.7.0-canary.0-7c57cdd",
-    "@oaknational/oak-components": "^1.38.2",
+    "@oaknational/oak-components": "^1.40.0",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "^1.27.1",
     "@oaknational/oak-pupil-client": "^2.12.1",


### PR DESCRIPTION
## Description

Music year: 1960

- Bump oak components to include new subject icon `subject-cooking-nutrition`
- This icon does not exist in cloudinary yet (should be added this week) so will appear broken until then: 
![Screenshot 2024-10-10 at 14 31 01](https://github.com/user-attachments/assets/e52e9871-cfbd-4c87-8d9c-b6053e9b619f)

https://deploy-preview-2870--oak-web-application.netlify.thenational.academy/teachers/search?term=macbeth

