### PR TITLE
Fix/lesq 1172/unit filter button mobile [LESQ-1172]

### DIFF
--- a/src/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters.stories.tsx
+++ b/src/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { oakDefaultTheme, OakThemeProvider } from "@oaknational/oak-components";
+
+import DesktopUnitFilters from "./DesktopUnitFilters";
+
+const meta: Meta<typeof DesktopUnitFilters> = {
+  component: DesktopUnitFilters,
+  decorators: [
+    (Story) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <Story />
+      </OakThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DesktopUnitFilters>;
+
+export const Default: Story = {
+  render: (args) => <DesktopUnitFilters {...args} />,
+
+  args: {
+    keyStageSlug: "ks4",
+    keyStageTitle: "Key Stage 4",
+    programmeSlug: "maths-secondary-ks4-foundation",
+    selectedThemeSlug: "ratio-and-proportion",
+    subjectSlug: "maths",
+    subjectTitle: "Maths",
+    yearGroupSlug: "year-10",
+    yearGroups: [
+      {
+        yearTitle: "Year 10",
+        year: "year-10",
+      },
+      {
+        yearTitle: "Year 11",
+        year: "year-11",
+      },
+    ],
+    learningThemes: [
+      {
+        themeTitle: "Algebra",
+        themeSlug: "algebra",
+      },
+      {
+        themeTitle: "Geometry and Measure",
+        themeSlug: "geometry-and-measure",
+      },
+      {
+        themeTitle: "Number",
+        themeSlug: "number",
+      },
+      {
+        themeTitle: "Probability",
+        themeSlug: "probability",
+      },
+      {
+        themeTitle: "Ratio and Proportion",
+        themeSlug: "ratio-and-proportion",
+      },
+      {
+        themeTitle: "Statistics",
+        themeSlug: "statistics",
+      },
+    ],
+    subjectCategories: [
+      {
+        label: "Maths",
+        iconName: "maths-icon",
+        slug: "maths",
+      },
+      {
+        label: "Science",
+        iconName: "science-icon",
+        slug: "science",
+      },
+    ],
+    learningThemesId: "theme1",
+  },
+};

--- a/src/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters.tsx
+++ b/src/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters.tsx
@@ -1,0 +1,160 @@
+import {
+  OakBox,
+  OakFieldset,
+  OakFlex,
+  OakHeading,
+  OakSecondaryButton,
+} from "@oaknational/oak-components";
+
+import YearGroupFilters from "../YearGroupFilters";
+import SubjectCategoryFilters from "../SubjectCategoryFilters";
+import UnitsLearningThemeFilters from "../UnitsLearningThemeFilters";
+
+import {
+  BrowseRefinedProperties,
+  KeyStageTitleValueType,
+} from "@/browser-lib/avo/Avo";
+import {
+  LearningThemes,
+  SubjectCategory,
+  YearGroups,
+} from "@/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema";
+
+export type DesktopUnitFiltersProps = {
+  showFilters: boolean;
+  filtersRef: React.RefObject<HTMLDivElement> | null;
+  onFocus: () => void;
+  onBlur: () => void;
+  yearGroups: YearGroups;
+  subjectCategories: Array<SubjectCategory>;
+  learningThemes: LearningThemes;
+  skipFiltersButton: boolean;
+  programmeSlug: string;
+  selectedThemeSlug: string | undefined;
+  categorySlug: string | undefined;
+  yearGroupSlug: string | undefined;
+  subjectSlug: string;
+  subjectTitle: string;
+  keyStageSlug: string;
+  keyStageTitle: string;
+  learningThemesId: string;
+  browseRefined: (properties: BrowseRefinedProperties) => void;
+  setSelectedThemeSlug: (themeSlug: string | undefined) => void;
+};
+const DesktopUnitFilters = (props: DesktopUnitFiltersProps) => {
+  const {
+    showFilters,
+    filtersRef,
+    onFocus,
+    onBlur,
+    yearGroups,
+    subjectCategories,
+    learningThemes,
+    skipFiltersButton,
+    selectedThemeSlug,
+    programmeSlug,
+    setSelectedThemeSlug,
+    categorySlug,
+    yearGroupSlug,
+    subjectSlug,
+    subjectTitle,
+    keyStageSlug,
+    keyStageTitle,
+    learningThemesId,
+    browseRefined,
+  } = props;
+  return (
+    <OakBox
+      $display={["none", "none", "block"]}
+      $position={[null, null, "sticky"]}
+      $pt={["inner-padding-xl4"]}
+      $maxWidth={"all-spacing-20"}
+    >
+      <OakFieldset>
+        {showFilters && (
+          <OakBox $mb={"space-between-m2"}>
+            <OakHeading tag="h3" $font="heading-6" $mb={"space-between-ssx"}>
+              Filters
+            </OakHeading>
+
+            <OakBox ref={filtersRef}>
+              <OakSecondaryButton
+                element="a"
+                aria-label="Skip to units"
+                href="#unit-list"
+                onFocus={onFocus}
+                onBlur={onBlur}
+                style={
+                  skipFiltersButton
+                    ? {}
+                    : {
+                        position: "absolute",
+                        top: "-9999px",
+                        left: "-9999px",
+                      }
+                }
+              >
+                Skip to units
+              </OakSecondaryButton>
+            </OakBox>
+          </OakBox>
+        )}
+        {yearGroups.length > 1 && (
+          <YearGroupFilters
+            yearGroups={yearGroups}
+            idSuffix="desktop"
+            browseRefined={browseRefined}
+            selectedThemeSlug={selectedThemeSlug}
+            programmeSlug={programmeSlug}
+          />
+        )}
+        {subjectCategories && subjectCategories.length > 1 && (
+          <SubjectCategoryFilters
+            idSuffix="desktop"
+            subjectCategories={subjectCategories}
+            categorySlug={categorySlug}
+            browseRefined={browseRefined}
+            programmeSlug={programmeSlug}
+            selectedThemeSlug={selectedThemeSlug}
+          />
+        )}
+        {learningThemes?.length > 1 && (
+          <OakFlex $flexDirection={"column"}>
+            <OakHeading
+              id={learningThemesId}
+              tag="h3"
+              $font="heading-7"
+              $mb="space-between-s"
+            >
+              {/* Though still called "Learning themes" internally, these should be referred to as "Threads" in user facing displays */}
+              Threads
+            </OakHeading>
+            <UnitsLearningThemeFilters
+              idSuffix="desktop"
+              onChangeCallback={setSelectedThemeSlug}
+              labelledBy={learningThemesId}
+              learningThemes={learningThemes}
+              selectedThemeSlug={selectedThemeSlug ?? "all"}
+              categorySlug={categorySlug}
+              yearGroupSlug={yearGroupSlug}
+              programmeSlug={programmeSlug}
+              linkProps={{
+                page: "unit-index",
+                programmeSlug,
+              }}
+              trackingProps={{
+                keyStageSlug,
+                keyStageTitle: keyStageTitle as KeyStageTitleValueType,
+                subjectTitle,
+                subjectSlug,
+              }}
+              browseRefined={browseRefined}
+            />
+          </OakFlex>
+        )}
+      </OakFieldset>
+    </OakBox>
+  );
+};
+
+export default DesktopUnitFilters;

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
@@ -32,6 +32,11 @@ const subjectCategorySchema = z.object({
 });
 export type SubjectCategory = z.infer<typeof subjectCategorySchema>;
 
+const yearGroupsSchema = z.array(
+  z.object({ year: yearSlugs, yearTitle: yearDescriptions }),
+);
+export type YearGroups = z.infer<typeof yearGroupsSchema>;
+
 const reshapedUnitData = z.object({
   slug: z.string(),
   title: z.string(),
@@ -101,9 +106,7 @@ const unitListingData = z.object({
   hasNewContent: z.boolean(),
   learningThemes: learningThemes,
   phase: phaseSlugs,
-  yearGroups: z.array(
-    z.object({ year: yearSlugs, yearTitle: yearDescriptions }),
-  ),
+  yearGroups: yearGroupsSchema,
   subjectCategories: z.array(subjectCategorySchema),
   pathwayTitle: pathways.nullable(),
 });

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -168,6 +168,145 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
     }
   };
 
+  const MobileUnitFilterButton = () => {
+    return isFiltersAvailable ? (
+      <OakBox $display={["auto", "auto", "none"]}>
+        <MobileUnitFilters
+          {...curriculumData}
+          numberOfUnits={filteredUnits.length}
+          browseRefined={track.browseRefined}
+          setSelectedThemeSlug={setSelectedThemeSlug}
+          learningThemesFilterId={learningThemesFilterId}
+        />
+      </OakBox>
+    ) : null;
+  };
+
+  const TierTabsOrUnitCountHeader = () => {
+    return tiers.length > 0 ? (
+      <nav aria-label="tiers" data-testid="tiers-nav">
+        <TabularNav
+          $mb={[10, 10, 24]}
+          label="tiers"
+          links={tiers.map(
+            ({ tierTitle: title, tierSlug: slug, tierProgrammeSlug }) => ({
+              label: title,
+              programmeSlug: tierProgrammeSlug,
+              page: "unit-index",
+              isCurrent: tierSlug === slug,
+              currentStyles: ["underline"],
+            }),
+          )}
+        />
+      </nav>
+    ) : (
+      <OakFlex
+        $minWidth={"all-spacing-16"}
+        $mb={"space-between-s"}
+        $position={"relative"}
+      >
+        <OakHeading $font={"heading-5"} tag={"h2"}>
+          {`Units (${filteredUnits.length})`}
+        </OakHeading>
+      </OakFlex>
+    );
+  };
+
+  const DesktopFilters = () => {
+    return (
+      <OakBox
+        $display={["none", "none", "block"]}
+        $position={[null, null, "sticky"]}
+        $pt={["inner-padding-xl4"]}
+        $maxWidth={"all-spacing-20"}
+      >
+        <OakFieldset>
+          {isFiltersAvailable && (
+            <OakBox $mb={"space-between-m2"}>
+              <OakHeading tag="h3" $font="heading-6" $mb={"space-between-ssx"}>
+                Filters
+              </OakHeading>
+
+              <OakBox ref={filtersRef}>
+                <OakSecondaryButton
+                  element="a"
+                  aria-label="Skip to units"
+                  href="#unit-list"
+                  onFocus={() => setSkipFiltersButton(true)}
+                  onBlur={() => setSkipFiltersButton(false)}
+                  style={
+                    skipFiltersButton
+                      ? {}
+                      : {
+                          position: "absolute",
+                          top: "-9999px",
+                          left: "-9999px",
+                        }
+                  }
+                >
+                  Skip to units
+                </OakSecondaryButton>
+              </OakBox>
+            </OakBox>
+          )}
+          {yearGroups.length > 1 && (
+            <YearGroupFilters
+              yearGroups={yearGroups}
+              idSuffix="desktop"
+              browseRefined={track.browseRefined}
+              selectedThemeSlug={selectedThemeSlug}
+              programmeSlug={programmeSlug}
+            />
+          )}
+          {subjectCategories && subjectCategories.length > 1 && (
+            <SubjectCategoryFilters
+              idSuffix="desktop"
+              subjectCategories={subjectCategories}
+              categorySlug={categorySlug}
+              browseRefined={track.browseRefined}
+              programmeSlug={programmeSlug}
+              selectedThemeSlug={selectedThemeSlug}
+            />
+          )}
+          {learningThemes?.length > 1 && (
+            <OakFlex $flexDirection={"column"}>
+              <OakHeading
+                id={learningThemesId}
+                tag="h3"
+                $font="heading-7"
+                $mb="space-between-s"
+              >
+                {/* Though still called "Learning themes" internally, these should be referred to as "Threads" in user facing displays */}
+                Threads
+              </OakHeading>
+              <UnitsLearningThemeFilters
+                idSuffix="desktop"
+                onChangeCallback={setSelectedThemeSlug}
+                labelledBy={learningThemesId}
+                learningThemes={learningThemes}
+                selectedThemeSlug={selectedThemeSlug ?? "all"}
+                categorySlug={categorySlug}
+                yearGroupSlug={yearGroupSlug}
+                programmeSlug={programmeSlug}
+                linkProps={{
+                  page: "unit-index",
+                  programmeSlug,
+                }}
+                trackingProps={{
+                  keyStageSlug,
+                  keyStageTitle: keyStageTitle as KeyStageTitleValueType,
+                  subjectTitle,
+                  subjectSlug,
+                }}
+                browseRefined={track.browseRefined}
+              />
+            </OakFlex>
+          )}
+        </OakFieldset>
+      </OakBox>
+    );
+  };
+
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
       <AppLayout seoProps={unitsSEO}>
@@ -210,6 +349,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
           {...curriculumData}
         />
         <OakMaxWidth $ph={"inner-padding-m"}>
+          {/* Legacy content banner, only shown on certain legacy unit listing pages  */}
           <OakGrid>
             <OakGridArea $colSpan={[12, 12, 9]}>
               <NewContentBanner
@@ -223,108 +363,16 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
             </OakGridArea>
           </OakGrid>
           <OakGrid>
+            {/* Desktop filters side bar */}
             <OakGridArea
               $order={[0, 2, 2]}
               $colSpan={[12, 12, 3]}
               $pl={["inner-padding-xl"]}
             >
-              <OakBox
-                $display={["none", "none", "block"]}
-                $position={[null, null, "sticky"]}
-                $pt={["inner-padding-xl4"]}
-                $maxWidth={"all-spacing-20"}
-              >
-                <OakFieldset>
-                  {isFiltersAvailable && (
-                    <OakBox $mb={"space-between-m2"}>
-                      <OakHeading
-                        tag="h3"
-                        $font="heading-6"
-                        $mb={"space-between-ssx"}
-                      >
-                        Filters
-                      </OakHeading>
-
-                      <OakBox ref={filtersRef}>
-                        <OakSecondaryButton
-                          element="a"
-                          aria-label="Skip to units"
-                          href="#unit-list"
-                          onFocus={() => setSkipFiltersButton(true)}
-                          onBlur={() => setSkipFiltersButton(false)}
-                          style={
-                            skipFiltersButton
-                              ? {}
-                              : {
-                                  position: "absolute",
-                                  top: "-9999px",
-                                  left: "-9999px",
-                                }
-                          }
-                        >
-                          Skip to units
-                        </OakSecondaryButton>
-                      </OakBox>
-                    </OakBox>
-                  )}
-                  {yearGroups.length > 1 && (
-                    <YearGroupFilters
-                      yearGroups={yearGroups}
-                      idSuffix="desktop"
-                      browseRefined={track.browseRefined}
-                      selectedThemeSlug={selectedThemeSlug}
-                      programmeSlug={programmeSlug}
-                    />
-                  )}
-                  {subjectCategories && subjectCategories.length > 1 && (
-                    <SubjectCategoryFilters
-                      idSuffix="desktop"
-                      subjectCategories={subjectCategories}
-                      categorySlug={categorySlug}
-                      browseRefined={track.browseRefined}
-                      programmeSlug={programmeSlug}
-                      selectedThemeSlug={selectedThemeSlug}
-                    />
-                  )}
-                  {learningThemes?.length > 1 && (
-                    <OakFlex $flexDirection={"column"}>
-                      <OakHeading
-                        id={learningThemesId}
-                        tag="h3"
-                        $font="heading-7"
-                        $mb="space-between-s"
-                      >
-                        {/* Though still called "Learning themes" internally, these should be referred to as "Threads" in user facing displays */}
-                        Threads
-                      </OakHeading>
-                      <UnitsLearningThemeFilters
-                        idSuffix="desktop"
-                        onChangeCallback={setSelectedThemeSlug}
-                        labelledBy={learningThemesId}
-                        learningThemes={learningThemes}
-                        selectedThemeSlug={selectedThemeSlug ?? "all"}
-                        categorySlug={categorySlug}
-                        yearGroupSlug={yearGroupSlug}
-                        programmeSlug={programmeSlug}
-                        linkProps={{
-                          page: "unit-index",
-                          programmeSlug,
-                        }}
-                        trackingProps={{
-                          keyStageSlug,
-                          keyStageTitle:
-                            keyStageTitle as KeyStageTitleValueType,
-                          subjectTitle,
-                          subjectSlug,
-                        }}
-                        browseRefined={track.browseRefined}
-                      />
-                    </OakFlex>
-                  )}
-                </OakFieldset>
-              </OakBox>
+              <DesktopFilters />
             </OakGridArea>
 
+            {/* Header Row */}
             <OakGridArea
               $order={[1, 1, 0]}
               $colSpan={[12, 12, 9]}
@@ -334,71 +382,17 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                 $flexDirection={["column-reverse", "column-reverse", "column"]}
               >
                 <OakFlex
+                  $justifyContent={"space-between"}
                   $flexDirection={"row"}
                   $minWidth={["100%", "auto"]}
-                  $justifyContent={"space-between"}
                   $position={"relative"}
                 >
-                  {tiers.length === 0 && (
-                    <>
-                      <OakFlex
-                        $minWidth={"all-spacing-16"}
-                        $mb={"space-between-s"}
-                        $position={"relative"}
-                      >
-                        <OakHeading $font={"heading-5"} tag={"h2"}>
-                          {`Units (${filteredUnits.length})`}
-                        </OakHeading>
-                      </OakFlex>
-                      {isFiltersAvailable && (
-                        <OakBox $display={["auto", "auto", "none"]}>
-                          <MobileUnitFilters
-                            {...curriculumData}
-                            numberOfUnits={filteredUnits.length}
-                            browseRefined={track.browseRefined}
-                            setSelectedThemeSlug={setSelectedThemeSlug}
-                            learningThemesFilterId={learningThemesFilterId}
-                          />
-                        </OakBox>
-                      )}
-                    </>
-                  )}
+                  <TierTabsOrUnitCountHeader />
+                  <MobileUnitFilterButton />
                 </OakFlex>
-                {tiers.length > 0 && (
-                  <OakFlex $justifyContent={"space-between"}>
-                    <nav aria-label="tiers" data-testid="tiers-nav">
-                      <TabularNav
-                        $mb={[10, 10, 24]}
-                        label="tiers"
-                        links={tiers.map(
-                          ({
-                            tierTitle: title,
-                            tierSlug: slug,
-                            tierProgrammeSlug,
-                          }) => ({
-                            label: title,
-                            programmeSlug: tierProgrammeSlug,
-                            page: "unit-index",
-                            isCurrent: tierSlug === slug,
-                            currentStyles: ["underline"],
-                          }),
-                        )}
-                      />
-                    </nav>
-                    {isFiltersAvailable && (
-                      <OakBox $display={["auto", "auto", "none"]}>
-                        <MobileUnitFilters
-                          {...curriculumData}
-                          numberOfUnits={filteredUnits.length}
-                          browseRefined={track.browseRefined}
-                          setSelectedThemeSlug={setSelectedThemeSlug}
-                          learningThemesFilterId={learningThemesFilterId}
-                        />
-                      </OakBox>
-                    )}
-                  </OakFlex>
-                )}
               </OakFlex>
+
+              {/* Main Content */}
               {currentPageItems.length >= 1 ? (
                 <UnitList
                   {...curriculumData}

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -13,11 +13,9 @@ import {
   OakGrid,
   OakGridArea,
   OakHeading,
-  OakSecondaryButton,
   OakThemeProvider,
   oakDefaultTheme,
   OakFlex,
-  OakFieldset,
   OakMaxWidth,
 } from "@oaknational/oak-components";
 
@@ -30,7 +28,6 @@ import AppLayout from "@/components/SharedComponents/AppLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import usePagination from "@/components/SharedComponents/Pagination/usePagination";
 import UnitList from "@/components/TeacherComponents/UnitList";
-import UnitsLearningThemeFilters from "@/components/TeacherComponents/UnitsLearningThemeFilters";
 import TabularNav from "@/components/SharedComponents/TabularNav";
 import { RESULTS_PER_PAGE } from "@/utils/resultsPerPage";
 import getPageProps from "@/node-lib/getPageProps";
@@ -48,9 +45,8 @@ import {
 import { toSentenceCase } from "@/node-lib/curriculum-api-2023/helpers";
 import NewContentBanner from "@/components/TeacherComponents/NewContentBanner/NewContentBanner";
 import PaginationHead from "@/components/SharedComponents/Pagination/PaginationHead";
-import SubjectCategoryFilters from "@/components/TeacherComponents/SubjectCategoryFilters";
-import YearGroupFilters from "@/components/TeacherComponents/YearGroupFilters";
 import MobileUnitFilters from "@/components/TeacherComponents/MobileUnitFilters";
+import DesktopUnitFilters from "@/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters";
 
 export type UnitListingPageProps = {
   curriculumData: UnitListingData;
@@ -212,101 +208,6 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
     );
   };
 
-  const DesktopFilters = () => {
-    return (
-      <OakBox
-        $display={["none", "none", "block"]}
-        $position={[null, null, "sticky"]}
-        $pt={["inner-padding-xl4"]}
-        $maxWidth={"all-spacing-20"}
-      >
-        <OakFieldset>
-          {isFiltersAvailable && (
-            <OakBox $mb={"space-between-m2"}>
-              <OakHeading tag="h3" $font="heading-6" $mb={"space-between-ssx"}>
-                Filters
-              </OakHeading>
-
-              <OakBox ref={filtersRef}>
-                <OakSecondaryButton
-                  element="a"
-                  aria-label="Skip to units"
-                  href="#unit-list"
-                  onFocus={() => setSkipFiltersButton(true)}
-                  onBlur={() => setSkipFiltersButton(false)}
-                  style={
-                    skipFiltersButton
-                      ? {}
-                      : {
-                          position: "absolute",
-                          top: "-9999px",
-                          left: "-9999px",
-                        }
-                  }
-                >
-                  Skip to units
-                </OakSecondaryButton>
-              </OakBox>
-            </OakBox>
-          )}
-          {yearGroups.length > 1 && (
-            <YearGroupFilters
-              yearGroups={yearGroups}
-              idSuffix="desktop"
-              browseRefined={track.browseRefined}
-              selectedThemeSlug={selectedThemeSlug}
-              programmeSlug={programmeSlug}
-            />
-          )}
-          {subjectCategories && subjectCategories.length > 1 && (
-            <SubjectCategoryFilters
-              idSuffix="desktop"
-              subjectCategories={subjectCategories}
-              categorySlug={categorySlug}
-              browseRefined={track.browseRefined}
-              programmeSlug={programmeSlug}
-              selectedThemeSlug={selectedThemeSlug}
-            />
-          )}
-          {learningThemes?.length > 1 && (
-            <OakFlex $flexDirection={"column"}>
-              <OakHeading
-                id={learningThemesId}
-                tag="h3"
-                $font="heading-7"
-                $mb="space-between-s"
-              >
-                {/* Though still called "Learning themes" internally, these should be referred to as "Threads" in user facing displays */}
-                Threads
-              </OakHeading>
-              <UnitsLearningThemeFilters
-                idSuffix="desktop"
-                onChangeCallback={setSelectedThemeSlug}
-                labelledBy={learningThemesId}
-                learningThemes={learningThemes}
-                selectedThemeSlug={selectedThemeSlug ?? "all"}
-                categorySlug={categorySlug}
-                yearGroupSlug={yearGroupSlug}
-                programmeSlug={programmeSlug}
-                linkProps={{
-                  page: "unit-index",
-                  programmeSlug,
-                }}
-                trackingProps={{
-                  keyStageSlug,
-                  keyStageTitle: keyStageTitle as KeyStageTitleValueType,
-                  subjectTitle,
-                  subjectSlug,
-                }}
-                browseRefined={track.browseRefined}
-              />
-            </OakFlex>
-          )}
-        </OakFieldset>
-      </OakBox>
-    );
-  };
-
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
       <AppLayout seoProps={unitsSEO}>
@@ -369,7 +270,27 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
               $colSpan={[12, 12, 3]}
               $pl={["inner-padding-xl"]}
             >
-              <DesktopFilters />
+              <DesktopUnitFilters
+                showFilters={isFiltersAvailable}
+                onFocus={() => setSkipFiltersButton(true)}
+                onBlur={() => setSkipFiltersButton(false)}
+                yearGroups={yearGroups}
+                subjectCategories={subjectCategories}
+                learningThemes={learningThemes}
+                filtersRef={filtersRef}
+                skipFiltersButton={skipFiltersButton}
+                programmeSlug={programmeSlug}
+                selectedThemeSlug={selectedThemeSlug}
+                categorySlug={categorySlug}
+                yearGroupSlug={yearGroupSlug}
+                subjectSlug={subjectSlug}
+                subjectTitle={subjectTitle}
+                keyStageSlug={keyStageSlug}
+                keyStageTitle={keyStageTitle}
+                learningThemesId={learningThemesId}
+                browseRefined={track.browseRefined}
+                setSelectedThemeSlug={setSelectedThemeSlug}
+              />
             </OakGridArea>
 
             {/* Header Row */}

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -89,7 +89,6 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
     yearGroups.length > 1 ||
     subjectCategories.length > 1 ||
     learningThemes.length > 1;
-
   const [selectedThemeSlug, setSelectedThemeSlug] = useState<
     string | undefined
   >(themeSlug);
@@ -340,7 +339,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                   $justifyContent={"space-between"}
                   $position={"relative"}
                 >
-                  {tiers.length === 0 && currentPageItems.length >= 1 && (
+                  {tiers.length === 0 && (
                     <>
                       <OakFlex
                         $minWidth={"all-spacing-16"}
@@ -365,7 +364,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
                     </>
                   )}
                 </OakFlex>
-                {tiers.length > 0 && currentPageItems.length >= 1 && (
+                {tiers.length > 0 && (
                   <OakFlex $justifyContent={"space-between"}>
                     <nav aria-label="tiers" data-testid="tiers-nav">
                       <TabularNav


### PR DESCRIPTION
## Description

Music year: 2022

- Remove conditional rendering of header row on mobile where the filter button lives
- Refactor unit listing page layout

## Issue(s)
Fixes https://www.notion.so/oaknationalacademy/Filter-button-disappears-on-mobile-13e26cc4e1b180a19183dcec5e00278c?pvs=4

## How to test

1. Go to https://deploy-preview-3175--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks4-aqa/units?category=literature&learning-theme=developing-fiction-writing
2. Open the filter menu on mobile / tablet view and apply filters until you arrive at 0 results 
3. You should see the filter button and a heading, either `Units (0)` or tabs for tiers
4. You should be able to go in an adjust the filters
5. Desktop view should be unchanged
6. Navigating by keyboard on desktop should work the same with regards to applying filters

## Screenshots
Before
<img width="415" alt="Screenshot 2025-02-04 at 09 00 50" src="https://github.com/user-attachments/assets/49f8a7f8-6cc9-4180-a233-fd5442b5c86c" />

After: Without Tiers
<img width="500" alt="Screenshot 2025-02-04 at 09 08 00" src="https://github.com/user-attachments/assets/ab8d3a1e-48b3-43e3-a793-0dbfe482aeaf" />


After: With Tiers
<img width="500" alt="Screenshot 2025-02-04 at 09 00 05" src="https://github.com/user-attachments/assets/7395ad1c-0064-469b-8a7d-cf7cc6291003" />
