### PR TITLE
Fix list item styling in curriculum explainers

### DIFF
--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -324,7 +324,18 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
                       value={curriculumExplainer.explainerRaw}
                       components={{
                         ...basePortableTextComponents.list,
-                        ...basePortableTextComponents.listItem,
+                        listItem: {
+                          bullet: (props) => (
+                            <OakLI $font={["list-item-2", "list-item-1"]}>
+                              {props.children}
+                            </OakLI>
+                          ),
+                          number: (props) => (
+                            <OakLI $font={["list-item-2", "list-item-1"]}>
+                              {props.children}
+                            </OakLI>
+                          ),
+                        },
                         block: {
                           ...basePortableTextComponents.block,
                           ...blockHeadingComponents,


### PR DESCRIPTION
## Description
Small fix to increase size of list items in curriculum explainers

## Issue(s)

Fixes `CUR-962`

## How to test
Enable cycle 2

1. Go to https://deploy-preview-2899--oak-web-application.netlify.thenational.academy
2. Navigate to new curriculum explainers
3. Check for correct list styling