### PR TITLE
Added `test:(components|pages)` test scripts

### DIFF
--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,0 +1,44 @@
+// Add any custom config to be passed to Jest
+module.exports = {
+  // increase the default timeout from 5s to 15s, as some tests are slow to run, especially on CI
+  testTimeout: 15000,
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "./src/**",
+    "!./**/*.json",
+    "!src/pages/_document.tsx",
+    "!src/styles/themes/types.ts",
+    "!e2e_tests/browser/engineering/*",
+    "!**/__snapshots__/**",
+    "!src/__tests__/__helpers__/*",
+    "!**/*.config.{js,ts}",
+    "!**/*.stories.*",
+  ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "node-lib/sanity-graphql/generated/*",
+    "src/storybook-decorators/*",
+    "src/components/ArchivedComponents/*",
+  ],
+  // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
+  moduleDirectories: ["node_modules", "<rootDir>/", "src"],
+  // Add more setup options before each test is run
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  testEnvironment: "jest-environment-jsdom",
+  testPathIgnorePatterns: [
+    "(\\.|/)(fixtures?)\\.[jt]sx?$",
+    "src/__tests__/__helpers__/*",
+    ".storybook/storybook.*.test.js$",
+    ".netlify/*",
+    ".yalc/*",
+  ],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+    // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
+    "^uuid$": require.resolve("uuid"),
+    "^@oaknational/oak-components$": require.resolve(
+      "@oaknational/oak-components",
+    ),
+  },
+  slowTestThreshold: 2,
+};

--- a/jest.components.config.js
+++ b/jest.components.config.js
@@ -1,0 +1,25 @@
+const nextJest = require("next/jest");
+
+const baseConfig = require("./jest.base.config");
+
+const createJestConfig = nextJest({
+  dir: "./",
+});
+
+/*
+ * To be run with
+ *
+ *    jest -c ./config/jest.components.config.js ./src/components
+ *
+ * Which tests only "./src/components" with coverage reported
+ */
+module.exports = createJestConfig({
+  ...baseConfig,
+  collectCoverageFrom: [
+    "./src/components/**",
+    "!./**/*.json",
+    "!**/__snapshots__/**",
+    "!**/*.config.{js,ts}",
+    "!**/*.stories.*",
+  ],
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,49 +8,8 @@ const createJestConfig = nextJest({
 });
 
 // Add any custom config to be passed to Jest
-const customJestConfig = {
-  // increase the default timeout from 5s to 15s, as some tests are slow to run, especially on CI
-  testTimeout: 15000,
-  collectCoverage: true,
-  collectCoverageFrom: [
-    "./src/**",
-    "!./**/*.json",
-    "!src/pages/_document.tsx",
-    "!src/styles/themes/types.ts",
-    "!e2e_tests/browser/engineering/*",
-    "!**/__snapshots__/**",
-    "!src/__tests__/__helpers__/*",
-    "!**/*.config.{js,ts}",
-    "!**/*.stories.*",
-  ],
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "node-lib/sanity-graphql/generated/*",
-    "src/storybook-decorators/*",
-    "src/components/ArchivedComponents/*",
-  ],
-  // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
-  moduleDirectories: ["node_modules", "<rootDir>/", "src"],
-  // Add more setup options before each test is run
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
-  testEnvironment: "jest-environment-jsdom",
-  testPathIgnorePatterns: [
-    "(\\.|/)(fixtures?)\\.[jt]sx?$",
-    "src/__tests__/__helpers__/*",
-    ".storybook/storybook.*.test.js$",
-    ".netlify/*",
-    ".yalc/*",
-  ],
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-    // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
-    "^uuid$": require.resolve("uuid"),
-    "^@oaknational/oak-components$": require.resolve(
-      "@oaknational/oak-components",
-    ),
-  },
-  slowTestThreshold: 2,
-};
+const customJestConfig = require("./jest.base.config");
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
 module.exports = createJestConfig(customJestConfig);
+module.exports.customJestConfig = customJestConfig;

--- a/jest.pages.config.js
+++ b/jest.pages.config.js
@@ -1,0 +1,25 @@
+const nextJest = require("next/jest");
+
+const baseConfig = require("./jest.base.config");
+
+const createJestConfig = nextJest({
+  dir: "./",
+});
+
+/*
+ * To be run with
+ *
+ *    jest -c ./config/jest.pages.config.js ./src/pages
+ *
+ * Which tests only "./src/pages" with coverage reported
+ */
+module.exports = createJestConfig({
+  ...baseConfig,
+  collectCoverageFrom: [
+    "./src/pages/**",
+    "!./**/*.json",
+    "!**/__snapshots__/**",
+    "!**/*.config.{js,ts}",
+    "!**/*.stories.*",
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test": "jest --watch --collectCoverage=false",
     "test:coverage": "jest --watch",
     "test:ci": "jest",
+    "test:pages": "jest -c ./jest.pages.config.js ./src/__tests__",
+    "test:components": "jest -c ./jest.components.config.js ./src/components",
     "test:storybook": "jest --config=jest.storybook.config.js",
     "use-local-components": "$npm_execpath remove @oaknational/oak-components && yalc add @oaknational/oak-components",
     "remove-local-components": "yalc remove @oaknational/oak-components && $npm_execpath install @oaknational/oak-components",


### PR DESCRIPTION
## Description
Added the following scripts to test just those parts of the codebase with coverage

 - `test:components`
 - `test:pages`

The issues I was having was when I was trying to work out which components needed additional test coverage the page/route tests were muddying the coverage stats.

You can now run `npm run test:components` and you'll be returned the coverage report for just the components directory. 


## Issue(s)

Fixes `CUR-999`

## How to test
Developers please check that the tests still work as expected for you locally.
