### PR TITLE
Invalid value for `w:beforeAutospacing` in docx

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
@@ -316,7 +316,7 @@ export default async function generate(
                   w:line="240"
                   w:before="0"
                   w:after="${line240(1)}"
-                  w:beforeAutospacing="${line240(0.2)}"
+                  w:beforeAutospacing="1"
                 />
               </w:pPr>
               ${content}

--- a/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
@@ -314,9 +314,8 @@ export default async function generate(
                 <w:spacing
                   w:lineRule="auto"
                   w:line="240"
-                  w:before="0"
+                  w:before="${line240(1)}"
                   w:after="${line240(1)}"
-                  w:beforeAutospacing="1"
                 />
               </w:pPr>
               ${content}

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
@@ -502,9 +502,8 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
         <w:spacing
           w:lineRule="auto"
           w:line="240"
-          w:before="0"
+          w:before="240"
           w:after="240"
-          w:beforeAutospacing="1"
         ></w:spacing>
       </w:pPr>
       <w:r>

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/5_subjectExplainer.test.ts.snap
@@ -504,7 +504,7 @@ exports[`5_subjectExplainer cycle 2 features 1`] = `
           w:line="240"
           w:before="0"
           w:after="240"
-          w:beforeAutospacing="48"
+          w:beforeAutospacing="1"
         ></w:spacing>
       </w:pPr>
       <w:r>


### PR DESCRIPTION
## Description
Fixes for docx validation errors and also visual issues with level 6 headings.

## Issue(s)

Fixes `CUR-1153`

## How to test

1. Go to https://deploy-preview-3070--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. From the picker "English secondary (AQA)"
3. Download docment
4. Level 6 heading should be correctly spaced.

## Screenshots
Before
<img width="608" alt="Screenshot 2024-12-16 at 16 19 02" src="https://github.com/user-attachments/assets/55f847f3-f83c-4181-95ef-fdc8084bda4b" />

After
<img width="608" alt="Screenshot 2024-12-16 at 16 18 48" src="https://github.com/user-attachments/assets/a4273dbf-73fb-4782-b3cf-20cca9fcff61" />
