### PR TITLE
Simplify and fix tracking event for opening unit modal

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { waitFor } from "@testing-library/dom";
+import { act } from "@testing-library/react";
 
 import CurriculumVisualiser from "./CurriculumVisualiser";
 
@@ -8,6 +9,7 @@ import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 const render = renderWithProviders();
 const curriculumThreadHighlighted = jest.fn();
 const yearGroupSelected = jest.fn();
+const unitInformationViewed = jest.fn();
 
 jest.mock("@/context/Analytics/useAnalytics", () => ({
   __esModule: true,
@@ -16,6 +18,8 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
       curriculumThreadHighlighted: (...args: unknown[]) =>
         curriculumThreadHighlighted(...args),
       yearGroupSelected: (...args: unknown[]) => yearGroupSelected(...args),
+      unitInformationViewed: (...args: unknown[]) =>
+        unitInformationViewed(...args),
     },
   }),
 }));
@@ -193,14 +197,27 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTabMobile", () => {
     );
 
     const units = await findAllByTestId("unit-cards");
-    const unit = units[0];
+    const unit = units[0]!;
 
-    if (unit) {
-      waitFor(async () => {
-        await userEvent.click(unit);
-        const sidebar = await findByTestId("sidebar-modal-wrapper");
-        expect(sidebar).toBeInTheDocument();
-      });
-    }
+    await act(async () => {
+      await userEvent.click(unit.querySelector("button")!);
+    });
+
+    await waitFor(async () => {
+      const sidebar = await findByTestId("sidebar-modal-wrapper");
+      expect(sidebar).toBeInTheDocument();
+    });
+
+    expect(unitInformationViewed).toHaveBeenCalledTimes(1);
+    expect(unitInformationViewed).toHaveBeenCalledWith({
+      unitName: "Step into the unknown: fiction reading and creative writing",
+      unitSlug: "step-into-the-unknown-fiction-reading-and-creative-writing",
+      yearGroupName: "7",
+      yearGroupSlug: "7",
+      subjectSlug: "english",
+      subjectTitle: "English",
+      unitHighlighted: false,
+      analyticsUseCase: null,
+    });
   });
 });

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/utils/curriculum/formatting";
 import { getUnitFeatures } from "@/utils/curriculum/features";
 import { anchorIntersectionObserver } from "@/utils/curriculum/dom";
+import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
+import useAnalytics from "@/context/Analytics/useAnalytics";
 
 export type YearData = {
   [key: string]: {
@@ -162,6 +164,9 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
   selectedThread,
   setVisibleMobileYearRefID,
 }) => {
+  const { track } = useAnalytics();
+  const { analyticsUseCase } = useAnalyticsPageProps();
+
   // Selection state helpers
   const [displayModal, setDisplayModal] = useState(false);
   const [unitOptionsAvailable, setUnitOptionsAvailable] =
@@ -192,8 +197,25 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
     }
   }, [setVisibleMobileYearRefID, yearData]);
 
+  const trackModalOpenEvent = (isOpen: boolean, unitData: Unit) => {
+    if (isOpen && unitData) {
+      track.unitInformationViewed({
+        unitName: unitData.title,
+        unitSlug: unitData.slug,
+        subjectTitle: unitData.subject,
+        subjectSlug: unitData.subject_slug,
+        yearGroupName: unitData.year,
+        yearGroupSlug: unitData.year,
+        unitHighlighted: isHighlightedUnit(unitData, selectedThread),
+        analyticsUseCase: analyticsUseCase,
+      });
+    }
+  };
+
   const handleOpenModal = (unitOptions: boolean, unit: Unit) => {
-    setDisplayModal((prev) => !prev);
+    const newDisplayModal = !displayModal;
+    setDisplayModal(newDisplayModal);
+    trackModalOpenEvent(newDisplayModal, unit);
     setUnitOptionsAvailable(unitOptions);
     setUnitData({ ...unit });
     setCurrentUnitLessons(unit.lessons ?? []);
@@ -481,9 +503,6 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
             displayModal={displayModal}
             setUnitOptionsAvailable={setUnitOptionsAvailable}
             unitOptionsAvailable={unitOptionsAvailable}
-            isHighlighted={
-              unitData ? isHighlightedUnit(unitData, selectedThread) : false
-            }
           />
         </UnitsTabSidebar>
       )}

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.test.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.test.tsx
@@ -9,17 +9,6 @@ import {
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
-const unitInformationViewed = jest.fn();
-jest.mock("@/context/Analytics/useAnalytics", () => ({
-  __esModule: true,
-  default: () => ({
-    track: {
-      unitInformationViewed: (...args: unknown[]) =>
-        unitInformationViewed(...args),
-    },
-  }),
-}));
-
 describe("Unit modal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,7 +23,6 @@ describe("Unit modal", () => {
         unitData={mockUnit}
         unitOptionsAvailable={false}
         setUnitOptionsAvailable={stateFn}
-        isHighlighted={false}
         setUnitVariantID={stateFn}
         yearData={mockYearData}
       />,
@@ -50,7 +38,6 @@ describe("Unit modal", () => {
         unitData={mockUnit}
         unitOptionsAvailable={false}
         setUnitOptionsAvailable={stateFn}
-        isHighlighted={false}
         setUnitVariantID={stateFn}
         yearData={mockYearData}
       />,
@@ -71,7 +58,6 @@ describe("Unit modal", () => {
         unitData={mockUnit}
         unitOptionsAvailable={false}
         setUnitOptionsAvailable={stateFn}
-        isHighlighted={false}
         setUnitVariantID={stateFn}
         yearData={mockYearData}
       />,
@@ -90,7 +76,6 @@ describe("Unit modal", () => {
           unitData={mockUnit}
           unitOptionsAvailable={false}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -107,7 +92,6 @@ describe("Unit modal", () => {
           unitData={mockUnit}
           unitOptionsAvailable={false}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -126,7 +110,6 @@ describe("Unit modal", () => {
           unitData={mockOptionalityUnit}
           unitOptionsAvailable={true}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -144,7 +127,6 @@ describe("Unit modal", () => {
           unitData={mockOptionalityUnit}
           unitOptionsAvailable={true}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -161,7 +143,6 @@ describe("Unit modal", () => {
           unitData={mockOptionalityUnit}
           unitOptionsAvailable={true}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -178,7 +159,6 @@ describe("Unit modal", () => {
           unitData={mockOptionalityUnit}
           unitOptionsAvailable={true}
           setUnitOptionsAvailable={stateFn}
-          isHighlighted={false}
           setUnitVariantID={stateFn}
           yearData={mockYearData}
         />,
@@ -198,7 +178,6 @@ describe("Unit modal", () => {
             unitData={mockOptionalityUnit}
             unitOptionsAvailable={true}
             setUnitOptionsAvailable={stateFn}
-            isHighlighted={false}
             setUnitVariantID={stateFn}
             yearData={mockYearData}
           />,
@@ -217,32 +196,6 @@ describe("Unit modal", () => {
       } else {
         throw new Error("Optionality button not found");
       }
-    });
-  });
-  test("calls tracking.unitInformationViewed once, with correct props", async () => {
-    renderWithTheme(
-      <UnitModal
-        setCurrentUnitLessons={stateFn}
-        displayModal={true}
-        unitData={mockOptionalityUnit}
-        unitOptionsAvailable={true}
-        setUnitOptionsAvailable={stateFn}
-        setUnitVariantID={stateFn}
-        isHighlighted={false}
-        yearData={mockYearData}
-      />,
-    );
-
-    expect(unitInformationViewed).toHaveBeenCalledTimes(1);
-    expect(unitInformationViewed).toHaveBeenCalledWith({
-      unitName: "Composition of numbers 6 to 10",
-      unitSlug: "composition-of-numbers-6-to-10",
-      subjectTitle: "Maths",
-      subjectSlug: "maths",
-      yearGroupName: "1",
-      yearGroupSlug: "1",
-      unitHighlighted: false,
-      analyticsUseCase: null,
     });
   });
 });

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -13,8 +13,6 @@ import {
   CurriculumUnitDetailsProps,
   CurriculumUnitDetails,
 } from "@/components/CurriculumComponents/CurriculumUnitDetails";
-import useAnalytics from "@/context/Analytics/useAnalytics";
-import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
 import { getUnitFeatures } from "@/utils/curriculum/features";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 
@@ -26,7 +24,6 @@ type UnitModalProps = {
   setCurrentUnitLessons: (x: Lesson[]) => void;
   setUnitVariantID: (x: number | null) => void;
   unitOptionsAvailable: boolean;
-  isHighlighted: boolean;
 };
 
 export type Lesson = {
@@ -43,10 +40,7 @@ const UnitModal: FC<UnitModalProps> = ({
   setCurrentUnitLessons,
   setUnitVariantID,
   unitOptionsAvailable,
-  isHighlighted,
 }) => {
-  const { track } = useAnalytics();
-  const { analyticsUseCase } = useAnalyticsPageProps();
   const [optionalityModalOpen, setOptionalityModalOpen] =
     useState<boolean>(false);
 
@@ -74,25 +68,6 @@ const UnitModal: FC<UnitModalProps> = ({
     optionalityModalOpen,
     setUnitVariantID,
   ]);
-
-  useEffect(() => {
-    // For tracking open model events
-    if (displayModal === true) {
-      if (unitData) {
-        track.unitInformationViewed({
-          unitName: unitData.title,
-          unitSlug: unitData.slug,
-          subjectTitle: unitData.subject,
-          subjectSlug: unitData.subject_slug,
-          yearGroupName: unitData.year,
-          yearGroupSlug: unitData.year,
-          unitHighlighted: isHighlighted,
-          analyticsUseCase: analyticsUseCase,
-          //update to include optionality units
-        });
-      }
-    }
-  });
 
   const subjectTitle =
     getUnitFeatures(unitData)?.programmes_fields_overrides.subject ??


### PR DESCRIPTION
## Description
Simplify and fix tracking event for opening unit modal in curriculum visualiser

Note this also fixes double events being triggered when opening the modal. Previously we got two events triggered rather than one.


## Issue(s)
Fixes `CUR-507`

## How to test

1. Go to {owa_deployment_url}
2. Navigate to the curriculum visualiser
3. Open a modal
4. Check only one tracking event is fired.
