### PR TITLE
LESQ-1117: onboarding login fixes

### DIFF
--- a/src/browser-lib/hubspot/forms/getHubspotFormPayloads.ts
+++ b/src/browser-lib/hubspot/forms/getHubspotFormPayloads.ts
@@ -4,12 +4,12 @@ import { UtmParams } from "../../../hooks/useUtmParams";
 
 import { HubspotPayload } from "./hubspotSubmitForm";
 
-import { useOfOakSchema } from "@/components/TeacherComponents/OnboardingForm/OnboardingForm.schema";
 import {
+  useOfOakSchema,
   OakSupportKey,
-  oakSupportMap,
-} from "@/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view";
+} from "@/components/TeacherComponents/OnboardingForm/OnboardingForm.schema";
 import { extractUrnAndSchool } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
+import { oakSupportMap } from "@/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view";
 
 export const USER_ROLES = ["Teacher", "Parent", "Student", "Other"] as const;
 export type UserRole = (typeof USER_ROLES)[number];

--- a/src/components/SharedComponents/FieldError/FieldError.tsx
+++ b/src/components/SharedComponents/FieldError/FieldError.tsx
@@ -11,6 +11,7 @@ type FieldErrorProps = {
   withoutMarginBottom?: boolean;
   variant?: FieldErrorVariant | null;
   ariaLive?: "off" | "polite" | "assertive";
+  ariaHidden?: boolean;
 };
 
 const FieldError = (props: FieldErrorProps) => {
@@ -27,6 +28,7 @@ const FieldError = (props: FieldErrorProps) => {
       $alignItems={"center"}
       $flexDirection={"row"}
       $mb={withoutMarginBottom ? "space-between-none" : "space-between-m"}
+      aria-hidden={props.ariaHidden}
     >
       <OakFlex $alignSelf={"flex-start"} $mr="space-between-sssx">
         <Icon name="content-guidance" $color={"red"} />

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -40,12 +40,9 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
       ? "downloads-auth"
       : "downloads";
 
-  const { user, isLoaded } = useUser();
+  const { isSignedIn } = useUser();
 
-  const displaySignInMessage =
-    isLoaded &&
-    downloads === "downloads-auth" &&
-    !user?.publicMetadata?.owa?.isOnboarded;
+  const displaySignInMessage = downloads === "downloads-auth" && !isSignedIn;
 
   if (expired || !showDownloadAll) {
     return null;

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.test.ts
@@ -1,0 +1,36 @@
+import { ZodError } from "zod";
+
+import { extendedUseOfOakSchema } from "./OnboardingForm.schema";
+
+describe("extendedUseOfOakSchema", () => {
+  const baseData = {
+    newsletterSignUp: false,
+    school: "000000",
+  };
+
+  it("requires a support option to have been selected when continuing", () => {
+    expect(() => {
+      extendedUseOfOakSchema.parse({ ...baseData, submitMode: "continue" });
+    }).toThrow(
+      new ZodError([
+        {
+          code: "custom",
+          message: "Please tell us how Oak can support you",
+          path: ["root"],
+        },
+      ]),
+    );
+  });
+
+  it("removes support options when skipping", () => {
+    expect(
+      extendedUseOfOakSchema.parse({
+        ...baseData,
+        submitMode: "skip",
+        curriculumDesign: true,
+      }),
+    ).not.toMatchObject({
+      curriculumDesign: true,
+    });
+  });
+});

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.test.ts
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.test.ts
@@ -15,7 +15,7 @@ describe("extendedUseOfOakSchema", () => {
       new ZodError([
         {
           code: "custom",
-          message: "Please tell us how Oak can support you",
+          message: "Please select the ways Oak can support you",
           path: ["root"],
         },
       ]),

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.schema.ts
@@ -98,7 +98,7 @@ export const extendedUseOfOakSchema = useOfOakSchema
       return true;
     },
     {
-      message: "Please tell us how Oak can support you",
+      message: "Please select the ways Oak can support you",
       path: ["root"],
     },
   )

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -59,6 +59,7 @@ const OnboardingForm = ({
   control: Control<OnboardingFormProps>;
   trigger: UseFormTrigger<OnboardingFormProps>;
   forceHideNewsletterSignUp?: boolean;
+  continueButtonDescription?: string;
 }) => {
   const router = useRouter();
   const utmParams = useUtmParams();
@@ -270,7 +271,9 @@ const OnboardingForm = ({
               type="submit"
               onClick={props.onSubmit}
               name="continue"
-              aria-description={submitError ?? undefined}
+              aria-description={
+                props.continueButtonDescription ?? submitError ?? undefined
+              }
             >
               Continue
             </OakPrimaryButton>

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -90,7 +90,7 @@ const OnboardingForm = ({
     data: OnboardingFormProps,
     event?: BaseSyntheticEvent,
   ) => {
-    if (isSubmitting) {
+    if (isSubmitting && !props.canSubmit) {
       return;
     }
 
@@ -216,7 +216,13 @@ const OnboardingForm = ({
         as="form"
         noValidate
         onSubmit={
-          (event) => void props.handleSubmit(onFormSubmit)(event) // https://github.com/orgs/react-hook-form/discussions/8622}
+          (event) => {
+            if (props.canSubmit) {
+              props.handleSubmit(onFormSubmit)(event);
+            } else {
+              event.preventDefault();
+            }
+          } // https://github.com/orgs/react-hook-form/discussions/8622}
         }
       >
         <Logo height={48} width={104} variant="with text" />
@@ -259,7 +265,7 @@ const OnboardingForm = ({
             $flexDirection="column"
           >
             <OakPrimaryButton
-              disabled={!props.canSubmit || isSubmitting}
+              disabled={isSubmitting}
               width="100%"
               type="submit"
               onClick={props.onSubmit}

--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.test.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.test.tsx
@@ -48,18 +48,17 @@ describe("HowCanOakSupport", () => {
     const continueButton = screen.getByRole("button", { name: /continue/i });
     await waitFor(() => expect(continueButton).toBeEnabled());
   });
-  it("disabled buttons and renders an error message if there is missing data", async () => {
+  it("renders an error message if there is missing data", async () => {
     mockRouter.setCurrentUrl({
       pathname: "/onboarding/how-can-oak-support",
       query: {},
     });
     renderWithProviders()(<HowCanOakSupport />);
-    const continueButton = screen.getByRole("button", { name: /continue/i });
-    await waitFor(() => expect(continueButton).toBeDisabled());
-    const skipButton = screen.getByRole("button", { name: /skip/i });
-    await waitFor(() => expect(skipButton).toBeDisabled());
-    const errorMessage = screen.getByText(/An error occurred. Please/i);
-    await waitFor(() => expect(errorMessage).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText(/An error occurred. Please/i),
+      ).toBeInTheDocument(),
+    );
   });
 
   it.each(["Continue", "Skip"])(
@@ -67,8 +66,6 @@ describe("HowCanOakSupport", () => {
     async (buttonName) => {
       renderWithProviders()(<HowCanOakSupport />);
       const button = screen.getByRole("button", { name: buttonName });
-
-      await waitFor(() => expect(button).toBeEnabled());
 
       await userEvent.click(
         screen.getByLabelText(

--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.test.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.test.tsx
@@ -1,5 +1,7 @@
 import { screen, waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
+import fetchMock from "jest-fetch-mock";
 
 import HowCanOakSupport, { oakSupportMap } from "./HowCanOakSupport.view";
 
@@ -11,7 +13,20 @@ import { OnboardingFormProps } from "@/components/TeacherComponents/OnboardingFo
 
 jest.mock("next/router", () => require("next-router-mock"));
 
+fetchMock.enableMocks();
+
 describe("HowCanOakSupport", () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl({
+      pathname: "/onboarding/how-can-oak-support",
+      query: encodeOnboardingDataQueryParam({}, {
+        newsletterSignUp: true,
+        schoolName: "Jefferson House, Cheshire West and Chester, CW7 1JT",
+        school: "142332-Jefferson House",
+      } as OnboardingFormProps),
+    });
+  });
+
   it("renders the onboarding layout with the correct prompt", () => {
     renderWithProviders()(<HowCanOakSupport />);
     const promptHeading = screen.getByText(/Last step.../i);
@@ -27,14 +42,6 @@ describe("HowCanOakSupport", () => {
     expect(checkboxes).toHaveLength(Object.keys(oakSupportMap).length);
   });
   it("renders a continue button that is enabled by default", async () => {
-    mockRouter.push({
-      pathname: "/onboarding/how-can-oak-support",
-      query: encodeOnboardingDataQueryParam({}, {
-        newsletterSignUp: true,
-        schoolName: "Jefferson House, Cheshire West and Chester, CW7 1JT",
-        school: "142332-Jefferson House",
-      } as OnboardingFormProps),
-    });
     renderWithProviders({ ...allProviders, router: mockRouter })(
       <HowCanOakSupport />,
     );
@@ -42,7 +49,7 @@ describe("HowCanOakSupport", () => {
     await waitFor(() => expect(continueButton).toBeEnabled());
   });
   it("disabled buttons and renders an error message if there is missing data", async () => {
-    mockRouter.push({
+    mockRouter.setCurrentUrl({
       pathname: "/onboarding/how-can-oak-support",
       query: {},
     });
@@ -54,4 +61,22 @@ describe("HowCanOakSupport", () => {
     const errorMessage = screen.getByText(/An error occurred. Please/i);
     await waitFor(() => expect(errorMessage).toBeInTheDocument());
   });
+
+  it.each(["Continue", "Skip"])(
+    `can be submitted with the %p button`,
+    async (buttonName) => {
+      renderWithProviders()(<HowCanOakSupport />);
+      const button = screen.getByRole("button", { name: buttonName });
+
+      await waitFor(() => expect(button).toBeEnabled());
+
+      await userEvent.click(
+        screen.getByLabelText(
+          "To support my department with specialist resources",
+        ),
+      );
+
+      await userEvent.click(button);
+    },
+  );
 });

--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
@@ -91,6 +91,7 @@ const HowCanOakSupport = () => {
             Skip
           </OakSecondaryButton>
         )}
+        continueButtonDescription={formState.errors.root?.message}
       >
         <OakFlex $flexDirection="column" $gap="space-between-s">
           <div

--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
@@ -6,7 +6,7 @@ import {
   OakSecondaryButton,
   OakSpan,
 } from "@oaknational/oak-components";
-import { Control, UseFormTrigger, useForm } from "react-hook-form";
+import { Control, Controller, UseFormTrigger, useForm } from "react-hook-form";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import Link from "next/link";
@@ -37,7 +37,7 @@ export const oakSupportMap: Record<OakSupportKey, string> = {
 const HowCanOakSupport = () => {
   const router = useRouter();
   const onboardingState = decodeOnboardingDataQueryParam(router.query);
-  const { formState, setValue, handleSubmit, getValues, control, trigger } =
+  const { formState, setValue, handleSubmit, control, trigger } =
     useForm<UseOfOakFormProps>({
       resolver: zodResolver(extendedUseOfOakSchema),
       mode: "onBlur",
@@ -55,13 +55,6 @@ const HowCanOakSupport = () => {
   useEffect(() => {
     trigger();
   }, [trigger]);
-
-  const handleToggleCheckbox = (key: OakSupportKey) => {
-    const currentValue = getValues(key);
-    setValue("submitMode", "skip");
-    setValue(key, !currentValue);
-    trigger();
-  };
 
   const hasMissingFormData = Object.entries(formState.errors)
     .filter(([key]) => key !== "root")
@@ -88,7 +81,7 @@ const HowCanOakSupport = () => {
         secondaryButton={(isSubmitting) => (
           <OakSecondaryButton
             width="100%"
-            disabled={hasMissingFormData || isSubmitting}
+            disabled={isSubmitting}
             name="skip"
             onClick={() => {
               setValue("submitMode", "skip");
@@ -100,15 +93,22 @@ const HowCanOakSupport = () => {
         )}
       >
         <OakFlex $flexDirection="column" $gap="space-between-s">
-          <FieldError id="root-error" ariaLive="polite" withoutMarginBottom>
-            {formState.errors.root?.message}
-          </FieldError>
+          <div
+            aria-live="assertive"
+            aria-label={formState.errors.root?.message}
+          >
+            <FieldError id="root-error" ariaHidden withoutMarginBottom>
+              {formState.errors.root?.message}
+            </FieldError>
+          </div>
           {Object.entries(oakSupportMap).map(([key, value]) => (
-            <OakCheckBox
-              id={key}
+            <Controller
+              control={control}
+              name={key as OakSupportKey}
               key={key}
-              value={value}
-              onChange={() => handleToggleCheckbox(key as OakSupportKey)}
+              render={({ field }) => (
+                <OakCheckBox id={key} key={key} {...field} value={value} />
+              )}
             />
           ))}
           {hasMissingFormData && (

--- a/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
+++ b/src/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view.tsx
@@ -37,7 +37,7 @@ export const oakSupportMap: Record<OakSupportKey, string> = {
 const HowCanOakSupport = () => {
   const router = useRouter();
   const onboardingState = decodeOnboardingDataQueryParam(router.query);
-  const { formState, setValue, handleSubmit, control, trigger } =
+  const { formState, setValue, handleSubmit, control, clearErrors, trigger } =
     useForm<UseOfOakFormProps>({
       resolver: zodResolver(extendedUseOfOakSchema),
       mode: "onBlur",
@@ -108,7 +108,16 @@ const HowCanOakSupport = () => {
               name={key as OakSupportKey}
               key={key}
               render={({ field }) => (
-                <OakCheckBox id={key} key={key} {...field} value={value} />
+                <OakCheckBox
+                  id={key}
+                  key={key}
+                  {...field}
+                  value={value}
+                  onChange={(event) => {
+                    clearErrors();
+                    field.onChange(event);
+                  }}
+                />
               )}
             />
           ))}

--- a/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
+++ b/src/components/TeacherViews/Onboarding/SchoolSelection/SchoolSelection.test.tsx
@@ -52,21 +52,6 @@ describe("Onboarding view", () => {
     expect(contactUs.closest("a")).toHaveAttribute("href", "/contact-us");
   });
 
-  it("it disables the continue button when the form is invalid", async () => {
-    renderWithProviders()(<SchoolSelectionView />);
-    const continueButton = await screen.findByRole("button", {
-      name: "Continue",
-    });
-
-    const user = userEvent.setup();
-    await user.click(continueButton);
-
-    expect(
-      await screen.findByRole("button", {
-        name: "Continue",
-      }),
-    ).toBeDisabled();
-  });
   it("clears the input when a school is not completed", async () => {
     renderWithProviders()(<SchoolSelectionView />);
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

## Issue(s)

Fixes
* Download button asking users to Sign in when they have signed in but have not onboarded
* Validation when clicking "Continue" or "Skip" on the "How can Oak support you" step of onboarding

## How to test

### Scenario #1 — Validation of "How can Oak support you" page

1. Go to https://deploy-preview-2917--oak-web-application.netlify.thenational.academy/onboarding
2. Click on take the teacher journey through onboarding
3. On the "How can Oak support you" step
4. Don't select any options
5. Click "Continue"
6. You should see a validation error
7. Select some options
8. Click "Skip"
9. The form should submit
10. `how_can_oak_support_you_` should be omitted from the form sent to Hubspot

### Scenario #2

1. Sign in as a user who has not onboarded in OWA (`owa.isOnboarded` is not `true` in Clerk)
2. Go to https://deploy-preview-2917--oak-web-application.netlify.thenational.academy/teachers/programmes/citizenship-secondary-ks3-l/units/citizenship-whats-it-all-about-e038/lessons/what-is-citizenship-c4t38d#slide-deck
3. The download button should read "Download all resources"
4. Clicking "Download all resources" should take you to onboarding

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
