### PR TITLE
Fix text size on learning tiers in curriculum visualiser

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -345,7 +345,6 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
                       );
                       return (
                         <Button
-                          $font={"heading-6"}
                           $mb={20}
                           $mr={24}
                           key={tier.tier_slug}


### PR DESCRIPTION
## Description
Decreased the text size on learning tiers in curriculum visualiser in line with the other UI elements

## Issue(s)

Fixes `CUR-637`

## How to test

1. Go to {owa_deployment_url}
2. Navigate to the curriculum visualiser
3. Check the text size for learning tiers is correct.

## Screenshots
Before
<img width="311" alt="Screenshot 2024-10-17 at 15 26 29" src="https://github.com/user-attachments/assets/b2a34d01-26bf-49c8-a0c0-c3c5f77a6893">

After
<img width="311" alt="Screenshot 2024-10-17 at 15 25 03" src="https://github.com/user-attachments/assets/e1c88fc8-3292-43f5-be79-56ef11d83ad1">

