### PR TITLE
Incorrect breakpoint in curric picker

### DIFF
--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -202,7 +202,7 @@ const SubjectContainerWrapper = styled.div`
   overflow-y: auto;
   padding-left: 8px;
 
-  @media (min-width: 769px) {
+  @media (min-width: 749px) {
     padding-left: 0px;
     max-height: auto;
     overflow-y: visible;
@@ -217,7 +217,7 @@ const PhaseContainerWrapper = styled.div`
   overflow-y: auto;
   position: relative;
 
-  @media (min-width: 769px) {
+  @media (min-width: 749px) {
     max-height: auto;
     overflow-y: visible;
   }


### PR DESCRIPTION
## Description
Fixes invalid causing close button to be visually clipped (hidden) in the UI 

## Issue(s)

Fixes `CUR-1144`

## How to test

1. Go to https://deploy-preview-3067--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check subject phase picker breakpoints for visual errors (see  `CUR-1144` for particular issue addressed)
