### PR TITLE
feat: remove feature flag restriction from share buttons and tracking

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -263,7 +263,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
         ogDescription:
           "View lesson content and choose resources to download or share",
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-        canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
+        canonical: `NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
         robots: "index,follow",
       });
     });
@@ -276,7 +276,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
 
       expect(seo).toEqual(
         expect.objectContaining({
-          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
+          canonical: `NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           description:
             "View lesson content and choose resources to download or share",
           ogDescription:
@@ -313,7 +313,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
           ogDescription:
             "View lesson content and choose resources to download or share",
           ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
+          canonical: `NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           robots: "index,follow",
         }),
       );
@@ -340,7 +340,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
           ogImage:
             "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2024",
           ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
-          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
+          canonical: `NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           robots: "index,follow",
         }),
       );

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -249,6 +249,8 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
     it("renders the correct SEO details", async () => {
       const { seo } = renderWithSeo()(<LessonOverviewPage {...props} />);
 
+      const { lessonSlug, unitSlug, programmeSlug } = props.curriculumData;
+
       expect(seo).toEqual({
         ...mockSeoResult,
         ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
@@ -261,7 +263,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
         ogDescription:
           "View lesson content and choose resources to download or share",
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-        canonical: "NEXT_PUBLIC_SEO_APP_URL",
+        canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
         robots: "index,follow",
       });
     });
@@ -270,9 +272,11 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
         <LessonOverviewPage {...propsWithTier} />,
       );
 
+      const { lessonSlug, unitSlug, programmeSlug } = props.curriculumData;
+
       expect(seo).toEqual(
         expect.objectContaining({
-          canonical: "NEXT_PUBLIC_SEO_APP_URL",
+          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           description:
             "View lesson content and choose resources to download or share",
           ogDescription:
@@ -294,6 +298,9 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
         <LessonOverviewPage {...propsWithExamBoard} />,
       );
 
+      const { lessonSlug, unitSlug, programmeSlug } =
+        propsWithExamBoard.curriculumData;
+
       expect(seo).toEqual(
         expect.objectContaining({
           title:
@@ -306,7 +313,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
           ogDescription:
             "View lesson content and choose resources to download or share",
           ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-          canonical: "NEXT_PUBLIC_SEO_APP_URL",
+          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           robots: "index,follow",
         }),
       );
@@ -315,6 +322,9 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
       const { seo } = renderWithSeo()(
         <LessonOverviewPage {...propsWithTierAndExamBoard} />,
       );
+
+      const { lessonSlug, unitSlug, programmeSlug } =
+        propsWithTierAndExamBoard.curriculumData;
 
       expect(seo).toEqual(
         expect.objectContaining({
@@ -330,7 +340,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
           ogImage:
             "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2024",
           ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
-          canonical: "NEXT_PUBLIC_SEO_APP_URL",
+          canonical: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           robots: "index,follow",
         }),
       );

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -60,7 +60,7 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
     .splice(0, pathElems.indexOf(lessonSlug) + 1)
     .join("/");
 
-  const { shareExperimentFlag, shareUrl, shareActivated } = useShareExperiment({
+  const { shareUrl, shareActivated } = useShareExperiment({
     lessonSlug,
     unitSlug: isCanonical ? undefined : (unitSlug ?? undefined), // NB. unitSlug can sometimes be defined for canonical state
     programmeSlug: isCanonical ? undefined : (programmeSlug ?? undefined),
@@ -76,15 +76,14 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
     },
   });
 
-  const teacherShareButton =
-    shareExperimentFlag === "test" ? (
-      <TeacherShareButton
-        label="Share resources with colleague"
-        shareUrl={shareUrl}
-        shareActivated={shareActivated}
-        variant="primary"
-      />
-    ) : null;
+  const teacherShareButton = (
+    <TeacherShareButton
+      label="Share resources with colleague"
+      shareUrl={shareUrl}
+      shareActivated={shareActivated}
+      variant="primary"
+    />
+  );
 
   return (
     <>

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiment.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import { getUpdatedUrl } from "./getUpdatedUrl";
 import {
@@ -57,18 +56,6 @@ export const useShareExperiment = ({
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [browserUrl, setBrowserUrl] = useState<string | null>(null);
 
-  const flags = {
-    "lesson-browse": "share-advocate-lesson",
-    "lesson-canonical": "share-advocate-lesson",
-    "download-browse": "share-advocate-download",
-    "download-canonical": "share-advocate-download",
-    "lesson-listing": "share-advocate-unit",
-  };
-
-  const flag = flags[source];
-
-  const shareExperimentFlag = useFeatureFlagVariantKey(flag);
-
   const { track } = useAnalytics();
 
   const coreTrackingProps: CoreProperties = useMemo(
@@ -109,7 +96,7 @@ export const useShareExperiment = ({
       }
     }
 
-    if (!shareIdRef.current && shareExperimentFlag) {
+    if (!shareIdRef.current) {
       // we update the url and send the share initiated event for any users in the experiment
       const { url, shareIdKey, shareId } = getUpdatedUrl({
         url: window.location.href,
@@ -152,7 +139,6 @@ export const useShareExperiment = ({
     unitSlug,
     shareBaseUrl,
     curriculumTrackingProps,
-    shareExperimentFlag,
     source,
     track,
     coreTrackingProps,
@@ -179,7 +165,6 @@ export const useShareExperiment = ({
   };
 
   return {
-    shareExperimentFlag,
     shareIdRef,
     shareIdKeyRef,
     shareUrl,

--- a/src/pages-helpers/teacher/share-experiments/useShareExperiments.test.ts
+++ b/src/pages-helpers/teacher/share-experiments/useShareExperiments.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from "@testing-library/react";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import {
   CurriculumTrackingProps,
@@ -62,27 +61,7 @@ describe("useShareExperiments", () => {
     localStorage.clear();
   });
 
-  it("should return null values if the feature flag is not found", () => {
-    // hook wrapper
-    const { result } = renderHook(() =>
-      useShareExperiment({
-        lessonSlug: "lessonSlug",
-        unitSlug: "unitSlug",
-        programmeSlug: "programmeSlug",
-        source: "lesson-canonical",
-        curriculumTrackingProps,
-      }),
-    );
-
-    const { shareIdRef, shareIdKeyRef } = result.current;
-    expect(shareIdRef.current).toBeNull();
-    expect(shareIdKeyRef.current).toBeNull();
-  });
-
-  it("should generate a shareId if the feature flag is enabled", () => {
-    // mock the feature flag
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
-
+  it("should generate a shareId", () => {
     // hook wrapper
     const { result } = renderHook(() =>
       useShareExperiment({
@@ -101,9 +80,6 @@ describe("useShareExperiments", () => {
 
   it("should return a shareId based on the shareBaseUrl", () => {
     jest.spyOn(window.history, "replaceState").mockImplementation(() => {});
-
-    // mock the feature flag
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
 
     // hook wrapper
     const { result } = renderHook(() =>
@@ -126,10 +102,7 @@ describe("useShareExperiments", () => {
     );
   });
 
-  it("should call track shareInitiated if there is no storage and the feature flag is enabled", () => {
-    // mock the feature flag
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
-
+  it("should call track shareInitiated if there is no storage", () => {
     const mockTrack = useAnalytics().track;
 
     // hook wrapper
@@ -147,8 +120,6 @@ describe("useShareExperiments", () => {
   });
 
   it("should not call share initiated if the storage is already present", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
-
     const mockTrack = useAnalytics().track;
 
     // set the storage
@@ -168,9 +139,7 @@ describe("useShareExperiments", () => {
     expect(mockTrack.teacherShareInitiated).not.toHaveBeenCalled();
   });
 
-  it("should call track shareConverted the url shareId is present and there is no storageId or feature flag", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
-
+  it("should call track shareConverted the url shareId is present and there is no storageId", () => {
     const mockTrack = useAnalytics().track;
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
@@ -192,8 +161,6 @@ describe("useShareExperiments", () => {
   });
 
   it("should not call track shareConverted if the url shareId matches storageId ", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
-
     const mockTrack = useAnalytics().track;
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
@@ -218,8 +185,6 @@ describe("useShareExperiments", () => {
   });
 
   it("should store the conversion shareId in a storage", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
-
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
 
     window.location.search = `?${key}=xxxxxxxxxx&sm=0&src=1`;
@@ -240,8 +205,6 @@ describe("useShareExperiments", () => {
   });
 
   it("should not send a conversion event if the conversion shareId is already present", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue(false);
-
     const mockTrack = useAnalytics().track;
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");
@@ -266,8 +229,6 @@ describe("useShareExperiments", () => {
   });
 
   it("sends an activation event when shareActivated is called", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
-
     const mockTrack = useAnalytics().track;
 
     const { result } = renderHook(() =>
@@ -286,8 +247,6 @@ describe("useShareExperiments", () => {
   });
 
   it("doesn't send an activation event when shareActivated is called and the storage is already present", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("test");
-
     const mockTrack = useAnalytics().track;
 
     const key = getShareIdKey("lessonSlug_unitSlug_programmeSlug");

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -8,6 +8,7 @@ import {
   OakThemeProvider,
   oakDefaultTheme,
 } from "@oaknational/oak-components";
+import { useEffect } from "react";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import getPageProps from "@/node-lib/getPageProps";
@@ -40,33 +41,33 @@ export default function LessonOverviewCanonicalPage({
   lesson,
   isSpecialist,
 }: PageProps): JSX.Element {
-  const { shareExperimentFlag, shareUrl, browserUrl, shareActivated } =
-    useShareExperiment({
-      lessonSlug: lesson.lessonSlug,
-      source: "lesson-canonical",
-      curriculumTrackingProps: {
-        lessonName: lesson.lessonTitle,
-        unitName: null,
-        subjectSlug: null,
-        subjectTitle: null,
-        keyStageSlug: null,
-        keyStageTitle: null,
-      },
-    });
+  const { shareUrl, browserUrl, shareActivated } = useShareExperiment({
+    lessonSlug: lesson.lessonSlug,
+    source: "lesson-canonical",
+    curriculumTrackingProps: {
+      lessonName: lesson.lessonTitle,
+      unitName: null,
+      subjectSlug: null,
+      subjectTitle: null,
+      keyStageSlug: null,
+      keyStageTitle: null,
+    },
+  });
 
-  if (shareExperimentFlag && window.location.href !== browserUrl) {
-    window.history.replaceState({}, "", browserUrl);
-  }
+  useEffect(() => {
+    if (window.location.href !== browserUrl) {
+      window.history.replaceState({}, "", browserUrl);
+    }
+  }, [browserUrl]);
 
-  const teacherShareButton =
-    shareExperimentFlag === "test" ? (
-      <TeacherShareButton
-        label="Share resources with colleague"
-        variant={"secondary"}
-        shareUrl={shareUrl}
-        shareActivated={shareActivated}
-      />
-    ) : null;
+  const teacherShareButton = (
+    <TeacherShareButton
+      label="Share resources with colleague"
+      variant={"secondary"}
+      shareUrl={shareUrl}
+      shareActivated={shareActivated}
+    />
+  );
 
   const pathwayGroups = groupLessonPathways(lesson.pathways);
   return (

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -76,6 +76,7 @@ export default function LessonOverviewCanonicalPage({
         ...getSeoProps({
           title: `Lesson: ${lesson.lessonTitle}`,
           description: "Overview of lesson",
+          canonicalURL: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/lessons/${lesson.lessonSlug}`,
         }),
       }}
     >

--- a/src/pages/teachers/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/lessons/[lessonSlug].tsx
@@ -27,6 +27,7 @@ import { LessonOverviewCanonical } from "@/node-lib/curriculum-api-2023/queries/
 import { populateLessonWithTranscript } from "@/utils/handleTranscript";
 import { useShareExperiment } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
 import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
+import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 
 type PageProps = {
   lesson: LessonOverviewCanonical;
@@ -76,7 +77,7 @@ export default function LessonOverviewCanonicalPage({
         ...getSeoProps({
           title: `Lesson: ${lesson.lessonTitle}`,
           description: "Overview of lesson",
-          canonicalURL: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/lessons/${lesson.lessonSlug}`,
+          canonicalURL: `${getBrowserConfig("seoAppUrl")}/teachers/lessons/${lesson.lessonSlug}`,
         }),
       }}
     >

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   NextPage,
   GetStaticProps,
@@ -79,35 +79,34 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
     subjectSlug,
   } = curriculumData;
 
-  const { shareExperimentFlag, shareUrl, browserUrl, shareActivated } =
-    useShareExperiment({
-      unitSlug: unitSlug ?? undefined,
-      programmeSlug: programmeSlug ?? undefined,
-      source: "lesson-listing",
-      curriculumTrackingProps: {
-        lessonName: null,
-        unitName: unitTitle,
-        subjectSlug,
-        subjectTitle,
-        keyStageSlug,
-        keyStageTitle:
-          keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
-      },
-    });
+  const { shareUrl, browserUrl, shareActivated } = useShareExperiment({
+    unitSlug: unitSlug ?? undefined,
+    programmeSlug: programmeSlug ?? undefined,
+    source: "lesson-listing",
+    curriculumTrackingProps: {
+      lessonName: null,
+      unitName: unitTitle,
+      subjectSlug,
+      subjectTitle,
+      keyStageSlug,
+      keyStageTitle: keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
+    },
+  });
 
-  if (shareExperimentFlag && window.location.href !== browserUrl) {
-    window.history.replaceState({}, "", browserUrl);
-  }
+  useEffect(() => {
+    if (window.location.href !== browserUrl) {
+      window.history.replaceState({}, "", browserUrl);
+    }
+  }, [browserUrl]);
 
-  const teacherShareButton =
-    shareExperimentFlag == "test" ? (
-      <TeacherShareButton
-        variant="primary"
-        shareUrl={shareUrl}
-        shareActivated={shareActivated}
-        label="Share unit with colleague"
-      />
-    ) : null;
+  const teacherShareButton = (
+    <TeacherShareButton
+      variant="primary"
+      shareUrl={shareUrl}
+      shareActivated={shareActivated}
+      label="Share unit with colleague"
+    />
+  );
 
   const lessons = getHydratedLessonsFromUnit(curriculumData);
   const hasNewContent = lessons[0]?.lessonCohort === NEW_COHORT;

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -23,6 +23,7 @@ import {
   CurriculumTrackingProps,
 } from "@/pages-helpers/teacher/share-experiments/useShareExperiment";
 import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
+import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 
 export type LessonOverviewPageProps = {
   curriculumData: LessonOverviewPageData;
@@ -92,7 +93,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
           title: `Lesson: ${lessonTitle}${getLessonData()} | ${keyStageSlug.toUpperCase()} ${subjectTitle}`,
           description:
             "View lesson content and choose resources to download or share",
-          canonicalURL: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
+          canonicalURL: `${getBrowserConfig("seoAppUrl")}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
         }),
       }}
     >

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -92,6 +92,7 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
           title: `Lesson: ${lessonTitle}${getLessonData()} | ${keyStageSlug.toUpperCase()} ${subjectTitle}`,
           description:
             "View lesson content and choose resources to download or share",
+          canonicalURL: `${process.env.NEXT_PUBLIC_APP_URL}/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
         }),
       }}
     >

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   GetStaticPathsResult,
   GetStaticProps,
@@ -45,36 +45,35 @@ const LessonOverviewPage: NextPage<LessonOverviewPageProps> = ({
     keyStageTitle,
   } = curriculumData;
 
-  const { shareExperimentFlag, shareUrl, browserUrl, shareActivated } =
-    useShareExperiment({
-      lessonSlug,
-      unitSlug,
-      programmeSlug,
-      source: "lesson-browse",
-      curriculumTrackingProps: {
-        lessonName: lessonTitle,
-        unitName: unitTitle,
-        subjectSlug,
-        subjectTitle,
-        keyStageSlug,
-        keyStageTitle:
-          keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
-      },
-    });
+  const { shareUrl, browserUrl, shareActivated } = useShareExperiment({
+    lessonSlug,
+    unitSlug,
+    programmeSlug,
+    source: "lesson-browse",
+    curriculumTrackingProps: {
+      lessonName: lessonTitle,
+      unitName: unitTitle,
+      subjectSlug,
+      subjectTitle,
+      keyStageSlug,
+      keyStageTitle: keyStageTitle as CurriculumTrackingProps["keyStageTitle"],
+    },
+  });
 
-  if (shareExperimentFlag && window.location.href !== browserUrl) {
-    window.history.replaceState({}, "", browserUrl);
-  }
+  useEffect(() => {
+    if (window.location.href !== browserUrl) {
+      window.history.replaceState({}, "", browserUrl);
+    }
+  }, [browserUrl]);
 
-  const teacherShareButton =
-    shareExperimentFlag === "test" ? (
-      <TeacherShareButton
-        label="Share resources with colleague"
-        variant={"secondary"}
-        shareUrl={shareUrl}
-        shareActivated={shareActivated}
-      />
-    ) : null;
+  const teacherShareButton = (
+    <TeacherShareButton
+      label="Share resources with colleague"
+      variant={"secondary"}
+      shareUrl={shareUrl}
+      shareActivated={shareActivated}
+    />
+  );
 
   const getLessonData = () => {
     if (tierTitle && examBoardTitle) {


### PR DESCRIPTION
### Job Story

**When I view a lesson**

I want a button to share it with a colleague

So that I can advocate for oak

### Implementation details

- remove flag fetching code from useShareExperiment
- remove the flag condition from useShareExperiment
- remove flag condition for displaying share buttons
- remove the url updates

**OR** 

- Add a canonical link to the headers of the effected pages
- remove flag fetching code from useShareExperiment
- remove the flag condition from useShareExperiment
- remove flag condition for displaying share buttons

### Acceptance criteria

- [x]  urls no longer updated OR canonical link added
- [x]  share buttons appear without feature flag
- [x]  tests updated

## How to test

1. Go to 
https://deploy-preview-3066--oak-web-application.netlify.thenational.academy/teachers/lessons/transverse-waves
https://deploy-preview-3066--oak-web-application.netlify.thenational.academy/teachers/programmes/combined-science-secondary-ks4-foundation-aqa/units/measuring-waves/lessons/transverse-waves
https://deploy-preview-3066--oak-web-application.netlify.thenational.academy/teachers/programmes/combined-science-secondary-ks4-foundation-aqa/units/measuring-waves
https://deploy-preview-3066--oak-web-application.netlify.thenational.academy/teachers/lessons/transverse-waves/downloads

2. in each case you should see the share button (downloads you need to download first)
3. in each case open the console and look in the headers (you should see a canonical link the for page <link rel="canonical"  href="a sensible href for the page without query params" / >


