### PR TITLE
Feat/pupil 1185/deploy teacher notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.83.1",
+        "@oaknational/oak-components": "^1.84.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.50.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7169,9 +7169,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.83.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.83.1.tgz",
-      "integrity": "sha512-FpCJlfA52nTFKix1tToee7cAkGGICEnXMVYG7QegAsYiyQzoOVEnj/wc4ellvBmK7dxqNrSPxPvKt/dqlhlQHw==",
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.84.1.tgz",
+      "integrity": "sha512-oGoqzRXjGBtbRsCeb9GTMyJotpzX/4XILFH0oDMMH87zBdUKkUqgJgMYFW6JJgZyGDJYqlvqtiD0IeSWaGax4g==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.83.1",
+    "@oaknational/oak-components": "^1.84.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.50.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/components/TeacherComponents/TeacherNotesModal/TeacherNotesModal.tsx
+++ b/src/components/TeacherComponents/TeacherNotesModal/TeacherNotesModal.tsx
@@ -13,6 +13,8 @@ import {
   TeacherNote,
 } from "@oaknational/oak-pupil-client";
 
+import { resolveOakHref } from "@/common-lib/urls";
+
 const StyledEditorContent = styled(EditorContent)`
   .tiptap:focus {
     outline: none;
@@ -231,6 +233,10 @@ export const TeacherNotesModal = ({
       progressSaved={noteSaved && !noteShared}
       noteShared={noteShared}
       error={Boolean(error)}
+      termsAndConditionsHref={resolveOakHref({
+        page: "legal",
+        legalSlug: "terms-and-conditions",
+      })}
     />
   );
 };


### PR DESCRIPTION
### Job Story

Final tweaks to teacher notes

### Implementation details

latest design

https://www.figma.com/design/OEMJMj2akckSSxkbumdJAD/%F0%9F%A7%AA-Lesson-Delivery-Squad-Experiments?node-id=4591-49961&m=dev

revised title:
”Add a teacher note to the page and share the link with your colleague.”

### Acceptance criteria

- [x]  content warning message
- [x]  revised modal title

### Testing

- ensure that you have the teacher notes feature flag enabled using the posthog toolbar
- goto a lesson eg . https://deploy-preview-3213--oak-web-application.netlify.app/teachers/lessons/transverse-waves
- there should now be a warning which links to the T&Cs 
- the title should now be changed