### PR TITLE
Revert `@prettier/plugin-xml` to fix linting of embedded XML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "@next/env": "^14.2.20",
         "@next/eslint-plugin-next": "^14.2.20",
         "@percy/cli": "v1.30.2",
-        "@prettier/plugin-xml": "3.4.1",
+        "@prettier/plugin-xml": "3.2.2",
         "@sanity/client": "^6.24.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
@@ -7737,10 +7737,11 @@
       }
     },
     "node_modules/@prettier/plugin-xml": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.1.tgz",
-      "integrity": "sha512-Uf/6/+9ez6z/IvZErgobZ2G9n1ybxF5BhCd7eMcKqfoWuOzzNUxBipNo3QAP8kRC1VD18TIo84no7LhqtyDcTg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.2.2.tgz",
+      "integrity": "sha512-SoE70SQF1AKIvK7LVK80JcdAe6wrDcbodFFjcoqb1FkOqV0G0oSlgAFDwoRXPqkUE5p/YF2nGsnUbnfm6471sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@xml-tools/parser": "^1.0.11"
       },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@next/env": "^14.2.20",
     "@next/eslint-plugin-next": "^14.2.20",
     "@percy/cli": "v1.30.2",
-    "@prettier/plugin-xml": "3.4.1",
+    "@prettier/plugin-xml": "3.2.2",
     "@sanity/client": "^6.24.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",

--- a/src/pages-helpers/curriculum/docx/builder/10_threadsDetail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/10_threadsDetail.ts
@@ -19,34 +19,36 @@ function renderUnits(units: Unit[], numbering: { unitNumbering: string }) {
     ${units
       .map(
         (unit) => safeXml`
-      <w:p>
-        <w:pPr>
-          <w:numPr>
-            <w:ilvl w:val="0" />
-            <w:numId w:val="${numbering.unitNumbering}" />
-          </w:numPr>
-          <w:spacing w:line="276" w:lineRule="auto" />
-          <w:ind w:left="425" w:right="-17" w:hanging="360" />
-        </w:pPr>
-        <w:r>
-          <w:rPr>
-            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-            <w:b />
-            <w:color w:val="222222" />
-            <w:sz w:val="24" />
-          </w:rPr>
-          <w:t xml:space="preserve">${cdata(`Unit ${unit.order + 1}, `)}</w:t>
-        </w:r>
-        <w:r>
-          <w:rPr>
-            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-            <w:color w:val="222222" />
-            <w:sz w:val="24" />
-          </w:rPr>
-          <w:t>${cdata(`'${unit.title}'`)}</w:t>
-        </w:r>
-      </w:p>
-    `,
+          <w:p>
+            <w:pPr>
+              <w:numPr>
+                <w:ilvl w:val="0" />
+                <w:numId w:val="${numbering.unitNumbering}" />
+              </w:numPr>
+              <w:spacing w:line="276" w:lineRule="auto" />
+              <w:ind w:left="425" w:right="-17" w:hanging="360" />
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+              </w:rPr>
+              <w:t xml:space="preserve">${cdata(
+                  `Unit ${unit.order + 1}, `,
+                )}</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+              </w:rPr>
+              <w:t>${cdata(`'${unit.title}'`)}</w:t>
+            </w:r>
+          </w:p>
+        `,
       )
       .join("")}
   `;
@@ -91,37 +93,39 @@ export default async function generate(
     const isLast = threadIndex === allThreadOptions.length - 1;
 
     const threadTitle = safeXml`
-      <w:p>
-        <w:pPr>
-          <w:pStyle w:val="Heading3" />
-        </w:pPr>
-        <w:r>
-          <w:rPr>
-            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-            <w:color w:val="222222" />
-            <w:sz w:val="36" />
-          </w:rPr>
-          <w:t xml:space="preserve">${cdata(`Thread, `)}</w:t>
-        </w:r>
-        <w:r>
-          <w:rPr>
-            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-            <w:b />
-            <w:color w:val="222222" />
-            <w:sz w:val="36" />
-          </w:rPr>
-          <w:t>${cdata(`'${thread.title}'`)}</w:t>
-        </w:r>
-      </w:p>
-      <w:p>
-        <w:r>
-          <w:rPr>
-            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-            <w:sz w:val="24" />
-          </w:rPr>
-          <w:t xml:space="preserve"> </w:t>
-        </w:r>
-      </w:p>
+      <XML_FRAGMENT>
+        <w:p>
+          <w:pPr>
+            <w:pStyle w:val="Heading3" />
+          </w:pPr>
+          <w:r>
+            <w:rPr>
+              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+              <w:color w:val="222222" />
+              <w:sz w:val="36" />
+            </w:rPr>
+            <w:t xml:space="preserve">${cdata(`Thread, `)}</w:t>
+          </w:r>
+          <w:r>
+            <w:rPr>
+              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+              <w:b />
+              <w:color w:val="222222" />
+              <w:sz w:val="36" />
+            </w:rPr>
+            <w:t>${cdata(`'${thread.title}'`)}</w:t>
+          </w:r>
+        </w:p>
+        <w:p>
+          <w:r>
+            <w:rPr>
+              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+              <w:sz w:val="24" />
+            </w:rPr>
+            <w:t xml:space="preserve"> </w:t>
+          </w:r>
+        </w:p>
+      </XML_FRAGMENT>
     `;
 
     let contentElements: string[];
@@ -146,6 +150,7 @@ export default async function generate(
         .map(([year, units]) => {
           const yearTitle = getYearGroupTitle(yearData, year);
           return safeXml`
+            <XML_FRAGMENT>
               <w:p>
                 <w:pPr>
                   <w:pStyle w:val="Heading4" />
@@ -170,7 +175,8 @@ export default async function generate(
                   <w:t />
                 </w:r>
               </w:p>
-            `;
+            </XML_FRAGMENT>
+          `;
         })
         .join("");
     });
@@ -234,31 +240,41 @@ export default async function generate(
                   .map(([year, units]) => {
                     const yearTitle = getYearGroupTitle(yearData, year);
                     return safeXml`
-                      <w:p>
-                        <w:pPr>
-                          <w:pStyle w:val="Heading5" />
-                        </w:pPr>
-                        <w:r>
-                          <w:rPr>
-                            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-                            <w:b />
-                            <w:i w:val="0" />
-                            <w:color w:val="222222" />
-                            <w:sz w:val="24" />
-                          </w:rPr>
-                          <w:t>${cdata(yearTitle)}</w:t>
-                        </w:r>
-                      </w:p>
-                      ${renderUnits(sortByOrder(units), numbering)}
-                      <w:p>
-                        <w:r>
-                          <w:rPr>
-                            <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-                            <w:sz w:val="24" />
-                          </w:rPr>
-                          <w:t />
-                        </w:r>
-                      </w:p>
+                      <XML_FRAGMENT>
+                        <w:p>
+                          <w:pPr>
+                            <w:pStyle w:val="Heading5" />
+                          </w:pPr>
+                          <w:r>
+                            <w:rPr>
+                              <w:rFonts
+                                w:ascii="Arial"
+                                w:hAnsi="Arial"
+                                w:cs="Arial"
+                              />
+                              <w:b />
+                              <w:i w:val="0" />
+                              <w:color w:val="222222" />
+                              <w:sz w:val="24" />
+                            </w:rPr>
+                            <w:t>${cdata(yearTitle)}</w:t>
+                          </w:r>
+                        </w:p>
+                        ${renderUnits(sortByOrder(units), numbering)}
+                        <w:p>
+                          <w:r>
+                            <w:rPr>
+                              <w:rFonts
+                                w:ascii="Arial"
+                                w:hAnsi="Arial"
+                                w:cs="Arial"
+                              />
+                              <w:sz w:val="24" />
+                            </w:rPr>
+                            <w:t />
+                          </w:r>
+                        </w:p>
+                      </XML_FRAGMENT>
                     `;
                   })
                   .join("")}
@@ -273,17 +289,15 @@ export default async function generate(
       <XML_FRAGMENT>
         ${threadTitle}
         ${contentElements.join("")}
-        ${
-          !isLast
-            ? safeXml`
+        ${!isLast
+          ? safeXml`
               <w:p>
                 <w:r>
                   <w:br w:type="page" />
                 </w:r>
               </w:p>
             `
-            : ""
-        }
+          : ""}
       </XML_FRAGMENT>
     `;
   });

--- a/src/pages-helpers/curriculum/docx/builder/11_backCover.ts
+++ b/src/pages-helpers/curriculum/docx/builder/11_backCover.ts
@@ -187,31 +187,31 @@ export default async function generate(
         ${wrapInLinkTo(
           links.ogl,
           safeXml`
-          <w:r>
-            <w:rPr>
-              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-              <w:b />
-              <w:color w:val="222222" />
-              <w:sz w:val="24" />
-              <w:u w:val="single" />
-            </w:rPr>
-            <w:t>Open Government Licence v3.0</w:t>
-          </w:r>
-          <w:r>
-            <w:rPr>
-              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-              <w:b />
-              <w:color w:val="222222" />
-              <w:sz w:val="24" />
-              <w:u w:val="none" />
-            </w:rPr>
-            ${createImage(images.jumpOutArrow, {
-              width: cmToEmu(0.41),
-              height: cmToEmu(0.35),
-              isDecorative: true,
-            })}
-          </w:r>
-        `,
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+                <w:u w:val="single" />
+              </w:rPr>
+              <w:t>Open Government Licence v3.0</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+                <w:u w:val="none" />
+              </w:rPr>
+              ${createImage(images.jumpOutArrow, {
+                width: cmToEmu(0.41),
+                height: cmToEmu(0.35),
+                isDecorative: true,
+              })}
+            </w:r>
+          `,
         )}
         <w:r>
           <w:rPr>
@@ -224,31 +224,31 @@ export default async function generate(
         ${wrapInLinkTo(
           links.terms,
           safeXml`
-          <w:r>
-            <w:rPr>
-              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-              <w:b />
-              <w:color w:val="222222" />
-              <w:sz w:val="24" />
-              <w:u w:val="single" />
-            </w:rPr>
-            <w:t>Oak terms and conditions</w:t>
-          </w:r>
-          <w:r>
-            <w:rPr>
-              <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-              <w:b />
-              <w:color w:val="222222" />
-              <w:sz w:val="24" />
-              <w:u w:val="none" />
-            </w:rPr>
-            ${createImage(images.jumpOutArrow, {
-              width: cmToEmu(0.41),
-              height: cmToEmu(0.35),
-              isDecorative: true,
-            })}
-          </w:r>
-        `,
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+                <w:u w:val="single" />
+              </w:rPr>
+              <w:t>Oak terms and conditions</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="24" />
+                <w:u w:val="none" />
+              </w:rPr>
+              ${createImage(images.jumpOutArrow, {
+                width: cmToEmu(0.41),
+                height: cmToEmu(0.35),
+                isDecorative: true,
+              })}
+            </w:r>
+          `,
         )}
         <w:r>
           <w:rPr>

--- a/src/pages-helpers/curriculum/docx/builder/4_threadsExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/4_threadsExplainer.ts
@@ -289,11 +289,7 @@ export default async function generate(
               </w:pPr>
               <w:r>
                 <w:rPr>
-                  <w:rFonts
-                    w:ascii="Arial"
-                    w:hAnsi="Arial"
-                    w:cs="Arial"
-                  />
+                  <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
                   <w:color w:val="222222" />
                   <w:sz w:val="24" />
                 </w:rPr>

--- a/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
+++ b/src/pages-helpers/curriculum/docx/builder/5_subjectExplainer.ts
@@ -378,34 +378,34 @@ export default async function generate(
   );
 
   const pageXml = safeXml`
-      <root>
-        <w:p>
-          <w:pPr>
-            <w:pStyle w:val="Heading2" />
-          </w:pPr>
-          ${wrapInBookmarkPoint(
-            "section_curriculum_overview",
-            safeXml`
-              <w:r>
-                <w:rPr>
-                  <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-                  <w:b />
-                  <w:color w:val="222222" />
-                  <w:sz w:val="56" />
-                </w:rPr>
-                <w:t>${cdata(`${data.subjectTitle} curriculum explainer`)}</w:t>
-              </w:r>
-            `,
-          )}
-        </w:p>
-        <w:p />
-        <w:p />
-        ${explainerXml}
+    <root>
+      <w:p>
+        <w:pPr>
+          <w:pStyle w:val="Heading2" />
+        </w:pPr>
+        ${wrapInBookmarkPoint(
+          "section_curriculum_overview",
+          safeXml`
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="56" />
+              </w:rPr>
+              <w:t>${cdata(`${data.subjectTitle} curriculum explainer`)}</w:t>
+            </w:r>
+          `,
+        )}
+      </w:p>
+      <w:p />
+      <w:p />
+      ${explainerXml}
         ${Array(4)
-          .fill(true)
-          .map(() => safeXml`<w:p />`)}
-      </root>
-    `;
+        .fill(true)
+        .map(() => safeXml`<w:p />`)}
+    </root>
+  `;
 
   await appendBodyElements(zip, xmlElementToJson(pageXml)?.elements);
 }

--- a/src/pages-helpers/curriculum/docx/builder/8_units/8_units.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/8_units.ts
@@ -184,8 +184,8 @@ function buildOptions({
               <w:rtl w:val="0" />
             </w:rPr>
             <w:t xml:space="preserve">${cdata(
-              unitOptions.length,
-            )} unit option${cdata(unitOptions.length > 1 ? "s" : "")}</w:t>
+                unitOptions.length,
+              )} unit option${cdata(unitOptions.length > 1 ? "s" : "")}</w:t>
           </w:r>
         </w:p>
       </XML_FRAGMENT>
@@ -201,17 +201,13 @@ function buildEmpty(columnIndex: number) {
         <w:tcW w:type="pct" w:w="33.333333333333336%" />
         <w:tcBorders>
           <w:top w:val="single" w:color="FFFFFF" w:sz="48" />
-          ${
-            columnIndex > 0
-              ? `<w:left w:val="single" w:color="FFFFFF" w:sz="48"/>`
-              : ""
-          }
+          ${columnIndex > 0
+            ? `<w:left w:val="single" w:color="FFFFFF" w:sz="48"/>`
+            : ""}
           <w:bottom w:val="single" w:color="FFFFFF" w:sz="48" />
-          ${
-            columnIndex < 2
-              ? `<w:right w:val="single" w:color="FFFFFF" w:sz="48"/>`
-              : ""
-          }
+          ${columnIndex < 2
+            ? `<w:right w:val="single" w:color="FFFFFF" w:sz="48"/>`
+            : ""}
         </w:tcBorders>
         <w:shd w:val="solid" w:color="FFFFFF" w:fill="FFFFFF" />
         <w:tcMar>
@@ -243,17 +239,13 @@ function buildYearColumn({
         <w:tcW w:type="pct" w:w="33.333333333333336%" />
         <w:tcBorders>
           <w:top w:val="single" w:color="FFFFFF" w:sz="48" />
-          ${
-            columnIndex > 0
-              ? `<w:left w:val="single" w:color="FFFFFF" w:sz="48"/>`
-              : ""
-          }
+          ${columnIndex > 0
+            ? `<w:left w:val="single" w:color="FFFFFF" w:sz="48"/>`
+            : ""}
           <w:bottom w:val="single" w:color="FFFFFF" w:sz="48" />
-          ${
-            columnIndex < 2
-              ? `<w:right w:val="single" w:color="FFFFFF" w:sz="48"/>`
-              : ""
-          }
+          ${columnIndex < 2
+            ? `<w:right w:val="single" w:color="FFFFFF" w:sz="48"/>`
+            : ""}
         </w:tcBorders>
         <w:shd w:val="solid" w:color="E4F8E0" w:fill="E4F8E0" />
         <w:tcMar>
@@ -423,15 +415,15 @@ async function buildYear(
             <w:pPr>
               <w:pStyle w:val="Heading3" />
             </w:pPr>
-              <w:r>
-                <w:rPr>
-                  <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
-                  <w:b />
-                  <w:color w:val="222222" />
-                  <w:sz w:val="36" />
-                </w:rPr>
-                <w:t>${cdata(subjectCategory.title)}</w:t>
-              </w:r>
+            <w:r>
+              <w:rPr>
+                <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial" />
+                <w:b />
+                <w:color w:val="222222" />
+                <w:sz w:val="36" />
+              </w:rPr>
+              <w:t>${cdata(subjectCategory.title)}</w:t>
+            </w:r>
           </w:p>
           ${buildUnitBlock(catUnits)};
         </XML_FRAGMENT>
@@ -526,10 +518,9 @@ async function buildYear(
 
   const xml = safeXml`
     <XML_FRAGMENT>
-      ${
-        !subjectTierPathwayTitle
-          ? ""
-          : safeXml`
+      ${!subjectTierPathwayTitle
+        ? ""
+        : safeXml`
             <w:p>
               <w:r>
                 <w:rPr>
@@ -544,12 +535,11 @@ async function buildYear(
                   <w:szCs w:val="28" />
                 </w:rPr>
                 <w:t xml:space="preserve">${cdata(
-                  subjectTierPathwayTitle,
-                )}</w:t>
+                    subjectTierPathwayTitle,
+                  )}</w:t>
               </w:r>
             </w:p>
-          `
-      }
+          `}
       <w:p>
         <w:pPr>
           <w:pStyle w:val="Heading2" />
@@ -569,10 +559,9 @@ async function buildYear(
           `,
         )}
       </w:p>
-      ${
-        !isSwimming
-          ? ""
-          : safeXml`
+      ${!isSwimming
+        ? ""
+        : safeXml`
             <XML_FRAGMENT>
               <w:p>
                 <w:r>
@@ -590,8 +579,7 @@ async function buildYear(
               </w:p>
               <w:p />
             </XML_FRAGMENT>
-          `
-      }
+          `}
       <w:p>
         ${wrapInLinkTo(
           links.interactiveSequence!,

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -275,10 +275,9 @@ export async function buildUnit(
             <w:t>${cdata(priorUnitTitle)}</w:t>
           </w:r>
         </w:p>
-        ${
-          !unitOptionIfAvailable.connection_prior_unit_description
-            ? ""
-            : safeXml`
+        ${!unitOptionIfAvailable.connection_prior_unit_description
+          ? ""
+          : safeXml`
               <w:p>
                 <w:r>
                   <w:rPr>
@@ -291,8 +290,7 @@ export async function buildUnit(
                   </w:t>
                 </w:r>
               </w:p>
-            `
-        }
+            `}
         <w:p>
           <w:r>
             <w:rPr>
@@ -341,10 +339,9 @@ export async function buildUnit(
             <w:t>${cdata(futureUnitTitle)}</w:t>
           </w:r>
         </w:p>
-        ${
-          !unitOptionIfAvailable.connection_future_unit_description
-            ? ""
-            : safeXml`
+        ${!unitOptionIfAvailable.connection_future_unit_description
+          ? ""
+          : safeXml`
               <w:p>
                 <w:r>
                   <w:rPr>
@@ -357,8 +354,7 @@ export async function buildUnit(
                   </w:t>
                 </w:r>
               </w:p>
-            `
-        }
+            `}
       </XML_FRAGMENT>
     `;
   } else {
@@ -526,10 +522,9 @@ export async function buildUnit(
 
       <w:p />
 
-      ${
-        !hasPublishedLessons
-          ? ""
-          : safeXml`
+      ${!hasPublishedLessons
+        ? ""
+        : safeXml`
             <w:p>
               ${wrapInLinkTo(
                 links.onlineResources,
@@ -569,8 +564,7 @@ export async function buildUnit(
                 `,
               )}
             </w:p>
-          `
-      }
+          `}
       <w:p>
         <w:r>
           <w:rPr>
@@ -602,11 +596,9 @@ export async function buildUnit(
         </w:r>
       </w:p>
       <w:p />
-      ${
-        unitOption && unitOptionIndex !== undefined
-          ? buildUnitOptionTitle(unitOption, unitOptionIndex, images)
-          : ""
-      }
+      ${unitOption && unitOptionIndex !== undefined
+        ? buildUnitOptionTitle(unitOption, unitOptionIndex, images)
+        : ""}
       <w:p>
         <w:pPr>
           <w:sectPr>
@@ -659,13 +651,11 @@ export async function buildUnit(
         <w:pPr>
           <w:pStyle w:val="Heading4" />
         </w:pPr>
-        ${
-          DISABLE_COLUMN_BREAKS
-            ? ""
-            : `<w:r>
+        ${DISABLE_COLUMN_BREAKS
+          ? ""
+          : `<w:r>
           <w:br w:type="column" />
-        </w:r>`
-        }
+        </w:r>`}
         <w:r>
           <w:rPr>
             <w:rFonts


### PR DESCRIPTION
## Description
Revert `@prettier/plugin-xml` to fix linting of embedded XML via `safeXml` statements

## Issue(s)

Fixes `CUR-1177`

## How to test
This shouldn't have changed anything , however some code was touched in docx, so worth testing there

1. Go to https://deploy-preview-3139--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. Download a few documents and check they validate correctly via https://marketplace.visualstudio.com/items?itemName=mikeebowen.ooxml-validator-vscode
