### PR TITLE
Correct casing for subjects in unit listing page header [LESQ-1284]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.85.1",
+        "@oaknational/oak-components": "^1.86.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.50.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7110,9 +7110,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.85.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.85.1.tgz",
-      "integrity": "sha512-M1+zsHa8pF0dWZKCa2WihWra1hDeUEgzbewonG6aPtABtkVUmHUAFsPOxbBkuhCS0+05Mpv5Pvd1PtLLT/L2qw==",
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.86.0.tgz",
+      "integrity": "sha512-R68gZrsQVZ0s9tDLcCuG4Wyc0yIaBKgEERzMOtNaQAxFnuVE+AkYz/PqIDD0ZQNMjJjDr6bVrPDMnrF2feitRg==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.85.1",
+    "@oaknational/oak-components": "^1.86.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.50.0",
     "@oaknational/oak-pupil-client": "^2.14.0",


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- bumps oak components to latest pkg version
- subject titles will be rendered as given in unit listing header

## Issue(s)

Fixes #
incorrect casing for RSHE in unit listing header 

## How to test

1. Go to {owa_deployment_url}/teachers/programmes/rshe-pshe-secondary-ks4/units
3. You should see the subject header in all caps, matching the page header
4. All other subjects should match the casing of the unit page header and units subheader, mostly this will be sentence case, eg `Combined science`

## Screenshots

How it used to look (delete if n/a):

<img width="700" alt="Screenshot 2025-02-24 at 08 46 13" src="https://github.com/user-attachments/assets/0f1d43ad-49eb-4230-990e-2a7540180fb5" />


How it should now look:

<img width="700" alt="Screenshot 2025-02-24 at 08 35 50" src="https://github.com/user-attachments/assets/f1b21dbb-915f-4b59-8d25-2296e50167df" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
