### PR TITLE
Fix to use new icon URLs for curriculum downloads

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.test.ts
@@ -9,7 +9,7 @@ import { zipToSnapshotObject } from "./helper";
 jest.mock("@/pages-helpers/curriculum/docx/builder/helper", () => ({
   __esModule: true,
   ...jest.requireActual("@/pages-helpers/curriculum/docx/builder/helper"),
-  generateOakIconURL: jest.fn(() =>
+  generateIconURL: jest.fn(() =>
     join(
       process.cwd(),
       "src/pages-helpers/curriculum/docx/builder/images/icon.png",

--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -12,7 +12,7 @@ import {
   JSZipCached,
 } from "../docx";
 
-import { generateOakIconURL } from "./helper";
+import { generateIconURL } from "./helper";
 
 import { getShortPhaseText } from "@/utils/curriculum/formatting";
 
@@ -24,7 +24,7 @@ export default async function generate(
 ) {
   const images = await insertImages(zip, {
     icon: {
-      url: generateOakIconURL(slugs.subjectSlug),
+      url: generateIconURL(slugs.subjectSlug),
       width: PARTNER_IMG_WIDTH,
     },
     arrow: join(

--- a/src/pages-helpers/curriculum/docx/builder/helper.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.test.ts
@@ -1,10 +1,12 @@
+import { generateOakIconURL } from "@oaknational/oak-components";
+
 import { xmlRootToJson } from "../xml";
 
 import {
   generateGridCols,
   uncapitalize,
   uncapitalizeSubject,
-  generateOakIconURL,
+  generateIconURL,
 } from "./helper";
 
 describe("helper", () => {
@@ -66,21 +68,15 @@ describe("helper", () => {
     });
   });
 
-  describe("generateOakIconURL", () => {
-    const baseURL = `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}`;
+  describe("generateIconURL", () => {
     it("returns a books url when no valid subject icon is passed in", () => {
-      const url = generateOakIconURL("potions");
-      expect(url).toBe(baseURL + "/books.svg");
+      const url = generateIconURL("potions");
+      expect(url).toBe(generateOakIconURL("subject-english"));
     });
 
-    it("returns a valid url when cycle 1 subject icon is passed in", () => {
-      const url = generateOakIconURL("maths");
-      expect(url).toBe(baseURL + "/subject-icons/maths.svg");
-    });
-
-    it("returns a valid url when cycle 2 subject icon is passed in", () => {
-      const url = generateOakIconURL("cooking-nutrition");
-      expect(url).toBe(baseURL + "/subject-icons/cooking-nutrition.svg");
+    it("returns a valid url when valid subject icon is passed in", () => {
+      const url = generateIconURL("maths");
+      expect(url).toBe(generateOakIconURL("subject-maths"));
     });
   });
 });

--- a/src/pages-helpers/curriculum/docx/builder/helper.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.ts
@@ -1,6 +1,9 @@
 import { sum } from "lodash";
 import JSZip from "jszip";
-import { isValidIconName } from "@oaknational/oak-components";
+import {
+  generateOakIconURL,
+  isValidIconName,
+} from "@oaknational/oak-components";
 
 import { Slugs } from "..";
 import { zipToSimpleObject } from "../zip";
@@ -120,10 +123,8 @@ export function zipToSnapshotObject(zip: JSZip) {
   return zipToSimpleObject(zip, { hashBuffers: true });
 }
 
-export const generateOakIconURL = (subjectSlug: string): string => {
-  const iconPath = isValidIconName(`subject-${subjectSlug}`)
-    ? `subject-icons/${subjectSlug}`
-    : "books";
-
-  return `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/${iconPath}.svg`;
+export const generateIconURL = (subjectSlug: string): string => {
+  const key = `subject-${subjectSlug}`;
+  const iconName = isValidIconName(key) ? key : "subject-english";
+  return generateOakIconURL(iconName);
 };


### PR DESCRIPTION
## Description
Fix to use new subjects icon URLs for curriculum downloads (docx)

## Issue(s)

Fixes `CUR-1110`

## How to test

1. Go to https://deploy-preview-3010--oak-web-application.netlify.thenational.academy
2. Navigate to the curriculum visualiser
2. Download a document for each subject and check the subject icon appears correctly

