### PR TITLE
Fixes year count in new curriculum filtering

### DIFF
--- a/src/utils/curriculum/getNumberOfSelectedUnits.test.ts
+++ b/src/utils/curriculum/getNumberOfSelectedUnits.test.ts
@@ -53,7 +53,7 @@ describe("getNumberOfSelectedUnits", () => {
     };
     mockIsVisibleUnit.mockReturnValue(true);
 
-    const result = getNumberOfSelectedUnits(yearData, "", yearSelection);
+    const result = getNumberOfSelectedUnits(yearData, "all", yearSelection);
     expect(result).toBe(5);
     expect(mockIsVisibleUnit).toHaveBeenCalledTimes(5);
   });
@@ -82,7 +82,7 @@ describe("getNumberOfSelectedUnits", () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true);
 
-    const result = getNumberOfSelectedUnits(yearData, "", yearSelection);
+    const result = getNumberOfSelectedUnits(yearData, "all", yearSelection);
     expect(result).toBe(3);
     expect(mockIsVisibleUnit).toHaveBeenCalledTimes(5);
   });
@@ -94,7 +94,7 @@ describe("getNumberOfSelectedUnits", () => {
     };
     mockIsVisibleUnit.mockReturnValue(false);
 
-    const result = getNumberOfSelectedUnits(yearData, "", yearSelection);
+    const result = getNumberOfSelectedUnits(yearData, "all", yearSelection);
     expect(result).toBe(0);
     expect(mockIsVisibleUnit).toHaveBeenCalledTimes(5);
   });

--- a/src/utils/curriculum/getNumberOfSelectedUnits.ts
+++ b/src/utils/curriculum/getNumberOfSelectedUnits.ts
@@ -13,7 +13,7 @@ export function getNumberOfSelectedUnits(
   Object.keys(yearData).forEach((year) => {
     const units = yearData[year]?.units;
 
-    if (units && (selectedYear === "" || selectedYear === year)) {
+    if (units && (selectedYear === "all" || selectedYear === year)) {
       const filteredUnits = units.filter((unit: Unit) => {
         return isVisibleUnit(filter, year, unit);
       });


### PR DESCRIPTION
## Description
Fixes "year count" in new curriculum filtering branch.

## Issue(s)

Fixes `CUR-1169`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check hidden aria "units shown" text is correct when filters change
