### PR TITLE
fix(oakradio): remove explicit tab index from radio

### DIFF
--- a/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.tsx
+++ b/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.tsx
@@ -81,7 +81,6 @@ export const QuizMCQSingleAnswer = (props: QuizMCQSingleAnswerProps) => {
             <OakQuizRadioButton
               id={`${questionUid}-answer-${i}`}
               key={`${questionUid}-answer-${i}`}
-              tabIndex={i}
               value={`${questionUid}: ${i}`} // we make this unique to the question to prevent selection on later questions
               label={<MathJaxWrap>{label?.text}</MathJaxWrap>}
               feedback={feedback}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
