### PR TITLE
fix: add full stop after each item of content guidance

### DIFF
--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -113,8 +113,6 @@ export const PupilViewsLessonOverview = ({
       </OakP>
     ));
 
-  console.log(contentGuidance);
-
   return (
     <OakLessonLayout
       lessonSectionName={"overview"}

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -267,9 +267,9 @@ export const PupilViewsLessonOverview = ({
                 </OakFlex>
                 <OakSpan $font="body-1">
                   {contentGuidance.map(
-                    (item) => item.contentguidanceLabel + " ",
+                    (item) => item.contentguidanceLabel + ". ",
                   )}
-                  {supervisionLevel}
+                  {supervisionLevel + "."}
                 </OakSpan>
               </OakBox>
             )}

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -113,6 +113,8 @@ export const PupilViewsLessonOverview = ({
       </OakP>
     ));
 
+  console.log(contentGuidance);
+
   return (
     <OakLessonLayout
       lessonSectionName={"overview"}
@@ -266,9 +268,13 @@ export const PupilViewsLessonOverview = ({
                   </OakHeading>
                 </OakFlex>
                 <OakSpan $font="body-1">
-                  {contentGuidance.map(
-                    (item) => item.contentguidanceLabel + ". ",
-                  )}
+                  {contentGuidance.map((item) => {
+                    const contentGuidanceLabel = item.contentguidanceLabel;
+                    const hasFullStop = contentGuidanceLabel?.slice(-1) === ".";
+                    return contentGuidanceLabel && hasFullStop
+                      ? contentGuidanceLabel + " "
+                      : contentGuidanceLabel + ". ";
+                  })}
                   {supervisionLevel + "."}
                 </OakSpan>
               </OakBox>


### PR DESCRIPTION
## Description

Add full stop after each item of content guidance (unless it already has a full stop which is sometimes the case then only add a space to it).

Fixes [PUPIL-1067](https://www.notion.so/oaknationalacademy/Content-guidance-rendering-lesson-overview-page-10026cc4e1b18028a154da30451ca249)

## How to test

1. Navigate to a lesson with content guidance
2. Content guidance block of text with should have full stop after each line of content guidance.

Check this lessons:
- https://deploy-preview-2974--oak-web-application.netlify.app/pupils/programmes/drama-primary-year-3-l/units/stories-shared-across-the-world-2d56/lessons/dragons-c8v3cc/overview (content guidance item already has a full stop coming from database)
- https://deploy-preview-2974--oak-web-application.netlify.thenational.academy/pupils/programmes/english-secondary-year-10-aqa/units/macbeth-lady-macbeth-as-a-machiavellian-villain/lessons/an-exploration-of-act-1-scenes-1-4/overview (content guidance item does not have a full stop coming from database)


## Screenshots

How it used to look (delete if n/a):
screenshot in the ticket

How it should now look:
<img width="852" alt="Screenshot 2024-11-07 at 17 18 19" src="https://github.com/user-attachments/assets/8690b176-8839-4fdd-90ba-09555b17e313">
