### PR TITLE
feat: improve signed video token refreshing through use of event listeners

### DIFF
--- a/src/components/SharedComponents/VideoPlayer/useSignedVideoToken.test.ts
+++ b/src/components/SharedComponents/VideoPlayer/useSignedVideoToken.test.ts
@@ -1,10 +1,14 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 
 import { useSignedMuxToken } from "./useSignedVideoToken";
 
+import { isJwtExpiring } from "@/utils/jwtExpiry";
+
+const mockMutate = jest.fn();
 const mockUseSWR = jest.fn<{ data: unknown; error: unknown }, []>(() => ({
   data: null,
   error: null,
+  mutate: mockMutate,
 }));
 
 jest.mock("swr", () => ({
@@ -32,6 +36,11 @@ jest.mock("@/common-lib/error-reporter", () => ({
     () =>
     (...args: []) =>
       reportError(...args),
+}));
+
+jest.mock("@/utils/jwtExpiry", () => ({
+  __esModule: true,
+  isJwtExpiring: jest.fn().mockReturnValue(false),
 }));
 
 describe("useSignedMuxToken", () => {
@@ -128,5 +137,297 @@ describe("useSignedMuxToken", () => {
     );
 
     expect(reportError).toHaveBeenCalled();
+  });
+
+  describe("signed token refreshing", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockMutate.mockClear();
+      reportError.mockClear();
+
+      jest.spyOn(global, "setInterval");
+      jest.spyOn(global, "clearInterval");
+
+      // Mock document and window event listeners
+      jest.spyOn(document, "addEventListener").mockImplementation(jest.fn());
+      jest.spyOn(document, "removeEventListener").mockImplementation(jest.fn());
+      jest.spyOn(window, "addEventListener").mockImplementation(jest.fn());
+      jest.spyOn(window, "removeEventListener").mockImplementation(jest.fn());
+
+      // Reset mock for visibilityState
+      Object.defineProperty(document, "visibilityState", {
+        writable: true,
+        value: "hidden",
+      });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    test("should set up interval to check token expiry", () => {
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // Verify interval was set
+      expect(global.setInterval).toHaveBeenCalled();
+    });
+
+    test("should not set up interval for public videos", () => {
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "public",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // No interval should be set for public videos
+      expect(setInterval).not.toHaveBeenCalled();
+    });
+
+    test("should refresh token when it's expiring", () => {
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      // Simulate token to be expiring
+      jest.mocked(isJwtExpiring).mockReturnValueOnce(true);
+
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // Advance time to force the interval to check the token
+      act(() => {
+        jest.advanceTimersByTime(60 * 1000);
+      });
+
+      // The token should now have refreshed
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    test("should check token when document becomes visible", () => {
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      let visibilityHandler: (event: Event) => void;
+      jest
+        .mocked(document.addEventListener)
+        .mockImplementation((event, handler) => {
+          if (event === "visibilitychange") {
+            visibilityHandler = handler as (event: Event) => void;
+          }
+        });
+
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // Verify listener was added
+      expect(document.addEventListener).toHaveBeenCalledWith(
+        "visibilitychange",
+        expect.any(Function),
+      );
+
+      // Initial state - hidden, shouldn't call mutate
+      Object.defineProperty(document, "visibilityState", { value: "hidden" });
+      act(() => {
+        visibilityHandler(new Event("visibilitychange"));
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      // Simulate visibility change to visible
+      Object.defineProperty(document, "visibilityState", { value: "visible" });
+
+      // The token should not be refreshed if it's not expiring
+      act(() => {
+        visibilityHandler(new Event("visibilitychange"));
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      // Simulate token to be expiring
+      jest.mocked(isJwtExpiring).mockReturnValueOnce(true);
+
+      act(() => {
+        visibilityHandler(new Event("visibilitychange"));
+      });
+
+      // The token should now have refreshed
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    test("should check token on window focus", () => {
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      let focusHandler: (event: Event) => void;
+      jest
+        .mocked(window.addEventListener)
+        .mockImplementation((event, handler) => {
+          if (event === "focus") {
+            focusHandler = handler as (event: Event) => void;
+          }
+        });
+
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // Verify listener was added
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        "focus",
+        expect.any(Function),
+      );
+
+      // The token should not be refreshed if it's not expiring
+      act(() => {
+        focusHandler(new Event("focus"));
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      // Simulate token to be expiring
+      jest.mocked(isJwtExpiring).mockReturnValueOnce(true);
+
+      act(() => {
+        focusHandler(new Event("focus"));
+      });
+
+      // The token should now have refreshed
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    test("should check token when coming online", () => {
+      let onlineHandler: (event: Event) => void;
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      jest
+        .mocked(window.addEventListener)
+        .mockImplementation((event, handler) => {
+          if (event === "online") {
+            onlineHandler = handler as (event: Event) => void;
+          }
+        });
+
+      renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        "online",
+        expect.any(Function),
+      );
+
+      // The token should not be refreshed if it's not expiring
+      act(() => {
+        onlineHandler(new Event("online"));
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      // Simulate token to be expiring
+      jest.mocked(isJwtExpiring).mockReturnValueOnce(true);
+
+      act(() => {
+        onlineHandler(new Event("online"));
+      });
+
+      // The token should now have refreshed
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    test("should clean up event listeners and interval on unmount", () => {
+      let visibilityHandler, focusHandler, onlineHandler;
+      mockUseSWR.mockImplementationOnce(() => ({
+        data: JSON.stringify({ token: "1234" }),
+        error: null,
+        mutate: mockMutate,
+      }));
+
+      jest
+        .mocked(document.addEventListener)
+        .mockImplementation((event, handler) => {
+          if (event === "visibilitychange") visibilityHandler = handler;
+        });
+
+      jest
+        .mocked(window.addEventListener)
+        .mockImplementation((event, handler) => {
+          if (event === "focus") focusHandler = handler;
+          if (event === "online") onlineHandler = handler;
+        });
+
+      const { unmount } = renderHook(() =>
+        useSignedMuxToken({
+          playbackId: "123",
+          playbackPolicy: "signed",
+          type: "video",
+          isLegacy: true,
+        }),
+      );
+
+      // Unmount the hook
+      unmount();
+
+      // Verify cleanup
+      expect(global.clearInterval).toHaveBeenCalled();
+      expect(document.removeEventListener).toHaveBeenCalledWith(
+        "visibilitychange",
+        visibilityHandler,
+      );
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        "focus",
+        focusHandler,
+      );
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        "online",
+        onlineHandler,
+      );
+    });
   });
 });

--- a/src/components/SharedComponents/VideoPlayer/useSignedVideoToken.ts
+++ b/src/components/SharedComponents/VideoPlayer/useSignedVideoToken.ts
@@ -5,6 +5,7 @@ import getSignedVideoToken from "./getSignedVideoToken";
 
 import errorReporter from "@/common-lib/error-reporter";
 import OakError from "@/errors/OakError";
+import { isJwtExpiring } from "@/utils/jwtExpiry";
 
 const reportError = errorReporter("useSignedPlaybackId");
 export const apiEndpoint = "/api/video/signed-url";
@@ -48,7 +49,7 @@ export const useSignedMuxToken = ({
         }`
       : null;
 
-  const { data, error } = useSWR(url, getSignedVideoToken, options);
+  const { data, error, mutate } = useSWR(url, getSignedVideoToken, options);
 
   const token = data ? JSON.parse(data).token : undefined;
 
@@ -65,6 +66,41 @@ export const useSignedMuxToken = ({
       reportError(error);
     }
   }, [data, token, playbackId, playbackPolicy]);
+
+  useEffect(() => {
+    if (!token || playbackPolicy !== "signed") return;
+
+    const REFRESH_THRESHOLD = 30 * 60; // Refresh token if it expires in less than 30 minutes
+    const CHECK_INTERVAL = 60 * 1000; // Check every 60 seconds
+
+    // Function to check and refresh token if needed
+    const checkAndRefreshToken = () => {
+      if (isJwtExpiring(token, REFRESH_THRESHOLD)) {
+        mutate();
+      }
+    };
+
+    // Set up periodic checking
+    const intervalId = setInterval(checkAndRefreshToken, CHECK_INTERVAL);
+
+    // Handle visibility change (wake from sleep)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkAndRefreshToken();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", checkAndRefreshToken);
+    window.addEventListener("online", checkAndRefreshToken);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", checkAndRefreshToken);
+      window.removeEventListener("online", checkAndRefreshToken);
+    };
+  }, [token, playbackPolicy, mutate]);
 
   if (playbackPolicy === "public") {
     return {

--- a/src/utils/jwtExpiry.test.ts
+++ b/src/utils/jwtExpiry.test.ts
@@ -1,0 +1,138 @@
+import { isJwtExpiring } from "./jwtExpiry";
+
+/**
+ * Helper function to create a mock JWT token with a given expiration time.
+ *
+ * @param expiresInSeconds - the number of seconds until the token expires
+ */
+const createMockJwt = (expiresInSeconds: number): string => {
+  const currentTime = Math.floor(Date.now() / 1000);
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = { exp: currentTime + expiresInSeconds };
+
+  const base64Header = btoa(JSON.stringify(header));
+  const base64Payload = btoa(JSON.stringify(payload));
+  const signature = "mock_signature";
+
+  return `${base64Header}.${base64Payload}.${signature}`;
+};
+
+describe("isJwtExpiring", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-02-27T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test("should return true when token is expiring within threshold", () => {
+    // Create a token that expires in 30 seconds
+    const token = createMockJwt(30);
+
+    // Check if token is expiring with a 60s threshold
+    const result = isJwtExpiring(token, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should return false when token is not expiring within threshold", () => {
+    // Create a token that expires in 120 seconds
+    const token = createMockJwt(120);
+
+    // Check if token is expiring with a 60s threshold
+    const result = isJwtExpiring(token, 60);
+
+    expect(result).toBe(false);
+  });
+
+  test("should return true when token is exactly at the threshold", () => {
+    // Create a token that expires in 60 seconds
+    const token = createMockJwt(60);
+
+    // Check if token is expiring with a 60s threshold
+    const result = isJwtExpiring(token, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should return true when token is already expired", () => {
+    // Create a token that expired 10 seconds ago
+    const token = createMockJwt(-10);
+
+    // Check if token is expiring with any threshold
+    const result = isJwtExpiring(token, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should return true when token has invalid format", () => {
+    const invalidToken = "invalid.token";
+    const result = isJwtExpiring(invalidToken, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should return true when payload cannot be parsed", () => {
+    const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const invalidPayload = "not-valid-base64";
+    const signature = "mock_signature";
+
+    const invalidToken = `${header}.${invalidPayload}.${signature}`;
+
+    const result = isJwtExpiring(invalidToken, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should return true when payload is missing exp claim", () => {
+    const header = { alg: "HS256", typ: "JWT" };
+    const payload = { sub: "user123" };
+
+    const base64Header = btoa(JSON.stringify(header));
+    const base64Payload = btoa(JSON.stringify(payload));
+    const signature = "mock_signature";
+
+    const invalidToken = `${base64Header}.${base64Payload}.${signature}`;
+
+    const result = isJwtExpiring(invalidToken, 60);
+
+    expect(result).toBe(true);
+  });
+
+  test("should handle zero threshold correctly", () => {
+    // Create a token that expires in 1 second
+    const token = createMockJwt(1);
+
+    // With zero threshold, any token not yet expired should return false
+    const result = isJwtExpiring(token, 0);
+
+    expect(result).toBe(false);
+  });
+
+  test("should handle different threshold values", () => {
+    // Create a token that expires in 100 seconds
+    const token = createMockJwt(100);
+
+    // Test different thresholds
+    expect(isJwtExpiring(token, 50)).toBe(false); // More than 50 seconds left, not expiring
+    expect(isJwtExpiring(token, 100)).toBe(true); // Exactly 100 seconds left, expiring
+    expect(isJwtExpiring(token, 150)).toBe(true); // Less than 150 seconds left, expiring
+  });
+
+  test("should detect expiration after time passes", () => {
+    // Create a token that expires in 120 seconds
+    const token = createMockJwt(120);
+
+    // Should not be expiring yet with a 60s threshold
+    expect(isJwtExpiring(token, 60)).toBe(false);
+
+    // Advance time by 70 seconds
+    jest.advanceTimersByTime(70 * 1000);
+
+    // Now should be expiring (50 seconds left, threshold is 60)
+    expect(isJwtExpiring(token, 60)).toBe(true);
+  });
+});

--- a/src/utils/jwtExpiry.ts
+++ b/src/utils/jwtExpiry.ts
@@ -1,0 +1,26 @@
+/**
+ * Check if a JWT token is expiring soon based on the provided threshold.
+ * If there's an error parsing the token, it will be considered as expiring.
+ *
+ * @param token - the JWT token to check
+ * @param threshold - the threshold in seconds to consider the token as expiring
+ */
+const isJwtExpiring = (token: string, threshold: number): boolean => {
+  try {
+    const payloadBase64 = token.split(".")[1];
+    if (!payloadBase64) throw new Error("Invalid token format");
+
+    const payload = JSON.parse(atob(payloadBase64));
+    const exp = payload.exp;
+    if (!exp) throw new Error("Missing token expiry");
+
+    const currentTime = Math.floor(Date.now() / 1000);
+    const remainingTime = exp - currentTime;
+
+    return remainingTime <= threshold;
+  } catch (error) {
+    return true;
+  }
+};
+
+export { isJwtExpiring };


### PR DESCRIPTION
## Description

We previously tried to fix this by utilising SWRs `refreshInterval` option, but although it has helped, it's proven unreliable as it relies on the browser `setTimeout` function. This new approach runs the checks on an interval (60s), as well as key events such as a device regaining internet connection, the window being refocused after the device wakes up etc.

Music year: {owa_music_year}

- Added a `checkAndRefresh` method that checks if the token is expiring
- `checkAndRefresh` called by various event listeners to handle users sleeping laptops, switching tab focus, regaining internet connection etc.
- Tests added to cover above scenarios

## Issue(s)

Fixes ENG-1103

## How to test

1. Go to {owa_deployment_url}
2. Navigate to a lesson that has a video
3. Token auto-renews and no issues caused by expired tokens

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices