### PR TITLE
LESQ-1116: conditionally render share on eyfs pages

### DIFF
--- a/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.test.tsx
@@ -11,6 +11,7 @@ const props = {
   background: "pink30",
   isLegacyLesson: false,
   subjectIconBackgroundColor: "pink",
+  showShare: true,
 } as unknown as LessonOverviewHeaderProps;
 
 describe("LessonOverviewHeader", () => {

--- a/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
@@ -43,7 +43,7 @@ export type LessonOverviewHeaderProps = {
   onClickDownloadAll: () => void;
   onClickShareAll: () => void;
   showDownloadAll: boolean;
-  isEYFS: boolean;
+  showShare: boolean;
 };
 
 const LessonOverviewHeader: FC<LessonOverviewHeaderProps> = (props) => {

--- a/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
@@ -43,6 +43,7 @@ export type LessonOverviewHeaderProps = {
   onClickDownloadAll: () => void;
   onClickShareAll: () => void;
   showDownloadAll: boolean;
+  isEYFS: boolean;
 };
 
 const LessonOverviewHeader: FC<LessonOverviewHeaderProps> = (props) => {

--- a/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
@@ -28,8 +28,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
     isNew,
     subjectIconBackgroundColor,
     pupilLessonOutcome,
-    isSpecialist,
-    isEYFS,
+    showShare,
   } = props;
 
   return (
@@ -71,9 +70,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
               )}
               <OakFlex $gap="all-spacing-6">
                 <LessonOverviewHeaderDownloadAllButton {...props} />
-                {!isSpecialist && !isEYFS && (
-                  <LessonOverviewHeaderShareAllButton {...props} />
-                )}
+                {showShare && <LessonOverviewHeaderShareAllButton {...props} />}
               </OakFlex>
             </OakFlex>
           </OakFlex>

--- a/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
@@ -29,6 +29,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
     subjectIconBackgroundColor,
     pupilLessonOutcome,
     isSpecialist,
+    isEYFS,
   } = props;
 
   return (
@@ -70,7 +71,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
               )}
               <OakFlex $gap="all-spacing-6">
                 <LessonOverviewHeaderDownloadAllButton {...props} />
-                {!isSpecialist && (
+                {!isSpecialist && !isEYFS && (
                   <LessonOverviewHeaderShareAllButton {...props} />
                 )}
               </OakFlex>

--- a/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
@@ -28,6 +28,7 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
     isNew,
     subjectIconBackgroundColor,
     isSpecialist,
+    isEYFS,
   } = props;
 
   return (
@@ -62,7 +63,9 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
         </Box>
       )}
       <LessonOverviewHeaderDownloadAllButton {...props} />
-      {!isSpecialist && <LessonOverviewHeaderShareAllButton {...props} />}
+      {!isSpecialist && !isEYFS && (
+        <LessonOverviewHeaderShareAllButton {...props} />
+      )}
     </Flex>
   );
 };

--- a/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
@@ -27,8 +27,7 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
     pupilLessonOutcome,
     isNew,
     subjectIconBackgroundColor,
-    isSpecialist,
-    isEYFS,
+    showShare,
   } = props;
 
   return (
@@ -63,9 +62,7 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
         </Box>
       )}
       <LessonOverviewHeaderDownloadAllButton {...props} />
-      {!isSpecialist && !isEYFS && (
-        <LessonOverviewHeaderShareAllButton {...props} />
-      )}
+      {showShare && <LessonOverviewHeaderShareAllButton {...props} />}
     </Flex>
   );
 };

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -185,6 +185,8 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
   );
 
   const showDownloadAll = downloadsFilteredByCopyright.length > 0;
+  const showShare =
+    !isSpecialist && keyStageSlug !== "early-years-foundation-stage";
 
   return (
     <MathJaxLessonProvider>
@@ -226,7 +228,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
           keyLearningPoints,
         )}
         showDownloadAll={showDownloadAll}
-        isEYFS={keyStageSlug === "early-years-foundation-stage"}
+        showShare={showShare}
       />
       <MaxWidth $ph={16} $pb={80}>
         <NewContentBanner

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -226,6 +226,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
           keyLearningPoints,
         )}
         showDownloadAll={showDownloadAll}
+        isEYFS={keyStageSlug === "early-years-foundation-stage"}
       />
       <MaxWidth $ph={16} $pb={80}>
         <NewContentBanner

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -329,7 +329,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                   <LessonItemContainer
                     isSpecialist={isSpecialist}
                     ref={videoSectionRef}
-                    shareable={isLegacyLicense && !isSpecialist}
+                    shareable={isLegacyLicense && showShare}
                     slugs={slugs}
                     title={"Video"}
                     anchorId="video"
@@ -367,7 +367,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                         copyrightContent,
                       )
                     }
-                    shareable={isLegacyLicense && !isSpecialist}
+                    shareable={isLegacyLicense && showShare}
                     onDownloadButtonClick={() => {
                       trackDownloadResourceButtonClicked({
                         downloadResourceButtonName: "worksheet",
@@ -392,7 +392,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                     isSpecialist={isSpecialist}
                     ref={starterQuizSectionRef}
                     title={"Starter quiz"}
-                    shareable={isLegacyLicense && !isSpecialist}
+                    shareable={isLegacyLicense && showShare}
                     anchorId="starter-quiz"
                     pageLinks={pageLinks}
                     downloadable={
@@ -446,7 +446,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                         copyrightContent,
                       )
                     }
-                    shareable={isLegacyLicense && !isSpecialist}
+                    shareable={isLegacyLicense && showShare}
                     onDownloadButtonClick={() => {
                       trackDownloadResourceButtonClicked({
                         downloadResourceButtonName: "exit quiz",
@@ -486,7 +486,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
                         copyrightContent,
                       )
                     }
-                    shareable={isLegacyLicense && !isSpecialist}
+                    shareable={isLegacyLicense && showShare}
                     onDownloadButtonClick={() => {
                       trackDownloadResourceButtonClicked({
                         downloadResourceButtonName: "additional material",


### PR DESCRIPTION
## Description

Music year: 2010

- Adds isEYFS boolean to conditionally render share button on non EYFS pages
- KS1 - KS4 lesson pages still have share option

## Issue(s)

Fixes #LESQ-1116

## Acceptance Criteria:

- [ ]  Share functionality is not available on EYFS because there is no pupil equivalent

## How to test

1. Go to https://deploy-preview-2894--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2024-10-16 at 17 12 09](https://github.com/user-attachments/assets/0b7efddd-5ee8-43b5-977c-cc3855be426a)

How it should now look:
![Screenshot 2024-10-16 at 17 11 17](https://github.com/user-attachments/assets/f739fb22-5000-44f2-99c6-85bbb0c2aa74)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
