### PR TITLE
Preselected "all" category for subject category filters

### DIFF
--- a/src/pages-helpers/curriculum/docx/tab-helpers.ts
+++ b/src/pages-helpers/curriculum/docx/tab-helpers.ts
@@ -16,7 +16,11 @@ import {
   SubjectCategory,
 } from "@/utils/curriculum/types";
 import { getUnitFeatures } from "@/utils/curriculum/features";
-import { sortUnits, sortYears } from "@/utils/curriculum/sorting";
+import {
+  sortSubjectCategoriesOnFeatures,
+  sortUnits,
+  sortYears,
+} from "@/utils/curriculum/sorting";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 import { isExamboardSlug } from "@/pages-helpers/pupil/options-pages/options-pages-helpers";
 
@@ -255,6 +259,19 @@ export function createUnitsListingByYear(
 
   for (const year of Object.keys(yearData)) {
     const data = yearData[year]!;
+
+    const allSubjectCategoryTag: SubjectCategory = { id: -1, title: "All" };
+    const features = getUnitFeatures(units[0]);
+    // Add an "All" option if there are 2 or more subject categories. Set to -1 id as this shouldn't ever appear in the DB
+    if (!features?.subjectcategories?.all_disabled) {
+      if (data.subjectCategories.length >= 2) {
+        data.subjectCategories.unshift(allSubjectCategoryTag);
+      }
+    }
+    data.subjectCategories = data.subjectCategories.sort(
+      sortSubjectCategoriesOnFeatures(features),
+    );
+
     if (data.units.length > 0) {
       const labels = getUnitFeatures(data.units[0]!)?.labels ?? [];
       if (
@@ -350,7 +367,6 @@ export function formatCurriculumUnitsData(
   data: CurriculumUnitsTabData,
 ): CurriculumUnitsFormattedData {
   const { units } = data;
-  // const features = getUnitFeatures(units[0]);
   // Filtering for tiers, ideally this would be fixed in the MV, but for now we need to filter out here.
   const filteredUnits = units;
   const yearData = createUnitsListingByYear(filteredUnits);

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -4,30 +4,44 @@ import {
   getDefaultSubjectCategories,
   getDefaultTiers,
 } from "./filtering";
-import { Unit } from "./types";
 
 import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 describe("filtering", () => {
   it("getDefaultChildSubject", () => {
-    const out = getDefaultChildSubject([
-      { subject_parent: "science", subject_slug: "biology" },
-      { subject_parent: "science", subject_slug: "physics" },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultChildSubject(input);
     expect(out).toEqual(["biology"]);
   });
   it("getDefaultSubjectCategories", () => {
-    const out = getDefaultSubjectCategories([
-      { subjectcategories: [{ id: 1 }] },
-      { subjectcategories: [{ id: 2 }] },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        subjectCategories: [{ id: 1 }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        subjectCategories: [{ id: 2 }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultSubjectCategories(input);
     expect(out).toEqual(["1"]);
   });
   it("getDefaultTiers", () => {
-    const out = getDefaultTiers([
-      { tier_slug: "higher", tier: "Higher" },
-      { tier_slug: "foundation", tier: "Foundation" },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        tiers: [{ tier_slug: "higher", tier: "Higher" }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultTiers(input);
     expect(out).toEqual(["foundation"]);
   });
 
@@ -35,33 +49,25 @@ describe("filtering", () => {
     const out = getDefaultFilter({
       yearData: {
         "7": {
-          units: [
-            {
-              subject_parent: "science",
-              subject_slug: "biology",
-              subjectcategories: [{ id: 1 }],
-              tier_slug: "higher",
-              tier: "Higher",
-            },
-            {
-              subject_parent: "science",
-              subject_slug: "physics",
-              subjectcategories: [{ id: 2 }],
-              tier_slug: "foundation",
-              tier: "Foundation",
-            },
-          ],
-        },
-      } as unknown as CurriculumUnitsYearData,
+          tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
+          childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
+          subjectCategories: [{ id: 2 }],
+        } as CurriculumUnitsYearData[number],
+        "8": {
+          tiers: [{ tier_slug: "higher", tier: "Higher" }],
+          childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
+          subjectCategories: [{ id: 1 }],
+        } as CurriculumUnitsYearData[number],
+      },
       threadOptions: [],
-      yearOptions: ["7"],
+      yearOptions: ["7", "8"],
     });
     expect(out).toEqual({
       childSubjects: ["biology"],
-      subjectCategories: ["1"],
+      subjectCategories: ["2"],
       threads: [],
       tiers: ["foundation"],
-      years: ["7"],
+      years: ["7", "8"],
     });
   });
 });

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -1,20 +1,20 @@
 import { sortChildSubjects, sortTiers } from "./sorting";
-import { Subject, Tier, Unit } from "./types";
+import { Subject, Tier } from "./types";
 
 import {
   CurriculumUnitsFormattedData,
   CurriculumUnitsYearData,
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
-export function getDefaultChildSubject(units: Unit[]) {
+export function getDefaultChildSubject(data: CurriculumUnitsYearData) {
   const set = new Set<Subject>();
-  units.forEach((u) => {
-    if (u.subject_parent) {
+  Object.values(data).forEach((yearData) => {
+    yearData.childSubjects.forEach((childSubject) => {
       set.add({
-        subject_slug: u.subject_slug,
-        subject: u.subject,
+        subject_slug: childSubject.subject_slug,
+        subject: childSubject.subject,
       });
-    }
+    });
   });
   const childSubjects = [...set]
     .toSorted(sortChildSubjects)
@@ -24,22 +24,24 @@ export function getDefaultChildSubject(units: Unit[]) {
   }
   return [];
 }
-export function getDefaultSubjectCategories(units: Unit[]) {
+export function getDefaultSubjectCategories(data: CurriculumUnitsYearData) {
   const set = new Set<string>();
-  units.forEach((u) => {
-    u.subjectcategories?.forEach((sc) => set.add(String(sc.id)));
+  Object.values(data).forEach((yearData) => {
+    yearData.subjectCategories.forEach((subjectCategory) =>
+      set.add(String(subjectCategory.id)),
+    );
   });
   return [[...set][0]!];
 }
-export function getDefaultTiers(units: Unit[]) {
+export function getDefaultTiers(data: CurriculumUnitsYearData) {
   const set = new Set<Tier>();
-  units.forEach((u) => {
-    if (u.tier_slug && u.tier) {
+  Object.values(data).forEach((yearData) => {
+    yearData.tiers.forEach((tier) => {
       set.add({
-        tier_slug: u.tier_slug,
-        tier: u.tier,
+        tier_slug: tier.tier_slug,
+        tier: tier.tier,
       });
-    }
+    });
   });
   const tiers = [...set].toSorted(sortTiers).map((t) => t.tier_slug);
   if (tiers.length > 0) {
@@ -48,17 +50,11 @@ export function getDefaultTiers(units: Unit[]) {
   return [];
 }
 
-function unitsFrom(yearData: CurriculumUnitsYearData): Unit[] {
-  return Object.entries(yearData).flatMap(([, data]) => data.units);
-}
-
 export function getDefaultFilter(data: CurriculumUnitsFormattedData) {
-  const units = unitsFrom(data.yearData);
-
   return {
-    childSubjects: getDefaultChildSubject(units),
-    subjectCategories: getDefaultSubjectCategories(units),
-    tiers: getDefaultTiers(units),
+    childSubjects: getDefaultChildSubject(data.yearData),
+    subjectCategories: getDefaultSubjectCategories(data.yearData),
+    tiers: getDefaultTiers(data.yearData),
     years: data.yearOptions,
     threads: [],
   };


### PR DESCRIPTION
## Description
Added preselected all category for subject category filters

## Issue(s)

Fixes `CUR-1181` & `CUR-1190`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check new filters sidebar correctly displays "all" for subject categories (except english)
