### PR TITLE
Changes lot picker text for cycle 2 release

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -31,6 +31,7 @@ import { isExamboardSlug } from "@/pages-helpers/pupil/options-pages/options-pag
 import FocusIndicator from "@/components/CurriculumComponents/OakComponentsKitchen/FocusIndicator";
 import { getPhaseText } from "@/utils/curriculum/formatting";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
+import { useCycleTwoEnabled } from "@/utils/curriculum/features";
 
 const DEFAULT_KEYSTAGES = [
   { slug: "ks1" },
@@ -180,6 +181,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
   subjects,
   currentSelection,
 }) => {
+  const isCycleTwoEnabled = useCycleTwoEnabled();
   const router = useRouter();
   const tab = (router.query.tab as CurriculumTab) ?? "units";
 
@@ -462,7 +464,9 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                     Curriculum plans
                   </OakHeading>
                   <OakP $mb="space-between-s">
-                    Explore our new curricula for 2023/2024.
+                    {isCycleTwoEnabled
+                      ? "Explore our curricula for 2024/2025."
+                      : "Explore our new curricula for 2023/2024."}
                   </OakP>
                 </OakFlex>
                 <OakFlex


### PR DESCRIPTION
## Description
Changes to lot picker text to "Explore our curricula for 2024/2025." for cycle 2 release.

## Issue(s)
Fixes `CUR-947`

## How to test

 - Check text unchanged at https://deploy-preview-2872--oak-web-application.netlify.thenational.academy
 - Check when cycle 2 enabled locally text changes to "Explore our curricula for 2024/2025."
