### PR TITLE
Don't render non-valid examboard-less subjects/phases

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import CMSClient from "@/node-lib/cms";
 import curriculumApi from "@/node-lib/curriculum-api-2023";
 import CurriculumInfoPage, {
-  parseSubjectPhaseSlug,
   getStaticProps,
   getStaticPaths,
   formatCurriculumUnitsData,
@@ -22,6 +21,7 @@ import curriculumUnitsTabFixture from "@/node-lib/curriculum-api-2023/fixtures/c
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import subjectPhaseOptions from "@/browser-lib/fixtures/subjectPhaseOptions";
 import { mockPrerelease } from "@/utils/mocks";
+import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 
 const render = renderWithProviders();
 
@@ -538,6 +538,7 @@ jest.mock("@/node-lib/curriculum-api-2023", () => ({
   curriculumOverview: jest.fn(),
   curriculumUnits: jest.fn(),
   refreshedMVTime: jest.fn(),
+  subjectPhaseOptions: jest.fn(() => subjectPhaseOptions.subjects),
 }));
 const mockedCurriculumOverview = curriculumApi.curriculumOverview as jest.Mock;
 const mockedRefreshedMVTime = curriculumApi.refreshedMVTime as jest.Mock;
@@ -580,24 +581,6 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
     });
     window.IntersectionObserver = mockIntersectionObserver;
   });
-  describe("parses the subject / phase / examboard slug correctly", () => {
-    it("should extract from a valid slug", () => {
-      const slug = "english-secondary-aqa";
-      const parsed = parseSubjectPhaseSlug(slug);
-      expect(parsed).toEqual({
-        subjectSlug: "english",
-        phaseSlug: "secondary",
-        ks4OptionSlug: "aqa",
-      });
-    });
-
-    it("should reject an invalid slug", () => {
-      const slug = "not_a_valid_slug";
-      expect(() => parseSubjectPhaseSlug(slug)).toThrow(
-        "The params provided are incorrect",
-      );
-    });
-  });
 
   describe("components rendering on page", () => {
     it("renders the Curriculum Header", () => {
@@ -608,7 +591,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
         asPath: "",
       });
 
-      const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
+      const slugs = parseSubjectPhaseSlug("english-secondary-aqa")!;
       const { queryByTestId } = render(
         <CurriculumInfoPage
           mvRefreshTime={1721314874829}
@@ -648,7 +631,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
         });
 
         // Render the CurriculumInfoPage with necessary mock props
-        const slugs = parseSubjectPhaseSlug("maths-secondary");
+        const slugs = parseSubjectPhaseSlug("maths-secondary")!;
         const { queryByTestId } = render(
           <CurriculumInfoPage
             mvRefreshTime={1721314874829}
@@ -686,7 +669,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
         pathname: "/teachers-2023/curriculum/english-secondary-aqa/overview",
         asPath: "",
       });
-      const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
+      const slugs = parseSubjectPhaseSlug("english-secondary-aqa")!;
       const { queryByTestId, queryAllByTestId } = render(
         <CurriculumInfoPage
           mvRefreshTime={1721314874829}
@@ -709,7 +692,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
         isPreview: false,
         pathname: "/teachers-2023/curriculum/english-secondary-aqa/downloads",
       });
-      const slugs = parseSubjectPhaseSlug("english-secondary-aqa");
+      const slugs = parseSubjectPhaseSlug("english-secondary-aqa")!;
       const { queryByTestId } = render(
         <CurriculumInfoPage
           mvRefreshTime={1721314874829}

--- a/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
@@ -2,9 +2,9 @@ import { screen } from "@testing-library/react";
 
 import CurriculumDownloadTab, { createCurriculumDownloadsQuery } from ".";
 
-import { parseSubjectPhaseSlug } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[tab]";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { mockPrerelease } from "@/utils/mocks";
+import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 
 const render = renderWithProviders();
 const mvRefreshTime = 1721314874829;
@@ -40,7 +40,7 @@ describe("Component - Curriculum Download Tab", () => {
 
   const renderComponent = (overrides = {}) => {
     const defaultProps = {
-      slugs: parseSubjectPhaseSlug("english-secondary-aqa"),
+      slugs: parseSubjectPhaseSlug("english-secondary-aqa")!,
       mvRefreshTime,
       tiers: [],
       childSubjects: [],

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
@@ -4,9 +4,9 @@ import CurriculumHeader from "./CurriculumHeader";
 
 import curriculumHeaderFixture from "@/node-lib/curriculum-api-2023/fixtures/curriculumHeader.fixture";
 import subjectPhaseOptionsFixture from "@/node-lib/curriculum-api-2023/fixtures/subjectPhaseOptions.fixture";
-import { parseSubjectPhaseSlug } from "@/pages/teachers/curriculum/[subjectPhaseSlug]/[tab]";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { mockPrerelease } from "@/utils/mocks";
+import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 
 const render = renderWithProviders();
 
@@ -16,7 +16,7 @@ describe("Component - Curriculum Header", () => {
   });
   const renderComponent = (overrides = {}) => {
     const defaultProps = {
-      curriculumSelectionSlugs: parseSubjectPhaseSlug("english-secondary-aqa"),
+      curriculumSelectionSlugs: parseSubjectPhaseSlug("english-secondary-aqa")!,
       keyStages: ["ks3", "ks4"],
       subjectPhaseOptions: { subjects: subjectPhaseOptionsFixture() },
       pageSlug: "test-slug",

--- a/src/utils/curriculum/slugs.test.ts
+++ b/src/utils/curriculum/slugs.test.ts
@@ -1,0 +1,19 @@
+import { parseSubjectPhaseSlug } from "./slugs";
+
+describe("parseSubjectPhaseSlug", () => {
+  it("should extract from a valid slug", () => {
+    const slug = "english-secondary-aqa";
+    const parsed = parseSubjectPhaseSlug(slug);
+    expect(parsed).toEqual({
+      subjectSlug: "english",
+      phaseSlug: "secondary",
+      ks4OptionSlug: "aqa",
+    });
+  });
+
+  it("should reject an invalid slug", () => {
+    const slug = "not_a_valid_slug";
+    const parsed = parseSubjectPhaseSlug(slug);
+    expect(parsed).toEqual(undefined);
+  });
+});

--- a/src/utils/curriculum/slugs.ts
+++ b/src/utils/curriculum/slugs.ts
@@ -1,0 +1,22 @@
+export const parseSubjectPhaseSlug = (slug: string) => {
+  const parts = slug.split("-");
+  const lastSlug = parts.pop() ?? null;
+  let phaseSlug: string | null, ks4OptionSlug: string | null;
+  // Use phase to determine if examboard is present
+  if (lastSlug && ["primary", "secondary"].includes(lastSlug)) {
+    ks4OptionSlug = null;
+    phaseSlug = lastSlug;
+  } else {
+    ks4OptionSlug = lastSlug;
+    phaseSlug = parts.pop() ?? null;
+  }
+  const subjectSlug = parts.join("-");
+  if (!subjectSlug || !phaseSlug) {
+    return;
+  }
+  return {
+    phaseSlug: phaseSlug,
+    subjectSlug: subjectSlug,
+    ks4OptionSlug: ks4OptionSlug,
+  };
+};


### PR DESCRIPTION
## Description
Don't render (404) non-valid examboard-less subjects/phases. For example `/teachers/curriculum/english-secondary/units` now correctly 404's

## Issue(s)

Fixes `CUR-758`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Test all subjects/phases are still accessible (including cycle 2)
3. Test that examboard-less slugs 404