### PR TITLE
CTC-142 Don't round video duration to zero

### DIFF
--- a/src/components/SharedComponents/VideoPlayer/getDuration.test.ts
+++ b/src/components/SharedComponents/VideoPlayer/getDuration.test.ts
@@ -12,9 +12,9 @@ const createRef = (duration: number | undefined) => {
 };
 
 describe("getDuration", () => {
-  test("gets duration rounded down", () => {
+  test("gets duration rounded down to to coma spaces", () => {
     const ref = createRef(54.5467948);
-    expect(getDuration(ref)).toBe(54);
+    expect(getDuration(ref)).toBe(54.55);
   });
   test("returns null if duration undefined", () => {
     const ref = createRef(undefined);

--- a/src/components/SharedComponents/VideoPlayer/getDuration.ts
+++ b/src/components/SharedComponents/VideoPlayer/getDuration.ts
@@ -8,7 +8,7 @@ import MuxPlayerElement from "@mux/mux-player";
 const getDuration = (ref: RefObject<MuxPlayerElement>) => {
   const duration = ref.current?.duration;
   if (typeof duration === "number" && !isNaN(duration)) {
-    return Math.floor(duration);
+    return Number(duration.toFixed(2));
   }
 
   return null;


### PR DESCRIPTION
## Description

Don't round video duration to zero - round to two coma spaces instead

## Issue(s)

Fixes [CTC-142](https://www.notion.so/oaknationalacademy/Media-Page-Bug-Clips-less-than-a-second-do-not-play-18a26cc4e1b18093900ae93894a689ee)

## How to test

1. Go to https://deploy-preview-3207--oak-web-application.netlify.thenational.academy/teachers/programmes/spanish-secondary-ks4-edexcel/units/media-and-technology-actores-y-peliculas/lessons/dos-actores-famosos-ar-3rd-person-singular-and-plural-preterite/media
2. The videos under 1 second should play

