### PR TITLE
fix: missing Hubpost contacts throwing errors on download page

### DIFF
--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/fetchHubspotContactDetails.test.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/fetchHubspotContactDetails.test.ts
@@ -2,6 +2,8 @@ import fetchMock from "jest-fetch-mock";
 
 import { fetchHubspotContactDetails } from "./fetchHubspotContactDetails";
 
+import OakError from "@/errors/OakError";
+
 fetchMock.enableMocks();
 
 describe(fetchHubspotContactDetails, () => {
@@ -19,5 +21,13 @@ describe(fetchHubspotContactDetails, () => {
     fetchMock.mockResponseOnce("", { status: 204 });
 
     expect(await fetchHubspotContactDetails("foo@example.com")).toEqual(null);
+  });
+
+  it("throws when there is an error", () => {
+    fetchMock.mockResponseOnce("", { status: 500 });
+
+    expect(
+      fetchHubspotContactDetails("foo@example.com"),
+    ).rejects.toBeInstanceOf(OakError);
   });
 });

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/fetchHubspotContactDetails.test.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/fetchHubspotContactDetails.test.ts
@@ -1,0 +1,23 @@
+import fetchMock from "jest-fetch-mock";
+
+import { fetchHubspotContactDetails } from "./fetchHubspotContactDetails";
+
+fetchMock.enableMocks();
+
+describe(fetchHubspotContactDetails, () => {
+  it("returns the contact from the response", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ email: "foo@example.com" }), {
+      status: 200,
+    });
+
+    expect(await fetchHubspotContactDetails("foo@example.com")).toEqual({
+      email: "foo@example.com",
+    });
+  });
+
+  it("returns null when there is no contact", async () => {
+    fetchMock.mockResponseOnce("", { status: 204 });
+
+    expect(await fetchHubspotContactDetails("foo@example.com")).toEqual(null);
+  });
+});


### PR DESCRIPTION
Fixes #

Users not being able to download when signing up with an email that was not already a Hubspot contact.

## How to test

1. Go to https://deploy-preview-2906--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
