### PR TITLE
hotfix: allow singular programme factors in ui

### DIFF
--- a/src/components/PupilViews/PupilProgrammeListing/PupilProgrammeListing.view.tsx
+++ b/src/components/PupilViews/PupilProgrammeListing/PupilProgrammeListing.view.tsx
@@ -80,9 +80,9 @@ export const PupilViewsProgrammeListing = ({
 
   const availableFactors = orderedFactors.filter(
     (f) =>
-      (f === "pathway" && pathways.length > 1) ||
-      (f === "tier" && tiers.length > 1) ||
-      (f === "examboard" && examboards.length > 1),
+      (f === "pathway" && pathways.length >= 1) ||
+      (f === "tier" && tiers.length >= 1) ||
+      (f === "examboard" && examboards.length >= 1),
   );
 
   const currentFactor =


### PR DESCRIPTION
## Description

PE. is released with a single pathway GCSE at KS4. The pupil programme listing operated on the assumption of always being multiple or no pathways

Fixes #

- adjust the condition to accept just a single factor for any programme factors

## How to test

1. Go to https://deploy-preview-3101--oak-web-application.netlify.thenational.academy/pupils/programmes/physical-education-secondary-year-10/options
2. You should be prompted to choose a pathway and then an examboard
3. you should be able to successfully access a unit listing page
4. please check for any regressions around programme factors in other subjects - eg. combined science, maths, english
