### PR TITLE
Explainer font incorrectly using Aptos

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
@@ -347,6 +347,11 @@ export default async function generate(
         },
       },
       blockStyling: {
+        normal: () => {
+          return safeXml`
+            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+          `;
+        },
         heading1: () => {
           return safeXml`
             <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
@@ -385,7 +385,13 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
         ></w:spacing>
       </w:pPr>
       <w:r>
-        <w:rPr></w:rPr>
+        <w:rPr>
+          <w:rFonts
+            w:ascii="Arial"
+            w:hAnsi="Arial"
+            w:cs="Arial"
+          ></w:rFonts>
+        </w:rPr>
         <w:t><![CDATA[test]]></w:t>
       </w:r>
     </w:p>
@@ -433,7 +439,13 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
         ></w:spacing>
       </w:pPr>
       <w:r>
-        <w:rPr></w:rPr>
+        <w:rPr>
+          <w:rFonts
+            w:ascii="Arial"
+            w:hAnsi="Arial"
+            w:cs="Arial"
+          ></w:rFonts>
+        </w:rPr>
         <w:t><![CDATA[test]]></w:t>
       </w:r>
     </w:p>
@@ -481,7 +493,13 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
         ></w:spacing>
       </w:pPr>
       <w:r>
-        <w:rPr></w:rPr>
+        <w:rPr>
+          <w:rFonts
+            w:ascii="Arial"
+            w:hAnsi="Arial"
+            w:cs="Arial"
+          ></w:rFonts>
+        </w:rPr>
         <w:t><![CDATA[test]]></w:t>
       </w:r>
     </w:p>
@@ -530,7 +548,13 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
         ></w:spacing>
       </w:pPr>
       <w:r>
-        <w:rPr></w:rPr>
+        <w:rPr>
+          <w:rFonts
+            w:ascii="Arial"
+            w:hAnsi="Arial"
+            w:cs="Arial"
+          ></w:rFonts>
+        </w:rPr>
         <w:t><![CDATA[test]]></w:t>
       </w:r>
     </w:p>


### PR DESCRIPTION
## Description
Changes paragraph content pulled in from sanity to have the "Arial" (rather than "Aptos") typeface.

## Issue(s)

Fixes `CUR-1029`

## How to test

1. Go to https://deploy-preview-2990--oak-web-application.netlify.thenational.academy
2. Navigate to curriculum visualiser and download a document
3. Check the explainer content if rendering with Arial 
