### PR TITLE
Focus state fixes on curriculum modal accordion

### DIFF
--- a/src/components/CurriculumComponents/CurriculumUnitDetailsAccordion/CurriculumUnitDetailsAccordion.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetailsAccordion/CurriculumUnitDetailsAccordion.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { useFocusWithin } from "react-aria";
+import { useFocusVisible, useFocusWithin } from "react-aria";
 
 import useClickableCard from "@/hooks/useClickableCard";
 import Card from "@/components/SharedComponents/Card";
@@ -31,6 +31,7 @@ const CurriculumUnitDetailsAccordion: FC<
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isToggleOpen, setToggleOpen] = useState<boolean>(false);
 
+  const { isFocusVisible } = useFocusVisible();
   const { focusWithinProps } = useFocusWithin({
     onFocusWithinChange: setIsFocused,
   });
@@ -80,7 +81,7 @@ const CurriculumUnitDetailsAccordion: FC<
       </Flex>
       <BoxBorders hideLeft hideRight hideBottom={!lastAccordion || isFocused} />
 
-      {isFocused && (
+      {isFocused && isFocusVisible && (
         <Box
           $position={"absolute"}
           $height={4}


### PR DESCRIPTION
## Description
Added `isFocusVisible` to `isFocused` condition so only applies for keyboard users

## Issue(s)

Fixes `CUR-980`

## How to test

1. Go to https://deploy-preview-2900--oak-web-application.netlify.thenational.academy
2. Navigate to the curriculum visualiser modal
3. Click the accordions **should not** show focus state indicators
3. Using keyboard to select the accordions **should** show focus state indicators
