### PR TITLE
CTC-145 Display pathways in alphabetical order

### DIFF
--- a/src/pages-helpers/teacher/subject-listing-page/getCombinedSubjects.tsx
+++ b/src/pages-helpers/teacher/subject-listing-page/getCombinedSubjects.tsx
@@ -59,17 +59,20 @@ export const getCombinedSubjects = (
 
   type CombinedSubject = KeyStageSubjectData & { isNew: boolean };
 
-  function compareByPathway(a: CombinedSubject, b: CombinedSubject) {
-    if (a.pathwaySlug && b.pathwaySlug) {
-      if (a.pathwaySlug < b.pathwaySlug) {
+  const compareByPathway = (a: CombinedSubject, b: CombinedSubject) => {
+    const pathwaySlugA = a.pathwaySlug;
+    const pathwaySlugB = b.pathwaySlug;
+
+    if (pathwaySlugA && pathwaySlugB) {
+      if (pathwaySlugA < pathwaySlugB) {
         return -1;
       }
-      if (a.pathwaySlug > b.pathwaySlug) {
+      if (pathwaySlugA > pathwaySlugB) {
         return 1;
       }
     }
     return 0;
-  }
+  };
 
   const combinedSubjectArray: CombinedSubject[] =
     newSubjectArray.length > 0
@@ -105,17 +108,19 @@ export const getCombinedSubjects = (
             };
           })
           .sort(compareByPathway)
-      : legacySubjectArray.map((legacySubject) => ({
-          programmeSlug: legacySubject.programmeSlug,
-          programmeCount,
-          subjectSlug: legacySubject.subjectSlug,
-          subjectTitle: legacySubject.subjectTitle,
-          unitCount: legacySubject.unitCount,
-          lessonCount: legacySubject.lessonCount,
-          pathwaySlug: legacySubject.pathwaySlug,
-          pathwayTitle: legacySubject.pathwayTitle,
-          isNew: false,
-        }));
+      : legacySubjectArray
+          .map((legacySubject) => ({
+            programmeSlug: legacySubject.programmeSlug,
+            programmeCount,
+            subjectSlug: legacySubject.subjectSlug,
+            subjectTitle: legacySubject.subjectTitle,
+            unitCount: legacySubject.unitCount,
+            lessonCount: legacySubject.lessonCount,
+            pathwaySlug: legacySubject.pathwaySlug,
+            pathwayTitle: legacySubject.pathwayTitle,
+            isNew: false,
+          }))
+          .sort(compareByPathway);
 
   return combinedSubjectArray;
 };

--- a/src/pages-helpers/teacher/subject-listing-page/getCombinedSubjects.tsx
+++ b/src/pages-helpers/teacher/subject-listing-page/getCombinedSubjects.tsx
@@ -59,38 +59,52 @@ export const getCombinedSubjects = (
 
   type CombinedSubject = KeyStageSubjectData & { isNew: boolean };
 
+  function compareByPathway(a: CombinedSubject, b: CombinedSubject) {
+    if (a.pathwaySlug && b.pathwaySlug) {
+      if (a.pathwaySlug < b.pathwaySlug) {
+        return -1;
+      }
+      if (a.pathwaySlug > b.pathwaySlug) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
   const combinedSubjectArray: CombinedSubject[] =
     newSubjectArray.length > 0
-      ? newSubjectArray.map((newSubject) => {
-          const eyfsUnitCount = legacySubjectArray[0]?.unitCount ?? 0;
-          const eyfsLessonCount = legacySubjectArray[0]?.lessonCount ?? 0;
+      ? newSubjectArray
+          .map((newSubject) => {
+            const eyfsUnitCount = legacySubjectArray[0]?.unitCount ?? 0;
+            const eyfsLessonCount = legacySubjectArray[0]?.lessonCount ?? 0;
 
-          const legacyPathwayUnitCount = getLegacySubjectUnitCount(
-            newSubject.pathwaySlug,
-            legacySubjectArray,
-          );
-          const totalPathwayUnitCount =
-            newSubject.unitCount + legacyPathwayUnitCount;
+            const legacyPathwayUnitCount = getLegacySubjectUnitCount(
+              newSubject.pathwaySlug,
+              legacySubjectArray,
+            );
+            const totalPathwayUnitCount =
+              newSubject.unitCount + legacyPathwayUnitCount;
 
-          const legacyPathwayLessonCount = getLegacySubjectLessonCount(
-            newSubject.pathwaySlug,
-            legacySubjectArray,
-          );
-          const totalPathwayLessonCount =
-            newSubject.lessonCount + legacyPathwayLessonCount;
+            const legacyPathwayLessonCount = getLegacySubjectLessonCount(
+              newSubject.pathwaySlug,
+              legacySubjectArray,
+            );
+            const totalPathwayLessonCount =
+              newSubject.lessonCount + legacyPathwayLessonCount;
 
-          return {
-            programmeSlug: newSubject.programmeSlug,
-            programmeCount: programmeCount,
-            subjectSlug: newSubject.subjectSlug,
-            subjectTitle: newSubject.subjectTitle,
-            unitCount: isEyfs ? eyfsUnitCount : totalPathwayUnitCount,
-            lessonCount: isEyfs ? eyfsLessonCount : totalPathwayLessonCount,
-            pathwaySlug: newSubject.pathwaySlug,
-            pathwayTitle: newSubject.pathwayTitle,
-            isNew: true,
-          };
-        })
+            return {
+              programmeSlug: newSubject.programmeSlug,
+              programmeCount: programmeCount,
+              subjectSlug: newSubject.subjectSlug,
+              subjectTitle: newSubject.subjectTitle,
+              unitCount: isEyfs ? eyfsUnitCount : totalPathwayUnitCount,
+              lessonCount: isEyfs ? eyfsLessonCount : totalPathwayLessonCount,
+              pathwaySlug: newSubject.pathwaySlug,
+              pathwayTitle: newSubject.pathwayTitle,
+              isNew: true,
+            };
+          })
+          .sort(compareByPathway)
       : legacySubjectArray.map((legacySubject) => ({
           programmeSlug: legacySubject.programmeSlug,
           programmeCount,


### PR DESCRIPTION
## Description

Display pathways in alphabetical order so it's always consistent, regardless which order comes form the backend

## Issue(s)

Fixes [CTC-145](https://www.notion.so/oaknationalacademy/Pathways-Bug-Computing-Pathway-Cards-Not-in-Order-18b26cc4e1b1802b904be2a7cc517a98)

## How to test

1. Go to https://deploy-preview-3164--oak-web-application.netlify.thenational.academy
2. Go to KS 4 subject listing page
3. Check if the pathways are displayed in the same order for all subjects with pathways
