### PR TITLE
Improve docx test performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
         "jest-styled-components": "^7.2.0",
         "json-diff": "^1.0.6",
         "lint-staged": "^15.2.10",
+        "microdiff": "^1.5.0",
         "next-router-mock": "^0.9.13",
         "next-sitemap": "^3.1.55",
         "node-mocks-http": "^1.16.1",
@@ -27791,6 +27792,13 @@
       "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.1.2.tgz",
       "integrity": "sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g==",
       "dev": true
+    },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "jest-styled-components": "^7.2.0",
     "json-diff": "^1.0.6",
     "lint-staged": "^15.2.10",
+    "microdiff": "^1.5.0",
     "next-router-mock": "^0.9.13",
     "next-sitemap": "^3.1.55",
     "node-mocks-http": "^1.16.1",

--- a/src/pages-helpers/curriculum/docx/__snapshots__/docx.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/__snapshots__/docx.test.ts.snap
@@ -154,256 +154,320 @@ exports[`docx createImage no options 1`] = `
     "
 `;
 
+exports[`docx insertImages test 1`] = `
+[
+  {
+    "path": [
+      "word/_rels/document.xml.rels",
+      "elements",
+      0,
+      "elements",
+      7,
+    ],
+    "type": "CREATE",
+    "value": {
+      "attributes": {
+        "Id": "rIdf1c6d68f4906606ef3ae58fac887d210ae8b33ce7275c21ee8e177090278e249",
+        "Target": "media/hash_f1c6d68f4906606ef3ae58fac887d210ae8b33ce7275c21ee8e177090278e249png",
+        "Type": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+      },
+      "name": "Relationship",
+      "type": "element",
+    },
+  },
+  {
+    "path": [
+      "word/_rels/document.xml.rels",
+      "elements",
+      0,
+      "elements",
+      8,
+    ],
+    "type": "CREATE",
+    "value": {
+      "attributes": {
+        "Id": "rIdb29edb1ad79e3ac505ac9e6722aed45100902e97fd45f474aacb455a7b8d809f",
+        "Target": "media/hash_b29edb1ad79e3ac505ac9e6722aed45100902e97fd45f474aacb455a7b8d809ffoo",
+        "Type": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+      },
+      "name": "Relationship",
+      "type": "element",
+    },
+  },
+  {
+    "path": [
+      "word/media/",
+    ],
+    "type": "CREATE",
+    "value": "",
+  },
+  {
+    "path": [
+      "word/media/hash_f1c6d68f4906606ef3ae58fac887d210ae8b33ce7275c21ee8e177090278e249png",
+    ],
+    "type": "CREATE",
+    "value": "4a5204e50a2367de974264a2056566e7af61af9d192b8699883d11491a37b599",
+  },
+  {
+    "path": [
+      "word/media/hash_b29edb1ad79e3ac505ac9e6722aed45100902e97fd45f474aacb455a7b8d809ffoo",
+    ],
+    "type": "CREATE",
+    "value": "4a5204e50a2367de974264a2056566e7af61af9d192b8699883d11491a37b599",
+  },
+]
+`;
+
 exports[`docx insertNumbering test 1`] = `
-{
-  "word/numbering.xml": {
-    "elements": [
-      [
-        "~",
-        {
-          "elements__added": [
-            {
-              "attributes": {
-                "w15:restartNumberingAfterBreak": "0",
-                "w:abstractNumId": "10002",
-              },
-              "elements": [
-                {
-                  "attributes": {
-                    "w:val": "099A081C",
-                  },
-                  "name": "w:nsid",
-                  "type": "element",
-                },
-                {
-                  "attributes": {
-                    "w:val": "hybridMultilevel",
-                  },
-                  "name": "w:multiLevelType",
-                  "type": "element",
-                },
-                {
-                  "attributes": {
-                    "w:ilvl": "0",
-                  },
-                  "elements": [
-                    {
-                      "attributes": {
-                        "w:val": "1",
-                      },
-                      "name": "w:start",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "upperLetter",
-                      },
-                      "name": "w:numFmt",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "%1.",
-                      },
-                      "name": "w:lvlText",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "start",
-                      },
-                      "name": "w:lvlJc",
-                      "type": "element",
-                    },
-                    {
-                      "elements": [
-                        {
-                          "attributes": {
-                            "w:hanging": "360",
-                            "w:start": "360",
-                          },
-                          "name": "w:ind",
-                          "type": "element",
-                        },
-                      ],
-                      "name": "w:pPr",
-                      "type": "element",
-                    },
-                    {
-                      "elements": [
-                        {
-                          "attributes": {
-                            "w:ascii": "Arial Black",
-                            "w:hAnsi": "Arial Black",
-                          },
-                          "name": "w:rFonts",
-                          "type": "element",
-                        },
-                        {
-                          "attributes": {
-                            "w:val": "C00000",
-                          },
-                          "name": "w:color",
-                          "type": "element",
-                        },
-                        {
-                          "attributes": {
-                            "w:val": "28",
-                          },
-                          "name": "w:sz",
-                          "type": "element",
-                        },
-                      ],
-                      "name": "w:rPr",
-                      "type": "element",
-                    },
-                  ],
-                  "name": "w:lvl",
-                  "type": "element",
-                },
-              ],
-              "name": "w:abstractNum",
-              "type": "element",
-            },
-            {
-              "attributes": {
-                "w15:restartNumberingAfterBreak": "0",
-                "w:abstractNumId": "10000",
-              },
-              "elements": [
-                {
-                  "attributes": {
-                    "w:val": "099A081C",
-                  },
-                  "name": "w:nsid",
-                  "type": "element",
-                },
-                {
-                  "attributes": {
-                    "w:val": "hybridMultilevel",
-                  },
-                  "name": "w:multiLevelType",
-                  "type": "element",
-                },
-                {
-                  "attributes": {
-                    "w:ilvl": "0",
-                  },
-                  "elements": [
-                    {
-                      "attributes": {
-                        "w:val": "1",
-                      },
-                      "name": "w:start",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "upperLetter",
-                      },
-                      "name": "w:numFmt",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "%1.",
-                      },
-                      "name": "w:lvlText",
-                      "type": "element",
-                    },
-                    {
-                      "attributes": {
-                        "w:val": "start",
-                      },
-                      "name": "w:lvlJc",
-                      "type": "element",
-                    },
-                    {
-                      "elements": [
-                        {
-                          "attributes": {
-                            "w:hanging": "360",
-                            "w:start": "360",
-                          },
-                          "name": "w:ind",
-                          "type": "element",
-                        },
-                      ],
-                      "name": "w:pPr",
-                      "type": "element",
-                    },
-                    {
-                      "elements": [
-                        {
-                          "attributes": {
-                            "w:ascii": "Arial Black",
-                            "w:hAnsi": "Arial Black",
-                          },
-                          "name": "w:rFonts",
-                          "type": "element",
-                        },
-                        {
-                          "attributes": {
-                            "w:val": "C00000",
-                          },
-                          "name": "w:color",
-                          "type": "element",
-                        },
-                        {
-                          "attributes": {
-                            "w:val": "28",
-                          },
-                          "name": "w:sz",
-                          "type": "element",
-                        },
-                      ],
-                      "name": "w:rPr",
-                      "type": "element",
-                    },
-                  ],
-                  "name": "w:lvl",
-                  "type": "element",
-                },
-              ],
-              "name": "w:abstractNum",
-              "type": "element",
-            },
-            {
-              "attributes": {
-                "w:numId": "10001",
-              },
-              "elements": [
-                {
-                  "attributes": {
-                    "w:val": "10000",
-                  },
-                  "name": "w:abstractNumId",
-                  "type": "element",
-                },
-              ],
-              "name": "w:num",
-              "type": "element",
-            },
-            {
-              "attributes": {
-                "w:numId": "10003",
-              },
-              "elements": [
-                {
-                  "attributes": {
-                    "w:val": "10002",
-                  },
-                  "name": "w:abstractNumId",
-                  "type": "element",
-                },
-              ],
-              "name": "w:num",
-              "type": "element",
-            },
-          ],
+[
+  {
+    "path": [
+      "word/numbering.xml",
+      "elements",
+      0,
+      "elements",
+    ],
+    "type": "CREATE",
+    "value": [
+      {
+        "attributes": {
+          "w15:restartNumberingAfterBreak": "0",
+          "w:abstractNumId": "10002",
         },
-      ],
+        "elements": [
+          {
+            "attributes": {
+              "w:val": "099A081C",
+            },
+            "name": "w:nsid",
+            "type": "element",
+          },
+          {
+            "attributes": {
+              "w:val": "hybridMultilevel",
+            },
+            "name": "w:multiLevelType",
+            "type": "element",
+          },
+          {
+            "attributes": {
+              "w:ilvl": "0",
+            },
+            "elements": [
+              {
+                "attributes": {
+                  "w:val": "1",
+                },
+                "name": "w:start",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "upperLetter",
+                },
+                "name": "w:numFmt",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "%1.",
+                },
+                "name": "w:lvlText",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "start",
+                },
+                "name": "w:lvlJc",
+                "type": "element",
+              },
+              {
+                "elements": [
+                  {
+                    "attributes": {
+                      "w:hanging": "360",
+                      "w:start": "360",
+                    },
+                    "name": "w:ind",
+                    "type": "element",
+                  },
+                ],
+                "name": "w:pPr",
+                "type": "element",
+              },
+              {
+                "elements": [
+                  {
+                    "attributes": {
+                      "w:ascii": "Arial Black",
+                      "w:hAnsi": "Arial Black",
+                    },
+                    "name": "w:rFonts",
+                    "type": "element",
+                  },
+                  {
+                    "attributes": {
+                      "w:val": "C00000",
+                    },
+                    "name": "w:color",
+                    "type": "element",
+                  },
+                  {
+                    "attributes": {
+                      "w:val": "28",
+                    },
+                    "name": "w:sz",
+                    "type": "element",
+                  },
+                ],
+                "name": "w:rPr",
+                "type": "element",
+              },
+            ],
+            "name": "w:lvl",
+            "type": "element",
+          },
+        ],
+        "name": "w:abstractNum",
+        "type": "element",
+      },
+      {
+        "attributes": {
+          "w15:restartNumberingAfterBreak": "0",
+          "w:abstractNumId": "10000",
+        },
+        "elements": [
+          {
+            "attributes": {
+              "w:val": "099A081C",
+            },
+            "name": "w:nsid",
+            "type": "element",
+          },
+          {
+            "attributes": {
+              "w:val": "hybridMultilevel",
+            },
+            "name": "w:multiLevelType",
+            "type": "element",
+          },
+          {
+            "attributes": {
+              "w:ilvl": "0",
+            },
+            "elements": [
+              {
+                "attributes": {
+                  "w:val": "1",
+                },
+                "name": "w:start",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "upperLetter",
+                },
+                "name": "w:numFmt",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "%1.",
+                },
+                "name": "w:lvlText",
+                "type": "element",
+              },
+              {
+                "attributes": {
+                  "w:val": "start",
+                },
+                "name": "w:lvlJc",
+                "type": "element",
+              },
+              {
+                "elements": [
+                  {
+                    "attributes": {
+                      "w:hanging": "360",
+                      "w:start": "360",
+                    },
+                    "name": "w:ind",
+                    "type": "element",
+                  },
+                ],
+                "name": "w:pPr",
+                "type": "element",
+              },
+              {
+                "elements": [
+                  {
+                    "attributes": {
+                      "w:ascii": "Arial Black",
+                      "w:hAnsi": "Arial Black",
+                    },
+                    "name": "w:rFonts",
+                    "type": "element",
+                  },
+                  {
+                    "attributes": {
+                      "w:val": "C00000",
+                    },
+                    "name": "w:color",
+                    "type": "element",
+                  },
+                  {
+                    "attributes": {
+                      "w:val": "28",
+                    },
+                    "name": "w:sz",
+                    "type": "element",
+                  },
+                ],
+                "name": "w:rPr",
+                "type": "element",
+              },
+            ],
+            "name": "w:lvl",
+            "type": "element",
+          },
+        ],
+        "name": "w:abstractNum",
+        "type": "element",
+      },
+      {
+        "attributes": {
+          "w:numId": "10001",
+        },
+        "elements": [
+          {
+            "attributes": {
+              "w:val": "10000",
+            },
+            "name": "w:abstractNumId",
+            "type": "element",
+          },
+        ],
+        "name": "w:num",
+        "type": "element",
+      },
+      {
+        "attributes": {
+          "w:numId": "10003",
+        },
+        "elements": [
+          {
+            "attributes": {
+              "w:val": "10002",
+            },
+            "name": "w:abstractNumId",
+            "type": "element",
+          },
+        ],
+        "name": "w:num",
+        "type": "element",
+      },
     ],
   },
-}
+]
 `;


### PR DESCRIPTION
## Description
Improved docx test performance from around **~21s** down to **~1s**. I did this by replacing [json-diff](https://www.npmjs.com/package/json-diff) with [microdiff](https://github.com/AsyncBanana/microdiff)

Before

```
 PASS  src/pages-helpers/curriculum/docx/docx.test.ts (19.656 s)
  docx
    ✓ cmToEmu
    ✓ emuToCm
    ✓ lineHeight
    ✓ pointToDxa
    ✓ cmToTwip
    ✓ wrapInLinkTo
    ✓ wrapInLinkToBookmark
    ✓ wrapInBookmarkPoint
    ✓ getFooterFilenameFromContent
    ✓ degreeToOoxmlDegree
    checkWithinElement
      ✓ return true if check passes at least once (5 ms)
      ✓ return false if check always fails (1 ms)
    mapOverElements
      ✓ should not mutate if no changes
      ✓ should mutate changes made (1 ms)
    generateEmptyDocx
      ✓ test (23 ms)
    insertImages
      ✓ test (3382 ms)
    insertLinks
      ✓ test (3344 ms)
    insertNumbering
      ✓ test (6209 ms)
    appendBodyElements
      ✓ invalid (9 ms)
      ✓ empty (13 ms)
      ✓ valid (6289 ms)
    createImage
      ✓ no options
      ✓ all options (1 ms)

Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
Snapshots:   3 passed, 3 total
Time:        21.441 s
Ran all test suites matching /docx.test.ts/i.
```

After

```
 PASS  src/pages-helpers/curriculum/docx/docx.test.ts
  docx
    ✓ cmToEmu
    ✓ emuToCm
    ✓ lineHeight
    ✓ pointToDxa
    ✓ cmToTwip
    ✓ wrapInLinkTo
    ✓ wrapInLinkToBookmark
    ✓ wrapInBookmarkPoint (1 ms)
    ✓ getFooterFilenameFromContent (1 ms)
    ✓ degreeToOoxmlDegree
    checkWithinElement
      ✓ return true if check passes at least once (2 ms)
      ✓ return false if check always fails
    mapOverElements
      ✓ should not mutate if no changes
      ✓ should mutate changes made (2 ms)
    generateEmptyDocx
      ✓ test (22 ms)
    insertImages
      ✓ test (41 ms)
    insertLinks
      ✓ test (8 ms)
    insertNumbering
      ✓ test (9 ms)
    appendBodyElements
      ✓ invalid (8 ms)
      ✓ empty (13 ms)
      ✓ valid (7 ms)
    createImage
      ✓ no options
      ✓ all options

Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
Snapshots:   4 passed, 4 total
Time:        0.906 s, estimated 1 s
Ran all test suites matching /docx.test.ts/i.
```

## Issue
Fixes `CUR-1226`

## How to test
Does CI still pass: **yes**

