### PR TITLE
fix(LESQ-1115): remove the flicker of the "your details" section

### DIFF
--- a/percy.snapshot.list.js
+++ b/percy.snapshot.list.js
@@ -19,7 +19,7 @@ const snapshotRelativeUrls = getDeploymentTestUrls().map((url) => {
   const snapshotConfig = {
     url,
     // Wait for the Next app to load.
-    waitForSelector: "#__next",
+    waitForSelector: `#__next:not(:has([data-testid="loading"]))`,
     // waitForTimeout: 3000,
   };
   return snapshotConfig;

--- a/src/__tests__/__helpers__/mockUser.ts
+++ b/src/__tests__/__helpers__/mockUser.ts
@@ -26,6 +26,15 @@ export const mockUser = {
   },
 } as unknown as UserResource;
 
+export const mockOnboardedUser: UserResource = {
+  ...mockUser,
+  publicMetadata: {
+    owa: {
+      isOnboarded: true,
+    },
+  },
+};
+
 export const mockUserWithDownloadAccess: UserResource = {
   ...mockUser,
   publicMetadata: {

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.test.tsx
@@ -31,6 +31,7 @@ const props: PropsWithoutForm = {
   updatedAt: "2022-01-01T00:00:00Z",
   withHomeschool: true,
   showTermsAgreement: true,
+  isLoading: false,
 };
 
 const ComponentWrapper = (props: PropsWithoutForm) => {

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.test.tsx
@@ -30,7 +30,7 @@ const props: PropsWithoutForm = {
   resourcesHeader: "Lesson downloads",
   updatedAt: "2022-01-01T00:00:00Z",
   withHomeschool: true,
-  hasOnboardingDownloadDetails: true,
+  showTermsAgreement: true,
 };
 
 const ComponentWrapper = (props: PropsWithoutForm) => {

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -52,7 +52,7 @@ export type ResourcePageLayoutProps = ResourcePageDetailsCompletedProps &
     triggerForm: UseFormTrigger<ResourceFormProps>;
     apiError?: string | null;
     updatedAt: string;
-    hasOnboardingDownloadDetails: boolean | undefined;
+    showTermsAgreement: boolean;
   };
 
 const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
@@ -113,7 +113,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
                 </Box>
               )}
               {props.cardGroup}
-              {props.hasOnboardingDownloadDetails && (
+              {!props.showTermsAgreement && (
                 <>
                   <OakBox
                     $pb={"inner-padding-xl3"}
@@ -148,24 +148,25 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
               ))}
             {!props.showNoResources && (
               <>
-                <TermsAgreementForm
-                  form={{
-                    control: props.control,
-                    register: props.register,
-                    errors: props.errors,
-                    trigger: props.triggerForm,
-                  }}
-                  isLoading={props.showLoading}
-                  email={props.email}
-                  schoolId={props.schoolId}
-                  schoolName={props.school}
-                  setSchool={props.setSchool}
-                  showSavedDetails={props.showSavedDetails}
-                  handleEditDetailsCompletedClick={props.onEditClick}
-                  showPostAlbCopyright={props.showPostAlbCopyright}
-                  copyrightYear={props.updatedAt}
-                  hideDetails={props.hasOnboardingDownloadDetails}
-                />
+                {props.showTermsAgreement && (
+                  <TermsAgreementForm
+                    form={{
+                      control: props.control,
+                      register: props.register,
+                      errors: props.errors,
+                      trigger: props.triggerForm,
+                    }}
+                    isLoading={props.showLoading}
+                    email={props.email}
+                    schoolId={props.schoolId}
+                    schoolName={props.school}
+                    setSchool={props.setSchool}
+                    showSavedDetails={props.showSavedDetails}
+                    handleEditDetailsCompletedClick={props.onEditClick}
+                    showPostAlbCopyright={props.showPostAlbCopyright}
+                    copyrightYear={props.updatedAt}
+                  />
+                )}
                 {hasFormErrors && (
                   <OakFlex $flexDirection={"row"}>
                     <Icon name="content-guidance" $color={"red"} />
@@ -185,7 +186,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
                     </OakFlex>
                   </OakFlex>
                 )}
-                {!props.hasOnboardingDownloadDetails && props.cta}
+                {props.showTermsAgreement && props.cta}
 
                 {props.apiError && !hasFormErrors && (
                   <FieldError

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -71,7 +71,7 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
         </OakHeading>
         {props.isLoading ? (
           <OakBox $minHeight="all-spacing-21">
-            <DelayedLoadingSpinner $delay={300} />
+            <DelayedLoadingSpinner $delay={300} data-testid="loading" />
           </OakBox>
         ) : (
           <ResourcePageContent {...props} />

--- a/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
+++ b/src/components/TeacherComponents/ResourcePageLayout/ResourcePageLayout.tsx
@@ -12,7 +12,9 @@ import {
   OakUL,
   OakFlex,
   OakBox,
+  OakLoadingSpinner,
 } from "@oaknational/oak-components";
+import styled from "styled-components";
 
 import CopyrightNotice from "../CopyrightNotice";
 
@@ -53,10 +55,10 @@ export type ResourcePageLayoutProps = ResourcePageDetailsCompletedProps &
     apiError?: string | null;
     updatedAt: string;
     showTermsAgreement: boolean;
+    isLoading: boolean;
   };
 
 const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
-  const hasFormErrors = Object.keys(props.errors).length > 0;
   return (
     <Box $width="100%">
       <OakFlex
@@ -67,145 +69,181 @@ const ResourcePageLayout: FC<ResourcePageLayoutProps> = (props) => {
         <OakHeading tag="h1" $font={["heading-5", "heading-4"]}>
           {props.header}
         </OakHeading>
-        <OakFlex
-          $justifyContent="space-between"
-          $width="100%"
-          $flexDirection={["column", "column", "row"]}
-          $gap="all-spacing-9"
-        >
-          <OakBox
-            $pa={"inner-padding-none"}
-            $ba={"border-solid-none"}
-            as={props.page === "download" ? "fieldset" : "box"}
-          >
-            {props.page === "download" && (
-              <OakBox
-                as="legend"
-                $position="absolute"
-                $width="all-spacing-0"
-                $height="all-spacing-0"
-                $pa={"inner-padding-none"}
-                $overflow="hidden"
-              >
-                {`Select resources to ${props.page}`}
-              </OakBox>
-            )}
-            <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
-              {props.resourcesHeader && (
-                <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>
-                  {props.resourcesHeader}
-                </OakHeading>
-              )}
-              <FieldError id={"downloads-error"} withoutMarginBottom>
-                {props.errors?.resources?.message}
-              </FieldError>
-              {!props.hideSelectAll && (
-                <Box $maxWidth="max-content">
-                  <Checkbox
-                    checked={props.selectAllChecked}
-                    onChange={props.handleToggleSelectAll}
-                    id="select-all"
-                    name="select-all"
-                    variant="withLabel"
-                    labelText="Select all"
-                    labelFontWeight={600}
-                  />
-                </Box>
-              )}
-              {props.cardGroup}
-              {!props.showTermsAgreement && (
-                <>
-                  <OakBox
-                    $pb={"inner-padding-xl3"}
-                    $mt={"space-between-m"}
-                    $maxWidth={"all-spacing-22"}
-                  >
-                    <CopyrightNotice
-                      fullWidth
-                      showPostAlbCopyright={props.showPostAlbCopyright}
-                      openLinksExternally={true}
-                      copyrightYear={props.updatedAt}
-                    />
-                  </OakBox>
-
-                  {props.cta}
-                </>
-              )}
-            </Flex>
+        {props.isLoading ? (
+          <OakBox $minHeight="all-spacing-21">
+            <DelayedLoadingSpinner $delay={300} />
           </OakBox>
-
-          <Flex
-            $flexDirection="column"
-            $alignSelf="center"
-            $gap={16}
-            $maxWidth={420}
-          >
-            {props.showNoResources &&
-              (props.page === "download" ? (
-                <NoResourcesToDownload />
-              ) : (
-                <NoResourcesToShare />
-              ))}
-            {!props.showNoResources && (
-              <>
-                {props.showTermsAgreement && (
-                  <TermsAgreementForm
-                    form={{
-                      control: props.control,
-                      register: props.register,
-                      errors: props.errors,
-                      trigger: props.triggerForm,
-                    }}
-                    isLoading={props.showLoading}
-                    email={props.email}
-                    schoolId={props.schoolId}
-                    schoolName={props.school}
-                    setSchool={props.setSchool}
-                    showSavedDetails={props.showSavedDetails}
-                    handleEditDetailsCompletedClick={props.onEditClick}
-                    showPostAlbCopyright={props.showPostAlbCopyright}
-                    copyrightYear={props.updatedAt}
-                  />
-                )}
-                {hasFormErrors && (
-                  <OakFlex $flexDirection={"row"}>
-                    <Icon name="content-guidance" $color={"red"} />
-                    <OakFlex $flexDirection={"column"}>
-                      <OakP $ml="space-between-sssx" $color={"red"}>
-                        To complete correct the following:
-                      </OakP>
-                      <OakUL $mr="space-between-m">
-                        {getFormErrorMessages(props.errors).map((err, i) => {
-                          return (
-                            <OakLI $color={"red"} key={i}>
-                              {err}
-                            </OakLI>
-                          );
-                        })}
-                      </OakUL>
-                    </OakFlex>
-                  </OakFlex>
-                )}
-                {props.showTermsAgreement && props.cta}
-
-                {props.apiError && !hasFormErrors && (
-                  <FieldError
-                    id="download-error"
-                    data-testid="download-error"
-                    variant={"large"}
-                    withoutMarginBottom
-                    ariaLive="polite"
-                  >
-                    {props.apiError}
-                  </FieldError>
-                )}
-              </>
-            )}
-          </Flex>
-        </OakFlex>
+        ) : (
+          <ResourcePageContent {...props} />
+        )}
       </OakFlex>
     </Box>
   );
 };
 
 export default ResourcePageLayout;
+
+function ResourcePageContent(props: ResourcePageLayoutProps) {
+  const hasFormErrors = Object.keys(props.errors).length > 0;
+
+  return (
+    <OakFlex
+      $justifyContent="space-between"
+      $width="100%"
+      $flexDirection={["column", "column", "row"]}
+      $gap="all-spacing-9"
+    >
+      <OakBox
+        $pa={"inner-padding-none"}
+        $ba={"border-solid-none"}
+        as={props.page === "download" ? "fieldset" : "box"}
+      >
+        {props.page === "download" && (
+          <OakBox
+            as="legend"
+            $position="absolute"
+            $width="all-spacing-0"
+            $height="all-spacing-0"
+            $pa={"inner-padding-none"}
+            $overflow="hidden"
+          >
+            {`Select resources to ${props.page}`}
+          </OakBox>
+        )}
+        <Flex $flexDirection="column" $gap={24} $width={["100%", 720]}>
+          {props.resourcesHeader && (
+            <OakHeading tag="h2" $font={["heading-6", "heading-5"]}>
+              {props.resourcesHeader}
+            </OakHeading>
+          )}
+          <FieldError id={"downloads-error"} withoutMarginBottom>
+            {props.errors?.resources?.message}
+          </FieldError>
+          {!props.hideSelectAll && (
+            <Box $maxWidth="max-content">
+              <Checkbox
+                checked={props.selectAllChecked}
+                onChange={props.handleToggleSelectAll}
+                id="select-all"
+                name="select-all"
+                variant="withLabel"
+                labelText="Select all"
+                labelFontWeight={600}
+              />
+            </Box>
+          )}
+          {props.cardGroup}
+          {!props.showTermsAgreement && (
+            <>
+              <OakBox
+                $pb={"inner-padding-xl3"}
+                $mt={"space-between-m"}
+                $maxWidth={"all-spacing-22"}
+              >
+                <CopyrightNotice
+                  fullWidth
+                  showPostAlbCopyright={props.showPostAlbCopyright}
+                  openLinksExternally={true}
+                  copyrightYear={props.updatedAt}
+                />
+              </OakBox>
+
+              {props.cta}
+            </>
+          )}
+        </Flex>
+      </OakBox>
+
+      <Flex
+        $flexDirection="column"
+        $alignSelf="center"
+        $gap={16}
+        $maxWidth={420}
+      >
+        {props.showNoResources &&
+          (props.page === "download" ? (
+            <NoResourcesToDownload />
+          ) : (
+            <NoResourcesToShare />
+          ))}
+        {!props.showNoResources && (
+          <>
+            {props.showTermsAgreement && (
+              <TermsAgreementForm
+                form={{
+                  control: props.control,
+                  register: props.register,
+                  errors: props.errors,
+                  trigger: props.triggerForm,
+                }}
+                isLoading={props.showLoading}
+                email={props.email}
+                schoolId={props.schoolId}
+                schoolName={props.school}
+                setSchool={props.setSchool}
+                showSavedDetails={props.showSavedDetails}
+                handleEditDetailsCompletedClick={props.onEditClick}
+                showPostAlbCopyright={props.showPostAlbCopyright}
+                copyrightYear={props.updatedAt}
+              />
+            )}
+            {hasFormErrors && (
+              <OakFlex $flexDirection={"row"}>
+                <Icon name="content-guidance" $color={"red"} />
+                <OakFlex $flexDirection={"column"}>
+                  <OakP $ml="space-between-sssx" $color={"red"}>
+                    To complete correct the following:
+                  </OakP>
+                  <OakUL $mr="space-between-m">
+                    {getFormErrorMessages(props.errors).map((err, i) => {
+                      return (
+                        <OakLI $color={"red"} key={i}>
+                          {err}
+                        </OakLI>
+                      );
+                    })}
+                  </OakUL>
+                </OakFlex>
+              </OakFlex>
+            )}
+            {props.showTermsAgreement && props.cta}
+
+            {props.apiError && !hasFormErrors && (
+              <FieldError
+                id="download-error"
+                data-testid="download-error"
+                variant={"large"}
+                withoutMarginBottom
+                ariaLive="polite"
+              >
+                {props.apiError}
+              </FieldError>
+            )}
+          </>
+        )}
+      </Flex>
+    </OakFlex>
+  );
+}
+
+const DelayedLoadingSpinner = styled(OakLoadingSpinner)<{ $delay?: number }>`
+  ${({ $delay }) => {
+    if ($delay) {
+      return `
+        opacity: 0;
+        animation: delayed-spinner-show 0s;
+        animation-delay: ${$delay / 1000}s;
+        animation-fill-mode: forwards;
+      `;
+    }
+  }}
+
+  @keyframes delayed-spinner-show {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
@@ -75,14 +75,4 @@ describe("TermsAgreementForm (School, email and terms form within the teacher an
     const detailsCompletedComponent = getByTestId("termsCheckbox");
     expect(detailsCompletedComponent).toBeInTheDocument();
   });
-  it("Hides ResourcePageTermsAndConditionsCheckbox component when hideDetails = true", async () => {
-    // Render the component with required props
-    const { queryByTestId } = render(<Wrapper hideDetails={true} />);
-    const checkboxComponent = queryByTestId("termsCheckbox");
-    expect(checkboxComponent).not.toBeInTheDocument();
-    const newsletterComponent = queryByTestId("newsletter-policy");
-    expect(newsletterComponent).not.toBeInTheDocument();
-    const detailsCompletedComponent = queryByTestId("details-completed");
-    expect(detailsCompletedComponent).not.toBeInTheDocument();
-  });
 });

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -36,7 +36,6 @@ export type TermsAgreementFormProps = {
   handleEditDetailsCompletedClick?: () => void;
   showPostAlbCopyright?: boolean;
   copyrightYear: string;
-  hideDetails?: boolean;
 };
 
 const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
@@ -50,11 +49,7 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
   handleEditDetailsCompletedClick = () => {},
   showPostAlbCopyright = true,
   copyrightYear,
-  hideDetails,
 }) => {
-  if (hideDetails) {
-    return null;
-  }
   return (
     <>
       <OakHeading

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
@@ -62,19 +62,6 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
     useFeatureFlagVariantKey("teacher-download-auth") === "with-login";
   const { isSignedIn, user } = useUser();
 
-  const [hasOnboardingDownloadDetails, setHasOnboardingDownloadDetails] =
-    useState(false);
-
-  useEffect(() => {
-    if (user != null) {
-      // as user has signed in with full onboarding journey on OWA
-      const hasOnboardingDownloadDetails = Boolean(
-        authFlagEnabled && isSignedIn && user.publicMetadata?.owa?.isOnboarded,
-      );
-      setHasOnboardingDownloadDetails(hasOnboardingDownloadDetails);
-    }
-  }, [authFlagEnabled, isSignedIn, user, user?.publicMetadata?.owa?.isTeacher]);
-
   const {
     schoolFromLocalStorage,
     emailFromLocalStorage,
@@ -340,7 +327,6 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
     setActiveResources,
     handleToggleSelectAll,
     selectAllChecked,
-    hasOnboardingDownloadDetails,
     form: {
       trigger,
       setValue,

--- a/src/components/TeacherComponents/hooks/useOnboardingStatus.test.ts
+++ b/src/components/TeacherComponents/hooks/useOnboardingStatus.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useOnboardingStatus } from "./useOnboardingStatus";
+
+import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
+import {
+  mockLoadingUser,
+  mockLoggedIn,
+  mockOnboardedUser,
+} from "@/__tests__/__helpers__/mockUser";
+
+describe(useOnboardingStatus, () => {
+  it("waits until Clerk has loaded", () => {
+    setUseUserReturn(mockLoadingUser);
+
+    const { result, rerender } = renderHook(useOnboardingStatus);
+
+    expect(result.current).toEqual("loading");
+
+    setUseUserReturn(mockLoggedIn);
+
+    rerender();
+
+    expect(result.current).toEqual("not-onboarded");
+  });
+
+  it("returns `onboarded` when the user has onboarded in OWA", () => {
+    setUseUserReturn({ ...mockLoggedIn, user: mockOnboardedUser });
+
+    expect(renderHook(useOnboardingStatus).result.current).toEqual("onboarded");
+  });
+
+  it("times out if Clerk doesn't load in 10 seconds", () => {
+    jest.useFakeTimers();
+    setUseUserReturn(mockLoadingUser);
+
+    const { result } = renderHook(useOnboardingStatus);
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    expect(result.current).toEqual("unknown");
+  });
+
+  it("updates if Clerk eventually loads", () => {
+    jest.useFakeTimers();
+    setUseUserReturn(mockLoadingUser);
+
+    const { result, rerender } = renderHook(useOnboardingStatus);
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    setUseUserReturn(mockLoggedIn);
+
+    rerender();
+
+    expect(result.current).toEqual("not-onboarded");
+  });
+});

--- a/src/components/TeacherComponents/hooks/useOnboardingStatus.ts
+++ b/src/components/TeacherComponents/hooks/useOnboardingStatus.ts
@@ -1,0 +1,40 @@
+import { useUser } from "@clerk/nextjs";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Returns the onboarding status for the current session
+ *
+ * `loading` while Clerk is loading
+ * `not-onboarded` when there is no active user or the active user has not completed onboarding
+ * `onboarded` when the active user has completed onboarding
+ * `unknown` if Clerk fails to load in 10 seconds
+ */
+export function useOnboardingStatus() {
+  const { isLoaded, user } = useUser();
+  const [hasTimedout, setHasTimedout] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Don't trust 3rd parties to ever load
+  useEffect(() => {
+    const timer = (timerRef.current = setTimeout(() => {
+      setHasTimedout(true);
+    }, 10000));
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (isLoaded) {
+    typeof timerRef.current === "number" && clearTimeout(timerRef.current);
+    timerRef.current = null;
+
+    return user?.publicMetadata.owa?.isOnboarded
+      ? "onboarded"
+      : "not-onboarded";
+  }
+
+  if (hasTimedout) {
+    return "unknown";
+  }
+
+  return "loading";
+}

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -8,6 +8,7 @@ import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import { filterDownloadsByCopyright } from "../TeacherComponents/helpers/downloadAndShareHelpers/downloadsCopyright";
 import { LessonDownloadRegionBlocked } from "../TeacherComponents/LessonDownloadRegionBlocked/LessonDownloadRegionBlocked";
+import { useOnboardingStatus } from "../TeacherComponents/hooks/useOnboardingStatus";
 
 import Box from "@/components/SharedComponents/Box";
 import MaxWidth from "@/components/SharedComponents/MaxWidth";
@@ -171,11 +172,11 @@ export function LessonDownloads(props: LessonDownloadsProps) {
     handleToggleSelectAll,
     selectAllChecked,
     setEmailInLocalStorage,
-    hasOnboardingDownloadDetails,
   } = useResourceFormState({
     downloadResources: downloadsFilteredByCopyright,
     type: "download",
   });
+  const onboardingStatus = useOnboardingStatus();
 
   const noResourcesSelected =
     form.watch().resources === undefined || form.watch().resources.length === 0;
@@ -375,7 +376,10 @@ export function LessonDownloads(props: LessonDownloadsProps) {
               hideSelectAll={Boolean(expired)}
               updatedAt={updatedAt}
               withHomeschool={true}
-              hasOnboardingDownloadDetails={hasOnboardingDownloadDetails}
+              showTermsAgreement={
+                onboardingStatus === "not-onboarded" ||
+                onboardingStatus === "unknown"
+              }
               cardGroup={
                 !showNoResources && (
                   <DownloadCardGroup

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -380,6 +380,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
                 onboardingStatus === "not-onboarded" ||
                 onboardingStatus === "unknown"
               }
+              isLoading={onboardingStatus === "loading"}
               cardGroup={
                 !showNoResources && (
                   <DownloadCardGroup

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -230,6 +230,7 @@ export function LessonShare(props: LessonShareProps) {
             onboardingStatus === "not-onboarded" ||
             onboardingStatus === "unknown"
           }
+          isLoading={onboardingStatus === "loading"}
           onEditClick={handleEditDetailsCompletedClick}
           register={form.register}
           control={form.control}

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -38,6 +38,7 @@ import {
 import { useHubspotSubmit } from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useHubspotSubmit";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 import { SpecialistLessonShareData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema";
+import { useOnboardingStatus } from "@/components/TeacherComponents/hooks/useOnboardingStatus";
 
 export type LessonShareProps =
   | {
@@ -128,11 +129,11 @@ export function LessonShare(props: LessonShareProps) {
     selectAllChecked,
     editDetailsClicked,
     setEmailInLocalStorage,
-    hasOnboardingDownloadDetails,
   } = useResourceFormState({
     shareResources: shareableResources,
     type: "share",
   });
+  const onboardingStatus = useOnboardingStatus();
 
   const { onSubmit } = useResourceFormSubmit({
     type: "share",
@@ -225,7 +226,10 @@ export function LessonShare(props: LessonShareProps) {
           schoolId={schoolIdFromLocalStorage}
           setSchool={setSchool}
           showSavedDetails={shouldDisplayDetailsCompleted}
-          hasOnboardingDownloadDetails={hasOnboardingDownloadDetails}
+          showTermsAgreement={
+            onboardingStatus === "not-onboarded" ||
+            onboardingStatus === "unknown"
+          }
           onEditClick={handleEditDetailsCompletedClick}
           register={form.register}
           control={form.control}


### PR DESCRIPTION
## Description

Music year: 1969

Fixes 
* Flicker of the "Your details" section appearing when logged in
  * This was caused by the initial delay between the page rendering and Clerk loading.
  * Annoyingly this sort of loading experience is unavoidable with client side personalisation.

## How to test

1. With the [teacher-download-auth](https://eu.posthog.com/project/124/feature_flags/35482) feature flag set to "with-login" and while logged in
2. Go to https://deploy-preview-2902--oak-web-application.netlify.thenational.academy/teachers/programmes/computing-secondary-ks3-l/units/impact-of-technology-collaborating-online-respectfully-35d0/lessons/account-security-68rkee/downloads?preselected=all
3. Reload the page
4. You should see a slight delay (and potentially a loading spinner) before the download options appear
5. While logged out
6. Go to https://deploy-preview-2902--oak-web-application.netlify.thenational.academy/teachers/programmes/computing-secondary-ks3-l/units/impact-of-technology-collaborating-online-respectfully-35d0/lessons/account-security-68rkee/downloads?preselected=all
7. Reload the page
8. You should see a slight delay (and potentially a loading spinner) before the "Your details" form appears

🌮 **This is only an issue for direct links to the downloads page — users coming through the browse journey to the downloads page will not see this initial loading state as their user has already loaded. You won't see this on the downloads-auth page as this check has already taken place before the page is fully rendered**

## Screenshots

How it used to look

**Signed in**

https://github.com/user-attachments/assets/670519a4-b8b1-4385-a4db-e99c2cc64013

**Signed out**

https://github.com/user-attachments/assets/71db222a-0340-40d3-a13a-83826bfe3b37

How it should now look:

**Signed in**

https://github.com/user-attachments/assets/de72906b-b16b-4325-8346-da00129028ec

**Signed out**

https://github.com/user-attachments/assets/49ff37cf-6546-47c8-8824-9d24581fa8fe



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
