### PR TITLE
fix: remove numbering from hint text in quiz results

### DIFF
--- a/src/components/PupilComponents/QuizResultInner/QuizResultInner.tsx
+++ b/src/components/PupilComponents/QuizResultInner/QuizResultInner.tsx
@@ -81,7 +81,7 @@ export const QuizResultInner = (props: ResultsInnerProps) => {
   const questionStem = quizQuestion?.questionStem;
   const answers = quizQuestion?.answers;
   const grade = questionResult.grade;
-  const isInitMode = questionResult.mode === "init";
+  const isHint = questionResult.mode === "init";
 
   return (
     <OakFlex
@@ -90,7 +90,7 @@ export const QuizResultInner = (props: ResultsInnerProps) => {
       $flexDirection={["column", "row"]}
       role="listitem"
     >
-      {!isInitMode && (
+      {!isHint && (
         <OakIcon
           iconName={grade === 1 ? "tick" : "cross"}
           $background={grade === 1 ? "icon-success" : "icon-error"}
@@ -134,7 +134,7 @@ export const QuizResultInner = (props: ResultsInnerProps) => {
             pupilAnswers={questionResult.pupilAnswer}
           />
         )}
-        {grade === 0 && quizQuestion && !isInitMode && (
+        {grade === 0 && quizQuestion && !isHint && (
           <>
             <CorrectAnswerSection
               questionResult={questionResult}

--- a/src/components/PupilComponents/QuizResultInner/QuizResultInner.tsx
+++ b/src/components/PupilComponents/QuizResultInner/QuizResultInner.tsx
@@ -68,17 +68,21 @@ const CorrectAnswerSection = (props: CorectAnswerSectionProps) => {
 
 type ResultsInnerProps = {
   index: number;
+  displayIndex: number;
   quizArray: QuestionsArray;
   questionResult: QuestionState;
   lessonSection: "exit-quiz" | "starter-quiz";
 };
 
 export const QuizResultInner = (props: ResultsInnerProps) => {
-  const { index, quizArray, questionResult, lessonSection } = props;
+  const { index, displayIndex, quizArray, questionResult, lessonSection } =
+    props;
   const quizQuestion = quizArray[index];
   const questionStem = quizQuestion?.questionStem;
   const answers = quizQuestion?.answers;
   const grade = questionResult.grade;
+  const isInitMode = questionResult.mode === "init";
+
   return (
     <OakFlex
       key={`${lessonSection}-question-${index}`}
@@ -86,15 +90,20 @@ export const QuizResultInner = (props: ResultsInnerProps) => {
       $flexDirection={["column", "row"]}
       role="listitem"
     >
-      <OakIcon
-        iconName={grade === 1 ? "tick" : "cross"}
-        $background={grade === 1 ? "icon-success" : "icon-error"}
-        $colorFilter={"white"}
-        $borderRadius={"border-radius-circle"}
-      />
+      {!isInitMode && (
+        <OakIcon
+          iconName={grade === 1 ? "tick" : "cross"}
+          $background={grade === 1 ? "icon-success" : "icon-error"}
+          $colorFilter={"white"}
+          $borderRadius={"border-radius-circle"}
+        />
+      )}
       <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
         {questionStem && (
-          <QuizResultQuestionStem index={index} questionStem={questionStem} />
+          <QuizResultQuestionStem
+            displayIndex={displayIndex}
+            questionStem={questionStem}
+          />
         )}
         {answers?.["multiple-choice"] && isArray(questionResult?.feedback) && (
           <QuizResultMCQ
@@ -125,7 +134,7 @@ export const QuizResultInner = (props: ResultsInnerProps) => {
             pupilAnswers={questionResult.pupilAnswer}
           />
         )}
-        {grade === 0 && quizQuestion && (
+        {grade === 0 && quizQuestion && !isInitMode && (
           <>
             <CorrectAnswerSection
               questionResult={questionResult}

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.stories.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.stories.tsx
@@ -37,7 +37,7 @@ export const Default: Story = {
   },
   args: {
     questionStem: mcqText?.questionStem || [],
-    index: 0,
+    displayIndex: 1,
   },
 };
 
@@ -47,7 +47,7 @@ export const Text: Story = {
   },
   args: {
     questionStem: mcqText?.questionStem || [],
-    index: 0,
+    displayIndex: 1,
   },
 };
 
@@ -57,6 +57,6 @@ export const Image: Story = {
   },
   args: {
     questionStem: mcqStemImage?.questionStem || [],
-    index: 0,
+    displayIndex: 1,
   },
 };

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.test.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.test.tsx
@@ -19,7 +19,10 @@ describe("QuestionListItem", () => {
 
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultQuestionStem questionStem={mcqText.questionStem} index={0} />
+        <QuizResultQuestionStem
+          questionStem={mcqText.questionStem}
+          displayIndex={1}
+        />
       </OakThemeProvider>,
     );
     const primaryQuestionText = getByText("Q1. What is a main clause?");
@@ -34,7 +37,7 @@ describe("QuestionListItem", () => {
       <OakThemeProvider theme={oakDefaultTheme}>
         <QuizResultQuestionStem
           questionStem={mcqStemImage.questionStem}
-          index={0}
+          displayIndex={0}
         />
       </OakThemeProvider>,
     );
@@ -53,11 +56,50 @@ describe("QuestionListItem", () => {
 
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizResultQuestionStem questionStem={questionStem} index={0} />
+        <QuizResultQuestionStem questionStem={questionStem} displayIndex={0} />
       </OakThemeProvider>,
     );
     const secondaryText = getByText("This is some text");
 
     expect(secondaryText).toBeInTheDocument();
+  });
+
+  it("renders question number if displayIndex is other than 999", () => {
+    invariant(mcqStemImage?.questionStem, "mcqStemImage.questionStem is null");
+
+    const questionStem: ImageOrTextItem[] = [
+      ...mcqStemImage.questionStem,
+      { text: "This is some text", type: "text" },
+    ];
+
+    const { getByText } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <QuizResultQuestionStem questionStem={questionStem} displayIndex={24} />
+      </OakThemeProvider>,
+    );
+    const displayNumberText = getByText("Q24", { exact: false });
+
+    expect(displayNumberText).toBeInTheDocument();
+  });
+
+  it("does not render question number if displayIndex is 999", () => {
+    invariant(mcqStemImage?.questionStem, "mcqStemImage.questionStem is null");
+
+    const questionStem: ImageOrTextItem[] = [
+      ...mcqStemImage.questionStem,
+      { text: "This is some text", type: "text" },
+    ];
+
+    const { queryByText } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <QuizResultQuestionStem
+          questionStem={questionStem}
+          displayIndex={999}
+        />
+      </OakThemeProvider>,
+    );
+    const displayNumberText = queryByText("Q999");
+
+    expect(displayNumberText).toBeNull();
   });
 });

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
@@ -17,13 +17,13 @@ import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
 
 type QuizQuestionStemProps = {
   questionStem: (ImageItem | TextItem)[];
-  index: number;
+  displayIndex: number;
 };
 
 export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
-  const { questionStem, index } = props;
+  const { questionStem, displayIndex } = props;
 
-  const displayNumber = `Q${index + 1}.`;
+  const displayNumber = `Q${displayIndex}.`;
 
   return (
     <MathJaxWrap>
@@ -40,7 +40,7 @@ export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
               key={`q-${displayNumber}-stem-element-0`}
               $font={"body-2-bold"}
             >
-              {displayNumber}{" "}
+              {displayIndex !== 999 && displayNumber}{" "}
               {shortAnswerTitleFormatter(removeMarkdown(questionStem[0].text))}
             </OakSpan>
           )}

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
@@ -23,7 +23,8 @@ type QuizQuestionStemProps = {
 export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
   const { questionStem, displayIndex } = props;
 
-  const displayNumber = `Q${displayIndex}.`;
+  const isHint = displayIndex === 999;
+  const questionNumber = isHint ? "" : `Q${displayIndex}.`;
 
   return (
     <MathJaxWrap>
@@ -37,10 +38,10 @@ export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
         <OakFlex key="stem-header">
           {questionStem[0]?.type === "text" && (
             <OakSpan
-              key={`q-${displayNumber}-stem-element-0`}
+              key={`q-${displayIndex}-stem-element-0`}
               $font={"body-2-bold"}
             >
-              {displayIndex !== 999 && displayNumber}{" "}
+              {questionNumber}{" "}
               {shortAnswerTitleFormatter(removeMarkdown(questionStem[0].text))}
             </OakSpan>
           )}
@@ -50,7 +51,7 @@ export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
           if (stemItem.type === "text" && i > 0) {
             return (
               <OakSpan
-                key={`q-${displayNumber}-stem-element-${i}`}
+                key={`q-${displayIndex}-stem-element-${i}`}
                 $font={"body-2-bold"}
               >
                 {shortAnswerTitleFormatter(removeMarkdown(stemItem.text))}
@@ -58,7 +59,7 @@ export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
             );
           } else if (stemItem.type === "image") {
             return (
-              <OakFlex key={`q-${displayNumber}-stem-element-${i}`}>
+              <OakFlex key={`q-${displayIndex}-stem-element-${i}`}>
                 {stemItem.imageObject.publicId && (
                   <OakCloudinaryImage
                     cloudinaryId={stemItem.imageObject.publicId}

--- a/src/components/PupilComponents/QuizResults/QuizResults.tsx
+++ b/src/components/PupilComponents/QuizResults/QuizResults.tsx
@@ -15,19 +15,26 @@ export type QuizResultsProps = {
 };
 export const QuizResults = (props: QuizResultsProps) => {
   const { lessonSection, quizArray, sectionResults, copyrightNotice } = props;
+  let questionIndex = 1;
 
   return (
     <MathJaxProvider>
       <OakFlex $flexDirection={"column"} $gap={"space-between-xl"} role="list">
         {sectionResults[lessonSection]?.questionResults?.map(
-          (questionResult, index) => (
-            <QuizResultInner
-              index={index}
-              questionResult={questionResult}
-              quizArray={quizArray}
-              lessonSection={lessonSection}
-            />
-          ),
+          (questionResult, index) => {
+            const displayIndex =
+              questionResult.mode === "init" ? 999 : questionIndex++;
+            return (
+              <QuizResultInner
+                index={index}
+                key={index}
+                displayIndex={displayIndex}
+                questionResult={questionResult}
+                quizArray={quizArray}
+                lessonSection={lessonSection}
+              />
+            );
+          },
         )}
         <QuizAttribution questionData={quizArray} />
         {copyrightNotice}

--- a/src/components/PupilViews/PupilResults/PupilResults.view.tsx
+++ b/src/components/PupilViews/PupilResults/PupilResults.view.tsx
@@ -28,13 +28,22 @@ type PupilViewsResultsProps = {
 
 type QuizResultsProps = {
   index: number;
+  displayIndex: number;
   questionResult: QuestionState;
   quizQuestionArray: QuestionsArray;
   lessonSection: "exit-quiz" | "starter-quiz";
 };
 
 const QuizSectionRender = (props: QuizResultsProps) => {
-  const { index, questionResult, quizQuestionArray, lessonSection } = props;
+  const {
+    index,
+    displayIndex,
+    questionResult,
+    quizQuestionArray,
+    lessonSection,
+  } = props;
+  const isHint = questionResult.mode === "init";
+
   return (
     <OakFlex
       $position={"relative"}
@@ -45,6 +54,7 @@ const QuizSectionRender = (props: QuizResultsProps) => {
       <OakFlex $pb={["inner-padding-xl", "inner-padding-none"]}>
         <QuizResultInner
           index={index}
+          displayIndex={displayIndex}
           questionResult={questionResult}
           quizArray={quizQuestionArray}
           lessonSection={lessonSection}
@@ -58,14 +68,16 @@ const QuizSectionRender = (props: QuizResultsProps) => {
         $pl={["inner-padding-none", "inner-padding-xl"]}
         $ml={["space-between-none", "space-between-s"]}
       />
-      <OakJauntyAngleLabel
-        $position={"absolute"}
-        $bottom={"all-spacing-5"}
-        $right={"all-spacing-0"}
-        $background={"bg-neutral"}
-        $font={"heading-light-7"}
-        label={`Question hint used - ${questionResult.offerHint}`}
-      />
+      {!isHint && (
+        <OakJauntyAngleLabel
+          $position={"absolute"}
+          $bottom={"all-spacing-5"}
+          $right={"all-spacing-0"}
+          $background={"bg-neutral"}
+          $font={"heading-light-7"}
+          label={`Question hint used - ${questionResult.offerHint}`}
+        />
+      )}
     </OakFlex>
   );
 };
@@ -92,6 +104,7 @@ export const PupilViewsResults = (props: PupilViewsResultsProps) => {
       : 0;
 
   const iconSlug = `subject-${subjectSlug}`;
+  let questionIndex = 1;
 
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
@@ -128,14 +141,20 @@ export const PupilViewsResults = (props: PupilViewsResultsProps) => {
               </>
             )}
             {starterQuiz?.questionResults &&
-              starterQuiz.questionResults.map((questionResult, index) => (
-                <QuizSectionRender
-                  index={index}
-                  questionResult={questionResult}
-                  quizQuestionArray={starterQuizQuestionsArray}
-                  lessonSection={"starter-quiz"}
-                />
-              ))}
+              starterQuiz.questionResults.map((questionResult, index) => {
+                const displayIndex =
+                  questionResult.mode === "init" ? 999 : questionIndex++;
+
+                return (
+                  <QuizSectionRender
+                    index={index}
+                    displayIndex={displayIndex}
+                    questionResult={questionResult}
+                    quizQuestionArray={starterQuizQuestionsArray}
+                    lessonSection={"starter-quiz"}
+                  />
+                );
+              })}
 
             {exitQuiz?.questionResults && (
               <>
@@ -149,14 +168,20 @@ export const PupilViewsResults = (props: PupilViewsResultsProps) => {
               </>
             )}
             {exitQuiz?.questionResults &&
-              exitQuiz.questionResults.map((questionResult, index) => (
-                <QuizSectionRender
-                  index={index}
-                  questionResult={questionResult}
-                  quizQuestionArray={exitQuizQuestionsArray}
-                  lessonSection={"exit-quiz"}
-                />
-              ))}
+              exitQuiz.questionResults.map((questionResult, index) => {
+                const displayIndex =
+                  questionResult.mode === "init" ? 999 : questionIndex++;
+
+                return (
+                  <QuizSectionRender
+                    index={index}
+                    displayIndex={displayIndex}
+                    questionResult={questionResult}
+                    quizQuestionArray={exitQuizQuestionsArray}
+                    lessonSection={"exit-quiz"}
+                  />
+                );
+              })}
             <CopyrightNotice isLegacyLicense={isLegacy} />
           </OakFlex>
         </OakMaxWidth>


### PR DESCRIPTION
## Description

Fix text in quiz results so it is not marked incorrectly as another question (remove numbering, right/wrong icon and '
Question hint used - false' text).

Fixed in:
- lesson review quiz results
- printable results

## Issue(s)

Fixes [#PUPIL-1039](https://www.notion.so/oaknationalacademy/Lesson-Review-quiz-results-explanatory-text-marked-as-incorrect-10b26cc4e1b1802c84d2cb820389734b)

## How to test

1. Go to https://deploy-preview-2971--oak-web-application.netlify.thenational.academy/pupils/lessons/talk-about-school-life-part-13-6hj34t/overview
2. Complete the quiz
3. You should see explanatory text not having question related styling, numbering of the questions should not include explanatory text in it (it did before)
## Screenshots

How it used to look (delete if n/a):
screenshot attached to the issue

How it should now look:
<img width="1157" alt="Screenshot 2024-11-07 at 16 48 54" src="https://github.com/user-attachments/assets/f01209cb-6eeb-43af-98a0-bd4839e15a37">

