### PR TITLE
feat: promote unit downloads [LESQ-1199]

### DIFF
--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from "@testing-library/react";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import UnitDownloadButton from "./UnitDownloadButton";
 
@@ -23,29 +22,9 @@ jest.mock("@clerk/nextjs", () => ({
   SignUpButton: jest.fn(() => <button>Download unit</button>),
 }));
 
-jest.mock("posthog-js/react", () => ({
-  useFeatureFlagVariantKey: jest.fn(),
-}));
-
 describe("UnitDownloadButton", () => {
   beforeEach(() => {
     setUseUserReturn(mockLoggedIn);
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("option-a");
-  });
-  it("should not render when feature flag is off or control group", () => {
-    (useFeatureFlagVariantKey as jest.Mock).mockReturnValue("control");
-    renderWithProviders()(
-      <UnitDownloadButton
-        setDownloadError={jest.fn()}
-        setDownloadInProgress={jest.fn()}
-        setShowDownloadMessage={jest.fn()}
-        downloadInProgress={false}
-        onDownloadSuccess={jest.fn()}
-        unitFileId="mockSlug"
-      />,
-    );
-    const button = screen.queryByText("Download (.zip 1.2MB)");
-    expect(button).not.toBeInTheDocument;
   });
 
   it("should render a continue button when logged in but not onboarded", () => {


### PR DESCRIPTION
## Description

Music year: 1979

- removes the feature flag `teacher-unit-downloads`
- promote the download button to appear for all users
- promote the copy from option-a



## How to test

1. Go to https://deploy-preview-3148--oak-web-application.netlify.thenational.academy/teachers/programmes/maths-secondary-ks4-higher/units/algebraic-manipulation/lessons
3. You should see a unit download button
4. When signed out: it should say 'Download unit'
5. Clicking should take you through sign in/up and redirect back to the lesson listing page
6. When signed in: it should say Download (.zip ~size)
7. Clicking it should initiate download for the unit zip file

## Screenshots

How it used to look (delete if n/a):
depending on which cohort for the feature flag, you may see no download button
<img width="500" src="https://github.com/user-attachments/assets/70e0e0ea-3322-41bc-92bd-176b21a17429" />

How it should now look:
you should always see the download button with this copy
<img width="500" alt="Screenshot 2025-01-27 at 09 00 15" src="https://github.com/user-attachments/assets/7eb3f06f-4943-4ac5-8b28-e60dd3bff970" />

