### PR TITLE
Added `subjectFromUnits` method to pull title from data

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/1_frontCover.ts
@@ -12,7 +12,7 @@ import {
   JSZipCached,
 } from "../docx";
 
-import { generateIconURL } from "./helper";
+import { generateIconURL, subjectFromUnits } from "./helper";
 
 import { getShortPhaseText } from "@/utils/curriculum/formatting";
 
@@ -45,9 +45,9 @@ export default async function generate(
 
   const examboardTitle = data.examboardTitle ? `${data.examboardTitle}` : "";
   const tierTitle = slugs.tierSlug ? `${capitalize(slugs.tierSlug)}` : "";
-  const childSubjectTitle = slugs.childSubjectSlug
-    ? `${capitalize(slugs.childSubjectSlug.split("-").join(" "))}`
-    : "";
+
+  const childSubjectTitle =
+    subjectFromUnits(data.units, slugs.childSubjectSlug) ?? "";
 
   const subtitle =
     examboardTitle !== "" || tierTitle !== "" || childSubjectTitle !== ""

--- a/src/pages-helpers/curriculum/docx/builder/helper.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.test.ts
@@ -1,12 +1,14 @@
 import { generateOakIconURL } from "@oaknational/oak-components";
 
 import { xmlRootToJson } from "../xml";
+import { CombinedCurriculumData } from "..";
 
 import {
   generateGridCols,
   uncapitalize,
   uncapitalizeSubject,
   generateIconURL,
+  subjectFromUnits,
 } from "./helper";
 
 describe("helper", () => {
@@ -77,6 +79,26 @@ describe("helper", () => {
     it("returns a valid url when valid subject icon is passed in", () => {
       const url = generateIconURL("maths");
       expect(url).toBe(generateOakIconURL("subject-maths"));
+    });
+  });
+
+  describe("subjectFromUnits", () => {
+    const data = [
+      {},
+      { subject_slug: "combined-science", subject: "Combined science" },
+    ] as CombinedCurriculumData["units"];
+    it("return if exists and slug", () => {
+      expect(subjectFromUnits(data, "combined-science")).toEqual(
+        "Combined science",
+      );
+    });
+
+    it("undefined if no slug", () => {
+      expect(subjectFromUnits(data, undefined)).toEqual(undefined);
+    });
+
+    it("undefined if no unit with subject", () => {
+      expect(subjectFromUnits(data, "foobar")).toEqual(undefined);
     });
   });
 });

--- a/src/pages-helpers/curriculum/docx/builder/helper.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.ts
@@ -5,7 +5,7 @@ import {
   isValidIconName,
 } from "@oaknational/oak-components";
 
-import { Slugs } from "..";
+import { CombinedCurriculumData, Slugs } from "..";
 import { zipToSimpleObject } from "../zip";
 
 import { Unit } from "@/utils/curriculum/types";
@@ -47,6 +47,15 @@ export function uncapitalize(input: string, titleCaseWords: string[] = []) {
     i = j - 1;
   }
   return output;
+}
+
+export function subjectFromUnits(
+  units: CombinedCurriculumData["units"],
+  subject_slug?: string,
+) {
+  if (subject_slug) {
+    return units.find((u) => u.subject_slug === subject_slug)?.subject;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description
Added `subjectFromUnits` method to pull title from data rather than generating from the slug

## Issue(s)

Fixes `CUR-797`

## How to test

1. Go to https://deploy-preview-3068--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. Generate a docx with and without child subjects
3. Check for regressions in the cover page where the child subject is displayed. 
