### PR TITLE
Feat/pupil 1100/add share buttons

### DIFF
--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -11,6 +11,7 @@ import {
   useShareExperiment,
   CurriculumTrackingProps,
 } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
+import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
 
 type DownloadConfirmationProps = {
   lessonSlug: string;
@@ -53,7 +54,7 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
     focusRef.current?.focus();
   }, []);
 
-  const { shareIdRef, shareIdKeyRef } = useShareExperiment({
+  const { shareExperimentFlag, shareUrl, shareActivated } = useShareExperiment({
     lessonSlug,
     unitSlug: unitSlug ?? undefined,
     programmeSlug: programmeSlug ?? undefined,
@@ -67,7 +68,10 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
       subjectTitle,
     },
   });
-  console.log(shareIdRef, shareIdKeyRef);
+
+  const teacherShareButton = shareExperimentFlag ? (
+    <TeacherShareButton shareUrl={shareUrl} shareActivated={shareActivated} />
+  ) : null;
 
   return (
     <>
@@ -145,6 +149,7 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
           <OakHeading tag="h1" $font={["heading-4", "heading-3"]}>
             Thanks for downloading
           </OakHeading>
+          {teacherShareButton}
 
           <OakP $font={"body-1"}>
             We hope you find the resources useful. Click the question mark in

--- a/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
+++ b/src/components/TeacherComponents/HeaderListing/HeaderListing.tsx
@@ -33,6 +33,7 @@ export type HeaderListingProps = {
   title: string;
   programmeFactor: string;
   hasCurriculumDownload?: boolean;
+  shareButton?: React.ReactNode;
 };
 
 const HeaderListing: FC<HeaderListingProps> = (props) => {
@@ -50,6 +51,7 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
     examBoardTitle,
     tierTitle,
     yearTitle,
+    shareButton,
   } = props;
 
   const isKeyStagesAvailable = keyStageSlug && keyStageTitle;
@@ -119,6 +121,7 @@ const HeaderListing: FC<HeaderListingProps> = (props) => {
           />
         )}
       </Flex>
+      {shareButton}
     </LessonHeaderWrapper>
   );
 };

--- a/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeader/LessonOverviewHeader.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import React, { FC } from "react";
 
 import { Breadcrumb } from "@/components/SharedComponents/Breadcrumbs";
 import { LessonHeaderWrapper } from "@/components/TeacherComponents/LessonHeaderWrapper";
@@ -46,6 +46,8 @@ export type LessonOverviewHeaderProps = {
   onClickShareAll: () => void;
   showDownloadAll: boolean;
   showShare: boolean;
+  // teacher share
+  teacherShareButton?: React.ReactNode;
 };
 
 const LessonOverviewHeader: FC<LessonOverviewHeaderProps> = (props) => {

--- a/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDesktop/LessonOverviewHeaderDesktop.tsx
@@ -40,6 +40,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
     showShare,
     isCanonical,
     phonicsOutcome,
+    teacherShareButton,
   } = props;
 
   return (
@@ -89,6 +90,7 @@ export const LessonOverviewHeaderDesktop: FC<LessonOverviewHeaderProps> = (
               </OakBox>
               <OakFlex $gap="all-spacing-6">
                 <LessonOverviewHeaderDownloadAllButton {...props} />
+                {teacherShareButton}
                 {showShare && <LessonOverviewHeaderShareAllButton {...props} />}
               </OakFlex>
             </OakFlex>

--- a/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderMobile/LessonOverviewHeaderMobile.tsx
@@ -28,6 +28,7 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
     showShare,
     isCanonical,
     phonicsOutcome,
+    teacherShareButton,
   } = props;
 
   return (
@@ -69,6 +70,7 @@ export const LessonOverviewHeaderMobile: FC<LessonOverviewHeaderProps> = (
         </OakBox>
       </OakBox>
       <LessonOverviewHeaderDownloadAllButton {...props} />
+      {teacherShareButton}
       {showShare && <LessonOverviewHeaderShareAllButton {...props} />}
     </OakFlex>
   );

--- a/src/components/TeacherComponents/TeacherShareButton/TeacherShareButton.test.tsx
+++ b/src/components/TeacherComponents/TeacherShareButton/TeacherShareButton.test.tsx
@@ -1,0 +1,62 @@
+import { act, render, screen } from "@testing-library/react";
+import { oakDefaultTheme, OakThemeProvider } from "@oaknational/oak-components";
+
+import { TeacherShareButton } from "./TeacherShareButton";
+
+describe("TeacherShareButton", () => {
+  it("renders", () => {
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <TeacherShareButton shareUrl={"test"} />
+      </OakThemeProvider>,
+    );
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("copies a link to the clipboard when the button is clicked", async () => {
+    // Mock the clipboard API
+    const clipboardWriteTextMock = jest.fn();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: clipboardWriteTextMock,
+      },
+    });
+
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <TeacherShareButton shareUrl={"test"} />
+      </OakThemeProvider>,
+    );
+
+    const button = screen.getByRole("button");
+    act(() => {
+      button.click();
+    });
+
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith("test");
+  });
+
+  it("calls shareActivated when the button is clicked the first time", async () => {
+    const shareActivatedMock = jest.fn();
+
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <TeacherShareButton
+          shareUrl={"test"}
+          shareActivated={shareActivatedMock}
+        />
+      </OakThemeProvider>,
+    );
+
+    const button = screen.getByRole("button");
+
+    act(() => {
+      button.click();
+    });
+    expect(shareActivatedMock).toHaveBeenCalledTimes(1);
+    act(() => {
+      button.click();
+    });
+    expect(shareActivatedMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/TeacherComponents/TeacherShareButton/TeacherShareButton.tsx
+++ b/src/components/TeacherComponents/TeacherShareButton/TeacherShareButton.tsx
@@ -1,0 +1,32 @@
+import { OakFlex, OakSecondaryButton } from "@oaknational/oak-components";
+import { useState } from "react";
+
+export const TeacherShareButton = ({
+  shareUrl,
+  shareActivated,
+}: {
+  shareUrl: string | null;
+  shareActivated?: () => void;
+}) => {
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  const handleClick = () => {
+    if (!shareUrl) return;
+    if (!linkCopied && shareActivated) {
+      shareActivated();
+    }
+
+    setLinkCopied(true);
+    // copy url to clipboard
+    navigator.clipboard.writeText(shareUrl);
+  };
+
+  return (
+    <OakFlex $flexDirection={"column"}>
+      <OakSecondaryButton onClick={handleClick} disabled={!shareUrl}>
+        Share with teacher
+      </OakSecondaryButton>
+      {linkCopied && <div>Link copied to clipboard</div>}
+    </OakFlex>
+  );
+};

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -52,7 +52,9 @@ import { GridArea } from "@/components/SharedComponents/Grid.deprecated";
 import AspectRatio from "@/components/SharedComponents/AspectRatio";
 
 export type LessonOverviewProps = {
-  lesson: LessonOverviewAll & { downloads: LessonOverviewDownloads };
+  lesson: LessonOverviewAll & { downloads: LessonOverviewDownloads } & {
+    teacherShareButton?: React.ReactNode;
+  };
 };
 
 // helper function to remove key learning points from the header in legacy lessons
@@ -94,6 +96,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
     updatedAt,
     isCanonical,
     lessonGuideUrl,
+    teacherShareButton,
   } = lesson;
   const { track } = useAnalytics();
   const { analyticsUseCase } = useAnalyticsPageProps();
@@ -240,6 +243,7 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
         )}
         showDownloadAll={showDownloadAll}
         showShare={showShare}
+        teacherShareButton={teacherShareButton}
       />
       <MaxWidth $ph={16} $pb={80}>
         <NewContentBanner

--- a/src/pages-helpers/teacher/share-experiments/createShareId.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.ts
@@ -35,6 +35,12 @@ export const storeConversionShareId = (id: string) => {
 export const getConversionShareId = (id: string): string | undefined =>
   Cookies.get(`cv-${id}`);
 
+export const storeActivationKey = (key: string) =>
+  Cookies.set(`av-${key}`, "true", { expires: 30 });
+
+export const getActivationKey = (key: string): string | undefined =>
+  Cookies.get(`av-${key}`);
+
 export const shareMethods = {
   url: 0,
   button: 1,

--- a/src/pages-helpers/teacher/share-experiments/createShareId.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.ts
@@ -3,6 +3,8 @@ import crypto from "crypto";
 import { nanoid } from "nanoid";
 import Cookies from "js-cookie";
 
+// TODO switch to local storage to avoid cookie size limits
+
 export const getShareIdKey = (unhashedKey: string): string => {
   const hash = crypto
     .createHash("sha256")

--- a/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.ts
+++ b/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.ts
@@ -16,23 +16,25 @@ export const getUpdatedUrl = ({
   cookieShareId,
   unhashedKey,
   source,
+  shareMethod = "url",
 }: {
   url: string;
   cookieShareId: string | undefined;
   unhashedKey: string;
   source: keyof typeof shareSources;
+  shareMethod?: keyof typeof shareMethods;
 }) => {
   const shareIdKey = getShareIdKey(unhashedKey);
   const strippedUrl = url.split("?")[0];
 
   if (cookieShareId) {
-    const updatedUrl = `${strippedUrl}?${shareIdKey}=${cookieShareId}&sm=${shareMethods.url}&src=${shareSources[source]}`;
+    const updatedUrl = `${strippedUrl}?${shareIdKey}=${cookieShareId}&sm=${shareMethods[shareMethod]}&src=${shareSources[source]}`;
     return { url: updatedUrl, shareIdKey, shareId: cookieShareId };
   }
 
   // generate share-id and store it as a cookie
   const { id, key } = createAndStoreShareId(unhashedKey);
 
-  const updatedUrl = `${strippedUrl}?${key}=${id}&sm=${shareMethods.url}&src=${shareSources[source]}`;
+  const updatedUrl = `${strippedUrl}?${key}=${id}&sm=${shareMethods[shareMethod]}&src=${shareSources[source]}`;
   return { url: updatedUrl, shareIdKey: key, shareId: id };
 };

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
@@ -3,10 +3,12 @@ import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import { getUpdatedUrl } from "./getUpdatedUrl";
 import {
+  getActivationKey,
   getConversionShareId,
   getShareIdFromCookie,
   getShareIdKey,
   shareSources,
+  storeActivationKey,
   storeConversionShareId,
 } from "./createShareId";
 
@@ -146,21 +148,25 @@ export const useShareExperiment = ({
   ]);
 
   const shareActivated = () => {
-    if (!shareIdRef.current) {
+    if (!shareIdRef.current || !shareIdKeyRef.current) {
       return;
     }
 
-    //TODO : cookie tracking for deduping share activated events
+    if (!getActivationKey(shareIdKeyRef.current)) {
+      //TODO : cookie tracking for deduping share activated events
 
-    track.teacherShareActivated({
-      shareId: shareIdRef.current,
-      linkUrl: window.location.href,
-      lessonSlug,
-      unitSlug,
-      sourcePageSlug: window.location.pathname,
-      ...coreTrackingProps,
-      ...curriculumTrackingProps,
-    });
+      track.teacherShareActivated({
+        shareId: shareIdRef.current,
+        linkUrl: window.location.href,
+        lessonSlug,
+        unitSlug,
+        sourcePageSlug: window.location.pathname,
+        ...coreTrackingProps,
+        ...curriculumTrackingProps,
+      });
+
+      storeActivationKey(shareIdKeyRef.current);
+    }
   };
 
   return {

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -25,6 +25,7 @@ import OakError from "@/errors/OakError";
 import { LessonOverviewCanonical } from "@/node-lib/curriculum-api-2023/queries/lessonOverview/lessonOverview.schema";
 import { populateLessonWithTranscript } from "@/utils/handleTranscript";
 import { useShareExperiment } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
+import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
 
 type PageProps = {
   lesson: LessonOverviewCanonical;
@@ -39,7 +40,7 @@ export default function LessonOverviewCanonicalPage({
   lesson,
   isSpecialist,
 }: PageProps): JSX.Element {
-  const { shareIdRef, shareIdKeyRef } = useShareExperiment({
+  const { shareExperimentFlag, shareUrl, shareActivated } = useShareExperiment({
     lessonSlug: lesson.lessonSlug,
     source: "lesson-canonical",
     curriculumTrackingProps: {
@@ -51,7 +52,10 @@ export default function LessonOverviewCanonicalPage({
       keyStageTitle: null,
     },
   });
-  console.log(shareIdRef, shareIdKeyRef);
+
+  const teacherShareButton = shareExperimentFlag ? (
+    <TeacherShareButton shareUrl={shareUrl} shareActivated={shareActivated} />
+  ) : null;
 
   const pathwayGroups = groupLessonPathways(lesson.pathways);
   return (
@@ -65,7 +69,12 @@ export default function LessonOverviewCanonicalPage({
     >
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonOverview
-          lesson={{ ...lesson, isCanonical: true, isSpecialist }}
+          lesson={{
+            ...lesson,
+            isCanonical: true,
+            isSpecialist,
+            teacherShareButton,
+          }}
         />
         {!isSpecialist && (
           <OakFlex $background={"pink50"} $width={"100%"}>

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -44,6 +44,7 @@ import {
   CurriculumTrackingProps,
   useShareExperiment,
 } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
+import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
 
 export type LessonListingPageProps = {
   curriculumData: LessonListingPageData;
@@ -78,7 +79,7 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
     subjectSlug,
   } = curriculumData;
 
-  const { shareIdRef, shareIdKeyRef } = useShareExperiment({
+  const { shareExperimentFlag, shareUrl, shareActivated } = useShareExperiment({
     unitSlug: unitSlug ?? undefined,
     programmeSlug: programmeSlug ?? undefined,
     source: "lesson-listing",
@@ -91,7 +92,10 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
       keyStageTitle: keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
     },
   });
-  console.log(shareIdRef, shareIdKeyRef);
+
+  const teacherShareButton = shareExperimentFlag ? (
+    <TeacherShareButton shareUrl={shareUrl} shareActivated={shareActivated} />
+  ) : null;
 
   const lessons = getHydratedLessonsFromUnit(curriculumData);
   const hasNewContent = lessons[0]?.lessonCohort === NEW_COHORT;
@@ -198,6 +202,7 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
           isNew={isNew}
           hasCurriculumDownload={isSlugLegacy(programmeSlug)}
           {...curriculumData}
+          shareButton={teacherShareButton}
         />
         <MaxWidth $ph={16}>
           <OakGrid>

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -22,6 +22,7 @@ import {
   useShareExperiment,
   CurriculumTrackingProps,
 } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
+import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewPageData;
@@ -44,7 +45,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
     keyStageTitle,
   } = curriculumData;
 
-  const { shareIdRef, shareIdKeyRef } = useShareExperiment({
+  const { shareExperimentFlag, shareUrl, shareActivated } = useShareExperiment({
     lessonSlug,
     unitSlug,
     programmeSlug,
@@ -58,7 +59,10 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
       keyStageTitle: keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
     },
   });
-  console.log(shareIdRef, shareIdKeyRef);
+
+  const teacherShareButton = shareExperimentFlag ? (
+    <TeacherShareButton shareUrl={shareUrl} shareActivated={shareActivated} />
+  ) : null;
 
   const getLessonData = () => {
     if (tierTitle && examBoardTitle) {
@@ -86,6 +90,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
             ...curriculumData,
             isCanonical: false,
             isSpecialist: false,
+            teacherShareButton: teacherShareButton,
           }}
         />
       </OakThemeProvider>


### PR DESCRIPTION
### Job Story

**When** I press a share button,
**I want to copy the url to the clipboard**
**So that I can share the url with another user**.

### Implementation details

See [[Share tracking plan](https://www.notion.so/Share-tracking-plan-13f26cc4e1b180379bf6c664fd120a77?pvs=21)](https://www.notion.so/Share-tracking-plan-13f26cc4e1b180379bf6c664fd120a77?pvs=21) 

- Send share-id and page-variant to posthog when sent

### Acceptance criteria

- [x]  lesson listing page
- [x]  lesson overview
- [x]  lesson download
- [ ]  ~~event sent on copy from browser bar  ?~~
- [x]  behind feature flag
- [x]  copies url to clip board when pressed
- [x]  correct events sent when pressed
- [x]  correct urls provided

## How to test

1. Go to https://deploy-preview-3016--oak-web-application.netlify.thenational.academy
2. Click on https://deploy-preview-3016--oak-web-application.netlify.thenational.academy/teachers/lessons/transverse-waves
3. You should see the share button appear
4. click on the button
5. it should fire an activation event
6. it should say copied to clipboard and the text on the clipboard should be a link 
7. paste the link in another browser - it should go to the same page and fire a conversion event
8. repeat for browse-lesson, lesson listing and downloads


