### PR TITLE
Parallelize CI a little more

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -12,8 +12,8 @@ on:
   merge_group:
 
 jobs:
-  lint_test_sonar:
-    name: lint, check types, test, Sonar
+  check:
+    name: lint, check types
     runs-on: ubuntu-latest
     steps:
       # Check out full history so Sonar can identify PR changes.
@@ -37,6 +37,23 @@ jobs:
 
       # Check types.
       - run: npm run check-types
+
+  test:
+    name: test, Sonar
+    runs-on: ubuntu-latest
+    steps:
+      # Check out full history so Sonar can identify PR changes.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+
+      # Install.
+      - run: npm ci
 
       # Unit tests, no integration tests.
       - run: npm run test:ci


### PR DESCRIPTION
## Description
This should hopefully speed up CI a little

We're just moving these checks off into their own job and running checks(lint, check types) and tests(test,sonar) in parallel. This should save us ~1min on the test run 🤞

<img width="732" alt="Screenshot 2025-02-11 at 16 43 56" src="https://github.com/user-attachments/assets/3a134945-7cf2-4fba-90cc-482d4a67768f" />


