### PR TITLE
Subject specific grouping labels (ks3/ks4)

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -44,11 +44,13 @@ export default function CurriculumVisualiserFiltersDesktop({
   const childSubjectsAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "childSubjects",
+    filters.years,
   );
   const subjectCategoriesAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "subjectCategories",
-  );
+    filters.years,
+  ).filter((ks) => !childSubjectsAt.includes(ks));
   const tiersAt = presentAtKeyStageSlugs(keyStageSlugData, "tiers");
 
   function isSelectedThread(thread: Thread) {
@@ -114,7 +116,7 @@ export default function CurriculumVisualiserFiltersDesktop({
         </OakRadioGroup>
       </>
 
-      {subjectCategories.length > 0 && (
+      {subjectCategoriesAt.length > 0 && (
         <>
           <OakHandDrawnHR
             hrColor={"grey40"}

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -20,53 +20,13 @@ import { highlightedUnitCount } from "./helpers";
 
 import { getValidSubjectCategoryIconById } from "@/utils/getValidSubjectCategoryIconById";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
-import {
-  Thread,
-  Subject,
-  SubjectCategory,
-  Tier,
-} from "@/utils/curriculum/types";
-import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { Thread } from "@/utils/curriculum/types";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
+import { getFilterData } from "@/utils/curriculum/filtering";
 import {
-  sortChildSubjects,
-  sortSubjectCategoriesOnFeatures,
-  sortTiers,
-} from "@/utils/curriculum/sorting";
-
-function getFilterData(
-  yearData: CurriculumUnitsFormattedData["yearData"],
-  years: string[],
-) {
-  const childSubjects = new Map<string, Subject>();
-  const subjectCategories = new Map<number, SubjectCategory>();
-  const tiers = new Map<string, Tier>();
-  years.forEach((year) => {
-    const obj = yearData[year]!;
-    obj.childSubjects.forEach((childSubject) =>
-      childSubjects.set(childSubject.subject_slug, childSubject),
-    );
-    obj.tiers.forEach((tier) => tiers.set(tier.tier_slug, tier));
-    obj.subjectCategories.forEach((subjectCategory) =>
-      subjectCategories.set(subjectCategory.id, subjectCategory),
-    );
-  });
-
-  const childSubjectsArray = [...childSubjects.values()].toSorted(
-    sortChildSubjects,
-  );
-  const subjectCategoriesArray = [...subjectCategories.values()].toSorted(
-    sortSubjectCategoriesOnFeatures(null),
-  );
-  const tiersArray = [...tiers.values()].toSorted(sortTiers);
-
-  return {
-    childSubjects: childSubjectsArray.length > 1 ? childSubjectsArray : [],
-    subjectCategories:
-      childSubjectsArray.length < 1 ? subjectCategoriesArray : [],
-    tiers: tiersArray,
-  };
-}
+  byKeyStageSlug,
+  presentAtKeyStageSlugs,
+} from "@/utils/curriculum/keystage";
 
 export default function CurriculumVisualiserFiltersDesktop({
   filters,
@@ -79,6 +39,17 @@ export default function CurriculumVisualiserFiltersDesktop({
     data.yearData,
     filters.years,
   );
+
+  const keyStageSlugData = byKeyStageSlug(yearData);
+  const childSubjectsAt = presentAtKeyStageSlugs(
+    keyStageSlugData,
+    "childSubjects",
+  );
+  const subjectCategoriesAt = presentAtKeyStageSlugs(
+    keyStageSlugData,
+    "subjectCategories",
+  );
+  const tiersAt = presentAtKeyStageSlugs(keyStageSlugData, "tiers");
 
   function isSelectedThread(thread: Thread) {
     return filters.threads.includes(thread.slug);
@@ -156,7 +127,10 @@ export default function CurriculumVisualiserFiltersDesktop({
             $font={"heading-6"}
             $mb="space-between-s"
           >
-            Category {childSubjects.length > 0 ? "(KS3)" : ""}
+            Category{" "}
+            {subjectCategoriesAt.length === 1
+              ? `(${subjectCategoriesAt[0]?.toUpperCase()})`
+              : ""}
           </OakHeading>
 
           <OakRadioGroup
@@ -198,7 +172,10 @@ export default function CurriculumVisualiserFiltersDesktop({
             $font={"heading-6"}
             $mb="space-between-s"
           >
-            Exam subject (KS4)
+            Exam subject{" "}
+            {childSubjectsAt.length === 1
+              ? `(${childSubjectsAt[0]?.toUpperCase()})`
+              : ""}
           </OakHeading>
           <OakRadioGroup
             name="childSubjects"
@@ -235,7 +212,8 @@ export default function CurriculumVisualiserFiltersDesktop({
             $font={"heading-6"}
             $mb="space-between-s"
           >
-            Learning tier (KS4)
+            Learning tier{" "}
+            {tiersAt.length === 1 ? `(${tiersAt[0]?.toUpperCase()})` : ""}
           </OakHeading>
           <OakRadioGroup
             name="tiers"

--- a/src/pages-helpers/curriculum/docx/tab-helpers.ts
+++ b/src/pages-helpers/curriculum/docx/tab-helpers.ts
@@ -16,7 +16,11 @@ import {
   SubjectCategory,
 } from "@/utils/curriculum/types";
 import { getUnitFeatures } from "@/utils/curriculum/features";
-import { sortUnits, sortYears } from "@/utils/curriculum/sorting";
+import {
+  sortSubjectCategoriesOnFeatures,
+  sortUnits,
+  sortYears,
+} from "@/utils/curriculum/sorting";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 import { isExamboardSlug } from "@/pages-helpers/pupil/options-pages/options-pages-helpers";
 
@@ -255,6 +259,19 @@ export function createUnitsListingByYear(
 
   for (const year of Object.keys(yearData)) {
     const data = yearData[year]!;
+
+    const allSubjectCategoryTag: SubjectCategory = { id: -1, title: "All" };
+    const features = getUnitFeatures(units[0]);
+    // Add an "All" option if there are 2 or more subject categories. Set to -1 id as this shouldn't ever appear in the DB
+    if (!features?.subjectcategories?.all_disabled) {
+      if (data.subjectCategories.length >= 2) {
+        data.subjectCategories.unshift(allSubjectCategoryTag);
+      }
+    }
+    data.subjectCategories = data.subjectCategories.sort(
+      sortSubjectCategoriesOnFeatures(features),
+    );
+
     if (data.units.length > 0) {
       const labels = getUnitFeatures(data.units[0]!)?.labels ?? [];
       if (
@@ -350,7 +367,6 @@ export function formatCurriculumUnitsData(
   data: CurriculumUnitsTabData,
 ): CurriculumUnitsFormattedData {
   const { units } = data;
-  // const features = getUnitFeatures(units[0]);
   // Filtering for tiers, ideally this would be fixed in the MV, but for now we need to filter out here.
   const filteredUnits = units;
   const yearData = createUnitsListingByYear(filteredUnits);

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -3,6 +3,7 @@ import {
   getDefaultFilter,
   getDefaultSubjectCategories,
   getDefaultTiers,
+  getFilterData,
 } from "./filtering";
 
 import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
@@ -69,5 +70,93 @@ describe("filtering", () => {
       tiers: ["foundation"],
       years: ["7", "8"],
     });
+  });
+});
+
+test("getFilterData", () => {
+  const definition = {
+    "7": {
+      tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
+      childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
+      subjectCategories: [{ id: 2 }],
+    } as CurriculumUnitsYearData[number],
+    "8": {
+      tiers: [{ tier_slug: "higher", tier: "Higher" }],
+      childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
+      subjectCategories: [{ id: 1 }],
+    } as CurriculumUnitsYearData[number],
+  };
+  const allYearOutput = getFilterData(definition, ["7", "8"]);
+  expect(allYearOutput).toEqual({
+    childSubjects: [
+      {
+        subject: "Biology",
+        subject_slug: "biology",
+      },
+      {
+        subject: "Physics",
+        subject_slug: "physics",
+      },
+    ],
+    subjectCategories: [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+    ],
+    tiers: [
+      {
+        tier: "Foundation",
+        tier_slug: "foundation",
+      },
+      {
+        tier: "Higher",
+        tier_slug: "higher",
+      },
+    ],
+  });
+
+  const all7Output = getFilterData(definition, ["7"]);
+  expect(all7Output).toEqual({
+    childSubjects: [
+      {
+        subject: "Physics",
+        subject_slug: "physics",
+      },
+    ],
+    subjectCategories: [
+      {
+        id: 2,
+      },
+    ],
+    tiers: [
+      {
+        tier: "Foundation",
+        tier_slug: "foundation",
+      },
+    ],
+  });
+
+  const all8Output = getFilterData(definition, ["8"]);
+  expect(all8Output).toEqual({
+    childSubjects: [
+      {
+        subject: "Biology",
+        subject_slug: "biology",
+      },
+    ],
+    subjectCategories: [
+      {
+        id: 1,
+      },
+    ],
+    tiers: [
+      {
+        tier: "Higher",
+        tier_slug: "higher",
+      },
+    ],
   });
 });

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -4,30 +4,44 @@ import {
   getDefaultSubjectCategories,
   getDefaultTiers,
 } from "./filtering";
-import { Unit } from "./types";
 
 import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 describe("filtering", () => {
   it("getDefaultChildSubject", () => {
-    const out = getDefaultChildSubject([
-      { subject_parent: "science", subject_slug: "biology" },
-      { subject_parent: "science", subject_slug: "physics" },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultChildSubject(input);
     expect(out).toEqual(["biology"]);
   });
   it("getDefaultSubjectCategories", () => {
-    const out = getDefaultSubjectCategories([
-      { subjectcategories: [{ id: 1 }] },
-      { subjectcategories: [{ id: 2 }] },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        subjectCategories: [{ id: 1 }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        subjectCategories: [{ id: 2 }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultSubjectCategories(input);
     expect(out).toEqual(["1"]);
   });
   it("getDefaultTiers", () => {
-    const out = getDefaultTiers([
-      { tier_slug: "higher", tier: "Higher" },
-      { tier_slug: "foundation", tier: "Foundation" },
-    ] as Unit[]);
+    const input = {
+      "7": {
+        tiers: [{ tier_slug: "higher", tier: "Higher" }],
+      } as CurriculumUnitsYearData[number],
+      "8": {
+        tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
+      } as CurriculumUnitsYearData[number],
+    };
+    const out = getDefaultTiers(input);
     expect(out).toEqual(["foundation"]);
   });
 
@@ -35,33 +49,25 @@ describe("filtering", () => {
     const out = getDefaultFilter({
       yearData: {
         "7": {
-          units: [
-            {
-              subject_parent: "science",
-              subject_slug: "biology",
-              subjectcategories: [{ id: 1 }],
-              tier_slug: "higher",
-              tier: "Higher",
-            },
-            {
-              subject_parent: "science",
-              subject_slug: "physics",
-              subjectcategories: [{ id: 2 }],
-              tier_slug: "foundation",
-              tier: "Foundation",
-            },
-          ],
-        },
-      } as unknown as CurriculumUnitsYearData,
+          tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
+          childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
+          subjectCategories: [{ id: 2 }],
+        } as CurriculumUnitsYearData[number],
+        "8": {
+          tiers: [{ tier_slug: "higher", tier: "Higher" }],
+          childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
+          subjectCategories: [{ id: 1 }],
+        } as CurriculumUnitsYearData[number],
+      },
       threadOptions: [],
-      yearOptions: ["7"],
+      yearOptions: ["7", "8"],
     });
     expect(out).toEqual({
       childSubjects: ["biology"],
-      subjectCategories: ["1"],
+      subjectCategories: ["2"],
       threads: [],
       tiers: ["foundation"],
-      years: ["7"],
+      years: ["7", "8"],
     });
   });
 });

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -1,5 +1,9 @@
-import { sortChildSubjects, sortTiers } from "./sorting";
-import { Subject, Tier } from "./types";
+import {
+  sortChildSubjects,
+  sortSubjectCategoriesOnFeatures,
+  sortTiers,
+} from "./sorting";
+import { Subject, SubjectCategory, Tier } from "./types";
 
 import {
   CurriculumUnitsFormattedData,
@@ -57,5 +61,38 @@ export function getDefaultFilter(data: CurriculumUnitsFormattedData) {
     tiers: getDefaultTiers(data.yearData),
     years: data.yearOptions,
     threads: [],
+  };
+}
+
+export function getFilterData(
+  yearData: CurriculumUnitsYearData,
+  years: string[],
+) {
+  const childSubjects = new Map<string, Subject>();
+  const subjectCategories = new Map<number, SubjectCategory>();
+  const tiers = new Map<string, Tier>();
+  years.forEach((year) => {
+    const obj = yearData[year]!;
+    obj.childSubjects.forEach((childSubject) =>
+      childSubjects.set(childSubject.subject_slug, childSubject),
+    );
+    obj.tiers.forEach((tier) => tiers.set(tier.tier_slug, tier));
+    obj.subjectCategories.forEach((subjectCategory) =>
+      subjectCategories.set(subjectCategory.id, subjectCategory),
+    );
+  });
+
+  const childSubjectsArray = [...childSubjects.values()].toSorted(
+    sortChildSubjects,
+  );
+  const subjectCategoriesArray = [...subjectCategories.values()].toSorted(
+    sortSubjectCategoriesOnFeatures(null),
+  );
+  const tiersArray = [...tiers.values()].toSorted(sortTiers);
+
+  return {
+    childSubjects: childSubjectsArray,
+    subjectCategories: subjectCategoriesArray,
+    tiers: tiersArray,
   };
 }

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -1,20 +1,20 @@
 import { sortChildSubjects, sortTiers } from "./sorting";
-import { Subject, Tier, Unit } from "./types";
+import { Subject, Tier } from "./types";
 
 import {
   CurriculumUnitsFormattedData,
   CurriculumUnitsYearData,
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
-export function getDefaultChildSubject(units: Unit[]) {
+export function getDefaultChildSubject(data: CurriculumUnitsYearData) {
   const set = new Set<Subject>();
-  units.forEach((u) => {
-    if (u.subject_parent) {
+  Object.values(data).forEach((yearData) => {
+    yearData.childSubjects.forEach((childSubject) => {
       set.add({
-        subject_slug: u.subject_slug,
-        subject: u.subject,
+        subject_slug: childSubject.subject_slug,
+        subject: childSubject.subject,
       });
-    }
+    });
   });
   const childSubjects = [...set]
     .toSorted(sortChildSubjects)
@@ -24,22 +24,24 @@ export function getDefaultChildSubject(units: Unit[]) {
   }
   return [];
 }
-export function getDefaultSubjectCategories(units: Unit[]) {
+export function getDefaultSubjectCategories(data: CurriculumUnitsYearData) {
   const set = new Set<string>();
-  units.forEach((u) => {
-    u.subjectcategories?.forEach((sc) => set.add(String(sc.id)));
+  Object.values(data).forEach((yearData) => {
+    yearData.subjectCategories.forEach((subjectCategory) =>
+      set.add(String(subjectCategory.id)),
+    );
   });
   return [[...set][0]!];
 }
-export function getDefaultTiers(units: Unit[]) {
+export function getDefaultTiers(data: CurriculumUnitsYearData) {
   const set = new Set<Tier>();
-  units.forEach((u) => {
-    if (u.tier_slug && u.tier) {
+  Object.values(data).forEach((yearData) => {
+    yearData.tiers.forEach((tier) => {
       set.add({
-        tier_slug: u.tier_slug,
-        tier: u.tier,
+        tier_slug: tier.tier_slug,
+        tier: tier.tier,
       });
-    }
+    });
   });
   const tiers = [...set].toSorted(sortTiers).map((t) => t.tier_slug);
   if (tiers.length > 0) {
@@ -48,17 +50,11 @@ export function getDefaultTiers(units: Unit[]) {
   return [];
 }
 
-function unitsFrom(yearData: CurriculumUnitsYearData): Unit[] {
-  return Object.entries(yearData).flatMap(([, data]) => data.units);
-}
-
 export function getDefaultFilter(data: CurriculumUnitsFormattedData) {
-  const units = unitsFrom(data.yearData);
-
   return {
-    childSubjects: getDefaultChildSubject(units),
-    subjectCategories: getDefaultSubjectCategories(units),
-    tiers: getDefaultTiers(units),
+    childSubjects: getDefaultChildSubject(data.yearData),
+    subjectCategories: getDefaultSubjectCategories(data.yearData),
+    tiers: getDefaultTiers(data.yearData),
     years: data.yearOptions,
     threads: [],
   };

--- a/src/utils/curriculum/keystage.test.ts
+++ b/src/utils/curriculum/keystage.test.ts
@@ -1,0 +1,153 @@
+import { byKeyStageSlug, presentAtKeyStageSlugs } from "./keystage";
+
+test("byKeyStageSlug", () => {
+  const output = byKeyStageSlug({
+    "7": {
+      tiers: [
+        { tier: "Higher", tier_slug: "higher" },
+        { tier: "Foundation", tier_slug: "foundation" },
+      ],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+    "8": {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [
+        {
+          id: 3,
+          title: "test1",
+        },
+        {
+          id: 4,
+          title: "test2",
+        },
+      ],
+    },
+    "9": {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+    "10": {
+      tiers: [],
+      childSubjects: [
+        {
+          subject: "english",
+          subject_slug: "English",
+        },
+        {
+          subject: "geography",
+          subject_slug: "Geography",
+        },
+      ],
+      subjectCategories: [],
+    },
+    "11": {
+      tiers: [
+        { tier: "Higher", tier_slug: "higher" },
+        { tier: "Foundation", tier_slug: "foundation" },
+      ],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+  });
+
+  expect(output).toEqual({
+    ks1: {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+    ks2: {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+    ks3: {
+      tiers: [
+        { tier: "Higher", tier_slug: "higher" },
+        { tier: "Foundation", tier_slug: "foundation" },
+      ],
+      childSubjects: [],
+      subjectCategories: [
+        {
+          id: 3,
+          title: "test1",
+        },
+        {
+          id: 4,
+          title: "test2",
+        },
+      ],
+    },
+    ks4: {
+      tiers: [
+        { tier: "Higher", tier_slug: "higher" },
+        { tier: "Foundation", tier_slug: "foundation" },
+      ],
+      childSubjects: [
+        {
+          subject: "english",
+          subject_slug: "English",
+        },
+        {
+          subject: "geography",
+          subject_slug: "Geography",
+        },
+      ],
+      subjectCategories: [],
+    },
+  });
+});
+
+test("presentAtKeyStageSlugs", () => {
+  const definition = {
+    ks1: {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+    ks2: {
+      tiers: [],
+      childSubjects: [],
+      subjectCategories: [
+        {
+          id: 3,
+          title: "test1",
+        },
+        {
+          id: 4,
+          title: "test2",
+        },
+      ],
+    },
+    ks3: {
+      tiers: [],
+      childSubjects: [
+        {
+          subject: "english",
+          subject_slug: "English",
+        },
+        {
+          subject: "geography",
+          subject_slug: "Geography",
+        },
+      ],
+      subjectCategories: [],
+    },
+    ks4: {
+      tiers: [
+        { tier: "Higher", tier_slug: "higher" },
+        { tier: "Foundation", tier_slug: "foundation" },
+      ],
+      childSubjects: [],
+      subjectCategories: [],
+    },
+  };
+  expect(presentAtKeyStageSlugs(definition, "tiers")).toEqual(["ks4"]);
+  expect(presentAtKeyStageSlugs(definition, "childSubjects")).toEqual(["ks3"]);
+  expect(presentAtKeyStageSlugs(definition, "subjectCategories")).toEqual([
+    "ks2",
+  ]);
+});

--- a/src/utils/curriculum/keystage.ts
+++ b/src/utils/curriculum/keystage.ts
@@ -1,0 +1,84 @@
+import { KeyStageSlug, Subject, SubjectCategory, Tier } from "./types";
+
+export type YearDataPartialYearData = {
+  tiers: Set<Tier>;
+  childSubjects: Set<Subject>;
+  subjectCategories: Set<SubjectCategory>;
+};
+export type YearDataPartialYearDataArray = {
+  tiers: Tier[];
+  childSubjects: Subject[];
+  subjectCategories: SubjectCategory[];
+};
+
+export function byKeyStageSlug(
+  data: Record<string, YearDataPartialYearDataArray>,
+) {
+  const out: Record<KeyStageSlug, YearDataPartialYearData> = {
+    ks1: {
+      tiers: new Set([]),
+      childSubjects: new Set([]),
+      subjectCategories: new Set([]),
+    },
+    ks2: {
+      tiers: new Set([]),
+      childSubjects: new Set([]),
+      subjectCategories: new Set([]),
+    },
+    ks3: {
+      tiers: new Set([]),
+      childSubjects: new Set([]),
+      subjectCategories: new Set([]),
+    },
+    ks4: {
+      tiers: new Set([]),
+      childSubjects: new Set([]),
+      subjectCategories: new Set([]),
+    },
+  };
+
+  const mappings: [string[], KeyStageSlug][] = [
+    [["1", "2"], "ks1"],
+    [["3", "4", "5", "6"], "ks2"],
+    [["7", "8", "9"], "ks3"],
+    [["10", "11"], "ks4"],
+  ];
+
+  for (const [year, yearData] of Object.entries(data)) {
+    for (const [years, key] of mappings) {
+      if (years.includes(year)) {
+        yearData.tiers.forEach((tier) => out[key].tiers.add(tier));
+        yearData.childSubjects.forEach((childSubject) =>
+          out[key].childSubjects.add(childSubject),
+        );
+        yearData.subjectCategories.forEach((subjectCategory) =>
+          out[key].subjectCategories.add(subjectCategory),
+        );
+      }
+    }
+  }
+
+  const output: Record<string, YearDataPartialYearDataArray> = {};
+  for (const [ksKey, obj] of Object.entries(out)) {
+    output[ksKey as KeyStageSlug] = {
+      tiers: [...obj.tiers],
+      childSubjects: obj.childSubjects.size > 1 ? [...obj.childSubjects] : [],
+      subjectCategories:
+        obj.childSubjects.size < 1 ? [...obj.subjectCategories] : [],
+    };
+  }
+  return output;
+}
+
+export function presentAtKeyStageSlugs(
+  KeyStageSlugData: Record<KeyStageSlug, YearDataPartialYearDataArray>,
+  key: keyof YearDataPartialYearDataArray,
+) {
+  const out: KeyStageSlug[] = [];
+  for (const [KeyStageSlug, data] of Object.entries(KeyStageSlugData)) {
+    if (data[key].length > 0) {
+      out.push(KeyStageSlug as KeyStageSlug);
+    }
+  }
+  return out;
+}

--- a/src/utils/curriculum/keystage.ts
+++ b/src/utils/curriculum/keystage.ts
@@ -11,6 +11,13 @@ export type YearDataPartialYearDataArray = {
   subjectCategories: SubjectCategory[];
 };
 
+const keystageYearMappings: Record<KeyStageSlug, string[]> = {
+  ks1: ["1", "2"],
+  ks2: ["3", "4", "5", "6"],
+  ks3: ["7", "8", "9"],
+  ks4: ["10", "11"],
+};
+
 export function byKeyStageSlug(
   data: Record<string, YearDataPartialYearDataArray>,
 ) {
@@ -37,15 +44,9 @@ export function byKeyStageSlug(
     },
   };
 
-  const mappings: [string[], KeyStageSlug][] = [
-    [["1", "2"], "ks1"],
-    [["3", "4", "5", "6"], "ks2"],
-    [["7", "8", "9"], "ks3"],
-    [["10", "11"], "ks4"],
-  ];
-
   for (const [year, yearData] of Object.entries(data)) {
-    for (const [years, key] of mappings) {
+    for (const [keyStr, years] of Object.entries(keystageYearMappings)) {
+      const key = keyStr as KeyStageSlug;
       if (years.includes(year)) {
         yearData.tiers.forEach((tier) => out[key].tiers.add(tier));
         yearData.childSubjects.forEach((childSubject) =>
@@ -73,11 +74,18 @@ export function byKeyStageSlug(
 export function presentAtKeyStageSlugs(
   KeyStageSlugData: Record<KeyStageSlug, YearDataPartialYearDataArray>,
   key: keyof YearDataPartialYearDataArray,
+  availableYears?: string[],
 ) {
   const out: KeyStageSlug[] = [];
-  for (const [KeyStageSlug, data] of Object.entries(KeyStageSlugData)) {
-    if (data[key].length > 0) {
-      out.push(KeyStageSlug as KeyStageSlug);
+  for (const [keyStageSlugStr, data] of Object.entries(KeyStageSlugData)) {
+    const keyStageSlug = keyStageSlugStr as KeyStageSlug;
+    const isValid =
+      !availableYears ||
+      availableYears.find((value) =>
+        keystageYearMappings[keyStageSlug].includes(value),
+      );
+    if (isValid && data[key].length > 0) {
+      out.push(keyStageSlug as KeyStageSlug);
     }
   }
   return out;

--- a/src/utils/curriculum/types.ts
+++ b/src/utils/curriculum/types.ts
@@ -43,4 +43,6 @@ export type YearData = {
   };
 };
 
+export type KeyStageSlug = "ks1" | "ks2" | "ks3" | "ks4";
+
 export type Unit = CurriculumUnitsTabData["units"][number];


### PR DESCRIPTION
## Description
Adds ks3/ks4 suffixes where required in new curriculum filter sidebar.  

> [!NOTE]
> Builds on PR #3193


## Issue(s)
Fixes `CUR-1191`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Test new ks3/ks4 suffixes work as intended.

## Screenshots
<img width="777" alt="Screenshot 2025-02-11 at 14 27 33" src="https://github.com/user-attachments/assets/a42aab81-2348-4976-81e0-c71176e13360" />

