### PR TITLE
More awkward to update `<Box/>` to `<OakBox/>` in curriculum components

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -6,18 +6,17 @@ import {
   OakFlex,
   OakHandDrawnCardWithIcon,
   OakBox,
+  OakColorToken,
 } from "@oaknational/oak-components";
 
 import CurriculumHeaderTabNav from "../CurriculumHeaderTabNav";
 
-import Box from "@/components/SharedComponents/Box";
 import Flex from "@/components/SharedComponents/Flex.deprecated";
 import { Hr } from "@/components/SharedComponents/Typography";
 import Breadcrumbs from "@/components/SharedComponents/Breadcrumbs/Breadcrumbs";
 import SubjectPhasePicker, {
   SubjectPhasePickerData,
 } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
-import { OakColorName } from "@/styles/theme/types";
 import { ButtonAsLinkProps } from "@/components/SharedComponents/Button/ButtonAsLink";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
@@ -27,8 +26,8 @@ export type CurriculumHeaderPageProps = {
   subjectPhaseOptions: SubjectPhasePickerData;
   curriculumSelectionSlugs: CurriculumSelectionSlugs;
   keyStages: string[];
-  color1?: OakColorName;
-  color2?: OakColorName;
+  color1?: OakColorToken;
+  color2?: OakColorToken;
 };
 
 const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
@@ -101,9 +100,9 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   ];
 
   return (
-    <Box $mb={40}>
+    <OakBox $mb="space-between-l">
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
-      <Flex $background={color1} $pv={[18]}>
+      <OakFlex $background={color1} $pv="inner-padding-l">
         <OakBox
           $maxWidth="all-spacing-24"
           $mh={"auto"}
@@ -140,8 +139,8 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
             currentSelection={currentSelection}
           />
         </OakBox>
-      </Flex>
-      <Box $background={color2}>
+      </OakFlex>
+      <OakBox $background={color2}>
         {/* @todo replace with OakFlex - work out padding as max padding in oak-components is 24px */}
         <Flex $pb={[24, 24]} $pt={[20, 30]}>
           <OakBox
@@ -209,8 +208,8 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
             />
           </OakBox>
         </Flex>
-      </Box>
-    </Box>
+      </OakBox>
+    </OakBox>
   );
 };
 export default CurriculumHeader;

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -175,7 +175,12 @@ function StickyBit({
         data-test-id="filter-mobiles"
       >
         <OakBox>
-          <Box $dropShadow="mobileFilterSelector" $ph={[16, 0]} $pb={16}>
+          <OakBox
+            $bb={"border-solid-s"}
+            $borderColor={"grey30"}
+            $ph={["inner-padding-m", "inner-padding-none"]}
+            $pb={"inner-padding-m"}
+          >
             <Button
               label="Highlight a thread"
               icon="chevron-right"
@@ -196,7 +201,7 @@ function StickyBit({
                 >
                   {threadDef(selectedThread)?.title}
                 </Box>
-                <Box $mh={6}> • </Box>
+                <OakBox $mh="space-between-ssx"> • </OakBox>
                 <OakBox data-testid="highlighted-units-box-mobile">
                   <OakSpan aria-live="polite" aria-atomic="true">
                     {highlightedUnits} units highlighted
@@ -204,17 +209,21 @@ function StickyBit({
                 </OakBox>
               </OakFlex>
             )}
-          </Box>
-          <Box
-            $pt={2}
-            $dropShadow="mobileFilterSelector"
+          </OakBox>
+          <OakBox
+            $bb={"border-solid-s"}
+            $borderColor={"grey30"}
             $width={"100%"}
             data-testid={"year-selection-mobile"}
           >
             <ScrollableWrapper>
               <StyledButtonGroup aria-label="Select a year group">
                 {yearOptions.map((yearOption) => (
-                  <Box key={yearOption} $pt={8} $ml={5}>
+                  <OakBox
+                    key={yearOption}
+                    $pt="inner-padding-xs"
+                    $ml="space-between-sssx"
+                  >
                     <FocusIndicator
                       data-testid="year-group-focus-indicator"
                       $display={"inline-block"}
@@ -240,11 +249,11 @@ function StickyBit({
                         {getYearGroupTitle(yearData, yearOption)}
                       </StyledButton>
                     </FocusIndicator>
-                  </Box>
+                  </OakBox>
                 ))}
               </StyledButtonGroup>
             </ScrollableWrapper>
-          </Box>
+          </OakBox>
         </OakBox>
       </OakBox>
     </OakBox>

--- a/src/components/CurriculumComponents/OakComponentsKitchen/AcceptTerms/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/AcceptTerms/index.tsx
@@ -1,16 +1,15 @@
 import {
+  OakBox,
   OakCheckBox,
   OakFieldError,
   OakFlex,
 } from "@oaknational/oak-components";
 
-import Box from "@/components/SharedComponents/Box";
 import BrushBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BrushBorders";
 
 /*
  * Waiting for the following components to be in oak-components
  *
- *  - <Box />
  *  - <BrushBorders />
  */
 type AcceptTermsProps = {
@@ -35,7 +34,12 @@ export default function AcceptTerms({
           <OakFieldError>{error}</OakFieldError>
         </div>
       )}
-      <Box $position={"relative"} $background={"grey20"} $pv={6} $ph={6}>
+      <OakBox
+        $position={"relative"}
+        $background={"grey20"}
+        $pv="inner-padding-xs"
+        $ph="inner-padding-xs"
+      >
         <BrushBorders hideOnMobileH hideOnMobileV color={"grey20"} />
         <OakCheckBox
           displayValue={"I accept terms and conditions (required)"}
@@ -46,7 +50,7 @@ export default function AcceptTerms({
           data-testid="download-accept-terms"
           name={"accept-terms"}
         />
-      </Box>
+      </OakBox>
     </OakFlex>
   );
 }

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -313,7 +313,12 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
         )}
       </OakBox>
       <OakBox $background={"bg-decorative1-subdued"} $pv="inner-padding-xl4">
-        <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>
+        <OakBox
+          $maxWidth="all-spacing-24"
+          $mh={"auto"}
+          $ph="inner-padding-l"
+          $width={"100%"}
+        >
           <OakFlex
             $gap={["space-between-m", "space-between-m2"]}
             $flexDirection={"column"}
@@ -388,7 +393,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
               )}
             </OakFlex>
           </OakFlex>
-        </Box>
+        </OakBox>
       </OakBox>
     </>
   );

--- a/src/components/CurriculumComponents/SuccessMessage/index.tsx
+++ b/src/components/CurriculumComponents/SuccessMessage/index.tsx
@@ -4,6 +4,7 @@ import {
   OakHeading,
   OakP,
   OakIcon,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import Box from "@/components/SharedComponents/Box";
@@ -20,7 +21,13 @@ const SuccessMessage: FC<SuccessMessageProps> = ({
   buttonProps,
 }) => {
   return (
-    <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"} $pb={[32, 48]}>
+    <OakBox
+      $maxWidth="all-spacing-24"
+      $mh={"auto"}
+      $ph="inner-padding-l"
+      $width={"100%"}
+      $pb={["inner-padding-xl2", "inner-padding-xl4"]}
+    >
       <OakFlex
         $width={"100%"}
         $flexDirection={["column", "row", "row"]}
@@ -63,7 +70,7 @@ const SuccessMessage: FC<SuccessMessageProps> = ({
           <OakP $font={["body-1"]}>{message}</OakP>
         </OakFlex>
       </OakFlex>
-    </Box>
+    </OakBox>
   );
 };
 

--- a/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
+++ b/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
@@ -4,7 +4,6 @@ import { FocusOn } from "react-focus-on";
 import { OakBox, OakFlex } from "@oaknational/oak-components";
 import styled from "styled-components";
 
-import Box from "@/components/SharedComponents/Box";
 import { SideMenu } from "@/components/AppComponents/AppHeaderMenu";
 import MenuBackdrop from "@/components/AppComponents/MenuBackdrop";
 import IconButton from "@/components/SharedComponents/Button/IconButton";
@@ -83,7 +82,11 @@ const UnitsTabSidebar: FC<ModalProps> = ({
               $overflowY={"scroll"}
             >
               <OakFlex $flexDirection={"column"} $minWidth={"100%"}>
-                <Box $position={"fixed"} $top={20} $right={16}>
+                <OakBox
+                  $position={"fixed"}
+                  $top="all-spacing-5"
+                  $right="all-spacing-4"
+                >
                   <IconButtonFocusVisible
                     aria-label="Close Menu"
                     icon={"cross"}
@@ -93,7 +96,7 @@ const UnitsTabSidebar: FC<ModalProps> = ({
                     data-testid="close-button"
                     aria-expanded={displayModal}
                   />
-                </Box>
+                </OakBox>
                 <OakFlex $overflowY={"auto"} $flexGrow={1}>
                   {children}
                 </OakFlex>

--- a/src/styles/utils/dropShadow.ts
+++ b/src/styles/utils/dropShadow.ts
@@ -9,7 +9,6 @@ type DropShadowVariant =
   | "subjectCardHover"
   | "subjectCard"
   | "expandableContainerHover"
-  | "mobileFilterSelector"
   | "none";
 export type DropShadowProps = {
   $dropShadow?: DropShadowVariant;
@@ -21,7 +20,6 @@ export const DROP_SHADOW: Record<DropShadowVariant, string> = {
   subjectCardHover: "0px 8px 0px 0px rgba(0, 0, 0, 1)",
   subjectCard: "0px 0px 0px 0px rgba(0, 0, 0, 0)",
   expandableContainerHover: "inset 0px -8px 0px 0px rgba(0, 0, 0, 1)",
-  mobileFilterSelector: "0px 1px 0px 0px rgba(170, 170, 170, 0.50)",
   none: "none",
 };
 const parseDropShadow = (variant?: DropShadowVariant | null) => {


### PR DESCRIPTION
## Description
Update curriculum components to use `<OakBox/>` rather than `<Box/>`

## How to test
See screenshot below for changes

## Screenshots
Increased size either side of bullet in "highlight a thread" also the "Units that make up" get pushed down a little `40px` to `48px` (before/after)
<img width="350" alt="Screenshot 2025-01-13 at 13 21 33" src="https://github.com/user-attachments/assets/67f8f2ba-4bd2-4dc7-9f2b-95cd2d4d6cdd" /> <img width="350" alt="Screenshot 2025-01-13 at 13 22 03" src="https://github.com/user-attachments/assets/7fe8843b-38d7-4caf-9f7f-8a3672941cb0" /> 

Overview pages pushed down slightly in `/teachers/curriculum/art-primary/overview`  (before/after)
<img width="313" alt="Screenshot 2025-01-13 at 13 27 46" src="https://github.com/user-attachments/assets/191e6c41-2d0c-4617-af47-6bc7a1c583f1" /> <img width="313" alt="Screenshot 2025-01-13 at 13 27 34" src="https://github.com/user-attachments/assets/05759c72-332b-417d-8847-6f98124af664" />


Success message padding slightly changes (before/after)

<img width="365" alt="Screenshot 2025-01-13 at 13 30 13" src="https://github.com/user-attachments/assets/790f61c4-2964-407a-a6fe-34bcb7c0a553" />
<img width="365" alt="Screenshot 2025-01-13 at 13 29 57" src="https://github.com/user-attachments/assets/b36e80cc-30e7-41fc-87c0-0ca2f036bdee" />

Very minor pixel change to the "year 1", "year 2", "year 3" header over in

 <img width="348" alt="Screenshot 2025-01-13 at 13 33 27" src="https://github.com/user-attachments/assets/a62c2424-7f96-4a53-8b7c-e19d00a47183" /> <img width="348" alt="Screenshot 2025-01-13 at 13 33 40" src="https://github.com/user-attachments/assets/f3ae471f-18b2-41ef-8b66-5e212bcbcdf1" />

