### PR TITLE
Restyle subject category filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^8.8.0",
         "@mux/mux-player-react": "^3.1.0",
-        "@oaknational/oak-components": "^1.80.1",
+        "@oaknational/oak-components": "^1.82.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.48.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7056,9 +7056,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.80.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.80.1.tgz",
-      "integrity": "sha512-TV9D8tr9GyYGJwhwNrNYz9OnyTLbppuSrk3f7M84Dp/3mPCwjjE67sUeJngABE2v8ujnOV7T3bpV5VXPROa1/w==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.82.0.tgz",
+      "integrity": "sha512-DJMg11sPXFmo5ljTJo+J8fVHGUwdhDcrI8i02cmg3buH4k40z528HbxPAPgmvU1K5BCvg30BrKWI33xpvfCFbQ==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^8.8.0",
     "@mux/mux-player-react": "^3.1.0",
-    "@oaknational/oak-components": "^1.80.1",
+    "@oaknational/oak-components": "^1.82.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.48.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -4,6 +4,7 @@ import {
   OakHeading,
   OakRadioGroup,
   OakRadioAsButton,
+  OakHandDrawnHR,
 } from "@oaknational/oak-components";
 import { isEqual } from "lodash";
 
@@ -143,6 +144,11 @@ export default function CurriculumVisualiserFiltersDesktop({
 
       {subjectCategories.length > 0 && (
         <>
+          <OakHandDrawnHR
+            hrColor={"grey40"}
+            $mt={"space-between-m"}
+            $mb={"space-between-m2"}
+          />
           <OakHeading
             id="subject-categories-label"
             tag="h4"
@@ -176,6 +182,12 @@ export default function CurriculumVisualiserFiltersDesktop({
 
       {childSubjects.length > 0 && (
         <>
+          <OakHandDrawnHR
+            hrColor={"grey40"}
+            $mt={"space-between-m"}
+            $mb={"space-between-m2"}
+          />
+
           <OakHeading
             id="child-subjects-label"
             tag="h4"
@@ -207,6 +219,12 @@ export default function CurriculumVisualiserFiltersDesktop({
 
       {tiers.length > 0 && (
         <>
+          <OakHandDrawnHR
+            hrColor={"grey40"}
+            $mt={"space-between-m"}
+            $mb={"space-between-m2"}
+          />
+
           <OakHeading
             id="tiers-label"
             tag="h4"
@@ -235,6 +253,11 @@ export default function CurriculumVisualiserFiltersDesktop({
         </>
       )}
 
+      <OakHandDrawnHR
+        hrColor={"grey40"}
+        $mt={"space-between-m"}
+        $mb={"space-between-m2"}
+      />
       <Fieldset data-testid={"threads-filter-desktop"}>
         <FieldsetLegend $font={"heading-6"} $mt="space-between-m2">
           Highlight a thread

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -18,6 +18,7 @@ import {
 } from "./CurriculumVisualiserFilters";
 import { highlightedUnitCount } from "./helpers";
 
+import { getValidSubjectCategoryIconById } from "@/utils/getValidSubjectCategoryIconById";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import {
   Thread,
@@ -175,7 +176,7 @@ export default function CurriculumVisualiserFiltersDesktop({
                   key={subjectCategory.id}
                   value={String(subjectCategory.id)}
                   displayValue={subjectCategory.title}
-                  icon={getValidSubjectIconName(subjectCategory)}
+                  icon={getValidSubjectCategoryIconById(subjectCategory.id)}
                 />
               );
             })}

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -169,13 +169,16 @@ export default function CurriculumVisualiserFiltersDesktop({
             $gap="space-between-ssx"
             aria-labelledby="subject-categories-label"
           >
-            {subjectCategories.map((subjectCategory) => (
-              <OakRadioAsButton
-                key={subjectCategory.id}
-                value={String(subjectCategory.id)}
-                displayValue={subjectCategory.title}
-              />
-            ))}
+            {subjectCategories.map((subjectCategory) => {
+              return (
+                <OakRadioAsButton
+                  key={subjectCategory.id}
+                  value={String(subjectCategory.id)}
+                  displayValue={subjectCategory.title}
+                  icon={getValidSubjectIconName(subjectCategory)}
+                />
+              );
+            })}
           </OakRadioGroup>
         </>
       )}

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -1,0 +1,22 @@
+const subjectCategoryIconMap: Record<number, string> = {
+  1: "subject-biology",
+  2: "subject-chemistry",
+  3: "subject-physics",
+  4: "subject-english-reading-writing-oracy",
+  5: "subject-english-grammar",
+  6: "subject-english-handwriting",
+  7: "subject-english-spelling",
+  8: "subject-english-vocabulary",
+  18: "subject-english-language",
+  19: "subject-english-reading-for-pleasure",
+};
+
+export function getValidSubjectCategoryIconById(id: number): string {
+  const subjectSlug = subjectCategoryIconMap[id];
+
+  if (!subjectSlug) {
+    return "books";
+  }
+
+  return subjectSlug;
+}

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -1,22 +1,25 @@
+import { OakIconName } from "@oaknational/oak-components";
+
+import { getValidSubjectIconName } from "./getValidSubjectIconName";
 const subjectCategoryIconMap: Record<number, string> = {
-  1: "subject-biology",
-  2: "subject-chemistry",
-  3: "subject-physics",
-  4: "subject-english-reading-writing-oracy",
-  5: "subject-english-grammar",
-  6: "subject-english-handwriting",
-  7: "subject-english-spelling",
-  8: "subject-english-vocabulary",
-  18: "subject-english-language",
-  19: "subject-english-reading-for-pleasure",
+  1: "biology",
+  2: "chemistry",
+  3: "physics",
+  4: "english-reading-writing-oracy",
+  5: "english-grammar",
+  6: "english-handwriting",
+  7: "english-spelling",
+  8: "english-vocabulary",
+  18: "english-language",
+  19: "english-reading-for-pleasure",
 };
 
-export function getValidSubjectCategoryIconById(id: number): string {
+export function getValidSubjectCategoryIconById(id: number): OakIconName {
   const subjectSlug = subjectCategoryIconMap[id];
 
   if (!subjectSlug) {
     return "books";
   }
 
-  return subjectSlug;
+  return getValidSubjectIconName(subjectSlug);
 }

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -17,9 +17,5 @@ const subjectCategoryIconMap: Record<number, string> = {
 export function getValidSubjectCategoryIconById(id: number): OakIconName {
   const subjectSlug = subjectCategoryIconMap[id];
 
-  if (!subjectSlug) {
-    return "books";
-  }
-
-  return getValidSubjectIconName(subjectSlug);
+  return getValidSubjectIconName(subjectSlug ?? null);
 }

--- a/src/utils/getValidSubjectIconName.ts
+++ b/src/utils/getValidSubjectIconName.ts
@@ -1,11 +1,18 @@
 import { OakIconName, isValidIconName } from "@oaknational/oak-components";
 
+import { getValidSubjectCategoryIconById } from "./getValidSubjectCategoryIconById";
+
+import { SubjectCategory } from "@/utils/curriculum/types";
 import errorReporter from "@/common-lib/error-reporter";
 import OakError from "@/errors/OakError";
 
 export const getValidSubjectIconName = (
-  subject: string | null,
+  subject: string | null | number | SubjectCategory,
 ): OakIconName => {
+  if (subject && typeof subject === "object" && "id" in subject) {
+    return getValidSubjectCategoryIconById(subject.id) as OakIconName;
+  }
+
   const subjectIconName = `subject-${subject}`;
   if (!isValidIconName(subjectIconName)) {
     // Subject will be null when a canonical lesson appears in multiple subjects

--- a/src/utils/getValidSubjectIconName.ts
+++ b/src/utils/getValidSubjectIconName.ts
@@ -1,18 +1,11 @@
 import { OakIconName, isValidIconName } from "@oaknational/oak-components";
 
-import { getValidSubjectCategoryIconById } from "./getValidSubjectCategoryIconById";
-
-import { SubjectCategory } from "@/utils/curriculum/types";
 import errorReporter from "@/common-lib/error-reporter";
 import OakError from "@/errors/OakError";
 
 export const getValidSubjectIconName = (
-  subject: string | null | number | SubjectCategory,
+  subject: string | null,
 ): OakIconName => {
-  if (subject && typeof subject === "object" && "id" in subject) {
-    return getValidSubjectCategoryIconById(subject.id) as OakIconName;
-  }
-
   const subjectIconName = `subject-${subject}`;
   if (!isValidIconName(subjectIconName)) {
     // Subject will be null when a canonical lesson appears in multiple subjects


### PR DESCRIPTION
## Description

Music year: 1966

- Add HR elements between each filter section
  - @rightsaidjames Note that the custom HR component has been removed from the codebase in our attempt to standardise components and try to use components from the component library where possible. As such instead of the `Hr` component being used I had to use `OakHandDrawnHr`. Due to this the divider has a slightly different style and could only take specific margin-top and bottom spacing values – which therefore meant that it diverges very slightly in look from the Figma designs. I talked with @HelenHarlow about this and she was fine with the changes.

Note that there seems to be a slight bug with the filter at the moment, where subject categories and exam subjects aren't displayed at the same time when all is selected (they're only conditioanlly displayed if you click into their associated years):

https://github.com/user-attachments/assets/c8bf8e90-acc0-435c-b714-fd179eaef6f1

Ignore this for the mean time, as we'll get around to fixing this as part of work in another ticket.

## Issue(s)

Fixes #[1172](https://www.notion.so/oaknationalacademy/Initial-defaults-in-filtering-17d26cc4e1b180929f2ae7c4a1d7e890?pvs=4)

## How to test

1. Go to https://deploy-preview-3183--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Select a subject from the curriculum visualiser
3. You should see that filter sections are now visible on the left, with an appropriately spaced separator in between each filter section

## Screenshots

How it used to look (delete if n/a):
<img width="764" alt="image" src="https://github.com/user-attachments/assets/d38a2284-6ec5-44fd-a60e-db063099e6e0" />

How it should now look:
<img width="467" alt="image" src="https://github.com/user-attachments/assets/e27c660b-a6dd-43aa-8d89-1e03ee5bf4e3" />

## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [ ] Does this PR update a package with a breaking change
