### PR TITLE
feat: use OakPrimaryButton to link to lesson resources

### DIFF
--- a/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
+++ b/src/components/CurriculumComponents/UnitsTabSidebar/UnitsTabSidebar.tsx
@@ -1,17 +1,22 @@
 import React, { FC, HTMLProps } from "react";
 import { Transition } from "react-transition-group";
 import { FocusOn } from "react-focus-on";
-import { OakFlex, OakHandDrawnHR, OakBox } from "@oaknational/oak-components";
+import {
+  OakFlex,
+  OakHandDrawnHR,
+  OakBox,
+  OakPrimaryButton,
+} from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import { SideMenu } from "@/components/AppComponents/AppHeaderMenu";
 import MenuBackdrop from "@/components/AppComponents/MenuBackdrop";
 import IconButton from "@/components/SharedComponents/Button/IconButton";
-import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
 import { TagFunctional } from "@/components/SharedComponents/TagFunctional";
 import { Lesson } from "@/components/CurriculumComponents/UnitModal/UnitModal";
 import { IconFocusUnderline } from "@/components/SharedComponents/Button/IconFocusUnderline";
 import { Unit } from "@/utils/curriculum/types";
+import { transformOwaLinkProps } from "@/components/SharedComponents/OwaLink";
 
 const IconButtonFocusVisible = styled(IconButton)`
   :focus ${IconFocusUnderline} {
@@ -72,6 +77,17 @@ const UnitsTabSidebar: FC<ModalProps> = ({
     }
   }
 
+  const lessonPageProps =
+    lessons && programmeSlug && resolvedUnitSlug
+      ? transformOwaLinkProps({
+          page: "lesson-index",
+          unitSlug: resolvedUnitSlug,
+          programmeSlug,
+        })
+      : null;
+
+  const lessonPageHref = lessonPageProps?.nextLinkProps?.href;
+
   return (
     <Transition in={displayModal} timeout={300} unmountOnExit>
       {(state) => (
@@ -128,35 +144,30 @@ const UnitsTabSidebar: FC<ModalProps> = ({
                       $ph="inner-padding-m"
                       $pb="inner-padding-m"
                     >
-                      <OakFlex
-                        $flexDirection={["column", "row"]}
-                        $alignItems={"flex-start"}
-                        $gap="all-spacing-2"
+                      <OakPrimaryButton
+                        data-testid="unit-lessons-button"
+                        iconName="chevron-right"
+                        isTrailingIcon={true}
+                        disabled={!lessonsAvailable}
+                        element={lessonsAvailable ? "a" : "button"}
+                        aria-disabled={!lessonsAvailable ? "true" : "false"}
+                        {...(lessonsAvailable && { href: lessonPageHref })}
                       >
-                        {lessonsAvailable === false && (
-                          <TagFunctional
-                            data-testid="coming-soon-flag"
-                            text={"Coming soon"}
-                            color="grey"
-                          />
-                        )}
-                        {lessons && programmeSlug && unitSlug && (
-                          <ButtonAsLink
-                            data-testid="unit-lessons-button"
-                            label="See lessons in unit"
-                            $font={"heading-7"}
-                            disabled={!lessonsAvailable}
-                            currentStyles={["color"]}
-                            icon="chevron-right"
-                            iconBackground="black"
-                            $iconPosition="trailing"
-                            variant="buttonStyledAsLink"
-                            page="lesson-index"
-                            unitSlug={resolvedUnitSlug}
-                            programmeSlug={programmeSlug}
-                          />
-                        )}
-                      </OakFlex>
+                        <OakFlex
+                          $flexDirection={"row"}
+                          $alignItems={"center"}
+                          $gap="all-spacing-2"
+                        >
+                          {lessonsAvailable === false && (
+                            <TagFunctional
+                              data-testid="coming-soon-flag"
+                              text={"Coming soon"}
+                              color="grey"
+                            />
+                          )}
+                          See lessons in unit
+                        </OakFlex>
+                      </OakPrimaryButton>
                     </OakFlex>
                   </OakFlex>
                 )}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Swapped out the `ButtonAsLink` component and used the `OakPrimaryButton` component instead
- Nested the `TagFunctional` within the `OakPrimaryButton` component 
- Added logic which would resolve the link to the correct lesson resource page

## Issue(s)

Fixes #[1210](https://www.notion.so/oaknationalacademy/Restyle-link-to-lesson-resources-from-unit-modal-18f26cc4e1b1807fa5cef4cafc2cceaa?pvs=4)

## How to test

1. Go to {owa_deployment_url}/curriculum/religious-education-primary/units
2. Click on the "The World: How do different people explain how it started?" in Year 1
3. You should see the new button linking to lesson resources disabled with the Coming soon tag nested within it

## Screenshots

How it used to look (delete if n/a):
<img width="665" alt="image" src="https://github.com/user-attachments/assets/bab1cef5-00f2-414b-a27b-eaf0fe608720" />

How it should now look:
<img width="531" alt="image" src="https://github.com/user-attachments/assets/a4a34aee-4a78-4076-ba1e-524ae530cf52" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [ ] Does this PR update a package with a breaking change
