### PR TITLE
Fix/testmonials image url

### DIFF
--- a/src/components/GenericPagesComponents/Testimonials/Testimonials.test.tsx
+++ b/src/components/GenericPagesComponents/Testimonials/Testimonials.test.tsx
@@ -26,6 +26,14 @@ jest.mock("@oaknational/oak-components", () => ({
   )),
 }));
 
+// mock the imageBuilder function
+jest.mock("@/components/HooksAndUtils/sanityImageBuilder", () => ({
+  imageBuilder: {
+    image: jest.fn().mockReturnThis(),
+    url: jest.fn().mockReturnValue("https://example.com/image.jpg"),
+  },
+}));
+
 describe("Testimonials", () => {
   // Reset mocks before each test
   beforeEach(() => {
@@ -42,7 +50,7 @@ describe("Testimonials", () => {
       },
       image: {
         asset: {
-          _id: "test_quote_author",
+          _id: "image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg",
           url: "https://example.com/image.jpg",
         },
       },

--- a/src/components/GenericPagesComponents/Testimonials/Testimonials.tsx
+++ b/src/components/GenericPagesComponents/Testimonials/Testimonials.tsx
@@ -1,6 +1,7 @@
 import { OakCarousel, OakQuote } from "@oaknational/oak-components";
 
 import { HomePage } from "@/common-lib/cms-types";
+import { imageBuilder } from "@/components/HooksAndUtils/sanityImageBuilder";
 
 export type TestimonialsProps = {
   testimonials: HomePage["testimonials"];
@@ -13,10 +14,18 @@ export const Testimonials = ({ testimonials }: TestimonialsProps) => {
     const authorTitle = testimonial.quote.organisation
       ? `${testimonial.quote.role}, ${testimonial.quote.organisation}`
       : testimonial.quote.role;
+
+    /**
+     * finalUrl is the proxied url
+     */
+    const finalUrl = testimonial.image?.asset
+      ? imageBuilder.image(testimonial.image.asset).url()?.toString()
+      : undefined;
+
     return (
       <OakQuote
         quote={testimonial.quote.text}
-        authorImageSrc={testimonial.image?.asset?.url}
+        authorImageSrc={finalUrl}
         authorName={testimonial.quote.attribution}
         authorTitle={authorTitle}
         color="transparent"

--- a/src/components/HooksAndUtils/sanityImageBuilder.test.ts
+++ b/src/components/HooksAndUtils/sanityImageBuilder.test.ts
@@ -1,0 +1,69 @@
+import { getSanityRefId, getImageDimensions } from "./sanityImageBuilder";
+
+describe("getSanityRefId", () => {
+  it("should return the string if imageSource is a string", () => {
+    const result = getSanityRefId("image-123");
+    expect(result).toBe("image-123");
+  });
+
+  it("should return asset _ref if present", () => {
+    const imageSource = { asset: { _ref: "image-123-ref" } };
+    const result = getSanityRefId(imageSource);
+    expect(result).toBe("image-123-ref");
+  });
+
+  it("should return asset _id if _ref is not present", () => {
+    const imageSource = { asset: { _id: "image-123-id" } };
+    const result = getSanityRefId(imageSource);
+    expect(result).toBe("image-123-id");
+  });
+
+  it("should return _ref if present in imageSource", () => {
+    const imageSource = { _ref: "image-123-ref" };
+    const result = getSanityRefId(imageSource);
+    expect(result).toBe("image-123-ref");
+  });
+
+  it("should return _id if present in imageSource", () => {
+    const imageSource = { _id: "image-123-id" };
+    const result = getSanityRefId(imageSource);
+    expect(result).toBe("image-123-id");
+  });
+
+  it("should return an empty string if no valid id is found", () => {
+    const imageSource = {};
+    const result = getSanityRefId(imageSource);
+    expect(result).toBe("");
+  });
+});
+
+describe("getImageDimensions", () => {
+  it("should return undefined dimensions if fill is true", () => {
+    const result = getImageDimensions("image-123-800x600", { fill: true });
+    expect(result).toEqual({
+      width: undefined,
+      height: undefined,
+      aspectRatio: undefined,
+    });
+  });
+
+  it("should return default dimensions if id is undefined", () => {
+    const result = getImageDimensions(undefined, { fill: false });
+    expect(result).toEqual({ width: 0, height: 0, aspectRatio: undefined });
+  });
+
+  it("should return default dimensions if id does not contain dimensions", () => {
+    const result = getImageDimensions("image-123", { fill: false });
+    expect(result).toEqual({ width: 0, height: 0, aspectRatio: undefined });
+  });
+
+  it("should return parsed dimensions and aspect ratio if id contains valid dimensions", () => {
+    const result = getImageDimensions("image-123-800x600", { fill: false });
+    expect(result).toEqual({ width: 800, height: 600, aspectRatio: 800 / 600 });
+  });
+
+  it("should return default dimensions if width or height is not a number", () => {
+    const result = getImageDimensions("image-123-800xNaN", { fill: false });
+    expect(result).toEqual({ width: 0, height: 0, aspectRatio: undefined });
+  });
+});

--- a/src/components/HooksAndUtils/sanityImageBuilder.ts
+++ b/src/components/HooksAndUtils/sanityImageBuilder.ts
@@ -4,7 +4,7 @@ import {
   SanityImageSource,
 } from "@sanity/image-url/lib/types/types";
 
-import getBrowserConfig from "../../../browser-lib/getBrowserConfig";
+import getBrowserConfig from "../../browser-lib/getBrowserConfig";
 
 /**
  * Provide a "client like" object instead of using the

--- a/src/components/SharedComponents/CMSImage/CMSImage.tsx
+++ b/src/components/SharedComponents/CMSImage/CMSImage.tsx
@@ -7,8 +7,7 @@ import {
   getImageDimensions,
   getSanityRefId,
   imageBuilder,
-} from "./sanityImageBuilder";
-
+} from "@/components/HooksAndUtils/sanityImageBuilder";
 import { Image } from "@/common-lib/cms-types";
 import { SizeValues } from "@/styles/utils/size";
 import OwaImage, {

--- a/src/components/SharedComponents/CMSImage/index.ts
+++ b/src/components/SharedComponents/CMSImage/index.ts
@@ -1,3 +1,2 @@
 export { default } from "./CMSImage";
-export { sanityClientLike } from "./sanityImageBuilder";
 export type { CMSImageProps } from "./CMSImage";

--- a/src/pages/blog/[blogSlug].tsx
+++ b/src/pages/blog/[blogSlug].tsx
@@ -19,7 +19,7 @@ import {
 import { BlogJsonLd } from "@/browser-lib/seo/getJsonLd";
 import BlogPortableText from "@/components/GenericPagesComponents/PostPortableText/PostPortableText";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
-import { sanityClientLike } from "@/components/SharedComponents/CMSImage";
+import { sanityClientLike } from "@/components/HooksAndUtils/sanityImageBuilder";
 import { getBlogWebinarPostBreadcrumbs } from "@/components/SharedComponents/Breadcrumbs/getBreadcrumbs";
 import PostSingleLayout from "@/components/SharedComponents/PostSingleLayout";
 import getPageProps from "@/node-lib/getPageProps";

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -20,7 +20,7 @@ import { PlanALessonPage } from "@/common-lib/cms-types/planALessonPage";
 import { getNavItems } from "@/pages-helpers/home/plan-a-lesson/getNavItems";
 import LessonPlanningBlog from "@/components/GenericPagesComponents/LessonPlanningBlog";
 import { LandingPageSignUpForm } from "@/components/GenericPagesComponents/LandingPageSignUpForm";
-import { imageBuilder } from "@/components/SharedComponents/CMSImage/sanityImageBuilder";
+import { imageBuilder } from "@/components/HooksAndUtils/sanityImageBuilder";
 import usePostList from "@/components/SharedComponents/PostList/usePostList";
 import BlogAndWebinarList from "@/components/GenericPagesComponents/BlogAndWebinarList";
 import { getAndMergeWebinarsAndBlogs } from "@/utils/getAndMergeWebinarsAndBlogs";


### PR DESCRIPTION
## Issue(s)

OWA throws invalid src prop , because testimonials component doesn't proxy sanity image src.

Fixes #

Refactor code from CMSImage so that Testimonials can also proxy sanity cdn url.

## How to test

1. Go to https://deploy-preview-3222--oak-web-application.netlify.thenational.academy
2. Click through the testimonials


