### PR TITLE
Add new year group filter design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.67.0",
+        "@oaknational/oak-components": "^1.79.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.39.0",
         "@oaknational/oak-pupil-client": "^2.12.3",
@@ -7065,9 +7065,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.67.0.tgz",
-      "integrity": "sha512-syq5Ee7xvcHA5ZiKBqvbCI32JQQIpJeRUFs0p1o0jKs+/pnl+VKF8MCZKfHu88oin2/RV8awtq3Rqh+AndcdKg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.79.0.tgz",
+      "integrity": "sha512-m7+WiRe/I1+uh5VGtOW0v7LL07ZFWl7Ol51ZYDfa3H2bYDkML9jXcivNFOYZ/gtexcdMRM9kf2ljpJ7B3rfSuA==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.79.0",
+        "@oaknational/oak-components": "^1.80.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.39.0",
         "@oaknational/oak-pupil-client": "^2.12.3",
@@ -7065,9 +7065,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.79.0.tgz",
-      "integrity": "sha512-m7+WiRe/I1+uh5VGtOW0v7LL07ZFWl7Ol51ZYDfa3H2bYDkML9jXcivNFOYZ/gtexcdMRM9kf2ljpJ7B3rfSuA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.80.0.tgz",
+      "integrity": "sha512-ucGGCc8tfTDpmerAWcN21ntEl8lLETIdETD96LExoaQoNFh5wJhYjxluS4vRz36q8rpUivyxsTRiSxp6asyzhw==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.79.0",
+    "@oaknational/oak-components": "^1.80.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.39.0",
     "@oaknational/oak-pupil-client": "^2.12.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.67.0",
+    "@oaknational/oak-components": "^1.79.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.39.0",
     "@oaknational/oak-pupil-client": "^2.12.3",

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -100,7 +100,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   ];
 
   return (
-    <Box $mb={40}>
+    <Box $mb={48}>
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
       <Flex $background={color1} $pv={[20]}>
         <Box $maxWidth={1280} $mh={"auto"} $ph={18} $width={"100%"}>

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFilters.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFilters.tsx
@@ -9,16 +9,16 @@ import {
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 export type CurriculumFilters = {
-  childSubjects: Subject["subject_slug"][],
-  subjectCategories: string[],
-  tiers: Tier["tier_slug"][]
-  years: string[],
-  threads: Thread["slug"][],
-}
+  childSubjects: Subject["subject_slug"][];
+  subjectCategories: string[];
+  tiers: Tier["tier_slug"][];
+  years: string[];
+  threads: Thread["slug"][];
+};
 
 export type CurriculumVisualiserFiltersProps = {
-  filters: CurriculumFilters,
-  onChangeFilters: (newFilters: CurriculumFilters) => void,
+  filters: CurriculumFilters;
+  onChangeFilters: (newFilters: CurriculumFilters) => void;
   data: CurriculumUnitsFormattedData;
   trackingData: CurriculumUnitsTrackingData;
 };

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -17,6 +17,7 @@ import {
 } from "./CurriculumVisualiserFilters";
 import { highlightedUnitCount } from "./helpers";
 
+import { Hr } from "@/components/SharedComponents/Typography";
 import Box from "@/components/SharedComponents/Box";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import {
@@ -26,6 +27,7 @@ import {
   Tier,
 } from "@/utils/curriculum/types";
 import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 
 function getFilterData(
   yearData: CurriculumUnitsFormattedData["yearData"],
@@ -85,19 +87,21 @@ export default function CurriculumVisualiserFiltersDesktop({
     <OakBox $mr={"space-between-s"}>
       <SkipLink href="#content">Skip to units</SkipLink>
 
-      <h2 id="subject-label">Choose a subject</h2>
-      <OakRadioGroup name="test" aria-labelledby="subject-label">
-        <OakRadioAsButton value="Option 1" displayValue="Year 1" />
-        <OakRadioAsButton value="Option 2" displayValue="Year 2" />
-      </OakRadioGroup>
+      <OakHeading tag="h3" $font={"heading-5"} $mb="space-between-m">
+        Filter and highlight
+      </OakHeading>
 
-      <OakHeading tag="h3">Filter and highlight</OakHeading>
-
-      <Fieldset>
-        <FieldsetLegend $font={"heading-7"} $mb="space-between-xs">
+      <>
+        <OakHeading
+          tag="h4"
+          id="year-group-label"
+          $font={"heading-6"}
+          $mb="space-between-s"
+        >
           Year group
-        </FieldsetLegend>
-        <RadioGroup
+        </OakHeading>
+
+        <OakRadioGroup
           name="year"
           onChange={(e) =>
             addAllToFilter(
@@ -108,87 +112,130 @@ export default function CurriculumVisualiserFiltersDesktop({
           value={
             isEqual(filters.years, yearOptions) ? "all" : filters.years[0]!
           }
+          $gap="space-between-ssx"
+          $flexDirection="row"
+          $flexWrap="wrap"
+          aria-labelledby="year-group-label"
+          data-testid="year-group-filter-desktop"
         >
-          <RadioButton value={"all"}>All</RadioButton>
-          {yearOptions.map((yearOption) => {
-            return (
-              <RadioButton value={yearOption}>
-                {getYearGroupTitle(yearData, yearOption)}
-              </RadioButton>
-            );
-          })}
-        </RadioGroup>
-      </Fieldset>
+          <OakRadioAsButton
+            value="all"
+            displayValue="All"
+            data-testid={"all-years-radio"}
+          />
+          {yearOptions.map((yearOption) => (
+            <OakRadioAsButton
+              key={yearOption}
+              value={yearOption}
+              displayValue={getYearGroupTitle(yearData, yearOption)}
+              data-testid={"year-radio"}
+            />
+          ))}
+        </OakRadioGroup>
+      </>
 
       {subjectCategories.length > 0 && (
-        <Fieldset>
-          <FieldsetLegend $font={"heading-7"} $mb="space-between-xs">
+        <>
+          <Hr thickness={2} $color={"grey40"} $mt={30} $mb={40} />
+
+          <OakHeading
+            id="subject-categories-label"
+            tag="h4"
+            $font={"heading-6"}
+            $mb="space-between-s"
+          >
             Category {childSubjects.length > 0 ? "(KS3)" : ""}
-          </FieldsetLegend>
-          <RadioGroup
-            name="subjectCategories"
+          </OakHeading>
+
+          <OakRadioGroup
+            name="subject-categories"
             onChange={(e) =>
               setSingleInFilter("subjectCategories", e.target.value)
             }
             value={filters.subjectCategories[0]!}
+            $flexDirection="row"
+            $flexWrap="wrap"
+            $gap="space-between-ssx"
+            aria-labelledby="subject-categories-label"
           >
-            {subjectCategories.map((subjectCategory) => {
-              return (
-                <RadioButton value={String(subjectCategory.id)}>
-                  {subjectCategory.title}
-                </RadioButton>
-              );
-            })}
-          </RadioGroup>
-        </Fieldset>
-      )}
-
-      {tiers.length > 0 && (
-        <Fieldset>
-          <FieldsetLegend $font={"heading-7"} $mb="space-between-xs">
-            Learning tier (KS4)
-          </FieldsetLegend>
-          <RadioGroup
-            name="tiers"
-            onChange={(e) => setSingleInFilter("tiers", e.target.value)}
-            value={filters.tiers[0]!}
-          >
-            {tiers.map((tier) => {
-              return (
-                <RadioButton value={tier.tier_slug}>{tier.tier}</RadioButton>
-              );
-            })}
-          </RadioGroup>
-        </Fieldset>
+            {subjectCategories.map((subjectCategory) => (
+              <OakRadioAsButton
+                key={subjectCategory.id}
+                value={String(subjectCategory.id)}
+                displayValue={subjectCategory.title}
+              />
+            ))}
+          </OakRadioGroup>
+        </>
       )}
 
       {childSubjects.length > 0 && (
-        <Fieldset>
-          <FieldsetLegend $font={"heading-7"} $mb="space-between-xs">
+        <>
+          <Hr thickness={2} $color={"grey40"} $mt={30} $mb={40} />
+          <OakHeading
+            id="child-subjects-label"
+            tag="h4"
+            $font={"heading-6"}
+            $mb="space-between-s"
+          >
             Exam subject (KS4)
-          </FieldsetLegend>
-          <RadioGroup
+          </OakHeading>
+          <OakRadioGroup
             name="childSubjects"
             onChange={(e) => setSingleInFilter("childSubjects", e.target.value)}
             value={filters.childSubjects[0]!}
+            $flexDirection="row"
+            $flexWrap="wrap"
+            $gap="space-between-ssx"
+            aria-labelledby="child-subjects-label"
           >
-            {childSubjects.map((childSubject) => {
-              return (
-                <RadioButton value={childSubject.subject_slug}>
-                  {childSubject.subject}
-                </RadioButton>
-              );
-            })}
-          </RadioGroup>
-        </Fieldset>
+            {childSubjects.map((childSubject) => (
+              <OakRadioAsButton
+                key={childSubject.subject_slug}
+                value={childSubject.subject_slug}
+                displayValue={childSubject.subject}
+                icon={getValidSubjectIconName(childSubject.subject_slug)}
+              />
+            ))}
+          </OakRadioGroup>
+        </>
       )}
 
-      <Fieldset>
-        <FieldsetLegend
-          $font={"heading-7"}
-          $mb="space-between-xs"
-          $mt="space-between-m2"
-        >
+      {tiers.length > 0 && (
+        <>
+          <Hr thickness={2} $color={"grey40"} $mt={30} $mb={40} />
+          <OakHeading
+            id="tiers-label"
+            tag="h4"
+            $font={"heading-6"}
+            $mb="space-between-s"
+          >
+            Learning tier (KS4)
+          </OakHeading>
+          <OakRadioGroup
+            name="tiers"
+            onChange={(e) => setSingleInFilter("tiers", e.target.value)}
+            value={filters.tiers[0]!}
+            $flexDirection="row"
+            $flexWrap="wrap"
+            $gap="space-between-ssx"
+            aria-labelledby="tiers-label"
+          >
+            {tiers.map((tier) => (
+              <OakRadioAsButton
+                key={tier.tier_slug}
+                value={tier.tier_slug}
+                displayValue={tier.tier}
+              />
+            ))}
+          </OakRadioGroup>
+        </>
+      )}
+
+      <Hr thickness={2} $color={"grey40"} $mt={30} $mb={40} />
+
+      <Fieldset data-testid={"threads-filter-desktop"}>
+        <FieldsetLegend $font={"heading-6"} $mt="space-between-m2">
           Highlight a thread
         </FieldsetLegend>
         <RadioGroup
@@ -198,7 +245,7 @@ export default function CurriculumVisualiserFiltersDesktop({
           }
           value={filters.threads[0] ?? ""}
         >
-          <Box $mv={16} $pl={12} $bl={1} $borderColor="transparent">
+          <Box $mt={6} $mb={16} $pl={12} $bl={1} $borderColor="transparent">
             <RadioButton
               aria-label={"None highlighted"}
               value={""}
@@ -219,7 +266,7 @@ export default function CurriculumVisualiserFiltersDesktop({
               <Box
                 $ba={1}
                 $background={isSelected ? "black" : "white"}
-                $borderColor={isSelected ? "black" : "grey40"}
+                $borderColor={isSelected ? "black" : "grey50"}
                 $borderRadius={4}
                 $color={isSelected ? "white" : "black"}
                 $font={isSelected ? "heading-light-7" : "body-2"}
@@ -237,16 +284,14 @@ export default function CurriculumVisualiserFiltersDesktop({
                 >
                   <OakSpan>
                     {threadOption.title}
-                    <OakSpan>
-                      {isSelected && (
-                        <>
-                          <br />
-                          {highlightedCount}
-                          {highlightedCount === 1 ? " unit " : " units "}
-                          highlighted
-                        </>
-                      )}
-                    </OakSpan>
+                    {isSelected && (
+                      <>
+                        <br />
+                        {highlightedCount}
+                        {highlightedCount === 1 ? " unit " : " units "}
+                        highlighted
+                      </>
+                    )}
                   </OakSpan>
                 </RadioButton>
               </Box>

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -1,4 +1,10 @@
-import { OakSpan, OakBox, OakHeading } from "@oaknational/oak-components";
+import {
+  OakSpan,
+  OakBox,
+  OakHeading,
+  OakRadioGroup,
+  OakRadioAsButton,
+} from "@oaknational/oak-components";
 import { isEqual } from "lodash";
 
 import { Fieldset, FieldsetLegend } from "../OakComponentsKitchen/Fieldset";
@@ -78,6 +84,13 @@ export default function CurriculumVisualiserFiltersDesktop({
   return (
     <OakBox $mr={"space-between-s"}>
       <SkipLink href="#content">Skip to units</SkipLink>
+
+      <h2 id="subject-label">Choose a subject</h2>
+      <OakRadioGroup name="test" aria-labelledby="subject-label">
+        <OakRadioAsButton value="Option 1" displayValue="Year 1" />
+        <OakRadioAsButton value="Option 2" displayValue="Year 2" />
+      </OakRadioGroup>
+
       <OakHeading tag="h3">Filter and highlight</OakHeading>
 
       <Fieldset>
@@ -196,12 +209,11 @@ export default function CurriculumVisualiserFiltersDesktop({
           </Box>
           {threadOptions.map((threadOption) => {
             const isSelected = isSelectedThread(threadOption);
-            const highlightedCount =
-              highlightedUnitCount();
-              // yearData,
-              // selectedYear,
-              // yearSelection,
-              // selectedThread,
+            const highlightedCount = highlightedUnitCount();
+            // yearData,
+            // selectedYear,
+            // yearSelection,
+            // selectedThread,
 
             return (
               <Box

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -402,12 +402,12 @@ import React from "react";
 // }
 
 export default function CurriculumVisualiserFiltersMobile() {
-// {
-//   filters,
-//   onChangeFilters,
-//   trackingData,
-//   data,
-// }: CurriculumVisualiserFiltersProps
+  // {
+  //   filters,
+  //   onChangeFilters,
+  //   trackingData,
+  //   data,
+  // }: CurriculumVisualiserFiltersProps
   // const [mobileThreadModalOpen, setMobileThreadModalOpen] =
   //   useState<boolean>(false);
 

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
@@ -10,10 +10,10 @@
 // }
 
 export function highlightedUnitCount(): number {
-// yearData: CurriculumUnitsYearData,
-// selectedYear: string | null,
-// filters: CurriculumFilters,
-// selectedThread: Thread["slug"] | null,
+  // yearData: CurriculumUnitsYearData,
+  // selectedYear: string | null,
+  // filters: CurriculumFilters,
+  // selectedThread: Thread["slug"] | null,
   // let count = 0;
   // Object.keys(yearData).forEach((year) => {
   //   const units = yearData[year]?.units;

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { OakP, OakHeading, OakBox } from "@oaknational/oak-components";
+import { OakHeading, OakBox } from "@oaknational/oak-components";
 
 import CurriculumVisualiser from "../CurriculumVisualiser/CurriculumVisualiser";
 import CurriculumVisualiserLayout from "../CurriculumVisualiserLayout/CurriculumVisualiserLayout";
@@ -36,17 +36,15 @@ export default function UnitsTab({
   const { ks4OptionSlug } = trackingData;
   const [unitData, setUnitData] = useState<Unit | null>(null);
 
-  const unitCount =
-    getNumberOfSelectedUnits();
-    // yearData,
-    // selectedYear,
-    // yearSelection,
-  const highlightedUnits =
-    highlightedUnitCount();
-    // yearData,
-    // selectedYear,
-    // yearSelection,
-    // selectedThread,
+  const unitCount = getNumberOfSelectedUnits();
+  // yearData,
+  // selectedYear,
+  // yearSelection,
+  const highlightedUnits = highlightedUnitCount();
+  // yearData,
+  // selectedYear,
+  // yearSelection,
+  // selectedThread,
 
   return (
     <OakBox>
@@ -70,14 +68,6 @@ export default function UnitsTab({
             Unit sequence
           </OakHeading>
         </ScreenReaderOnly>
-        <OakP
-          $mh={["space-between-s", "space-between-none"]}
-          $mb={"space-between-xl"}
-          data-testid="units-heading"
-        >
-          Units that make up our curricula are fully sequenced, and aligned to
-          the national curriculum.
-        </OakP>
         {/* <CurriculumVisualiserFiltersMobile
           filters={filters}
           onChangeFilters={onChangeFilters}

--- a/src/components/TeacherComponents/LessonOverviewMediaClips/LessonOverviewClipWithThumbnail.tsx
+++ b/src/components/TeacherComponents/LessonOverviewMediaClips/LessonOverviewClipWithThumbnail.tsx
@@ -14,6 +14,7 @@ export type LessonOverviewClipWithThumbnail = Omit<
   playbackId: string;
   playbackPolicy: PlaybackPolicy;
   numberOfClips: number;
+  isAudioClip: boolean;
 };
 
 const LessonOverviewClipWithThumbnail: FC<LessonOverviewClipWithThumbnail> = ({
@@ -22,6 +23,7 @@ const LessonOverviewClipWithThumbnail: FC<LessonOverviewClipWithThumbnail> = ({
   playbackPolicy,
   numberOfClips,
   href,
+  isAudioClip,
 }: LessonOverviewClipWithThumbnail) => {
   const thumbnailImage = useMediaClipThumbnailUrl({
     playbackId,
@@ -36,6 +38,7 @@ const LessonOverviewClipWithThumbnail: FC<LessonOverviewClipWithThumbnail> = ({
       imageAltText=""
       href={href}
       numberOfClips={numberOfClips}
+      isAudioClip={isAudioClip}
     />
   );
 };

--- a/src/utils/curriculum/getNumberOfSelectedUnits.ts
+++ b/src/utils/curriculum/getNumberOfSelectedUnits.ts
@@ -2,9 +2,9 @@
 // import { YearData } from "./types";
 
 export function getNumberOfSelectedUnits(): number {
-// yearData: YearData,
-// selectedYear: string | null,
-// filter: CurriculumFilters,
+  // yearData: YearData,
+  // selectedYear: string | null,
+  // filter: CurriculumFilters,
   // let count = 0;
 
   // Object.keys(yearData).forEach((year) => {


### PR DESCRIPTION
## Description

Music year: 1976

- Uses the new OakRadioAsButton and OakRadioGroup components to implement radio button semantics for a group of buttons
- Remove FieldsetLegend component and use OakHeading in its place

## Issue(s)

Fixes #[1172](https://www.notion.so/oaknationalacademy/Restyle-year-groups-in-new-curriculum-filtering-to-match-new-designs-17526cc4e1b18026a9bdc4567043b3fd?pvs=4)

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="725" alt="image" src="https://github.com/user-attachments/assets/8d555b39-9df0-4ee3-8537-21146957ff69" />

How it should now look:
<img width="663" alt="image" src="https://github.com/user-attachments/assets/e22fd568-fb39-4ad1-acfa-e4de890cc840" />

## Checklist

- [ ] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [X] Does this PR update a package with a breaking change
