### PR TITLE
Speed up tests by adding missing key and minimising providers

### DIFF
--- a/src/__tests__/__helpers__/renderWithProviders.tsx
+++ b/src/__tests__/__helpers__/renderWithProviders.tsx
@@ -21,6 +21,7 @@ import { OverlayProvider } from "react-aria";
 import { MemoryRouterProviderProps } from "next-router-mock/dist/MemoryRouterProvider/MemoryRouterProvider";
 import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 import { MockOakConsentClient } from "@oaknational/oak-consent-client";
+import { pick } from "lodash";
 
 import "../../browser-lib/oak-globals/oakGlobals";
 import ErrorBoundary from "../../components/AppComponents/ErrorBoundary";
@@ -70,7 +71,7 @@ const providersByName: {
   overlay: [OverlayProvider],
   toast: [ToastProvider],
   menu: [MenuProvider],
-};
+} as const;
 
 type ProviderName = keyof ProviderPropsByName;
 
@@ -138,5 +139,11 @@ export const renderHookWithProviders = (
     });
   };
 };
+
+export function renderWithProvidersByName(
+  names: (keyof ProviderPropsByName)[],
+) {
+  return renderWithProviders(pick(allProviders, ...names));
+}
 
 export default renderWithProviders;

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -117,10 +117,10 @@ exports[`CurriculumTab renders 1`] = `
                           style="width: 50%;"
                         >
                           <div
-                            class="sc-fqkvVR sc-9dfc1bad-0 sc-b1725761-2 jEHEPk fAkCpO pplSM"
+                            class="sc-fqkvVR sc-9dfc1bad-0 sc-bdacaec4-2 jEHEPk fAkCpO hPodqY"
                           >
                             <button
-                              class="sc-b1725761-1 cfNUDx"
+                              class="sc-bdacaec4-1 cgYPZt"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
@@ -184,10 +184,10 @@ exports[`CurriculumTab renders 1`] = `
                             class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                           >
                             <div
-                              class="sc-fqkvVR sc-9dfc1bad-0 sc-b1725761-2 eMDDOo fAkCpO pplSM"
+                              class="sc-fqkvVR sc-9dfc1bad-0 sc-bdacaec4-2 eMDDOo fAkCpO hPodqY"
                             >
                               <button
-                                class="sc-b1725761-1 cfNUDx"
+                                class="sc-bdacaec4-1 cgYPZt"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
@@ -307,10 +307,10 @@ exports[`CurriculumTab renders 1`] = `
                       style="width: 50%;"
                     >
                       <div
-                        class="sc-fqkvVR sc-9dfc1bad-0 sc-b1725761-2 jEHEPk fAkCpO pplSM"
+                        class="sc-fqkvVR sc-9dfc1bad-0 sc-bdacaec4-2 jEHEPk fAkCpO hPodqY"
                       >
                         <button
-                          class="sc-b1725761-1 cfNUDx"
+                          class="sc-bdacaec4-1 cgYPZt"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
@@ -374,10 +374,10 @@ exports[`CurriculumTab renders 1`] = `
                         class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                       >
                         <div
-                          class="sc-fqkvVR sc-9dfc1bad-0 sc-b1725761-2 eMDDOo fAkCpO pplSM"
+                          class="sc-fqkvVR sc-9dfc1bad-0 sc-bdacaec4-2 eMDDOo fAkCpO hPodqY"
                         >
                           <button
-                            class="sc-b1725761-1 cfNUDx"
+                            class="sc-bdacaec4-1 cgYPZt"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
@@ -3,14 +3,14 @@ import { getByTestId, waitFor } from "@testing-library/react";
 
 import curriculumPhaseOptions from "@/browser-lib/fixtures/curriculumPhaseOptions";
 import SubjectPhasePicker from "@/components/SharedComponents/SubjectPhasePicker";
-import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
 
 jest.mock("@/hooks/useMediaQuery.tsx", () => ({
   __esModule: true,
   default: () => false,
 }));
 
-const render = renderWithProviders();
+const render = renderWithProvidersByName(["oakTheme", "theme"]);
 
 const curriculumVisualiserAccessed = jest.fn();
 jest.mock("@/context/Analytics/useAnalytics", () => ({

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -730,6 +730,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                     >
                       {sortBy(subjects, "title").map((subject) => (
                         <ButtonContainer
+                          key={subject.slug}
                           className={`lot-picker subject-selection ${
                             isSelected(subject) ? "selected" : ""
                           }`}


### PR DESCRIPTION
## Description
On from #3217 I've fixed the performance of some slow tests

It turns out that two things were causing slow downs, firstly whenever an error gets logged it needs to calculate a stacktrace. Fixing this seems to speed up by ~30-50ms

<img width="1497" alt="Screenshot 2025-02-19 at 07 20 12" src="https://github.com/user-attachments/assets/bc15c914-3a5e-4ae6-b1bd-00712b0ac31a" />

Secondly reducing the amount of providers included in tests with the following new function was a minor small bump.

```ts
const render = renderWithProvidersByName(["oakTheme", "theme"]);
```

Results are about 200ms saved on this test file alone (adds up quickly)

<img width="1705" alt="Screenshot 2025-02-19 at 13 49 48" src="https://github.com/user-attachments/assets/75d749a1-0726-4371-b247-99fdee0a38ae" />


## How to test
Just added a missing key to the SubjectPhasePicker

1. Go to https://deploy-preview-3219--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check phase picker works as intended
