### PR TITLE
PUPIL-1154 Update oak-components version to see versioned icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.64.0",
+        "@oaknational/oak-components": "^1.64.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.39.0",
         "@oaknational/oak-pupil-client": "^2.12.3",
@@ -7020,9 +7020,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.64.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.64.0.tgz",
-      "integrity": "sha512-kue51czxnJNmWx+Wp0Abp1puDFXKu1PDkQKwuAyXLD3fqjY0sWi5KMLAklPTa7fL76ZshR0czuHo/BfincwTZQ==",
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.64.1.tgz",
+      "integrity": "sha512-wuu0BoLlzdPz1K9zfeMZ0wCpxRzDm+4VqPL/LkZNnqsYPJhr0bk8h/AxE0apqgP9q7qe6M/3aLbaHZt5NeiZUA==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.61.1",
+        "@oaknational/oak-components": "^1.64.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.39.0",
         "@oaknational/oak-pupil-client": "^2.12.3",
@@ -7020,9 +7020,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.61.1.tgz",
-      "integrity": "sha512-tWndLTWjmtKPBPsl1/C5nArik8f3D/LpTwa8KXUHUg6QfLboj6swWmyB/3nFvt/vvXeQNs0IV1P3A7tk3armUw==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.64.0.tgz",
+      "integrity": "sha512-kue51czxnJNmWx+Wp0Abp1puDFXKu1PDkQKwuAyXLD3fqjY0sWi5KMLAklPTa7fL76ZshR0czuHo/BfincwTZQ==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.64.1",
+        "@oaknational/oak-components": "^1.65.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.39.0",
         "@oaknational/oak-pupil-client": "^2.12.3",
@@ -7020,9 +7020,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.64.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.64.1.tgz",
-      "integrity": "sha512-wuu0BoLlzdPz1K9zfeMZ0wCpxRzDm+4VqPL/LkZNnqsYPJhr0bk8h/AxE0apqgP9q7qe6M/3aLbaHZt5NeiZUA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.65.0.tgz",
+      "integrity": "sha512-Eo8Xfce5G11M9v86T7IEiGP43qJn9UHiwR9MJZ5w/yPMwynRAEw3S3wq4UfFqo5ZNU/pfvODN2F/VLliyJlqPQ==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.64.0",
+    "@oaknational/oak-components": "^1.64.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.39.0",
     "@oaknational/oak-pupil-client": "^2.12.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.61.1",
+    "@oaknational/oak-components": "^1.64.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.39.0",
     "@oaknational/oak-pupil-client": "^2.12.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.64.1",
+    "@oaknational/oak-components": "^1.65.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.39.0",
     "@oaknational/oak-pupil-client": "^2.12.3",

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -282,7 +282,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
           ogDescription:
             "View lesson content and choose resources to download or share",
           ogImage:
-            "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2024",
+            "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2025",
           ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
           ogTitle:
             "Lesson: Adverbial complex sentences | Higher | KS2 English | NEXT_PUBLIC_SEO_APP_NAME",
@@ -338,7 +338,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
             "View lesson content and choose resources to download or share",
           ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
           ogImage:
-            "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2024",
+            "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?2025",
           ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
           canonical: `NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/${programmeSlug}/units/${unitSlug}/lessons/${lessonSlug}`,
           robots: "index,follow",

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Fieldset all options 1`] = `
             data-nimg="fill"
             decoding="async"
             loading="lazy"
-            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699895534/icons/Icon-Success_aiiprx"
+            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699895534/icons/Icon-Success_aiiprx.svg"
             style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
           />
         </div>

--- a/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/Alert/__snapshots__/Alert.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Fieldset all options 1`] = `
         >
           <img
             alt="info"
-            class="sc-dcJsrY dAhYsf"
+            class="sc-dcJsrY beWtwI"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -45,7 +45,7 @@ exports[`Fieldset all options 1`] = `
         >
           <img
             alt="info"
-            class="sc-dcJsrY dAhYsf"
+            class="sc-dcJsrY beWtwI"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -74,7 +74,7 @@ exports[`Fieldset all options 1`] = `
         >
           <img
             alt="success"
-            class="sc-dcJsrY dAhYsf"
+            class="sc-dcJsrY beWtwI"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -103,7 +103,7 @@ exports[`Fieldset all options 1`] = `
         >
           <img
             alt="warning"
-            class="sc-dcJsrY dAhYsf"
+            class="sc-dcJsrY beWtwI"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -132,7 +132,7 @@ exports[`Fieldset all options 1`] = `
         >
           <img
             alt="error"
-            class="sc-dcJsrY dYJCWu"
+            class="sc-dcJsrY cGPxx"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -168,7 +168,7 @@ exports[`Fieldset default options 1`] = `
         >
           <img
             alt="info"
-            class="sc-dcJsrY dAhYsf"
+            class="sc-dcJsrY beWtwI"
             data-nimg="fill"
             decoding="async"
             loading="lazy"


### PR DESCRIPTION
## Description

- Updated `oak-components` version to see versioned icons

## Issue(s)

Fixes [PUPIL-1154](https://www.notion.so/oaknationalacademy/Use-versioned-versions-of-icons-16026cc4e1b180078e36d2bdede46e42)

## How to test

1. Go to https://deploy-preview-3084--oak-web-application.netlify.thenational.academy
2. Scan through pages and check that icons and backgrounds in lesson and unit views render without changes

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
