### PR TITLE
fix(LESQ-1138): send the correct URN for NI schools to hubspot

### DIFF
--- a/src/browser-lib/hubspot/forms/getHubspotFormPayload.test.ts
+++ b/src/browser-lib/hubspot/forms/getHubspotFormPayload.test.ts
@@ -168,7 +168,7 @@ describe("getHubspotOnboardingFormPayload", () => {
       data: {
         email: "email value",
         newsletterSignUp: true,
-        school: "school_id value",
+        school: "999999-value",
         schoolName: "school_name value",
         oakUserId: "oak_user_id value",
         utm_campaign: "a campaign",
@@ -180,7 +180,7 @@ describe("getHubspotOnboardingFormPayload", () => {
     });
     expect(result.fields).toEqual([
       { name: "contact_school_name", value: "school_name value" },
-      { name: "contact_school_urn", value: "school_id value" },
+      { name: "contact_school_urn", value: "999999" },
       { name: "do_you_work_in_a_school", value: "Yes" },
       { name: "email", value: "email value" },
       { name: "email_consent_on_account_creation", value: "Yes" },

--- a/src/browser-lib/hubspot/forms/getHubspotFormPayloads.ts
+++ b/src/browser-lib/hubspot/forms/getHubspotFormPayloads.ts
@@ -9,6 +9,7 @@ import {
   OakSupportKey,
   oakSupportMap,
 } from "@/components/TeacherViews/Onboarding/HowCanOakSupport/HowCanOakSupport.view";
+import { extractUrnAndSchool } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
 
 export const USER_ROLES = ["Teacher", "Parent", "Student", "Other"] as const;
 export type UserRole = (typeof USER_ROLES)[number];
@@ -204,7 +205,9 @@ export const getHubspotOnboardingFormPayload = (props: {
       : isInternationalTeacher
         ? data.manualSchoolName
         : "notListed",
-    contact_school_urn: isUkTeacher ? data.school.split("-")[0] : undefined,
+    contact_school_urn: isUkTeacher
+      ? extractUrnAndSchool(data.school).urn
+      : undefined,
     manual_input_school_address: isInternationalTeacher
       ? data.schoolAddress
       : undefined,

--- a/src/components/TeacherComponents/OnboardingForm/onboardingActions/collectOnboardingTrackingProps.ts
+++ b/src/components/TeacherComponents/OnboardingForm/onboardingActions/collectOnboardingTrackingProps.ts
@@ -1,6 +1,7 @@
 import { useUser } from "@clerk/nextjs";
 
 import { OnboardingFormProps } from "../OnboardingForm.schema";
+import { extractUrnAndSchool } from "../../helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
 
 import {
   onboardingRoleOptions,
@@ -124,7 +125,7 @@ function pickUserDefinedRole(data: OnboardingFormProps) {
 
 function pickSchoolUrn(data: OnboardingFormProps) {
   if ("school" in data) {
-    return extractUrn(data.school) ?? DUMMY_URN;
+    return extractUrnAndSchool(data.school).urn ?? DUMMY_URN;
   }
 
   if ("manualSchoolName" in data) {
@@ -132,17 +133,6 @@ function pickSchoolUrn(data: OnboardingFormProps) {
   }
 
   return null;
-}
-
-/**
- * Pulls the URN/IRN from the school picker output
- *
- * English and Welsh URNs are 6 digits
- * NI IRNs include a hypen `999-9999`
- * Scottish URNs are 7 digits
- */
-function extractUrn(school: string) {
-  return /^\d{6,7}|^\d{3}-\d{4}/.exec(school)?.at(0);
 }
 
 /**

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking.tsx
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking.tsx
@@ -48,8 +48,8 @@ export const getSchoolName = (
 export const extractUrnAndSchool = (school: string) => {
   const match = /^(?:(\d{7}|\d{6}|\d{3}-\d{4}))-(.*)/.exec(school);
   return {
-    urn: match ? match[1] : "",
-    schoolName: match ? match[2] : "",
+    urn: match?.at(1),
+    schoolName: match?.at(2),
   };
 };
 


### PR DESCRIPTION
## Description

Music year: 2010

Fixes

* Northern Irish URN (IRN) being truncated to 3 numbers when submitted to Hubspot


## How to test

1. Go to https://deploy-preview-2920--owa-storybook.netlify.app/onboarding
2. Follow the teacher onboarding journey
3. Select a Northern Irish school from the picker
4. Complete onboarding
5. Check the Hubspot form request/contact in Hubspot
6. The URN should be in the format `XXX-XXXX`

## Screenshots

How it used to look (delete if n/a):
<img width="765" alt="Screenshot 2024-10-23 at 16 55 15" src="https://github.com/user-attachments/assets/b529b366-1373-40f3-961f-3fec5018cdb8">

How it should now look:
<img width="814" alt="Screenshot 2024-10-23 at 16 55 26" src="https://github.com/user-attachments/assets/1da92a38-b0bb-432e-9d50-64447ee6e27f">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
