### PR TITLE
Chore/bump oak components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.84.1",
+        "@oaknational/oak-components": "^1.85.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.50.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7158,9 +7158,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.84.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.84.1.tgz",
-      "integrity": "sha512-oGoqzRXjGBtbRsCeb9GTMyJotpzX/4XILFH0oDMMH87zBdUKkUqgJgMYFW6JJgZyGDJYqlvqtiD0IeSWaGax4g==",
+      "version": "1.85.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.85.1.tgz",
+      "integrity": "sha512-M1+zsHa8pF0dWZKCa2WihWra1hDeUEgzbewonG6aPtABtkVUmHUAFsPOxbBkuhCS0+05Mpv5Pvd1PtLLT/L2qw==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.84.1",
+    "@oaknational/oak-components": "^1.85.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.50.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`CurriculumTab renders 1`] = `
                     </div>
                   </span>
                   <div
-                    class="sc-fqkvVR erqloa sc-fXSgeo kzeJBn"
+                    class="sc-fqkvVR kbnxKi sc-fXSgeo"
                   >
                     <img
                       alt="chevron-right"


### PR DESCRIPTION


## Issue(s)

Hydration error stemming from testimonials component in the front page causing next to switch to client base rendering.

Caused by div inside p in OakQuote

Fixes #

bump oak components where OakQuote has been fixed

## How to test

1. Go to https://deploy-preview-3218--oak-web-application.netlify.thenational.academy
There should be no hydration error





