### PR TITLE
feat: offer lower speed in MuxPlayer

### DIFF
--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -255,6 +255,7 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
         envKey={envKey}
         metadata={metadata}
         playbackId={playbackId}
+        playbackRates={[0.5, 0.7, 1, 1.2, 1.5, 1.7, 2]}
         start-time={startTime}
         tokens={tokens}
         thumbnailTime={thumbTime || undefined}


### PR DESCRIPTION
## Description

Added 0.5x and 0.7x speed to MuxPlayer (ticket mentioned only 0.5x but it is VERY slow)

## Issue(s)

Fixes [PUPIL-852](https://www.notion.so/oaknationalacademy/Offer-MUX-video-speed-1x-579808e7d7dc4432ba5cf8ec77f27dc0)

## How to test

1. Go to any page in the app with video in it
2. Video player should now offer 0.5x and 0.7x playback speeds

## Screenshots

How it should now look:
<img width="824" alt="Screenshot 2024-11-07 at 17 42 07" src="https://github.com/user-attachments/assets/2e28e5c1-c57e-43ca-8216-c7c99dd60a08">

