### PR TITLE
[CUR-1031] fix: update sanity query for equality of subject title

### DIFF
--- a/src/node-lib/sanity-graphql/generated/sdk.ts
+++ b/src/node-lib/sanity-graphql/generated/sdk.ts
@@ -3905,7 +3905,7 @@ export type CurriculumCorePageQuery = { __typename?: 'RootQuery', allCurriculumC
 
 export type CurriculumOverviewQueryVariables = Exact<{
   isDraftFilter?: InputMaybe<Sanity_DocumentFilter>;
-  subjectSlug?: InputMaybe<Scalars['String']['input']>;
+  subjectTitle?: InputMaybe<Scalars['String']['input']>;
   phaseSlug?: InputMaybe<Scalars['String']['input']>;
 }>;
 
@@ -4805,9 +4805,9 @@ ${TextBlockFragmentDoc}
 ${BlogPreviewFieldsFragmentDoc}
 ${SeoFragmentDoc}`;
 export const CurriculumOverviewDocument = gql`
-    query curriculumOverview($isDraftFilter: Sanity_DocumentFilter, $subjectSlug: String, $phaseSlug: String) {
+    query curriculumOverview($isDraftFilter: Sanity_DocumentFilter, $subjectTitle: String, $phaseSlug: String) {
   allCurriculumInfoPageOverview(
-    where: {_: $isDraftFilter, subject: {matches: $subjectSlug}, phase: {matches: $phaseSlug}}
+    where: {_: $isDraftFilter, subject: {eq: $subjectTitle}, phase: {matches: $phaseSlug}}
     sort: {_updatedAt: DESC}
     limit: 1
   ) {

--- a/src/node-lib/sanity-graphql/queries/curriculumOverview.gql
+++ b/src/node-lib/sanity-graphql/queries/curriculumOverview.gql
@@ -1,12 +1,12 @@
 query curriculumOverview(
   $isDraftFilter: Sanity_DocumentFilter
-  $subjectSlug: String
+  $subjectTitle: String
   $phaseSlug: String
 ) {
   allCurriculumInfoPageOverview(
     where: {
       _: $isDraftFilter
-      subject: { matches: $subjectSlug }
+      subject: { eq: $subjectTitle }
       phase: { matches: $phaseSlug }
     }
     sort: { _updatedAt: DESC }

--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -112,7 +112,7 @@ async function getData(opts: {
 
     curriculumOverviewSanityData = await CMSClient.curriculumOverviewPage({
       previewMode: false,
-      ...{ subjectSlug, phaseSlug },
+      ...{ subjectTitle: curriculumOverviewTabData.subjectTitle, phaseSlug },
     });
 
     if (!curriculumOverviewSanityData) {

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -605,7 +605,10 @@ export const getStaticProps: GetStaticProps<
       const curriculumOverviewSanityData =
         await CMSClient.curriculumOverviewPage({
           previewMode: isPreviewMode,
-          ...slugs,
+          ...{
+            subjectTitle: curriculumOverviewTabData.subjectTitle,
+            phaseSlug: slugs.phaseSlug,
+          },
         });
 
       if (!curriculumOverviewSanityData) {


### PR DESCRIPTION
## Description

Music year: 2017

- List of changes
- Changed GQL query to search by title instead of slug (no slug available in sanity)
- Changed query to look for equality instead of matching

## Issue(s)
PE and RE had switched explainers in prod due to fuzzy matching during querying. Hadn't had the issue before as most subjects are single words and not phrases

## How to test

1. Go to https://deploy-preview-2966--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Click on Physical education primary/secondary
3. You should see the correct explainer
4. Same for RE

## Screenshots

How it used to look (delete if n/a):
<img width="1156" alt="Screenshot 2024-11-07 at 13 49 21" src="https://github.com/user-attachments/assets/4844f8e4-44e8-42f9-a931-58be1f1fc10c">

How it should now look:
<img width="1239" alt="Screenshot 2024-11-07 at 13 49 07" src="https://github.com/user-attachments/assets/e73f5db1-c947-4cc4-92fc-d1192a798709">

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
