### PR TITLE
Sort subjects alphabetically in curriculum picker

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -12,6 +12,7 @@ import {
   OakSecondaryButton,
   OakSpan,
 } from "@oaknational/oak-components";
+import { sortBy } from "lodash";
 
 import OwaLink from "@/components/SharedComponents/OwaLink";
 import Box from "@/components/SharedComponents/Box";
@@ -481,7 +482,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                   $flexWrap={"wrap"}
                   $mt={"space-between-none"}
                 >
-                  {subjects.map((subject) => (
+                  {sortBy(subjects, "title").map((subject) => (
                     <ButtonContainer
                       className={`lot-picker subject-selection ${
                         isSelected(subject) ? "selected" : ""


### PR DESCRIPTION
## Description
Sort subjects alphabetically in curriculum picker

## Issue(s)

Fixes `CUR-985`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Open the picker
3. Check they are sorted alphabetically
