### PR TITLE
Fix/pupil 1119/share cookies to local storage

### DIFF
--- a/src/config/localStorageSchemas.ts
+++ b/src/config/localStorageSchemas.ts
@@ -6,3 +6,6 @@ export const LS_KEY_SCHOOL_SCHEMA = z.object({
   schoolName: z.string().optional(),
 });
 export const LS_KEY_TERMS_SCHEMA = z.boolean();
+export const LS_KEY_TEACHER_SHARE_KIDS_INITIATED_SCHEMA = z.string();
+export const LS_KEY_TEACHER_SHARE_KEYS_ACTIVATED_SCHEMA = z.boolean();
+export const LS_KEY_TEACHER_SHARE_IDS_CONVERTED_SCHEMA = z.boolean();

--- a/src/pages-helpers/teacher/share-experiments/createShareId.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.test.ts
@@ -1,7 +1,7 @@
 import {
   createAndStoreShareId,
   getConversionShareId,
-  getShareIdFromCookie,
+  getShareId,
   getShareIdKey,
   storeConversionShareId,
 } from "./createShareId";
@@ -15,8 +15,8 @@ describe("createShareId", () => {
     });
   });
 
-  describe("getShareIdFromCookie", () => {
-    it("should return the shareId from the cookie", () => {
+  describe("getShareId", () => {
+    it("should return the shareId from the storage", () => {
       const lessonSlug = "lesson-1";
       const key = getShareIdKey(lessonSlug);
       const obj: Record<string, string> = {};
@@ -27,7 +27,7 @@ describe("createShareId", () => {
         .mockImplementationOnce((key: string) => {
           return JSON.stringify(obj[key]);
         });
-      const result = getShareIdFromCookie(lessonSlug);
+      const result = getShareId(lessonSlug);
       expect(result).toEqual("1234");
     });
   });
@@ -42,7 +42,7 @@ describe("createShareId", () => {
       expect(result.key).toEqual(getShareIdKey(lessonSlug));
     });
 
-    it("should store the shareId in a cookie", () => {
+    it("should store the shareId storage", () => {
       const fn = jest.spyOn(Storage.prototype, "setItem");
       const lessonSlug = "lesson-1";
       const result = createAndStoreShareId(lessonSlug);
@@ -52,7 +52,7 @@ describe("createShareId", () => {
   });
 
   describe("storeConversionShareId", () => {
-    it("should store the conversion shareId in a cookie", () => {
+    it("should store the conversion shareId storage", () => {
       const fn = jest.spyOn(Storage.prototype, "setItem");
       const shareId = "1234";
       const key = `cv-${shareId}`;
@@ -68,7 +68,7 @@ describe("createShareId", () => {
   });
 
   describe("getConversionShareId", () => {
-    it("should return the conversion shareId from the cookie", () => {
+    it("should return the conversion shareId from the storage", () => {
       const shareId = "1234";
       const obj: Record<string, boolean> = {};
       obj[`cv-${shareId}`] = true;

--- a/src/pages-helpers/teacher/share-experiments/createShareId.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.test.ts
@@ -19,7 +19,14 @@ describe("createShareId", () => {
     it("should return the shareId from the cookie", () => {
       const lessonSlug = "lesson-1";
       const key = getShareIdKey(lessonSlug);
-      document.cookie = `${key}=1234`;
+      const obj: Record<string, string> = {};
+      obj[key] = "1234";
+
+      jest
+        .spyOn(Storage.prototype, "getItem")
+        .mockImplementationOnce((key: string) => {
+          return JSON.stringify(obj[key]);
+        });
       const result = getShareIdFromCookie(lessonSlug);
       expect(result).toEqual("1234");
     });
@@ -36,19 +43,21 @@ describe("createShareId", () => {
     });
 
     it("should store the shareId in a cookie", () => {
+      const fn = jest.spyOn(Storage.prototype, "setItem");
       const lessonSlug = "lesson-1";
       const result = createAndStoreShareId(lessonSlug);
       const key = getShareIdKey(lessonSlug);
-      expect(document.cookie).toContain(`${key}=${result.id}`);
+      expect(fn).toHaveBeenCalledWith(key, JSON.stringify(result.id));
     });
   });
 
   describe("storeConversionShareId", () => {
     it("should store the conversion shareId in a cookie", () => {
+      const fn = jest.spyOn(Storage.prototype, "setItem");
       const shareId = "1234";
       const key = `cv-${shareId}`;
       storeConversionShareId(shareId);
-      expect(document.cookie).toContain(`${key}=true`);
+      expect(fn).toHaveBeenCalledWith(key, JSON.stringify(true));
     });
 
     it("should return the key", () => {
@@ -61,10 +70,16 @@ describe("createShareId", () => {
   describe("getConversionShareId", () => {
     it("should return the conversion shareId from the cookie", () => {
       const shareId = "1234";
-      const key = `cv-${shareId}`;
-      document.cookie = `${key}=true`;
+      const obj: Record<string, boolean> = {};
+      obj[`cv-${shareId}`] = true;
+
+      jest
+        .spyOn(Storage.prototype, "getItem")
+        .mockImplementationOnce((key: string) => {
+          return JSON.stringify(obj[key]);
+        });
       const result = getConversionShareId(shareId);
-      expect(result).toEqual("true");
+      expect(result).toEqual(true);
     });
   });
 });

--- a/src/pages-helpers/teacher/share-experiments/createShareId.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.ts
@@ -12,8 +12,6 @@ import {
   setLocalstorageWithSchema,
 } from "@/utils/localstorage";
 
-// TODO switch to local storage to avoid cookie size limits
-
 export const getShareIdKey = (unhashedKey: string): string => {
   const hash = crypto
     .createHash("sha256")
@@ -23,7 +21,7 @@ export const getShareIdKey = (unhashedKey: string): string => {
   return `sid-${hash}`;
 };
 
-export const getShareIdFromCookie = (unhashedKey: string): string | undefined =>
+export const getShareId = (unhashedKey: string): string | undefined =>
   getNullableLocalstorageWithSchema(
     getShareIdKey(unhashedKey),
     LS_KEY_TEACHER_SHARE_KIDS_INITIATED_SCHEMA,

--- a/src/pages-helpers/teacher/share-experiments/createShareId.ts
+++ b/src/pages-helpers/teacher/share-experiments/createShareId.ts
@@ -1,7 +1,16 @@
 import crypto from "crypto";
 
 import { nanoid } from "nanoid";
-import Cookies from "js-cookie";
+
+import {
+  LS_KEY_TEACHER_SHARE_KIDS_INITIATED_SCHEMA,
+  LS_KEY_TEACHER_SHARE_IDS_CONVERTED_SCHEMA,
+  LS_KEY_TEACHER_SHARE_KEYS_ACTIVATED_SCHEMA,
+} from "@/config/localStorageSchemas";
+import {
+  getNullableLocalstorageWithSchema,
+  setLocalstorageWithSchema,
+} from "@/utils/localstorage";
 
 // TODO switch to local storage to avoid cookie size limits
 
@@ -15,31 +24,52 @@ export const getShareIdKey = (unhashedKey: string): string => {
 };
 
 export const getShareIdFromCookie = (unhashedKey: string): string | undefined =>
-  Cookies.get(getShareIdKey(unhashedKey));
+  getNullableLocalstorageWithSchema(
+    getShareIdKey(unhashedKey),
+    LS_KEY_TEACHER_SHARE_KIDS_INITIATED_SCHEMA,
+  );
 
 export const createAndStoreShareId = (
   unhashedKey: string,
 ): { key: string; id: string } => {
   const id = nanoid(10);
   const key = getShareIdKey(unhashedKey);
-  Cookies.set(key, id, { expires: 30 }); // cookie lasts 30 days
+  setLocalstorageWithSchema(
+    key,
+    LS_KEY_TEACHER_SHARE_KIDS_INITIATED_SCHEMA,
+    id,
+  );
   return { key, id };
 };
 
 export const storeConversionShareId = (id: string) => {
   const key = `cv-${id}`;
-  Cookies.set(key, "true", { expires: 30 }); // cookie lasts 30 days
+  setLocalstorageWithSchema(
+    key,
+    LS_KEY_TEACHER_SHARE_IDS_CONVERTED_SCHEMA,
+    true,
+  );
   return key;
 };
 
-export const getConversionShareId = (id: string): string | undefined =>
-  Cookies.get(`cv-${id}`);
+export const getConversionShareId = (id: string): boolean | undefined =>
+  getNullableLocalstorageWithSchema(
+    `cv-${id}`,
+    LS_KEY_TEACHER_SHARE_IDS_CONVERTED_SCHEMA,
+  );
 
 export const storeActivationKey = (key: string) =>
-  Cookies.set(`av-${key}`, "true", { expires: 30 });
+  setLocalstorageWithSchema(
+    `av-${key}`,
+    LS_KEY_TEACHER_SHARE_KEYS_ACTIVATED_SCHEMA,
+    true,
+  );
 
-export const getActivationKey = (key: string): string | undefined =>
-  Cookies.get(`av-${key}`);
+export const getActivationKey = (key: string): boolean | undefined =>
+  getNullableLocalstorageWithSchema(
+    `av-${key}`,
+    LS_KEY_TEACHER_SHARE_KEYS_ACTIVATED_SCHEMA,
+  );
 
 export const shareMethods = {
   url: 0,

--- a/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.test.ts
@@ -34,6 +34,7 @@ describe("getUpdatedUrl", () => {
   it("should generate a new share id and store it in a cookie if no cookieId provided", () => {
     const url = "http://example.com";
     const unhashedKey = "lesson-1";
+    const fn = jest.spyOn(Storage.prototype, "setItem");
     const result = getUpdatedUrl({
       url,
       cookieShareId: undefined,
@@ -43,8 +44,9 @@ describe("getUpdatedUrl", () => {
     expect(result.url).toEqual(
       "http://example.com?sid-c2d05c=xxxxxxxxxx&sm=0&src=1",
     );
+
     expect(result.shareIdKey).toEqual("sid-c2d05c");
     expect(result.shareId).toEqual("xxxxxxxxxx");
-    expect(document.cookie).toContain("sid-c2d05c=xxxxxxxxxx");
+    expect(fn).toHaveBeenCalledWith("sid-c2d05c", JSON.stringify("xxxxxxxxxx"));
   });
 });

--- a/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.test.ts
@@ -1,13 +1,13 @@
 import { getUpdatedUrl } from "./getUpdatedUrl";
 
 describe("getUpdatedUrl", () => {
-  it("should return an updated url with the share id in the cookie if available", () => {
+  it("should return an updated url with the share id in the storage if available", () => {
     const url = "http://example.com";
-    const cookieShareId = "1234";
+    const storageShareId = "1234";
     const unhashedKey = "lesson-1";
     const result = getUpdatedUrl({
       url,
-      cookieShareId,
+      storageShareId,
       unhashedKey,
       source: "lesson-canonical",
     });
@@ -16,13 +16,13 @@ describe("getUpdatedUrl", () => {
     expect(result.shareId).toEqual("1234");
   });
 
-  it("should override the url with the share id in the cookie if available", () => {
+  it("should override the url with the share id in the storage if available", () => {
     const url = "http://example.com?sid-c2d05c=xxxxxxxx&sm=0&src=1";
-    const cookieShareId = "1234";
+    const storageShareId = "1234";
     const unhashedKey = "lesson-1";
     const result = getUpdatedUrl({
       url,
-      cookieShareId,
+      storageShareId,
       unhashedKey,
       source: "lesson-canonical",
     });
@@ -31,13 +31,13 @@ describe("getUpdatedUrl", () => {
     expect(result.shareId).toEqual("1234");
   });
 
-  it("should generate a new share id and store it in a cookie if no cookieId provided", () => {
+  it("should generate a new share id and store it in a storage if no storageId provided", () => {
     const url = "http://example.com";
     const unhashedKey = "lesson-1";
     const fn = jest.spyOn(Storage.prototype, "setItem");
     const result = getUpdatedUrl({
       url,
-      cookieShareId: undefined,
+      storageShareId: undefined,
       unhashedKey,
       source: "lesson-canonical",
     });

--- a/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.ts
+++ b/src/pages-helpers/teacher/share-experiments/getUpdatedUrl.ts
@@ -7,19 +7,19 @@ import {
 
 /**
  *
- * updates the url with either the stored cookie share-id or a newly generated one
+ * updates the url with either the stored share-id or a newly generated one
  *
  */
 
 export const getUpdatedUrl = ({
   url,
-  cookieShareId,
+  storageShareId,
   unhashedKey,
   source,
   shareMethod = "url",
 }: {
   url: string;
-  cookieShareId: string | undefined;
+  storageShareId: string | undefined;
   unhashedKey: string;
   source: keyof typeof shareSources;
   shareMethod?: keyof typeof shareMethods;
@@ -27,12 +27,12 @@ export const getUpdatedUrl = ({
   const shareIdKey = getShareIdKey(unhashedKey);
   const strippedUrl = url.split("?")[0];
 
-  if (cookieShareId) {
-    const updatedUrl = `${strippedUrl}?${shareIdKey}=${cookieShareId}&sm=${shareMethods[shareMethod]}&src=${shareSources[source]}`;
-    return { url: updatedUrl, shareIdKey, shareId: cookieShareId };
+  if (storageShareId) {
+    const updatedUrl = `${strippedUrl}?${shareIdKey}=${storageShareId}&sm=${shareMethods[shareMethod]}&src=${shareSources[source]}`;
+    return { url: updatedUrl, shareIdKey, shareId: storageShareId };
   }
 
-  // generate share-id and store it as a cookie
+  // generate share-id and store
   const { id, key } = createAndStoreShareId(unhashedKey);
 
   const updatedUrl = `${strippedUrl}?${key}=${id}&sm=${shareMethods[shareMethod]}&src=${shareSources[source]}`;

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
@@ -5,7 +5,7 @@ import { getUpdatedUrl } from "./getUpdatedUrl";
 import {
   getActivationKey,
   getConversionShareId,
-  getShareIdFromCookie,
+  getShareId,
   getShareIdKey,
   shareSources,
   storeActivationKey,
@@ -78,12 +78,12 @@ export const useShareExperiment = ({
     // get the current url params
     const urlParams = new URLSearchParams(window.location.search);
     const urlShareId = urlParams.get(getShareIdKey(key));
-    const cookieShareId = getShareIdFromCookie(key);
+    const storageShareId = getShareId(key);
 
-    if (urlShareId && cookieShareId !== urlShareId) {
+    if (urlShareId && storageShareId !== urlShareId) {
       // check for  existing conversion shareId
       if (!getConversionShareId(urlShareId)) {
-        // TODO: store the converted shareId in a cookie for preventing multiple conversion events
+        // TODO: store the converted shareId in a storage for preventing multiple conversion events
         storeConversionShareId(urlShareId);
 
         // track the share converted event irrespective of whether the user is part of the experiment
@@ -101,7 +101,7 @@ export const useShareExperiment = ({
     if (!shareIdRef.current && shareExperimentFlag) {
       const { url, shareIdKey, shareId } = getUpdatedUrl({
         url: window.location.href,
-        cookieShareId,
+        storageShareId,
         unhashedKey: key,
         source,
         shareMethod: "url",
@@ -109,7 +109,7 @@ export const useShareExperiment = ({
 
       const { url: buttonUrl } = getUpdatedUrl({
         url: window.location.href,
-        cookieShareId: shareId, // we know that this will now be the shareId
+        storageShareId: shareId, // we know that this will now be the shareId
         unhashedKey: key,
         source,
         shareMethod: "button",
@@ -117,7 +117,7 @@ export const useShareExperiment = ({
 
       setShareUrl(buttonUrl);
 
-      if (!cookieShareId) {
+      if (!storageShareId) {
         // track the share initiated event
         track.teacherShareInitiated({
           unitSlug,
@@ -153,8 +153,6 @@ export const useShareExperiment = ({
     }
 
     if (!getActivationKey(shareIdKeyRef.current)) {
-      //TODO : cookie tracking for deduping share activated events
-
       track.teacherShareActivated({
         shareId: shareIdRef.current,
         linkUrl: window.location.href,

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
@@ -13,6 +13,10 @@ import {
 } from "./createShareId";
 
 import useAnalytics from "@/context/Analytics/useAnalytics";
+import {
+  KeyStageTitleValueType,
+  TeacherShareInitiatedProperties,
+} from "@/browser-lib/avo/Avo";
 
 export type CurriculumTrackingProps = {
   lessonName: string | null;

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
@@ -13,10 +13,6 @@ import {
 } from "./createShareId";
 
 import useAnalytics from "@/context/Analytics/useAnalytics";
-import {
-  KeyStageTitleValueType,
-  TeacherShareInitiatedProperties,
-} from "@/browser-lib/avo/Avo";
 
 export type CurriculumTrackingProps = {
   lessonName: string | null;

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiments.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiments.test.ts
@@ -125,7 +125,7 @@ describe("useShareExperiments", () => {
     );
   });
 
-  it("should call track shareInitiated if there is no cookie and the feature flag is enabled", () => {
+  it("should call track shareInitiated if there is no storage and the feature flag is enabled", () => {
     // mock the feature flag
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(true);
 
@@ -145,12 +145,12 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareInitiated).toHaveBeenCalled();
   });
 
-  it("should not call share initiated if the cookie is already present", () => {
+  it("should not call share initiated if the storage is already present", () => {
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(true);
 
     const mockTrack = useAnalytics().track;
 
-    // set the cookie
+    // set the storage
     createAndStoreShareId("lessonSlug_unitSlug_programmeSlug");
 
     // hook wrapper
@@ -167,7 +167,7 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareInitiated).not.toHaveBeenCalled();
   });
 
-  it("should call track shareConverted the url shareId is present and there is no cookieId or feature flag", () => {
+  it("should call track shareConverted the url shareId is present and there is no storageId or feature flag", () => {
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
 
     const mockTrack = useAnalytics().track;
@@ -190,14 +190,14 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareConverted).toHaveBeenCalled();
   });
 
-  it("should not call track shareConverted if the url shareId matches cookieId ", () => {
+  it("should not call track shareConverted if the url shareId matches storageId ", () => {
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
 
     const mockTrack = useAnalytics().track;
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
 
-    // set the cookie
+    // set the storage
     createAndStoreShareId("lessonSlug_unitSlug_programmeSlug");
 
     window.location.search = `?${key}=xxxxxxxxxx&sm=0&src=1`;
@@ -216,7 +216,7 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareConverted).not.toHaveBeenCalled();
   });
 
-  it("should store the conversion shareId in a cookie", () => {
+  it("should store the conversion shareId in a storage", () => {
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
@@ -247,7 +247,7 @@ describe("useShareExperiments", () => {
 
     window.location.search = `?${key}=xxxxxxxxxx&sm=0&src=1`;
 
-    // set the conversion cookie
+    // set the conversion storage
     localStorage.setItem("cv-xxxxxxxxxx", JSON.stringify(true));
 
     // hook wrapper
@@ -284,7 +284,7 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareActivated).toHaveBeenCalled();
   });
 
-  it("doesn't send an activation event when shareActivated is called and the cookie is already present", () => {
+  it("doesn't send an activation event when shareActivated is called and the storage is already present", () => {
     (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(true);
 
     const mockTrack = useAnalytics().track;

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -39,6 +39,30 @@ export function getLocalstorageWithSchema<Schema extends z.ZodTypeAny>(
   return out!;
 }
 
+export function getNullableLocalstorageWithSchema<Schema extends z.ZodTypeAny>(
+  key: string,
+  schema: Schema,
+): z.infer<Schema> | undefined {
+  let value: unknown;
+  const valueRaw = localStorage.getItem(key);
+  if (valueRaw === null) {
+    return undefined;
+  }
+
+  try {
+    value = JSON.parse(valueRaw);
+  } catch (err) {
+    throw new ErrorInvalidJson(key);
+  }
+
+  const results = schema.safeParse(value);
+  if (!results.success) {
+    throw results.error;
+  }
+  const out = results.data as z.infer<Schema>;
+  return out!;
+}
+
 export function setLocalstorageWithSchema<
   Schema extends z.ZodTypeAny,
   DataType extends z.infer<Schema> | undefined,


### PR DESCRIPTION
### Job Story

Switching from cookies to local storage to avoid hard limits and performance overheads

### Implementation details

Modify 

src/pages-helpers/teacher/share-experiments/createShareId.ts

to use local storage instead of cookies

update all tests relying on cookie mocks

### Acceptance criteria

- [x]  local storage used
- [x]  tests updated
- [x]  existing functionality uneffected

How to test
Go to https://deploy-preview-3018--owa-storybook.netlify.app/ and accept cookies and open the console
Go to  https://deploy-preview-3018--owa-storybook.netlify.app/teachers/lessons/atomic-structure-very-small-electron-mass
See that TeacherShareInitiated is sent
Copy the url into a different browser window (eg. a different google instance or safari)
See that both TeacherShareIniated and TeacherShareConverted are sent (accept cookies)
See that the url in the second browser is modified to a different id
Repeat the experiment with same urls and see that the events are not sent the second time
repeat for the various pages
try with feature flags disabled in either browser and note that conversions are still sent will initiated events are not


