### PR TITLE
fix: remove text feedback for image mcqs

### DIFF
--- a/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
+++ b/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
@@ -64,7 +64,7 @@ describe("QuizCorrectAnswers", () => {
     expect(getByText("Correct answers: one, two, three")).toBeInTheDocument();
   });
 
-  it("handles a image correct answers inside an array", () => {
+  it("handles an image multiple correct answers inside an array", () => {
     const context = getQuizEngineContext([
       {
         type: "image",
@@ -109,6 +109,28 @@ describe("QuizCorrectAnswers", () => {
     expect(
       getByText("Correct answer: a group of words that contains a verb"),
     ).toBeInTheDocument();
+  });
+
+  it("handles an image single correct answer inside an array", () => {
+    const context = getQuizEngineContext([
+      {
+        type: "image",
+        imageObject: {
+          secureUrl: "secureUrl",
+          metadata: [],
+        },
+      },
+    ]);
+
+    const { queryByText } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <QuizEngineContext.Provider value={context}>
+          <QuizCorrectAnswers />
+        </QuizEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    expect(queryByText("Correct answers:")).toBeNull();
   });
 
   it("handles no correct answer", () => {

--- a/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
+++ b/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
@@ -64,6 +64,35 @@ describe("QuizCorrectAnswers", () => {
     expect(getByText("Correct answers: one, two, three")).toBeInTheDocument();
   });
 
+  it("handles a image correct answers inside an array", () => {
+    const context = getQuizEngineContext([
+      {
+        type: "image",
+        imageObject: {
+          secureUrl: "secureUrl",
+          metadata: [],
+        },
+      },
+      {
+        type: "image",
+        imageObject: {
+          secureUrl: "secureUrl2",
+          metadata: [],
+        },
+      },
+    ]);
+
+    const { queryByText } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <QuizEngineContext.Provider value={context}>
+          <QuizCorrectAnswers />
+        </QuizEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    expect(queryByText("Correct answers:")).toBeNull();
+  });
+
   it("handles a single correct answer", () => {
     const context = getQuizEngineContext(
       "a group of words that contains a verb",

--- a/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.tsx
+++ b/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.tsx
@@ -11,6 +11,14 @@ export const QuizCorrectAnswers = () => {
     switch (true) {
       case currentQuestionState &&
         Array.isArray(currentQuestionState.correctAnswer) &&
+        currentQuestionState.correctAnswer.length > 1 &&
+        Object.prototype.hasOwnProperty.call(
+          currentQuestionState.correctAnswer[0],
+          "imageObject",
+        ):
+        return null;
+      case currentQuestionState &&
+        Array.isArray(currentQuestionState.correctAnswer) &&
         currentQuestionState.correctAnswer.length > 1:
         return (
           "Correct answers: " +

--- a/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.tsx
+++ b/src/components/PupilComponents/QuizCorrectAnswers/QuizCorrectAnswers.tsx
@@ -11,7 +11,6 @@ export const QuizCorrectAnswers = () => {
     switch (true) {
       case currentQuestionState &&
         Array.isArray(currentQuestionState.correctAnswer) &&
-        currentQuestionState.correctAnswer.length > 1 &&
         Object.prototype.hasOwnProperty.call(
           currentQuestionState.correctAnswer[0],
           "imageObject",

--- a/src/components/TeacherComponents/QuizQuestionsListItem/QuizQuestionsListItem.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsListItem/QuizQuestionsListItem.tsx
@@ -19,6 +19,7 @@ const QuizQuestionsListItem: FC<QuizQuestionsListItemProps> = (props) => {
   const { question, index, isMathJaxLesson } = props;
   const { questionStem, answers } = question;
   const MathJaxWrapper = isMathJaxLesson ? MathJaxWrap : Fragment;
+
   return (
     <MathJaxWrapper>
       <OakFlex


### PR DESCRIPTION
## Description

Remove text feedback for image MCQs 

## Issue(s)

Fixes [PUPIL-411](https://www.notion.so/oaknationalacademy/No-useful-text-feedback-for-image-MCQs-b5d420c0b8cc4ebb9df09b2e83a774ea)

## How to test

1. Go to https://deploy-preview-2979--oak-web-application.netlify.thenational.academy/pupils/programmes/maths-secondary-year-8/units/graphical-representations-of-data/lessons/constructing-bar-charts-by-utilising-technology/starter-quiz
2. Go to question 5
3. You should see 'Almost correct' feedback for one correct answer or 'Incorrect feedback' for no correct answers but the text listing correct answers (ie. Correct answers: xxxx) should not be visible

## Screenshots

How it should now look:
<img width="1474" alt="Screenshot 2024-11-11 at 11 25 49" src="https://github.com/user-attachments/assets/9d1f8bb1-a651-4022-84d6-718f52e373aa">
