### PR TITLE
Added `buildPageTitle` with update title rules for curric visualiser

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -21,6 +21,7 @@ import { ButtonAsLinkProps } from "@/components/SharedComponents/Button/ButtonAs
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 import { CurriculumTab } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { buildPageTitle } from "@/utils/curriculum/formatting";
 
 export type CurriculumHeaderPageProps = {
   curriculumPhaseOptions: SubjectPhasePickerData;
@@ -64,16 +65,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
     ks4Option ? `-${ks4Option.slug}` : ""
   }`;
 
-  let pageTitle: string = "";
-  const keyStageStrings: string[] = [];
-  if (keyStages.includes("ks1")) keyStageStrings.push("KS1");
-  if (keyStages.includes("ks2")) keyStageStrings.push("KS2");
-  if (keyStages.includes("ks3")) keyStageStrings.push("KS3");
-  if (keyStages.includes("ks4")) keyStageStrings.push("KS4");
-  const keyStageString = keyStageStrings.join(" & ");
-  if (["primary", "secondary"].includes(phase.slug)) {
-    pageTitle = `${keyStageString} ${subject.title}`;
-  }
+  const pageTitle = buildPageTitle(keyStages, subject, phase);
 
   const links: ButtonAsLinkProps[] = [
     {

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -3,6 +3,7 @@ import {
   getPhaseText,
   getShortPhaseText,
   getSuffixFromFeatures,
+  buildPageTitle,
 } from "./formatting";
 
 describe("getYearGroupTitle", () => {
@@ -225,4 +226,68 @@ describe("getSuffixFromFeatures", () => {
   it("undefined if override not present", () => {
     expect(getSuffixFromFeatures(undefined)).toBe(undefined);
   });
+});
+
+describe("buildPageTitle", () => {
+  const testCases = [
+    {
+      input: {
+        keyStages: ["ks1", "ks2"],
+        subject: { title: "English", slug: "english" },
+        phase: { title: "Primary", slug: "primary" },
+      },
+      expectedOutput: "KS1 & KS2 English curriculum",
+    },
+    {
+      input: {
+        keyStages: ["ks1", "ks2"],
+        subject: { title: "French", slug: "french" },
+        phase: { title: "Primary", slug: "primary" },
+      },
+      expectedOutput: "KS1 & KS2 French curriculum",
+    },
+    {
+      input: {
+        keyStages: ["ks1", "ks2"],
+        subject: { title: "Spanish", slug: "spanish" },
+        phase: { title: "Primary", slug: "primary" },
+      },
+      expectedOutput: "KS1 & KS2 Spanish curriculum",
+    },
+    {
+      input: {
+        keyStages: ["ks1", "ks2"],
+        subject: { title: "German", slug: "german" },
+        phase: { title: "Primary", slug: "primary" },
+      },
+      expectedOutput: "KS1 & KS2 German curriculum",
+    },
+    {
+      input: {
+        keyStages: ["ks1", "ks2"],
+        subject: { title: "Art and design", slug: "art-and-design" },
+        phase: { title: "Primary", slug: "primary" },
+      },
+      expectedOutput: "KS1 & KS2 art and design curriculum",
+    },
+    {
+      input: {
+        keyStages: ["ks3", "ks4"],
+        subject: { title: "Maths", slug: "maths" },
+        phase: { title: "Secondary", slug: "secondary" },
+      },
+      expectedOutput: "KS3 & KS4 maths curriculum",
+    },
+  ];
+
+  for (const { input, expectedOutput } of testCases) {
+    it(`output: ${expectedOutput}`, () => {
+      const actualOutput = buildPageTitle(
+        input.keyStages,
+        input.subject,
+        input.phase,
+      );
+      expect(expectedOutput).toEqual(actualOutput);
+    });
+  }
 });

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -71,3 +71,34 @@ export function getSuffixFromFeatures(features: Actions) {
   }
   return;
 }
+
+export function buildPageTitle(
+  keyStages: string[],
+  subject: { title: string; slug: string },
+  phase: { title: string; slug: string },
+) {
+  let pageTitle: string = "";
+  const keyStageStrings: string[] = [];
+  if (keyStages.includes("ks1")) keyStageStrings.push("KS1");
+  if (keyStages.includes("ks2")) keyStageStrings.push("KS2");
+  if (keyStages.includes("ks3")) keyStageStrings.push("KS3");
+  if (keyStages.includes("ks4")) keyStageStrings.push("KS4");
+  const keyStageString = keyStageStrings.join(" & ");
+
+  const caseSubjectTitle = (title: string) => {
+    if (
+      ["english", "french", "spanish", "german"].includes(title.toLowerCase())
+    ) {
+      return [
+        title.slice(0, 1).toUpperCase(),
+        title.slice(1).toLowerCase(),
+      ].join("");
+    }
+    return title.toLowerCase();
+  };
+
+  if (["primary", "secondary"].includes(phase.slug)) {
+    pageTitle = `${keyStageString} ${caseSubjectTitle(subject.title)} curriculum`;
+  }
+  return pageTitle;
+}


### PR DESCRIPTION
## Description
Added `buildPageTitle` method with updated title rules for curriculum visualisers `<h1/>` tag.

## Issue(s)
Fixes `CUR-1204`

## How to test

1. Go to https://deploy-preview-3214--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check new title rules for `<h1/>`
3. You should see \_\_\_\_\_\_

## Screenshots
<img width="393" alt="Screenshot 2025-02-18 at 16 47 35" src="https://github.com/user-attachments/assets/0459fca7-b454-4bc3-a64f-c8cad063af64" />
<img width="393" alt="Screenshot 2025-02-18 at 16 47 19" src="https://github.com/user-attachments/assets/640df885-e047-4002-aca2-575cd131a286" />
