### PR TITLE
PUPIL-807 unicode celcius error

### DIFF
--- a/src/browser-lib/mathjax/MathJaxProvider.tsx
+++ b/src/browser-lib/mathjax/MathJaxProvider.tsx
@@ -2,8 +2,18 @@
 import React, { PropsWithChildren } from "react";
 import { MathJaxContext } from "better-react-mathjax";
 
+const config = {
+  loader: { load: ["[tex]/unicode"] },
+  tex: {
+    packages: { "[+]": ["unicode"] },
+    unicode: ["unicode"],
+  },
+};
+
 const MathJaxProvider = ({ children }: PropsWithChildren) => (
-  <MathJaxContext src={"/mathjax/tex-chtml.js"}>{children}</MathJaxContext>
+  <MathJaxContext src={"/mathjax/tex-chtml.js"} config={config}>
+    {children}
+  </MathJaxContext>
 );
 
 export { MathJaxProvider };

--- a/src/browser-lib/mathjax/MathJaxProvider.tsx
+++ b/src/browser-lib/mathjax/MathJaxProvider.tsx
@@ -6,7 +6,6 @@ const config = {
   loader: { load: ["[tex]/unicode"] },
   tex: {
     packages: { "[+]": ["unicode"] },
-    unicode: ["unicode"],
   },
 };
 

--- a/src/browser-lib/mathjax/MathJaxWrap.tsx
+++ b/src/browser-lib/mathjax/MathJaxWrap.tsx
@@ -5,6 +5,7 @@ import React from "react";
 const MathJaxWrap = ({ children }: { children: React.ReactNode }) => {
   return (
     <MathJax hideUntilTypeset="every" dynamic>
+      {`$$\\require{unicode}$$`}
       {children}
     </MathJax>
   );

--- a/src/browser-lib/mathjax/MathJaxWrap.tsx
+++ b/src/browser-lib/mathjax/MathJaxWrap.tsx
@@ -5,7 +5,6 @@ import React from "react";
 const MathJaxWrap = ({ children }: { children: React.ReactNode }) => {
   return (
     <MathJax hideUntilTypeset="every" dynamic>
-      {`$$\\require{unicode}$$`}
       {children}
     </MathJax>
   );

--- a/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.tsx
+++ b/src/components/PupilComponents/QuizMCQMultiAnswer/QuizMCQMultiAnswer.tsx
@@ -91,7 +91,7 @@ export const QuizMCQMultiAnswer = ({ onChange }: QuizMCQMultiAnswerProps) => {
               : undefined;
 
           return (
-            <MathJaxWrap>
+            <MathJaxWrap key={`max-jax-wrap-${index}`}>
               <OakQuizCheckBox
                 key={`${questionUid}-answer-${index}`}
                 id={`${questionUid}-answer-${index}`}

--- a/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.tsx
+++ b/src/components/PupilComponents/QuizResultMCQ/QuizResultMCQ.tsx
@@ -42,7 +42,7 @@ export const QuizResultMCQ = ({
     const standardText = isText(text) && text?.text ? text.text : undefined;
 
     return (
-      <MathJaxWrap>
+      <MathJaxWrap key={`max-jax-wrap-${index}`}>
         <OakQuizResultItem
           key={index}
           standardText={standardText}


### PR DESCRIPTION
## Description

Fix unicode Celcius error

## Issue(s)

Fixes [PUPIL-807](https://www.notion.so/oaknationalacademy/Mathjax-unicode-error-when-displaying-Celsius-07376ff72ce64cdcb5fde46df86eb5b2)

## How to test

1. Go to https://deploy-preview-2986--oak-web-application.netlify.thenational.academy/pupils/programmes/maths-secondary-year-7/units/comparing-and-ordering-fractions-and-decimals-positive-and-negative/lessons/ordering-negative-integers/exit-quiz
3. Go to question 2 of the exit quiz
4. Celcius symbol should be displayed correctly

## Screenshots

How it should now look:
<img width="1395" alt="Screenshot 2024-11-12 at 16 35 53" src="https://github.com/user-attachments/assets/1d0c75ed-9cfb-404d-9c94-a76472007e78">

