### PR TITLE
Simple updates for `<Box/>` to <OakBox/>` in curriculum components

### DIFF
--- a/src/components/CurriculumComponents/Banners/__snapshots__/Banners.test.tsx.snap
+++ b/src/components/CurriculumComponents/Banners/__snapshots__/Banners.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Banners when cycle 2 enabled 1`] = `
 <div>
   <div
-    class="sc-ad0ad6f5-0 bZaRlP"
+    class="sc-fqkvVR dzjDLT"
     role="banner"
   >
     <div

--- a/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
@@ -137,7 +137,7 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = ({
   return (
     <OakBox $color="black">
       {onBackToKs4Options && (
-        <Box $mb={24}>
+        <OakBox $mb="space-between-m">
           <Button
             variant={"buttonStyledAsLink"}
             icon="chevron-left"
@@ -146,7 +146,7 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = ({
             label="Back to KS4 options"
             onClick={onBackToKs4Options}
           />
-        </Box>
+        </OakBox>
       )}
       <Container $gap={["space-between-m2", "space-between-l"]}>
         <Box $width={["100%", 510]} $textAlign={"left"}>

--- a/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads.tsx
@@ -12,7 +12,6 @@ import {
   OakBox,
 } from "@oaknational/oak-components";
 
-import Box from "@/components/SharedComponents/Box";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import getFormattedDetailsForTracking from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
 import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
@@ -240,15 +239,15 @@ function CurriculumDownloads(
   ]);
 
   return (
-    <Box
-      $maxWidth={1280}
+    <OakBox
+      $maxWidth="all-spacing-24"
       $mh={"auto"}
       $width={"100%"}
-      $ph={28}
-      $pb={80}
-      $pt={32}
+      $ph="inner-padding-xl"
+      $pb="inner-padding-xl8"
+      $pt="inner-padding-xl2"
     >
-      <Box $width="100%">
+      <OakBox $width="100%">
         <OakFlex
           $alignItems={"flex-start"}
           $flexDirection={"column"}
@@ -382,8 +381,8 @@ function CurriculumDownloads(
             </OakGrid>
           </form>
         </OakFlex>
-      </Box>
-    </Box>
+      </OakBox>
+    </OakBox>
   );
 }
 

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -5,6 +5,7 @@ import {
   OakP,
   OakFlex,
   OakHandDrawnCardWithIcon,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import CurriculumHeaderTabNav from "../CurriculumHeaderTabNav";
@@ -103,7 +104,12 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
     <Box $mb={40}>
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
       <Flex $background={color1} $pv={[20]}>
-        <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
+        <OakBox
+          $maxWidth="all-spacing-24"
+          $mh={"auto"}
+          $ph="inner-padding-l"
+          $width={"100%"}
+        >
           <Breadcrumbs
             breadcrumbs={[
               {
@@ -133,14 +139,23 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
             {...subjectPhaseOptions}
             currentSelection={currentSelection}
           />
-        </Box>
+        </OakBox>
       </Flex>
       <Box $background={color2}>
         {/* @todo replace with OakFlex - work out padding as max padding in oak-components is 24px */}
         <Flex $pb={[24, 24]} $pt={[20, 30]}>
-          <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
+          <OakBox
+            $maxWidth="all-spacing-24"
+            $mh={"auto"}
+            $ph="inner-padding-l"
+            $width={"100%"}
+          >
             <OakFlex>
-              <Box $minWidth={80} $mr={[12, 26]} $mv={"auto"}>
+              <OakBox
+                $minWidth="all-spacing-13"
+                $mr={["space-between-xs", "space-between-m"]}
+                $mv={"auto"}
+              >
                 <OakHandDrawnCardWithIcon
                   iconName={getValidSubjectIconName(subject.slug)}
                   fill={"mint50"}
@@ -151,7 +166,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
                   data-testid="subjectIcon"
                   alt=""
                 />
-              </Box>
+              </OakBox>
 
               <OakFlex
                 $rowGap={["all-spacing-2", "all-spacing-2"]}
@@ -175,10 +190,15 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
                 </OakHeading>
               </OakFlex>
             </OakFlex>
-          </Box>
+          </OakBox>
         </Flex>
         <Flex $borderColor="mint30" $bt={2}>
-          <Box $maxWidth={1280} $ph={[0, 20]} $mh={"auto"} $width={"100%"}>
+          <OakBox
+            $maxWidth="all-spacing-24"
+            $ph={["inner-padding-none", "inner-padding-l"]}
+            $mh={"auto"}
+            $width={"100%"}
+          >
             <CurriculumHeaderTabNav
               data-testid="tabularNav"
               label="Curriculum Selection"
@@ -187,7 +207,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
               $alignItems={"center"}
               $height={[60, 64]}
             />
-          </Box>
+          </OakBox>
         </Flex>
       </Box>
     </Box>

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -103,7 +103,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   return (
     <Box $mb={40}>
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
-      <Flex $background={color1} $pv={[20]}>
+      <Flex $background={color1} $pv={[18]}>
         <OakBox
           $maxWidth="all-spacing-24"
           $mh={"auto"}

--- a/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
@@ -8,7 +8,6 @@ import {
   OakBox,
 } from "@oaknational/oak-components";
 
-import Box from "@/components/SharedComponents/Box";
 import { TagFunctional } from "@/components/SharedComponents/TagFunctional";
 import { Lesson } from "@/components/CurriculumComponents/UnitModal/UnitModal";
 import CurriculumUnitDetailsAccordion from "@/components/CurriculumComponents/CurriculumUnitDetailsAccordion";
@@ -64,7 +63,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
       </OakP>
 
       {uniqueThreadsArray.length >= 1 && (
-        <Box $mb={[24, 32]}>
+        <OakBox $mb={["space-between-m", "space-between-m2"]}>
           <OakHeading tag="h3" $font={"heading-6"} $mb="space-between-ssx">
             Threads
           </OakHeading>
@@ -83,7 +82,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
               />
             ))}
           </OakFlex>
-        </Box>
+        </OakBox>
       )}
       <OakFlex $flexDirection={"column"}>
         {cycle === "2" && (

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -1,4 +1,4 @@
-import { OakP, OakSpan } from "@oaknational/oak-components";
+import { OakBox, OakP, OakSpan } from "@oaknational/oak-components";
 
 import { Fieldset, FieldsetLegend } from "../OakComponentsKitchen/Fieldset";
 import { RadioGroup, RadioButton } from "../OakComponentsKitchen/SimpleRadio";
@@ -7,7 +7,6 @@ import SkipLink from "../OakComponentsKitchen/SkipLink";
 import { CurriculumVisualiserFiltersProps } from "./CurriculumVisualiserFilters";
 import { highlightedUnitCount } from "./helpers";
 
-import Box from "@/components/SharedComponents/Box";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import { Thread } from "@/utils/curriculum/types";
 
@@ -46,7 +45,12 @@ export default function CurriculumVisualiserFiltersDesktop({
           value={selectedThread ?? ""}
         >
           <SkipLink href="#content">Skip to units</SkipLink>
-          <Box $mv={16} $pl={12} $bl={1} $borderColor="transparent">
+          <OakBox
+            $mv="space-between-s"
+            $pl="inner-padding-s"
+            $bl="border-solid-s"
+            $borderColor="transparent"
+          >
             <RadioButton
               aria-label={"None highlighted"}
               value={""}
@@ -54,7 +58,7 @@ export default function CurriculumVisualiserFiltersDesktop({
             >
               None highlighted
             </RadioButton>
-          </Box>
+          </OakBox>
           {threadOptions.map((threadOption) => {
             const isSelected = isSelectedThread(threadOption);
             const highlightedCount = highlightedUnitCount(
@@ -65,16 +69,16 @@ export default function CurriculumVisualiserFiltersDesktop({
             );
 
             return (
-              <Box
-                $ba={1}
+              <OakBox
+                $ba="border-solid-s"
                 $background={isSelected ? "black" : "white"}
                 $borderColor={isSelected ? "black" : "grey40"}
-                $borderRadius={4}
+                $borderRadius="border-radius-s"
                 $color={isSelected ? "white" : "black"}
                 $font={isSelected ? "heading-light-7" : "body-2"}
-                $ph={12}
-                $pt={12}
-                $mb={8}
+                $ph="inner-padding-s"
+                $pt="inner-padding-s"
+                $mb="space-between-ssx"
                 key={threadOption.slug}
               >
                 <RadioButton
@@ -98,7 +102,7 @@ export default function CurriculumVisualiserFiltersDesktop({
                     </OakSpan>
                   </OakSpan>
                 </RadioButton>
-              </Box>
+              </OakBox>
             );
           })}
         </RadioGroup>
@@ -117,7 +121,7 @@ export default function CurriculumVisualiserFiltersDesktop({
           value={selectedYear}
           onChange={(e) => onSelectYear(e.target.value)}
         >
-          <Box $mb={16}>
+          <OakBox $mb="space-between-s">
             <RadioButton
               aria-label="All year groups"
               value={""}
@@ -125,9 +129,9 @@ export default function CurriculumVisualiserFiltersDesktop({
             >
               All
             </RadioButton>
-          </Box>
+          </OakBox>
           {yearOptions.map((yearOption) => (
-            <Box key={yearOption} $mb={16}>
+            <OakBox key={yearOption} $mb="space-between-s">
               <RadioButton
                 value={yearOption}
                 data-testid={"year-radio"}
@@ -135,7 +139,7 @@ export default function CurriculumVisualiserFiltersDesktop({
               >
                 {getYearGroupTitle(yearData, yearOption)}
               </RadioButton>
-            </Box>
+            </OakBox>
           ))}
         </RadioGroup>
       </Fieldset>

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -289,7 +289,7 @@ function Modal({
     >
       <OakBox
         $position={"absolute"}
-        $top="all-spacing-6"
+        $top="all-spacing-5"
         $right="all-spacing-4"
         $zIndex={"in-front"}
       >

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { OakP, OakFlex, OakSpan } from "@oaknational/oak-components";
+import { OakP, OakFlex, OakSpan, OakBox } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import { Fieldset, FieldsetLegend } from "../OakComponentsKitchen/Fieldset";
@@ -162,19 +162,19 @@ function StickyBit({
   }
 
   return (
-    <Box
+    <OakBox
       $position={["sticky", "static"]}
       $display={["block", "none"]}
-      $top={0}
-      $zIndex={"fixedHeader"}
+      $top="all-spacing-0"
+      $zIndex={"fixed-header"}
     >
-      <Box
+      <OakBox
         $width={"100%"}
         $background={"white"}
-        $mb={8}
+        $mb="space-between-ssx"
         data-test-id="filter-mobiles"
       >
-        <Box>
+        <OakBox>
           <Box $dropShadow="mobileFilterSelector" $ph={[16, 0]} $pb={16}>
             <Button
               label="Highlight a thread"
@@ -197,11 +197,11 @@ function StickyBit({
                   {threadDef(selectedThread)?.title}
                 </Box>
                 <Box $mh={6}> • </Box>
-                <Box data-testid="highlighted-units-box-mobile">
+                <OakBox data-testid="highlighted-units-box-mobile">
                   <OakSpan aria-live="polite" aria-atomic="true">
                     {highlightedUnits} units highlighted
                   </OakSpan>
-                </Box>
+                </OakBox>
               </OakFlex>
             )}
           </Box>
@@ -245,9 +245,9 @@ function StickyBit({
               </StyledButtonGroup>
             </ScrollableWrapper>
           </Box>
-        </Box>
-      </Box>
-    </Box>
+        </OakBox>
+      </OakBox>
+    </OakBox>
   );
 }
 
@@ -279,15 +279,20 @@ function Modal({
   );
 
   return (
-    <Box
+    <OakBox
       $background={"white"}
       $position="fixed"
-      $top={0}
+      $top="all-spacing-0"
       $height={"100%"}
-      $zIndex={"modalDialog"}
+      $zIndex={"modal-dialog"}
       $display={["block", "none"]}
     >
-      <Box $position={"absolute"} $top={20} $right={16} $zIndex={"inFront"}>
+      <OakBox
+        $position={"absolute"}
+        $top="all-spacing-6"
+        $right="all-spacing-4"
+        $zIndex={"in-front"}
+      >
         <Button
           label=""
           aria-label="Close Menu"
@@ -297,7 +302,7 @@ function Modal({
           onClick={onOpenModal}
           aria-expanded={open}
         />
-      </Box>
+      </OakBox>
       <Fieldset
         $ml={16}
         $mt={32}
@@ -318,12 +323,12 @@ function Modal({
           value={selectedThread ?? ""}
           onChange={(e) => onSelectThread(e.target.value)}
         >
-          <Box>
-            <Box
-              $mv={16}
-              $pl={12}
+          <OakBox>
+            <OakBox
+              $mv="space-between-s"
+              $pl="inner-padding-s"
               $position={"relative"}
-              $bl={1}
+              $bl="border-solid-s"
               $borderColor="transparent"
             >
               <RadioButton
@@ -333,7 +338,7 @@ function Modal({
               >
                 None highlighted
               </RadioButton>
-            </Box>
+            </OakBox>
             {threadOptions.map((threadOption) => {
               const isSelectedMobile = isSelectedThread(threadOption);
               return (
@@ -376,7 +381,7 @@ function Modal({
                 </Box>
               );
             })}
-          </Box>
+          </OakBox>
         </RadioGroup>
       </Fieldset>
       <OakFlex
@@ -397,7 +402,7 @@ function Modal({
           onClick={onOpenModal}
         />
       </OakFlex>
-    </Box>
+    </OakBox>
   );
 }
 

--- a/src/components/CurriculumComponents/HomePageBanner/HomePageBanner.tsx
+++ b/src/components/CurriculumComponents/HomePageBanner/HomePageBanner.tsx
@@ -1,12 +1,11 @@
 import { FC } from "react";
-import { OakTypography } from "@oaknational/oak-components";
+import { OakBox, OakTypography } from "@oaknational/oak-components";
 
 import { OakColorName } from "@/styles/theme";
 import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly/";
 import { Hr } from "@/components/SharedComponents/Typography";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
 import Flex from "@/components/SharedComponents/Flex.deprecated";
-import Box from "@/components/SharedComponents/Box";
 import Tag from "@/components/SharedComponents/TagPromotional";
 import { ResolveOakHrefProps } from "@/common-lib/urls";
 
@@ -22,7 +21,7 @@ const HomePageBanner: FC<HomePageBannerProps> = ({
   ctaText,
   ...linkProps
 }) => (
-  <Box role="banner">
+  <OakBox role="banner">
     <Flex
       $background={background}
       $justifyContent={["center"]}
@@ -58,7 +57,7 @@ const HomePageBanner: FC<HomePageBannerProps> = ({
       </Flex>
     </Flex>
     <Hr $color={"black"} $background={"lemon"} thickness={4} $mb={0} $mt={0} />
-  </Box>
+  </OakBox>
 );
 
 export default HomePageBanner;

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -185,7 +185,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
 
   return (
     <>
-      <Box
+      <OakBox
         $minWidth={"100%"}
         style={{ marginTop: -40 }}
         $display={["block", "block", "none"]}
@@ -197,13 +197,13 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         >
           {contents}
         </OakBox>
-      </Box>
-      <Box
+      </OakBox>
+      <OakBox
         id="curriculum-overview"
         aria-labelledby="curriculum-overview-heading"
-        $maxWidth={1280}
+        $maxWidth="all-spacing-24"
         $mh={"auto"}
-        $ph={16}
+        $ph="inner-padding-m"
         $width={"100%"}
         role="region"
       >
@@ -217,15 +217,15 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
               Explainer
             </OakHeading>
           </ScreenReaderOnly>
-          <Box
-            $minWidth={300}
+          <OakBox
+            style={{ minWidth: 300 }}
             $position={["static", "static", "sticky"]}
-            $top={20}
-            $pb={40}
+            $top="all-spacing-5"
+            $pb="inner-padding-xl3"
             $display={["none", "none", "block"]}
           >
             {contents}
-          </Box>
+          </OakBox>
           <OakFlex
             $mb="space-between-ssx"
             $mt={["space-between-m", "space-between-m", "space-between-none"]}
@@ -311,7 +311,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
             </Flex>
           </OakFlex>
         )}
-      </Box>
+      </OakBox>
       <OakBox $background={"bg-decorative1-subdued"} $pv="inner-padding-xl4">
         <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
           <OakFlex

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect } from "react";
-import { OakHeading, OakFlex } from "@oaknational/oak-components";
+import { OakHeading, OakFlex, OakBox } from "@oaknational/oak-components";
 
 import BulletList from "../OakComponentsKitchen/BulletList";
 import CurriculumUnitCard from "../CurriculumUnitCard/CurriculumUnitCard";
@@ -91,8 +91,11 @@ const UnitModal: FC<UnitModalProps> = ({
           $overflowY={"scroll"}
           $mt="space-between-xxl"
         >
-          <Box $ph={[24, 72]}>
-            <Box $display={optionalityModalOpen ? "block" : "none"} $mb={16}>
+          <OakBox $ph={["inner-padding-xl", "inner-padding-xl7"]}>
+            <OakBox
+              $display={optionalityModalOpen ? "block" : "none"}
+              $mb="space-between-s"
+            >
               <Button
                 $mt={2}
                 icon="chevron-left"
@@ -108,7 +111,7 @@ const UnitModal: FC<UnitModalProps> = ({
                   setUnitVariantID(null);
                 }}
               />
-            </Box>
+            </OakBox>
             <OakFlex $gap="all-spacing-2" $flexWrap={"wrap"}>
               <BulletList
                 items={[subjectTitle, yearTitle]
@@ -122,7 +125,7 @@ const UnitModal: FC<UnitModalProps> = ({
                 : curriculumUnitDetails.unitTitle}
             </OakHeading>
             {!unitOptionsAvailable && (
-              <Box $display={optionalityModalOpen ? "none" : "block"}>
+              <OakBox $display={optionalityModalOpen ? "none" : "block"}>
                 <CurriculumUnitDetails
                   threads={unitData.threads}
                   cycle={unitData.cycle}
@@ -138,7 +141,7 @@ const UnitModal: FC<UnitModalProps> = ({
                   priorUnitTitle={unitData.connection_prior_unit_title}
                   futureUnitTitle={unitData.connection_future_unit_title}
                 />
-              </Box>
+              </OakBox>
             )}
 
             {/* @todo replace with OakFlex once display is fixed in OakFlex - currently display: flex overwrites "none" */}
@@ -224,11 +227,11 @@ const UnitModal: FC<UnitModalProps> = ({
             </Flex>
 
             {curriculumUnitDetails && (
-              <Box $display={optionalityModalOpen ? "block" : "none"}>
+              <OakBox $display={optionalityModalOpen ? "block" : "none"}>
                 <CurriculumUnitDetails {...curriculumUnitDetails} />
-              </Box>
+              </OakBox>
             )}
-          </Box>
+          </OakBox>
         </OakFlex>
       )}
     </>

--- a/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
+++ b/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, HTMLProps } from "react";
 import { Transition } from "react-transition-group";
 import { FocusOn } from "react-focus-on";
-import { OakFlex } from "@oaknational/oak-components";
+import { OakBox, OakFlex } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import Box from "@/components/SharedComponents/Box";
@@ -62,7 +62,7 @@ const UnitsTabSidebar: FC<ModalProps> = ({
   return (
     <Transition in={displayModal} timeout={300} unmountOnExit>
       {(state) => (
-        <Box $position={"absolute"} data-testid="sidebar-modal-wrapper">
+        <OakBox $position={"absolute"} data-testid="sidebar-modal-wrapper">
           <MenuBackdrop state={state} zIndex={"modalDialog"} />
           <FocusOn
             enabled={displayModal}
@@ -146,7 +146,7 @@ const UnitsTabSidebar: FC<ModalProps> = ({
               </OakFlex>
             </SideMenu>
           </FocusOn>
-        </Box>
+        </OakBox>
       )}
     </Transition>
   );


### PR DESCRIPTION
## Description
Easy updates for `<Box/>` to `<OakBox/>` in `./src/components/CurriculumComponents/`


## How to test
Regression test of curriculum pages

## Screenshots
Most of the updates are **no-ops** except for small changes to the padding in the curriculum header.  

How it used to look (delete if n/a):
<img width="876" alt="Screenshot 2025-01-13 at 11 27 20" src="https://github.com/user-attachments/assets/ca885c29-9bfd-49b6-be55-1a312cd4bcee" />

How it should now look:
<img width="876" alt="Screenshot 2025-01-13 at 11 27 33" src="https://github.com/user-attachments/assets/92769e40-31a4-4aa6-bf21-0ac0b6161ac8" />
