### PR TITLE
refactor: remove usage of deprecrated Flex component in PupilTab

### DIFF
--- a/src/components/GenericPagesComponents/PupilTab/PupilTab.tsx
+++ b/src/components/GenericPagesComponents/PupilTab/PupilTab.tsx
@@ -10,7 +10,6 @@ import {
 
 import ImageContainer from "@/components/GenericPagesComponents/ImageContainer";
 import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
-import Flex from "@/components/SharedComponents/Flex.deprecated";
 import MaxWidth from "@/components/SharedComponents/MaxWidth";
 
 const PupilTab: FC = () => {
@@ -19,13 +18,15 @@ const PupilTab: FC = () => {
       <MaxWidth $ph={[16]} $pb={24}>
         <OakGrid $cg={"all-spacing-4"}>
           <OakGridArea $colSpan={[12, 6]}>
-            <Flex
+            <OakFlex
               $flexDirection={"column"}
-              $maxWidth={[640]}
-              $pt={32}
+              $maxWidth={"all-spacing-22"}
+              $pt={"inner-padding-xl2"}
               $alignItems={"flex-start"}
-              $gap={24}
-              $flex={"0 1 auto"}
+              $gap={"space-between-m"}
+              $flexGrow={0}
+              $flexShrink={1}
+              $flexBasis={"auto"}
             >
               <OakHeading $font={"heading-7"} tag={"h1"} $color={"grey70"}>
                 Pupils
@@ -50,7 +51,7 @@ const PupilTab: FC = () => {
                 iconBackground="black"
                 $mb={24}
               />
-            </Flex>
+            </OakFlex>
           </OakGridArea>
           <OakGridArea $colSpan={[12, 6]} $alignItems={"flex-end"}>
             <ImageContainer imageSlug={"pupils-with-worksheet"}>


### PR DESCRIPTION
## Description

Music year: 2010

- Used OakFlex in place of Flex
- Spacing token values can be found here: https://www.notion.so/oaknationalacademy/It-s-not-you-it-s-me-15f26cc4e1b18033907ee9f91e71a5d9#17a26cc4e1b18005a20dd920c55a4f88
- Expanded flex shorthand into individual properties as OakFlex component does not support shorthand flex prop
  - Link to [OakFlex StoryBook](https://components.thenational.academy/?path=/docs/components-atoms-oakflex--docs)

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-3107--oak-web-application.netlify.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
