### PR TITLE
Easy to update `<Box/>` to `<OakBox>` in `./src/pages` 

### DIFF
--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -7,6 +7,7 @@ import {
 } from "next";
 import { useNextSanityImage } from "next-sanity-image";
 import { uniqBy } from "lodash/fp";
+import { OakBox } from "@oaknational/oak-components";
 
 import Layout from "@/components/AppComponents/Layout";
 import CMSClient from "@/node-lib/cms";
@@ -15,7 +16,6 @@ import {
   getFallbackBlockingConfig,
   shouldSkipInitialBuild,
 } from "@/node-lib/isr";
-import Box from "@/components/SharedComponents/Box";
 import { BlogJsonLd } from "@/browser-lib/seo/getJsonLd";
 import BlogPortableText from "@/components/GenericPagesComponents/PostPortableText/PostPortableText";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
@@ -70,9 +70,9 @@ const BlogSinglePage: NextPage<BlogSinglePageProps> = (props) => {
           "Blog",
         )}
       >
-        <Box $mt={[48]}>
+        <OakBox $mt="space-between-l">
           <BlogPortableText portableText={props.blog.contentPortableText} />
-        </Box>
+        </OakBox>
       </PostSingleLayout>
       <BlogJsonLd blog={props.blog} />
     </Layout>

--- a/src/pages/develop-your-curriculum.tsx
+++ b/src/pages/develop-your-curriculum.tsx
@@ -144,7 +144,7 @@ const Curriculum: NextPage<CurriculumPageProps> = ({ pageData }) => {
                   <BrushBorders hideOnMobileH color={"lemon50"} />
                   <OakBox
                     $display={["block", "none"]}
-                    $ph={["inner-padding-xl", "inner-padding-none"]}
+                    $ph={["inner-padding-m", "inner-padding-none"]}
                   >
                     <OakP
                       $mb={["space-between-m", "space-between-s"]}

--- a/src/pages/develop-your-curriculum.tsx
+++ b/src/pages/develop-your-curriculum.tsx
@@ -6,6 +6,7 @@ import {
   OakTypography,
   OakHeading,
   OakP,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import CMSClient from "@/node-lib/cms";
@@ -124,28 +125,34 @@ const Curriculum: NextPage<CurriculumPageProps> = ({ pageData }) => {
           >
             {elementsOfCurriculumDesignHeadings.map((heading, index) => (
               <OakGridArea key={`${index}-${heading}`} $colSpan={[12, 4]}>
-                <Box $ph={[16, 0]} $display={["none", "block"]}>
+                <OakBox
+                  $ph={["inner-padding-m", "inner-padding-none"]}
+                  $display={["none", "block"]}
+                >
                   <OakP
                     $mb={["space-between-m", "space-between-s"]}
                     $font={"heading-light-6"}
                   >
                     {heading}
                   </OakP>
-                </Box>
+                </OakBox>
               </OakGridArea>
             ))}
             {pageData.elements.posts.map((element, index) => (
               <Fragment key={`${index}-${element.title}`}>
                 <OakGridArea $colSpan={[12, 4]}>
                   <BrushBorders hideOnMobileH color={"lemon50"} />
-                  <Box $display={["block", "none"]} $ph={[16, 0]}>
+                  <OakBox
+                    $display={["block", "none"]}
+                    $ph={["inner-padding-xl", "inner-padding-none"]}
+                  >
                     <OakP
                       $mb={["space-between-m", "space-between-s"]}
                       $font={"heading-light-6"}
                     >
                       {elementsOfCurriculumDesignHeadings[index]}
                     </OakP>
-                  </Box>
+                  </OakBox>
                   <Card
                     $flexDirection={"column"}
                     $justifyContent={"center"}
@@ -156,19 +163,19 @@ const Curriculum: NextPage<CurriculumPageProps> = ({ pageData }) => {
                     $ph={[16, 24]}
                   >
                     <BoxBorders gapPosition="bottomRight" />
-                    <Box $mv={12}>
+                    <OakBox $mv="space-between-xs">
                       <OakHeading $font={"heading-7"} tag={"h5"}>
                         How to
-                        <Box $mt={8} $font={"heading-5"}>
+                        <OakBox $mt="space-between-ssx" $font={"heading-5"}>
                           <CardLink
                             page="blog-single"
                             blogSlug={element.post.slug}
                           >
                             {element.title}
                           </CardLink>
-                        </Box>
+                        </OakBox>
                       </OakHeading>
-                    </Box>
+                    </OakBox>
                   </Card>
                 </OakGridArea>
               </Fragment>

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -6,7 +6,11 @@ import {
 } from "next";
 import React from "react";
 import { useRouter } from "next/router";
-import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import {
+  OakBox,
+  OakThemeProvider,
+  oakDefaultTheme,
+} from "@oaknational/oak-components";
 import { uniq } from "lodash";
 
 import CMSClient from "@/node-lib/cms";
@@ -14,7 +18,6 @@ import CurriculumHeader from "@/components/CurriculumComponents/CurriculumHeader
 import OverviewTab from "@/components/CurriculumComponents/OverviewTab";
 import UnitsTab from "@/components/CurriculumComponents/UnitsTab";
 import AppLayout from "@/components/SharedComponents/AppLayout";
-import Box from "@/components/SharedComponents/Box";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import {
   decorateWithIsr,
@@ -141,7 +144,7 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
           color2="mint"
         />
 
-        <Box $background={"white"}>{tabContent}</Box>
+        <OakBox $background={"white"}>{tabContent}</OakBox>
       </AppLayout>
     </OakThemeProvider>
   );

--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -5,6 +5,7 @@ import {
   OakUL,
   OakLI,
   OakP,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
@@ -112,7 +113,7 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
               </Cover>
             </Box>
 
-            <Box $height={"100%"}>
+            <OakBox $height={"100%"}>
               <OakHeading
                 tag="h2"
                 $font={["heading-5", "heading-4"]}
@@ -155,7 +156,7 @@ const CurriculumHomePage: NextPage<CurriculumHomePageProps> = (props) => {
                   <Icon name={"chevron-right"} />
                 </OwaLink>
               </OakTypography>
-            </Box>
+            </OakBox>
           </Flex>
           <Flex
             $background={"grey20"}

--- a/src/pages/teachers/curriculum/previous-downloads.tsx
+++ b/src/pages/teachers/curriculum/previous-downloads.tsx
@@ -3,7 +3,7 @@ import assert from "assert";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { OakFlex, OakHeading, OakP } from "@oaknational/oak-components";
+import { OakBox, OakFlex, OakHeading, OakP } from "@oaknational/oak-components";
 
 import AppLayout from "@/components/SharedComponents/AppLayout";
 import Box from "@/components/SharedComponents/Box/Box";
@@ -107,7 +107,7 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
       }}
       $background={"white"}
     >
-      <Box $background={"mint"} $pt={[20]}>
+      <OakBox $background={"mint"} $pt="inner-padding-l">
         <Box
           $maxWidth={1280}
           $mh={"auto"}
@@ -156,7 +156,7 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
                 data-testid="icon"
               />
             </Box>
-            <Box $ml={32}>
+            <OakBox $ml="space-between-m2">
               <OakHeading
                 tag={"h1"}
                 $font={["heading-4", "heading-3"]}
@@ -172,12 +172,12 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
                   curriculum principles that underpin them.
                 </OakP>
               </Box>
-            </Box>
+            </OakBox>
           </OakFlex>
         </Box>
-      </Box>
+      </OakBox>
 
-      <Box $background={"mint30"}>
+      <OakBox $background={"mint30"}>
         <Box
           $display={["block", "none", "none"]}
           $maxWidth={1280}
@@ -221,7 +221,7 @@ const CurriculumPreviousDownloadsPage: NextPage = () => {
             data-testid="tabularNav"
           />
         </Box>
-      </Box>
+      </OakBox>
 
       <CurriculumDownloads
         category={activeTab}

--- a/src/pages/webinars/[webinarSlug].tsx
+++ b/src/pages/webinars/[webinarSlug].tsx
@@ -6,14 +6,13 @@ import {
 } from "next";
 import { useEffect } from "react";
 import { uniqBy } from "lodash/fp";
-import { OakFlex } from "@oaknational/oak-components";
+import { OakBox, OakFlex } from "@oaknational/oak-components";
 
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import Layout from "@/components/AppComponents/Layout";
 import CMSClient from "@/node-lib/cms";
 import { TeamMemberPreview, Webinar } from "@/common-lib/cms-types";
 import { getBlogWebinarPostBreadcrumbs } from "@/components/SharedComponents/Breadcrumbs/getBreadcrumbs";
-import Box from "@/components/SharedComponents/Box";
 import {
   getFallbackBlockingConfig,
   shouldSkipInitialBuild,
@@ -73,9 +72,9 @@ const WebinarSinglePage: NextPage<WebinarSinglePageProps> = (props) => {
         <OakFlex $position={"relative"} $mt="space-between-xl">
           <WebinarVideo webinar={webinar} />
         </OakFlex>
-        <Box $mt={[48]}>
+        <OakBox $mt="space-between-l">
           <BlogPortableText portableText={webinar.summaryPortableText} />
-        </Box>
+        </OakBox>
       </PostSingleLayout>
       <BlogJsonLd blog={props.webinar} />
     </Layout>


### PR DESCRIPTION
## Description
No-op updates for `<Box/>` to `<OakBox>` in `./src/pages` 

## How to test
Regression test

 - `/blog/[slug]`
 - `/develop-your-curriculum` (~looks like this only exists locally and has a redirect on production, see <https://www.thenational.academy/develop-your-curriculum>~ created a ticket in curric squad to remove this page)
 - `/teachers/curriculum/[subjectPhaseSlug]/[tab]`
 - `/teachers/curriculum/previous-downloads`
 - `/webinars/[webinarSlug]`
