### PR TITLE
Thread highlighting in new filters for curriculum

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -64,11 +64,13 @@ export function dedupUnits(units: Unit[]) {
   });
 }
 
-function isHighlightedUnit(unit: Unit, selectedThread: string | null) {
-  if (!selectedThread) {
+function isHighlightedUnit(unit: Unit, selectedThreads: string[] | null) {
+  if (!selectedThreads || selectedThreads?.length < 1) {
     return false;
   }
-  return unit.threads.some((t) => t.slug === selectedThread);
+  return unit.threads.some((t) => {
+    return selectedThreads.includes(t.slug);
+  });
 }
 
 // Function component
@@ -133,10 +135,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
         subjectSlug: unitData.subject_slug,
         yearGroupName: unitData.year,
         yearGroupSlug: unitData.year,
-        unitHighlighted: isHighlightedUnit(
-          unitData,
-          filters.threads[0] ?? null,
-        ),
+        unitHighlighted: isHighlightedUnit(unitData, filters.threads),
         analyticsUseCase: analyticsUseCase,
       });
     }
@@ -241,11 +240,10 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
                       <OakP>No units for filter in this year</OakP>
                     )}
                     {dedupedUnits.map((unit: Unit, index: number) => {
-                      const isHighlighted = false;
-                      // const isHighlighted = isHighlightedUnit(
-                      //   unit,
-                      //   selectedThread,
-                      // );
+                      const isHighlighted = isHighlightedUnit(
+                        unit,
+                        filters.threads,
+                      );
                       const unitOptions = unit.unit_options.length >= 1;
 
                       return (

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -253,11 +253,11 @@ export default function CurriculumVisualiserFiltersDesktop({
           </OakBox>
           {threadOptions.map((threadOption) => {
             const isSelected = isSelectedThread(threadOption);
-            const highlightedCount = highlightedUnitCount();
-            // yearData,
-            // selectedYear,
-            // yearSelection,
-            // selectedThread,
+            const highlightedCount = highlightedUnitCount(
+              yearData,
+              filters,
+              filters.threads,
+            );
 
             return (
               <OakBox

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/helpers.ts
@@ -1,33 +1,36 @@
-// import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
-// import { Unit, Thread } from "@/utils/curriculum/types";
-// import { CurriculumFilters } from "./CurriculumVisualiserFilters";
+import { CurriculumFilters } from "./CurriculumVisualiserFilters";
 
-// function isHighlightedUnit(unit: Unit, selectedThread: Thread["slug"] | null) {
-//   if (!selectedThread) {
-//     return false;
-//   }
-//   return unit.threads.some((t) => t.slug === selectedThread);
-// }
+import { Unit, Thread, YearData } from "@/utils/curriculum/types";
+import { isVisibleUnit } from "@/utils/curriculum/isVisibleUnit";
 
-export function highlightedUnitCount(): number {
-  // yearData: CurriculumUnitsYearData,
-  // selectedYear: string | null,
-  // filters: CurriculumFilters,
-  // selectedThread: Thread["slug"] | null,
-  // let count = 0;
-  // Object.keys(yearData).forEach((year) => {
-  //   const units = yearData[year]?.units;
-  //   if (units && (!selectedYear || selectedYear === year)) {
-  //     units.forEach((unit) => {
-  //       if (
-  //         isVisibleUnit(yearSelection, year, unit) &&
-  //         isHighlightedUnit(unit, selectedThread)
-  //       ) {
-  //         count++;
-  //       }
-  //     });
-  //   }
-  // });
-  // return count;
-  return 0;
+function isHighlightedUnit(
+  unit: Unit,
+  selectedThreads: Thread["slug"][] | null,
+) {
+  if (!selectedThreads) {
+    return false;
+  }
+  return unit.threads.some((t) => selectedThreads.includes(t.slug));
+}
+
+export function highlightedUnitCount(
+  yearData: YearData,
+  filters: CurriculumFilters,
+  selectedThreads: Thread["slug"][] | null,
+): number {
+  let count = 0;
+  Object.keys(yearData).forEach((year) => {
+    const units = yearData[year]?.units;
+    if (units && filters.years.includes(year)) {
+      units.forEach((unit) => {
+        if (
+          isVisibleUnit(filters, year, unit) &&
+          isHighlightedUnit(unit, selectedThreads)
+        ) {
+          count++;
+        }
+      });
+    }
+  });
+  return count;
 }

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -40,11 +40,11 @@ export default function UnitsTab({
 
   const unitCount = getNumberOfSelectedUnits(yearData, selectedYear, filters);
 
-  const highlightedUnits = highlightedUnitCount();
-  // yearData,
-  // selectedYear,
-  // yearSelection,
-  // selectedThread,
+  const highlightedUnits = highlightedUnitCount(
+    yearData,
+    filters,
+    filters.threads,
+  );
 
   return (
     <OakBox>


### PR DESCRIPTION
## Description
Fixes thread highlighting counts in new filter UI in the curriculum visualiser. 

## Issue(s)

Fixes `CUR-1183`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Test thread counts are correct for curriculum filter state
