### PR TITLE
Fix/pupil unit listing issue

### DIFF
--- a/src/__tests__/pages/pupils/programmes/[programmesSlug]/units.test.tsx
+++ b/src/__tests__/pages/pupils/programmes/[programmesSlug]/units.test.tsx
@@ -127,7 +127,23 @@ describe("pages/pupils/programmes/[programmeSlug]/units", () => {
           notFound: true,
         });
       });
-      it("Should return not found if no curriculum data", async () => {
+      it("Should return not found if no curriculum data for a legacy slug", async () => {
+        (
+          curriculumApi2023.default.pupilUnitListingQuery as jest.Mock
+        ).mockResolvedValueOnce([]);
+
+        const res = await getStaticProps({
+          params: {
+            programmeSlug: "maths-secondary-year-10-l",
+          },
+        });
+
+        expect(res).toEqual({
+          notFound: true,
+        });
+      });
+
+      it("Should return a redirect if no curriculum data for a non-legacy slug", async () => {
         (
           curriculumApi2023.default.pupilUnitListingQuery as jest.Mock
         ).mockResolvedValueOnce([
@@ -137,7 +153,7 @@ describe("pages/pupils/programmes/[programmeSlug]/units", () => {
               title: "unit-title-2",
             },
             supplementaryData: { unitOrder: 1 },
-            programmeSlug: "maths-secondary-year-10-foundation",
+            programmeSlug: "english-secondary-year-11-l",
             unitSlug: "unit-slug-2",
           }),
         ]);
@@ -147,10 +163,15 @@ describe("pages/pupils/programmes/[programmeSlug]/units", () => {
         const res = await getStaticProps({
           params: { programmeSlug: "english-secondary-year-11" },
         });
+
         expect(res).toEqual({
-          notFound: true,
+          redirect: {
+            destination: "/pupils/programmes/english-secondary-year-11-l/units",
+            permanent: false,
+          },
         });
       });
+
       it("should throw error is phase is foundation", async () => {
         const programmeFieldsSnake = programmeFieldsFixture({
           overrides: {

--- a/src/pages/pupils/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units.tsx
@@ -125,7 +125,7 @@ export const getStaticProps: GetStaticProps<
       );
 
       if (!selectedProgramme) {
-        if (programmeSlug.substring(-2) !== "-l") {
+        if (programmeSlug.slice(-2) !== "-l") {
           selectedProgramme = curriculumData.find(
             (unit) => unit.programmeSlug === `${programmeSlug}-l`,
           );

--- a/src/pages/pupils/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units.tsx
@@ -120,11 +120,25 @@ export const getStaticProps: GetStaticProps<
         return aUnitOrder - bUnitOrder;
       });
 
-      const selectedProgramme = curriculumData.find(
+      let selectedProgramme = curriculumData.find(
         (unit) => unit.programmeSlug === programmeSlug,
       );
+
       if (!selectedProgramme) {
-        throw new OakError({ code: "curriculum-api/not-found" });
+        if (programmeSlug.substring(-2) !== "-l") {
+          selectedProgramme = curriculumData.find(
+            (unit) => unit.programmeSlug === `${programmeSlug}-l`,
+          );
+
+          return {
+            redirect: {
+              destination: `/pupils/programmes/${programmeSlug}-l/units`,
+              permanent: false,
+            },
+          };
+        } else {
+          throw new OakError({ code: "curriculum-api/not-found" });
+        }
       }
 
       const { programmeFields, isLegacy } = selectedProgramme;
@@ -230,6 +244,7 @@ export const getStaticProps: GetStaticProps<
           programmeFields,
         },
       };
+
       return results;
     },
   });


### PR DESCRIPTION


## Issue(s)

When overrides and exceptions cause only legacy units to be available for a pupil unit listing page the page 404s. 

Fixes #

Instead get it to redirect to the legacy unit listing page. 

## How to test

1. Go to https://deploy-preview-3208--oak-web-application.netlify.thenational.academy/pupils/years/year-1/subjects
2. navigate to PE
3. you should arrive at the legacy listing

