### PR TITLE
fix: use subject title instead of slug for header [LESQ-1269]

### DIFF
--- a/src/components/TeacherComponents/UnitList/UnitList.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.tsx
@@ -120,6 +120,7 @@ const UnitList: FC<UnitListProps> = (props) => {
     subjectSlug,
     subjectParent,
     filteredUnits,
+    subjectTitle,
   } = props;
 
   const linkSubject = subjectParent
@@ -252,7 +253,7 @@ const UnitList: FC<UnitListProps> = (props) => {
     newPageItems.length && phaseSlug ? (
       <OakUnitsContainer
         isLegacy={false}
-        subject={category ?? subjectSlug}
+        subject={category ?? subjectTitle}
         phase={phaseSlug}
         curriculumHref={
           hideNewCurriculumDownloadButton


### PR DESCRIPTION
## Description

Music year: 1986

- use subjectTitle for unit list header instead of subjectSlug

## Issue(s)

Fixes #
Slugs showing for multi-word subjects

## How to test

1. Go to https://deploy-preview-3180--oak-web-application.netlify.thenational.academy/teachers/programmes/combined-science-secondary-ks4-higher-ocr/units
3. You should see the units header has no hyphen, and is in sentence case `Combined science units`
4. The same should be true for /teachers/programmes/physical-education-secondary-ks4-gcse-aqa/units `Physical education units`
5. Other subjects should be unaffected

## Screenshots

How it used to look (delete if n/a):
<img width="600" alt="Screenshot 2025-02-05 at 10 03 47" src="https://github.com/user-attachments/assets/ccafe5f1-e884-4bf1-9835-dbf6836a62f7" />


How it should now look:
<img width="600" alt="Screenshot 2025-02-05 at 10 10 40" src="https://github.com/user-attachments/assets/377f3596-2bcd-47f7-a47e-1d61a8858331" />

