### PR TITLE
[CUR-885] Update curriculum homepage metadata

### DIFF
--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -46,9 +46,10 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
     <AppLayout
       seoProps={{
         ...getSeoProps({
-          title: "Curriculum resources",
+          title:
+            "Free curriculum plans aligned with National Curriculum  | Oak National Academy",
           description:
-            "Explore our interactive curriculum tool for free, adaptable sequences perfectly aligned with the National Curriculum. Start browsing now.",
+            "Discover our free curriculum plans across subjects from KS1 to KS4, all high-quality, fully-sequenced and aligned with the national curriculum.",
         }),
       }}
       $background={"grey20"}


### PR DESCRIPTION
## Description

Music year: 1989

- Update metadata title and description as per https://www.notion.so/oaknationalacademy/Meta-Descriptions-clean-up-9dc8d8b3bb664a56b66222d640cdf549?pvs=4

## How to test

1. Go to https://deploy-preview-3063--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. The page title should be: `Free curriculum plans aligned with National Curriculum  | Oak National Academy`
3. The metadata description should be: `Discover our free curriculum plans across subjects from KS1 to KS4, all high-quality, fully-sequenced and aligned with the national curriculum.`

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
