### PR TITLE
Subject specific ordering for new curric filter

### DIFF
--- a/src/utils/curriculum/features.ts
+++ b/src/utils/curriculum/features.ts
@@ -1,5 +1,7 @@
 import { Unit } from "./types";
 
+import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+
 export function getUnitFeatures(unit?: Unit | null) {
   if (!unit) {
     return;
@@ -48,3 +50,20 @@ export function getUnitFeatures(unit?: Unit | null) {
   }
 }
 export type UnitFeatures = ReturnType<typeof getUnitFeatures>;
+
+// Note: Inefficient at the moment
+export function findFirstMatchingFeatures(
+  yearData: CurriculumUnitsYearData,
+  fn: (unit: Unit) => boolean,
+) {
+  const features = Object.values(yearData)
+    .flatMap((a) => a.units)
+    .map((unit) => {
+      return {
+        ...unit,
+        features: getUnitFeatures(unit),
+      };
+    })
+    .find(fn)?.features;
+  return features;
+}

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -65,7 +65,7 @@ describe("filtering", () => {
     });
     expect(out).toEqual({
       childSubjects: ["biology"],
-      subjectCategories: ["2"],
+      subjectCategories: ["1"],
       threads: [],
       tiers: ["foundation"],
       years: ["7", "8"],

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -1,3 +1,4 @@
+import { findFirstMatchingFeatures } from "./features";
 import {
   sortChildSubjects,
   sortSubjectCategoriesOnFeatures,
@@ -29,13 +30,23 @@ export function getDefaultChildSubject(data: CurriculumUnitsYearData) {
   return [];
 }
 export function getDefaultSubjectCategories(data: CurriculumUnitsYearData) {
-  const set = new Set<string>();
+  const set = new Set<Pick<SubjectCategory, "id">>();
   Object.values(data).forEach((yearData) => {
     yearData.subjectCategories.forEach((subjectCategory) =>
-      set.add(String(subjectCategory.id)),
+      set.add({ id: subjectCategory.id }),
     );
   });
-  return [[...set][0]!];
+  const subjectCategories = [...set]
+    .toSorted(
+      sortSubjectCategoriesOnFeatures(
+        findFirstMatchingFeatures(
+          data,
+          (unit) => unit.features?.subjectcategories?.default_category_id,
+        ),
+      ),
+    )
+    .map((s) => String(s.id));
+  return [subjectCategories[0]!];
 }
 export function getDefaultTiers(data: CurriculumUnitsYearData) {
   const set = new Set<Tier>();
@@ -86,7 +97,12 @@ export function getFilterData(
     sortChildSubjects,
   );
   const subjectCategoriesArray = [...subjectCategories.values()].toSorted(
-    sortSubjectCategoriesOnFeatures(null),
+    sortSubjectCategoriesOnFeatures(
+      findFirstMatchingFeatures(
+        yearData,
+        (unit) => unit.features?.subjectcategories?.default_category_id,
+      ),
+    ),
   );
   const tiersArray = [...tiers.values()].toSorted(sortTiers);
 


### PR DESCRIPTION
## Description
Fixed subject specific filter option ordering, for the new curriculum filtering UI

## Issue(s)
Fixes `CUR-1182`

## How to test

1. Go to `/teachers/curriculum`
2. Check filter ordering is correct as per `CUR-1182`

