### PR TITLE
Rename 'overview' to 'explainer' in curriculum downloads (docx)

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/2_tableOfContents.ts
+++ b/src/pages-helpers/curriculum/docx/builder/2_tableOfContents.ts
@@ -30,7 +30,7 @@ export default async function generate(
     },
     {
       anchorId: "section_curriculum_overview",
-      text: `${data.subjectTitle} curriculum overview`,
+      text: `${data.subjectTitle} curriculum explainer`,
     },
     ...yearOptions.map((year) => {
       return {

--- a/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
@@ -419,7 +419,7 @@ export default async function generate(
                   <w:color w:val="222222" />
                   <w:sz w:val="56" />
                 </w:rPr>
-                <w:t>${cdata(`${data.subjectTitle} curriculum overview`)}</w:t>
+                <w:t>${cdata(`${data.subjectTitle} curriculum explainer`)}</w:t>
               </w:r>
             `,
           )}

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/2_tableOfContents.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/2_tableOfContents.test.ts.snap
@@ -452,7 +452,7 @@ exports[`2_tableOfContents simple 1`] = `
               w:val="28"
             ></w:sz>
           </w:rPr>
-          <w:t><![CDATA[Physical education curriculum overview]]></w:t>
+          <w:t><![CDATA[Physical education curriculum explainer]]></w:t>
         </w:r>
       </w:hyperlink>
     </w:p>

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
@@ -333,7 +333,7 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
             w:val="56"
           ></w:sz>
         </w:rPr>
-        <w:t><![CDATA[Science curriculum overview]]></w:t>
+        <w:t><![CDATA[Science curriculum explainer]]></w:t>
       </w:r>
       <w:bookmarkEnd
         w:id="20002"


### PR DESCRIPTION
## Description
Rename 'overview' to 'explainer' in curriculum downloads (docx)

## Issue(s)

Fixes `CUR-1052`

## How to test

1. Go to https://deploy-preview-2995--oak-web-application.netlify.thenational.academy
2. Go to curriculum downloads and download a document
3. You should see 'explainer' rather than 'overview' as both the title and contents entry, for the explainers

## Screenshots

How it used to look (delete if n/a):

<img width="340" alt="Screenshot 2024-11-14 at 12 42 42" src="https://github.com/user-attachments/assets/9056be73-d9cc-4d86-b6e1-61940100595f">
<img width="340" alt="Screenshot 2024-11-14 at 12 42 39" src="https://github.com/user-attachments/assets/043d7613-dd7a-4494-a929-515ddb8609ae">


How it should now look:

<img width="340" alt="Screenshot 2024-11-14 at 12 34 21" src="https://github.com/user-attachments/assets/7ea27ab1-1831-4699-a48d-be643ef23bfa"><img width="340" alt="Screenshot 2024-11-14 at 12 34 17" src="https://github.com/user-attachments/assets/33b5192f-58c5-49c2-bc86-7f4c76a1cc6f">

