### PR TITLE
Destructuring array to prevent modifying it

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -821,7 +821,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                               $flexDirection={"row"}
                               $gap={"all-spacing-2"}
                             >
-                              {selectedSubject.ks4_options
+                              {[...selectedSubject.ks4_options]
                                 // sort Core/GSCE first
                                 .sort((a: KS4Option) =>
                                   isExamboardSlug(a.slug) ? 1 : -1,


### PR DESCRIPTION
## Description
Destructuring array to prevent modifying it when doing `.sort()`

## Issue(s)

Fixes `????`

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

