### PR TITLE
`:focus` -> `:focus-visible` for focus state in lot picker

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -77,7 +77,7 @@ const ButtonContainer = styled.div`
       border: 1px solid var(--Tokens-Border-border-neutral-lighter, #cacaca);
       background: var(--Tokens-Background-bg-primary, #fff);
 
-      :focus {
+      :focus-visible {
         /* drop-shadow-focus  */
         box-shadow:
           0px 0px 0px 2px #ffe555,


### PR DESCRIPTION
## Description
Changed `:focus` -> `:focus-visible` for focus state in lot picker

## Issue(s)
Fixes `CUR-976`

## How to test

1. Go to https://deploy-preview-2904--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. Check the focus state of lot picker when using mouse/keyboard