### PR TITLE
Initial curriculum login interim solution for docx downloads

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
@@ -1,0 +1,73 @@
+import { OakFlex, OakHeading } from "@oaknational/oak-components";
+
+import {
+  DOWNLOAD_TYPES,
+  DownloadType,
+  School,
+  assertValidDownloadType,
+} from "./helper";
+
+import RadioGroup from "@/components/SharedComponents/RadioButtons/RadioGroup";
+import ResourceCard from "@/components/TeacherComponents/ResourceCard";
+
+export type CurriculumDownloadViewData = {
+  schools: School[];
+  schoolId?: string;
+  schoolName?: string;
+  email?: string;
+  downloadType: DownloadType;
+  termsAndConditions?: boolean;
+  schoolNotListed?: boolean;
+};
+
+export type CurriculumDownloadViewErrors = Partial<{
+  schoolId: string;
+  email: string;
+  termsAndConditions: string;
+  schoolNotListed: string;
+}>;
+
+type CurriculumResourcesSectionProps = {
+  downloadType: DownloadType;
+  onChangeDownloadType: (newDownloadType: DownloadType) => void;
+};
+export function CurriculumResourcesSelector({
+  downloadType,
+  onChangeDownloadType,
+}: CurriculumResourcesSectionProps) {
+  return (
+    <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
+      <OakHeading tag="h3" $font={["heading-5"]} data-testid="download-heading">
+        Curriculum resources
+      </OakHeading>
+      <RadioGroup
+        aria-label="Subject Download Options"
+        value={downloadType}
+        onChange={(val) => {
+          const newDownloadType = assertValidDownloadType(val);
+          onChangeDownloadType(newDownloadType);
+        }}
+      >
+        <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
+          {DOWNLOAD_TYPES.map((download) => {
+            return (
+              <ResourceCard
+                id={download.id}
+                key={download.label}
+                name={download.label}
+                label={download.label}
+                subtitle={download.subTitle ?? ""}
+                resourceType="curriculum-pdf"
+                onChange={() => {}}
+                checked={false}
+                onBlur={() => {}}
+                useRadio={true}
+                subjectIcon={download.icon}
+              />
+            );
+          })}
+        </OakFlex>
+      </RadioGroup>
+    </OakFlex>
+  );
+}

--- a/src/components/CurriculumComponents/CurriculumDownloadView/SignedInFlow.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/SignedInFlow.tsx
@@ -1,0 +1,75 @@
+import { OakFlex, OakPrimaryButton } from "@oaknational/oak-components";
+import { useState } from "react";
+import { useUser } from "@clerk/nextjs";
+
+import { DOWNLOAD_TYPES, DownloadType, School } from "./helper";
+import { CurriculumResourcesSelector } from "./CurriculumResourcesSelector";
+
+import { CurriculumDownloadViewProps } from ".";
+
+import Box from "@/components/SharedComponents/Box";
+import { fetchHubspotContactDetails } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/fetchHubspotContactDetails";
+
+export type CurriculumDownloadViewData = {
+  schools: School[];
+  schoolId?: string;
+  schoolName?: string;
+  email?: string;
+  downloadType: DownloadType;
+  termsAndConditions?: boolean;
+  schoolNotListed?: boolean;
+};
+
+export type CurriculumDownloadViewErrors = Partial<{
+  schoolId: string;
+  email: string;
+  termsAndConditions: string;
+  schoolNotListed: string;
+}>;
+
+type SignedInFlowProps = CurriculumDownloadViewProps & {
+  user: ReturnType<typeof useUser>;
+};
+export default function SignedInFlow({ onSubmit, schools }: SignedInFlowProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [downloadType, setDownloadType] = useState(DOWNLOAD_TYPES[0]!.id);
+
+  const onDownload = async () => {
+    try {
+      setIsSubmitting(true);
+      const hubspotContact = await fetchHubspotContactDetails();
+
+      if (onSubmit && hubspotContact) {
+        onSubmit({
+          schools,
+          schoolId: hubspotContact.schoolId ?? undefined,
+          schoolName: hubspotContact.schoolName ?? undefined,
+          email: hubspotContact?.email,
+          downloadType: downloadType,
+          termsAndConditions: true,
+          schoolNotListed: !hubspotContact.schoolId,
+        });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <OakFlex
+      $gap={["space-between-m2", "space-between-l"]}
+      $flexDirection="column"
+      $alignItems={"flex-start"}
+    >
+      <Box $width={["100%", 510]} $textAlign={"left"}>
+        <CurriculumResourcesSelector
+          downloadType={downloadType}
+          onChangeDownloadType={setDownloadType}
+        />
+      </Box>
+      <OakPrimaryButton isLoading={isSubmitting} onClick={onDownload}>
+        Download
+      </OakPrimaryButton>
+    </OakFlex>
+  );
+}

--- a/src/components/CurriculumComponents/CurriculumDownloadView/SignedOutFlow.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/SignedOutFlow.tsx
@@ -1,0 +1,190 @@
+import {
+  OakFieldError,
+  OakFlex,
+  OakHeading,
+  OakLI,
+  OakP,
+  OakPrimaryButton,
+  OakUL,
+} from "@oaknational/oak-components";
+import { FormEvent, useId, useState } from "react";
+import styled from "styled-components";
+
+import AcceptTerms from "../OakComponentsKitchen/AcceptTerms";
+import YourDetails from "../OakComponentsKitchen/YourDetails";
+import Terms from "../OakComponentsKitchen/Terms";
+
+import { submitSchema } from "./schema";
+import { DownloadType, School, runSchema } from "./helper";
+import { CurriculumResourcesSelector } from "./CurriculumResourcesSelector";
+
+import Box from "@/components/SharedComponents/Box";
+import flex, { FlexCssProps } from "@/styles/utils/flex";
+import spacing, { SpacingProps } from "@/styles/utils/spacing";
+import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
+
+const StyledForm = styled.form<FlexCssProps & SpacingProps>`
+  ${flex}
+  ${spacing}
+    display: flex;
+`;
+
+export type CurriculumDownloadViewData = {
+  schools: School[];
+  schoolId?: string;
+  schoolName?: string;
+  email?: string;
+  downloadType: DownloadType;
+  termsAndConditions?: boolean;
+  schoolNotListed?: boolean;
+};
+
+export type CurriculumDownloadViewErrors = Partial<{
+  schoolId: string;
+  email: string;
+  termsAndConditions: string;
+  schoolNotListed: string;
+}>;
+
+type SignedOutFlowProps = {
+  isSubmitting: boolean;
+  data: CurriculumDownloadViewData;
+  schools: School[];
+  onChange?: (value: CurriculumDownloadViewData) => void;
+  onSubmit?: (value: CurriculumDownloadViewData) => void;
+  downloadType: DownloadType;
+  onChangeDownloadType: (newDownloadType: DownloadType) => void;
+};
+export default function SignedOutFlow({
+  schools,
+  data,
+  onChange,
+  onSubmit,
+  isSubmitting,
+  downloadType,
+  onChangeDownloadType,
+}: SignedOutFlowProps) {
+  const errorMessageListId = useId();
+  const [errors, setErrors] = useState<CurriculumDownloadViewErrors>({});
+  const hasErrors = Object.keys(errors).length;
+
+  const onChangeLocal = (partial: Partial<CurriculumDownloadViewData>) => {
+    const newData = {
+      ...data,
+      ...partial,
+    };
+    onChange?.(newData);
+  };
+
+  const onSubmitLocal = (e: FormEvent) => {
+    e.preventDefault();
+    if (onSubmit) {
+      const newSubmitValidatioResults = runSchema(submitSchema, data);
+      setErrors(newSubmitValidatioResults.errors);
+      if (newSubmitValidatioResults.success) {
+        onSubmit(data);
+      }
+    }
+  };
+
+  const [isComplete, setIsComplete] = useState(() => {
+    return (
+      (Boolean(data.schoolId?.length) || Boolean(data.email?.length)) &&
+      data.termsAndConditions
+    );
+  });
+
+  return (
+    <OakFlex
+      $gap={["space-between-m2", "space-between-l"]}
+      $flexDirection={["column", "row"]}
+    >
+      <Box $width={["100%", 510]} $textAlign={"left"}>
+        <CurriculumResourcesSelector
+          downloadType={downloadType}
+          onChangeDownloadType={onChangeDownloadType}
+        />
+      </Box>
+
+      <Box $maxWidth={["100%", 400]} $textAlign={"left"}>
+        <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
+          <OakHeading tag="h3" $font={["heading-5"]}>
+            Your details
+          </OakHeading>
+          <StyledForm onSubmit={onSubmitLocal} $alignItems={"center"}>
+            <OakFlex $flexDirection={"column"}>
+              {!isComplete && (
+                <OakFlex
+                  $width={"100%"}
+                  $flexDirection={"column"}
+                  $alignItems={"start"}
+                  $gap={["space-between-l"]}
+                >
+                  <YourDetails
+                    schools={schools}
+                    data={data}
+                    errors={errors}
+                    onChange={onChangeLocal}
+                  />
+
+                  <AcceptTerms
+                    value={!!data.termsAndConditions}
+                    error={errors.termsAndConditions}
+                    onChange={(v) =>
+                      onChangeLocal({
+                        termsAndConditions: v,
+                      })
+                    }
+                  />
+                </OakFlex>
+              )}
+
+              {isComplete && (
+                <ResourcePageDetailsCompleted
+                  school={
+                    data.schoolNotListed
+                      ? "My school isn’t listed"
+                      : data.schoolName
+                  }
+                  email={data.email}
+                  onEditClick={() => setIsComplete(false)}
+                />
+              )}
+
+              <OakFlex $flexDirection={"column"} $mt={"space-between-m"}>
+                <Terms />
+              </OakFlex>
+
+              <OakFlex
+                $flexDirection={"column"}
+                $gap={"space-between-m"}
+                $mv={"space-between-s"}
+              >
+                {hasErrors > 0 && (
+                  <div id={errorMessageListId}>
+                    <OakFieldError>
+                      <OakP>To download fix following errors:</OakP>
+                      <OakUL>
+                        {Object.entries(errors).map(([key, value]) => {
+                          return <OakLI key={key}>{value}</OakLI>;
+                        })}
+                      </OakUL>
+                    </OakFieldError>
+                  </div>
+                )}
+                <OakPrimaryButton
+                  aria-errormessage={errorMessageListId}
+                  isLoading={isSubmitting}
+                  type="submit"
+                  disabled={false}
+                >
+                  Download
+                </OakPrimaryButton>
+              </OakFlex>
+            </OakFlex>
+          </StyledForm>
+        </OakFlex>
+      </Box>
+    </OakFlex>
+  );
+}

--- a/src/components/CurriculumComponents/CurriculumDownloadView/helper.ts
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/helper.ts
@@ -1,7 +1,5 @@
 import { ZodType } from "zod";
 
-import { DownloadType } from ".";
-
 export type School = {
   urn: string;
   la: string;
@@ -48,3 +46,26 @@ export function assertValidDownloadType(val: string) {
   }
   return val as DownloadType;
 }
+
+export type DownloadType = (typeof validDownloadTypes)[number];
+
+export const DOWNLOAD_TYPES: {
+  id: DownloadType;
+  label: string;
+  disabled?: boolean;
+  icon: string;
+  subTitle?: string;
+}[] = [
+  {
+    id: "word",
+    label: "Curriculum plan",
+    subTitle: "Word (accessible)",
+    icon: "maths",
+  },
+  // {
+  //   id: "pdf",
+  //   label: "Curriculum plan",
+  //   subTitle: "PDF",
+  //   icon: "maths"
+  // },
+];

--- a/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
@@ -1,72 +1,13 @@
-import {
-  OakBox,
-  OakFieldError,
-  OakFlex,
-  OakHeading,
-  OakLI,
-  OakP,
-  OakPrimaryButton,
-  OakUL,
-} from "@oaknational/oak-components";
-import { FC, FormEvent, useId, useState } from "react";
-import styled from "styled-components";
+import { OakBox } from "@oaknational/oak-components";
+import { FC, useState } from "react";
+import { useUser } from "@clerk/nextjs";
 
-import AcceptTerms from "../OakComponentsKitchen/AcceptTerms";
-import YourDetails from "../OakComponentsKitchen/YourDetails";
-import Terms from "../OakComponentsKitchen/Terms";
-
-import { submitSchema } from "./schema";
-import {
-  School,
-  assertValidDownloadType,
-  runSchema,
-  validDownloadTypes,
-} from "./helper";
+import { DOWNLOAD_TYPES, DownloadType, School } from "./helper";
+import SignedOutFlow from "./SignedOutFlow";
+import SignedInFlow from "./SignedInFlow";
 
 import Box from "@/components/SharedComponents/Box";
-import flex, { FlexCssProps } from "@/styles/utils/flex";
-import spacing, { SpacingProps } from "@/styles/utils/spacing";
-import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
 import Button from "@/components/SharedComponents/Button";
-import ResourceCard from "@/components/TeacherComponents/ResourceCard";
-import RadioGroup from "@/components/SharedComponents/RadioButtons/RadioGroup";
-
-const StyledForm = styled.form<FlexCssProps & SpacingProps>`
-  ${flex}
-  ${spacing}
-  display: flex;
-`;
-
-const Container = styled(OakFlex)`
-  flex-direction: row;
-
-  @media (max-width: 800px) {
-    flex-direction: column;
-  }
-`;
-
-export type DownloadType = (typeof validDownloadTypes)[number];
-
-const DOWNLOAD_TYPES: {
-  id: DownloadType;
-  label: string;
-  disabled?: boolean;
-  icon: string;
-  subTitle?: string;
-}[] = [
-  {
-    id: "word",
-    label: "Curriculum plan",
-    subTitle: "Word (accessible)",
-    icon: "maths",
-  },
-  // {
-  //   id: "pdf",
-  //   label: "Curriculum plan",
-  //   subTitle: "PDF",
-  //   icon: "maths"
-  // },
-];
 
 export type CurriculumDownloadViewData = {
   schools: School[];
@@ -78,13 +19,6 @@ export type CurriculumDownloadViewData = {
   schoolNotListed?: boolean;
 };
 
-export type CurriculumDownloadViewErrors = Partial<{
-  schoolId: string;
-  email: string;
-  termsAndConditions: string;
-  schoolNotListed: string;
-}>;
-
 export type CurriculumDownloadViewProps = {
   isSubmitting: boolean;
   data: CurriculumDownloadViewData;
@@ -93,50 +27,13 @@ export type CurriculumDownloadViewProps = {
   onSubmit?: (value: CurriculumDownloadViewData) => void;
   onBackToKs4Options?: () => void;
 };
-const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = ({
-  schools,
-  data,
-  onChange,
-  onSubmit,
-  isSubmitting,
-  onBackToKs4Options,
-}) => {
+const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = (props) => {
   const [downloadType, setDownloadType] = useState(DOWNLOAD_TYPES[0]!.id);
-  const errorMessageListId = useId();
-  const [errors, setErrors] = useState<CurriculumDownloadViewErrors>(
-    () => ({}),
-  );
-  const hasErrors = Object.keys(errors).length;
-
-  const onChangeLocal = (partial: Partial<CurriculumDownloadViewData>) => {
-    const newData = {
-      ...data,
-      ...partial,
-    };
-    onChange?.(newData);
-  };
-
-  const onSubmitLocal = (e: FormEvent) => {
-    e.preventDefault();
-    if (onSubmit) {
-      const newSubmitValidatioResults = runSchema(submitSchema, data);
-      setErrors(newSubmitValidatioResults.errors);
-      if (newSubmitValidatioResults.success) {
-        onSubmit(data);
-      }
-    }
-  };
-
-  const [isComplete, setIsComplete] = useState(() => {
-    return (
-      (Boolean(data.schoolId?.length) || Boolean(data.email?.length)) &&
-      data.termsAndConditions
-    );
-  });
+  const user = useUser();
 
   return (
     <OakBox $color="black">
-      {onBackToKs4Options && (
+      {props.onBackToKs4Options && (
         <Box $mb={24}>
           <Button
             variant={"buttonStyledAsLink"}
@@ -144,130 +41,22 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = ({
             data-testid="back-to-downloads-link"
             size="small"
             label="Back to KS4 options"
-            onClick={onBackToKs4Options}
+            onClick={props.onBackToKs4Options}
           />
         </Box>
       )}
-      <Container $gap={["space-between-m2", "space-between-l"]}>
-        <Box $width={["100%", 510]} $textAlign={"left"}>
-          <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
-            <OakHeading
-              tag="h3"
-              $font={["heading-5"]}
-              data-testid="download-heading"
-            >
-              Curriculum resources
-            </OakHeading>
-            <RadioGroup
-              aria-label="Subject Download Options"
-              value={downloadType}
-              onChange={(val) => {
-                const newDownloadType = assertValidDownloadType(val);
-                setDownloadType(newDownloadType);
-              }}
-            >
-              <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
-                {DOWNLOAD_TYPES.map((download) => {
-                  return (
-                    <ResourceCard
-                      id={download.id}
-                      key={download.label}
-                      name={download.label}
-                      label={download.label}
-                      subtitle={download.subTitle ?? ""}
-                      resourceType="curriculum-pdf"
-                      onChange={() => {}}
-                      checked={false}
-                      onBlur={() => {}}
-                      useRadio={true}
-                      subjectIcon={download.icon}
-                    />
-                  );
-                })}
-              </OakFlex>
-            </RadioGroup>
-          </OakFlex>
-        </Box>
-        <Box $maxWidth={["100%", 400]} $textAlign={"left"}>
-          <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
-            <OakHeading tag="h3" $font={["heading-5"]}>
-              Your details
-            </OakHeading>
-            <StyledForm onSubmit={onSubmitLocal} $alignItems={"center"}>
-              <OakFlex $flexDirection={"column"}>
-                {!isComplete && (
-                  <OakFlex
-                    $width={"100%"}
-                    $flexDirection={"column"}
-                    $alignItems={"start"}
-                    $gap={["space-between-l"]}
-                  >
-                    <YourDetails
-                      schools={schools}
-                      data={data}
-                      errors={errors}
-                      onChange={onChangeLocal}
-                    />
-
-                    <AcceptTerms
-                      value={!!data.termsAndConditions}
-                      error={errors.termsAndConditions}
-                      onChange={(v) =>
-                        onChangeLocal({
-                          termsAndConditions: v,
-                        })
-                      }
-                    />
-                  </OakFlex>
-                )}
-
-                {isComplete && (
-                  <ResourcePageDetailsCompleted
-                    school={
-                      data.schoolNotListed
-                        ? "My school isn’t listed"
-                        : data.schoolName
-                    }
-                    email={data.email}
-                    onEditClick={() => setIsComplete(false)}
-                  />
-                )}
-
-                <OakFlex $flexDirection={"column"} $mt={"space-between-m"}>
-                  <Terms />
-                </OakFlex>
-
-                <OakFlex
-                  $flexDirection={"column"}
-                  $gap={"space-between-m"}
-                  $mv={"space-between-s"}
-                >
-                  {hasErrors > 0 && (
-                    <div id={errorMessageListId}>
-                      <OakFieldError>
-                        <OakP>To download fix following errors:</OakP>
-                        <OakUL>
-                          {Object.entries(errors).map(([key, value]) => {
-                            return <OakLI key={key}>{value}</OakLI>;
-                          })}
-                        </OakUL>
-                      </OakFieldError>
-                    </div>
-                  )}
-                  <OakPrimaryButton
-                    aria-errormessage={errorMessageListId}
-                    isLoading={isSubmitting}
-                    type="submit"
-                    disabled={false}
-                  >
-                    Download
-                  </OakPrimaryButton>
-                </OakFlex>
-              </OakFlex>
-            </StyledForm>
-          </OakFlex>
-        </Box>
-      </Container>
+      {user.isLoaded && (
+        <>
+          {!user.isSignedIn && (
+            <SignedOutFlow
+              {...props}
+              onChangeDownloadType={setDownloadType}
+              downloadType={downloadType}
+            />
+          )}
+          {user.isSignedIn && <SignedInFlow {...props} user={user} />}
+        </>
+      )}
     </OakBox>
   );
 };


### PR DESCRIPTION
## Description
Added functionality to skip user details when already logged in, in the curriculum download route.

## Issue(s)

Fixes `CUR-1147`

## How to test
When logged in

1. Go to {owa_deployment_url}//teachers/curriculum
2. Navigate to downloads
3. You should only see a "download" button and no option to enter details

When **not** logged in

1. Go to {owa_deployment_url}//teachers/curriculum
2. Navigate to downloads
3. You should see option to enter details and accept terms alongside the "download" button


