### PR TITLE
Make curric filter sidebar fixed width

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiserLayout/CurriculumVisualiserLayout.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserLayout/CurriculumVisualiserLayout.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 const CurriculumVisualiserLayoutLeft = styled(OakFlex)`
   min-width: 296px;
+  width: 296px;
 `;
 
 type CurriculumVisualiserLayoutProps = {


### PR DESCRIPTION
## Description
Fixes the width of the curriculum sidebar

## Issue(s)
Fixes `CUR-1143`

## How to test

1. Go to https://deploy-preview-3060--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. Navigate to the curric sequences 
3. Check width of the sidebar stays consistent
