### PR TITLE
fix: don't report errors for canonical pages with null subjects [LESQ-1121]

### DIFF
--- a/src/utils/getValidSubjectIconName.ts
+++ b/src/utils/getValidSubjectIconName.ts
@@ -8,13 +8,17 @@ export const getValidSubjectIconName = (
 ): OakIconName => {
   const subjectIconName = `subject-${subject}`;
   if (!isValidIconName(subjectIconName)) {
-    const reportError = errorReporter("generateSubjectIconName");
-    reportError(
-      new OakError({
-        code: "oak-components/invalid-icon-name",
-        meta: { iconName: subjectIconName },
-      }),
-    );
+    // Subject will be null when a canonical lesson appears in multiple subjects
+    // it's not helpful to receive error reports for these cases
+    if (subject !== null) {
+      const reportError = errorReporter("generateSubjectIconName");
+      reportError(
+        new OakError({
+          code: "oak-components/invalid-icon-name",
+          meta: { iconName: subjectIconName },
+        }),
+      );
+    }
     // fallback icon
     return "books";
   }


### PR DESCRIPTION
## Description

Music year: 1987

- don't report errors for canonical pages with null subjects
- this happens when a lesson is in multiple subjects, eg `To explore fronted adverbials` is in `english` and `english-grammar`
- we display a fallback icon 'books'
- it's not helpful to receive these errors as they tell us nothing new and clog up the errors channel


## How to test

1. Go to https://deploy-preview-2910--oak-web-application.netlify.thenational.academy/teachers/lessons/to-explore-fronted-adverbials-71h64t
3. You should see no `Invalid icon name provided to OakIcon` error in the console
4. You should see the 'books' icon in place of a subject icon

## ACs

- [ ] fallback books icon displayed when subject can't be determined
- [ ] no invalid icon error in console
