### PR TITLE
fix: update simple Flex to OakFlex on teacher and onboarding pages

### DIFF
--- a/src/components/TeacherComponents/ResourcePageSearchComboBox/ResourcePageSearchComboBox.tsx
+++ b/src/components/TeacherComponents/ResourcePageSearchComboBox/ResourcePageSearchComboBox.tsx
@@ -5,7 +5,7 @@ import {
 } from "@react-stately/combobox";
 import { useFilter } from "@react-aria/i18n";
 import { useComboBox } from "react-aria";
-import { OakSpan } from "@oaknational/oak-components";
+import { OakFlex, OakSpan } from "@oaknational/oak-components";
 
 import { Popover } from "@/components/SharedComponents/Popover";
 import { ListBox } from "@/components/SharedComponents/ListBox";
@@ -16,7 +16,6 @@ import {
 import { DropdownFocusUnderline } from "@/components/GenericPagesComponents/Select/Select";
 import { School } from "@/components/TeacherComponents/ResourcePageSchoolPicker";
 import { OakColorName } from "@/styles/theme/types";
-import Flex from "@/components/SharedComponents/Flex.deprecated";
 import BoxBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BoxBorders";
 
 // Reuse the ListBox and Popover from your component library. See below for details.
@@ -70,10 +69,10 @@ const ResourcePageSearchComboBox = <T extends School>(
   }
 
   return (
-    <Flex $width={"100%"} $position={"relative"} $display={"inline-block"}>
-      <Flex $width={"100%"} $position={"relative"}>
+    <OakFlex $width={"100%"} $position={"relative"} $display={"inline-block"}>
+      <OakFlex $width={"100%"} $position={"relative"}>
         <BoxBorders gapPosition="rightTop" />
-        <Flex $position={"absolute"}>
+        <OakFlex $position={"absolute"}>
           <RotatedInputLabel
             {...labelProps}
             aria-hidden="true"
@@ -92,7 +91,7 @@ const ResourcePageSearchComboBox = <T extends School>(
               props.label
             )}
           </RotatedInputLabel>
-        </Flex>
+        </OakFlex>
 
         <StyledInput
           {...inputProps}
@@ -116,7 +115,7 @@ const ResourcePageSearchComboBox = <T extends School>(
           name={"underline-1"}
           $font={"body-3"}
         />
-      </Flex>
+      </OakFlex>
 
       {state.isOpen && (
         <Popover
@@ -128,7 +127,7 @@ const ResourcePageSearchComboBox = <T extends School>(
           <ListBox {...listBoxProps} listBoxRef={listBoxRef} state={state} />
         </Popover>
       )}
-    </Flex>
+    </OakFlex>
   );
 };
 

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/node-lib/isr";
 import type { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
 import AppLayout from "@/components/SharedComponents/AppLayout";
-import Flex from "@/components/SharedComponents/Flex.deprecated";
 import MaxWidth from "@/components/SharedComponents/MaxWidth";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import usePagination from "@/components/SharedComponents/Pagination/usePagination";
@@ -342,11 +341,15 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                 >
                   {tiers.length === 0 && currentPageItems.length >= 1 && (
                     <>
-                      <Flex $minWidth={120} $mb={16} $position={"relative"}>
+                      <OakFlex
+                        $minWidth={"all-spacing-16"}
+                        $mb={"space-between-s"}
+                        $position={"relative"}
+                      >
                         <OakHeading $font={"heading-5"} tag={"h2"}>
                           {`Units (${filteredUnits.length})`}
                         </OakHeading>
-                      </Flex>
+                      </OakFlex>
                       {isFiltersAvailable && (
                         <OakBox $display={["auto", "auto", "none"]}>
                           <MobileUnitFilters


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Remove Flex and use OakFlex in ResourcePageSearchComboBox and units

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
