### PR TITLE
Fix for selected year in highlight threads mobile (curric visualiser)

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -39,7 +39,7 @@ function StickyBit({
 
   const highlightedUnits = highlightedUnitCount(
     yearData,
-    selectedYear,
+    null,
     yearSelection,
     selectedThread,
   );
@@ -152,7 +152,6 @@ function StickyBit({
 function Modal({
   data,
   selectedThread,
-  selectedYear,
   yearSelection,
   onSelectThread,
   onOpenModal,
@@ -172,7 +171,7 @@ function Modal({
 
   const highlightedUnits = highlightedUnitCount(
     yearData,
-    selectedYear,
+    null,
     yearSelection,
     selectedThread,
   );

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
@@ -11,7 +11,7 @@ function isHighlightedUnit(unit: Unit, selectedThread: Thread["slug"] | null) {
 
 export function highlightedUnitCount(
   yearData: CurriculumUnitsYearData,
-  selectedYear: string,
+  selectedYear: string | null,
   yearSelection: YearSelection,
   selectedThread: Thread["slug"] | null,
 ): number {


### PR DESCRIPTION
## Description
Fix for selected year in highlight threads mobile (curric visualiser)

## Issue(s)
Fixes `CUR-1033`

## How to test

1. Go to https://deploy-preview-2967--oak-web-application.netlify.thenational.academy
2. Navigate to mobile filters, check counts are correct
