### PR TITLE
Don’t show ‘All exam boards (KS4)’ when there is no KS4 in sequence

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
@@ -96,4 +96,11 @@ describe("Component - Curriculum Header", () => {
     const examboardMetadata = getByTestId("examboard-metadata");
     expect(examboardMetadata).toHaveTextContent("AQA (KS4)");
   });
+
+  test("no KS4 text when not ks4 keystage", () => {
+    const { baseElement } = renderComponent({
+      keyStages: ["ks3"],
+    });
+    expect(baseElement).not.toHaveTextContent("AQA (KS4)");
+  });
 });

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -160,7 +160,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
                 $justifyContent={"center"}
                 $flexDirection={"column"}
               >
-                {phase.slug === "secondary" && (
+                {keyStages.includes("ks4") && (
                   <OakP
                     $font={"heading-light-7"}
                     data-testid={"examboard-metadata"}


### PR DESCRIPTION
## Description
Don’t show ‘All exam boards (KS4)’ when there is no KS4 in sequence

## Issue(s)
Fixes `CUR-1049`

## How to test

1. Go to https://deploy-preview-2993--oak-web-application.netlify.thenational.academy
2. Go to the curriculum visualiser 
3. Secondary phases without KS4 shouldn't contain "All exam boards (KS4)' text

## Screenshots
How it used to look:
<img width="448" alt="Screenshot 2024-11-14 at 10 07 22" src="https://github.com/user-attachments/assets/3753623a-0e15-4046-89a1-f4c50ab5c848">

How it should now look:
<img width="448" alt="Screenshot 2024-11-14 at 10 07 04" src="https://github.com/user-attachments/assets/0c50b2e3-8dda-4da0-8f9f-90b8fd5f8e0f">



