### PR TITLE
Change colour of threads tag in curriculum unit modal

### DIFF
--- a/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
@@ -77,7 +77,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
               <TagFunctional
                 key={thread}
                 text={thread}
-                color={"grey"}
+                color={"lavender"}
                 data-testid="thread-tag"
               />
             ))}


### PR DESCRIPTION
## Description
Change the colour of threads tag in curriculum unit modal from `grey` to `lavender`

## Issue(s)

Fixes `CUR-1200`

## How to test

1. Go to https://deploy-preview-3144--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Go to the visualiser and select a unit 
3. Check threads in the unit modal are the correct colour (as per designs)
