### PR TITLE
fix(unitlisting): remove duplicate units within keystage

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
@@ -6,6 +6,7 @@ import {
 } from "./helpers/getAllCategories";
 import { getAllYearGroups } from "./helpers/getAllYearGroups";
 import {
+  GroupedUnitsSchema,
   ProgrammeFieldsCamel,
   rawQuerySchema,
   UnitListingData,
@@ -77,6 +78,37 @@ const unitListingQuery =
       subjectCategories,
       reshapedUnits,
     );
+
+    // this is a temporary fix for legacy data to remove duplicates units within key stage
+    // we will remove once legacy data is removed
+    const reduceBySlugAndYearOrder = (arr: GroupedUnitsSchema) => {
+      return Object.values(
+        arr.reduce(
+          (acc, item) => {
+            const { slug, yearOrder } = item[0] ?? {};
+            if (!slug || !yearOrder) {
+              return acc;
+            } else if (!acc[slug]) {
+              acc[slug] = item;
+              return acc;
+            } else {
+              if (acc[slug][0]) {
+                if (acc[slug][0].yearOrder > yearOrder) {
+                  acc[slug] = item;
+                }
+              }
+              return acc;
+            }
+          },
+          {} as { [key: string]: GroupedUnitsSchema[number] },
+        ),
+      );
+    };
+
+    const reducedUnitsArray = reduceBySlugAndYearOrder(
+      unitsWithSubjectCategories,
+    );
+
     const tiers = programmeFields.tierSlug
       ? getTierData(args.programmeSlug)
       : [];
@@ -96,7 +128,7 @@ const unitListingQuery =
       subjectParent: programmeFields.subjectParent || null,
       tierSlug: programmeFields.tierSlug,
       tiers: tiers,
-      units: unitsWithSubjectCategories,
+      units: reducedUnitsArray,
       phase: programmeFields.phaseSlug,
       learningThemes: learningThemes,
       hasNewContent,


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
