### PR TITLE
feat: add optionality title to unit modal

### DIFF
--- a/src/components/CurriculumComponents/UnitModal/UnitModal.test.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.test.tsx
@@ -192,6 +192,9 @@ describe("Unit modal", () => {
 
         expect(getByTestId("curriculum-unit-details")).toBeVisible();
 
+        const titleElement = getByTestId("unit-optionality-title");
+        expect(titleElement).toBeInTheDocument();
+        expect(titleElement).toHaveTextContent(mockOptionalityUnit.title);
         expect(getByText("Threads")).toBeInTheDocument();
       } else {
         throw new Error("Optionality button not found");

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect } from "react";
-import { OakHeading, OakFlex, OakBox } from "@oaknational/oak-components";
+import { OakHeading, OakFlex, OakBox, OakP } from "@oaknational/oak-components";
 
 import BulletList from "../OakComponentsKitchen/BulletList";
 import CurriculumUnitCard from "../CurriculumUnitCard/CurriculumUnitCard";
@@ -112,6 +112,7 @@ const UnitModal: FC<UnitModalProps> = ({
                 }}
               />
             </OakBox>
+
             <OakFlex $gap="all-spacing-2" $flexWrap={"wrap"}>
               <BulletList
                 items={[subjectTitle, yearTitle]
@@ -119,6 +120,17 @@ const UnitModal: FC<UnitModalProps> = ({
                   .map((text) => ({ text }))}
               />
             </OakFlex>
+
+            {curriculumUnitDetails && (
+              <OakP
+                $mt={"space-between-ssx"}
+                $mb={"space-between-xs"}
+                data-testid="unit-optionality-title"
+              >
+                {unitData.title}
+              </OakP>
+            )}
+
             <OakHeading tag="h2" $font={"heading-5"}>
               {!curriculumUnitDetails
                 ? unitData.title


### PR DESCRIPTION
## Description

Music year: 1951

- Added optionality title to unit modal
- Added test which tests for presence of optionality title the case of optional unit

## Issue(s)

Fixes #[1201](https://www.notion.so/oaknationalacademy/Add-optionality-title-to-unit-modal-18326cc4e1b18098a800fa8648f64ed8?pvs=4)

## How to test

1. Go to https://deploy-preview-3169--oak-web-application.netlify.thenational.academy
2. Visit a subject with optional units such as English (Secondary, AQA)
3. Find a unit  with multiple options and click it
4. Select one of the options
5. In the unit detail check to see that optionality title is present

## Screenshots

How it used to look (delete if n/a):
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/9b81d14d-58e9-4df2-8e63-7b96a4beb6ff" />

How it should now look:
<img width="974" alt="image" src="https://github.com/user-attachments/assets/2ed7f426-a1fc-4abf-95e0-ac6fbde022c5" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [] Does this PR update a package with a breaking change
