### PR TITLE
Added back in mobile modal filtering in curriculum filtering branch

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersDesktop.tsx
@@ -25,11 +25,17 @@ import {
   presentAtKeyStageSlugs,
 } from "@/utils/curriculum/keystage";
 
+type CurriculumVisualiserFiltersDesktopProps =
+  CurriculumVisualiserFiltersProps & {
+    excludeYears?: boolean;
+  };
+
 export default function CurriculumVisualiserFiltersDesktop({
   filters,
   onChangeFilters,
   data,
-}: CurriculumVisualiserFiltersProps) {
+  excludeYears = false,
+}: CurriculumVisualiserFiltersDesktopProps) {
   const { yearData, threadOptions, yearOptions } = data;
 
   const { childSubjects, subjectCategories, tiers } = getFilterData(
@@ -70,48 +76,50 @@ export default function CurriculumVisualiserFiltersDesktop({
         Filter and highlight
       </OakHeading>
 
-      <>
-        <OakHeading
-          tag="h4"
-          id="year-group-label"
-          $font={"heading-6"}
-          $mb="space-between-s"
-        >
-          Year group
-        </OakHeading>
+      {!excludeYears && (
+        <>
+          <OakHeading
+            tag="h4"
+            id="year-group-label"
+            $font={"heading-6"}
+            $mb="space-between-s"
+          >
+            Year group
+          </OakHeading>
 
-        <OakRadioGroup
-          name="year"
-          onChange={(e) =>
-            addAllToFilter(
-              "years",
-              e.target.value === "all" ? yearOptions : [e.target.value],
-            )
-          }
-          value={
-            isEqual(filters.years, yearOptions) ? "all" : filters.years[0]!
-          }
-          $gap="space-between-ssx"
-          $flexDirection="row"
-          $flexWrap="wrap"
-          aria-labelledby="year-group-label"
-          data-testid="year-group-filter-desktop"
-        >
-          <OakRadioAsButton
-            value="all"
-            displayValue="All"
-            data-testid={"all-years-radio"}
-          />
-          {yearOptions.map((yearOption) => (
+          <OakRadioGroup
+            name="year"
+            onChange={(e) =>
+              addAllToFilter(
+                "years",
+                e.target.value === "all" ? yearOptions : [e.target.value],
+              )
+            }
+            value={
+              isEqual(filters.years, yearOptions) ? "all" : filters.years[0]!
+            }
+            $gap="space-between-ssx"
+            $flexDirection="row"
+            $flexWrap="wrap"
+            aria-labelledby="year-group-label"
+            data-testid="year-group-filter-desktop"
+          >
             <OakRadioAsButton
-              key={yearOption}
-              value={yearOption}
-              displayValue={getYearGroupTitle(yearData, yearOption)}
-              data-testid={"year-radio"}
+              value="all"
+              displayValue="All"
+              data-testid={"all-years-radio"}
             />
-          ))}
-        </OakRadioGroup>
-      </>
+            {yearOptions.map((yearOption) => (
+              <OakRadioAsButton
+                key={yearOption}
+                value={yearOption}
+                displayValue={getYearGroupTitle(yearData, yearOption)}
+                data-testid={"year-radio"}
+              />
+            ))}
+          </OakRadioGroup>
+        </>
+      )}
 
       {subjectCategoriesAt.length > 0 && (
         <>

--- a/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiserFilters/CurriculumVisualiserFiltersMobile.tsx
@@ -1,11 +1,17 @@
 import React, { useState } from "react";
-import { OakFlex, OakSpan, OakBox } from "@oaknational/oak-components";
+import {
+  OakFlex,
+  OakSpan,
+  OakBox,
+  OakPrimaryButton,
+} from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import FocusIndicator from "../OakComponentsKitchen/FocusIndicator";
 
 import { CurriculumVisualiserFiltersProps } from "./CurriculumVisualiserFilters";
 import { highlightedUnitCount } from "./helpers";
+import CurriculumVisualiserFiltersDesktop from "./CurriculumVisualiserFiltersDesktop";
 
 import Box from "@/components/SharedComponents/Box";
 import Button from "@/components/SharedComponents/Button/Button";
@@ -263,160 +269,61 @@ function StickyBit({
   );
 }
 
-// function Modal({
-//   data,
-//   selectedThread,
-//   yearSelection,
-//   onSelectThread,
-//   onOpenModal,
-// }: Pick<
-//   CurriculumVisualiserFiltersProps,
-//   | "data"
-//   | "selectedThread"
-//   | "selectedYear"
-//   | "yearSelection"
-//   | "onSelectThread"
-// > & { onOpenModal: () => void }) {
-//   const { threadOptions, yearData } = data;
-
-//   function isSelectedThread(thread: Thread) {
-//     return selectedThread === thread.slug;
-//   }
-
-//   const highlightedUnits = highlightedUnitCount(
-//     yearData,
-//     null,
-//     yearSelection,
-//     selectedThread,
-//   );
-
-//   return (
-//     <OakBox
-//       $background={"white"}
-//       $position="fixed"
-//       $top="all-spacing-0"
-//       $height={"100%"}
-//       $zIndex={"modal-dialog"}
-//       $display={["block", "none"]}
-//     >
-//       <OakBox
-//         $position={"absolute"}
-//         $top="all-spacing-5"
-//         $right="all-spacing-4"
-//         $zIndex={"in-front"}
-//       >
-//         <Button
-//           label=""
-//           aria-label="Close Menu"
-//           icon={"cross"}
-//           variant={"minimal"}
-//           size={"large"}
-//           onClick={onOpenModal}
-//           aria-expanded={open}
-//         />
-//       </OakBox>
-//       <Fieldset
-//         $ml={16}
-//         $mt={32}
-//         $mr={16}
-//         data-testid="mobile-thread-modal"
-//         $height={"85%"}
-//         $overflow={"scroll"}
-//       >
-//         <FieldsetLegend $font={"heading-7"} $mb="space-between-m">
-//           Highlight a thread
-//         </FieldsetLegend>
-//         <OakP $mb="space-between-m">
-//           Threads are groups of units across the curriculum that build a common
-//           body of knowledge
-//         </OakP>
-//         <RadioGroup
-//           name="thread"
-//           value={selectedThread ?? ""}
-//           onChange={(e) => onSelectThread(e.target.value)}
-//         >
-//           <OakBox>
-//             <OakBox
-//               $mv="space-between-s"
-//               $pl="inner-padding-s"
-//               $position={"relative"}
-//               $bl="border-solid-s"
-//               $borderColor="transparent"
-//             >
-//               <RadioButton
-//                 aria-label={"None highlighted"}
-//                 value={""}
-//                 data-testid={"no-threads-radio-mobile"}
-//               >
-//                 None highlighted
-//               </RadioButton>
-//             </OakBox>
-//             {threadOptions.map((threadOption) => {
-//               const isSelectedMobile = isSelectedThread(threadOption);
-//               return (
-//                 <Box
-//                   $position={"relative"}
-//                   $ba={1}
-//                   $background={isSelectedMobile ? "black" : "white"}
-//                   $borderColor={isSelectedMobile ? "black" : "grey40"}
-//                   $borderRadius={4}
-//                   $color={isSelectedMobile ? "white" : "black"}
-//                   $font={isSelectedMobile ? "heading-light-7" : "body-2"}
-//                   $ph={12}
-//                   $pt={12}
-//                   $mb={8}
-//                   key={threadOption.slug}
-//                 >
-//                   <RadioButton
-//                     aria-label={threadOption.title}
-//                     value={threadOption.slug}
-//                     data-testid={
-//                       isSelectedMobile
-//                         ? "selected-thread-radio-mobile"
-//                         : "thread-radio-mobile"
-//                     }
-//                   >
-//                     <OakSpan>
-//                       {threadOption.title}
-//                       <OakSpan aria-live="polite" aria-atomic="true">
-//                         {isSelectedMobile && (
-//                           <>
-//                             <br />
-//                             {highlightedUnits}
-//                             {highlightedUnits === 1 ? " unit " : " units "}
-//                             highlighted
-//                           </>
-//                         )}
-//                       </OakSpan>
-//                     </OakSpan>
-//                   </RadioButton>
-//                 </Box>
-//               );
-//             })}
-//           </OakBox>
-//         </RadioGroup>
-//       </Fieldset>
-//       <OakFlex
-//         $position={"fixed"}
-//         $width={"100%"}
-//         $background={"white"}
-//         $bottom={["all-spacing-0"]}
-//         $right={["all-spacing-0"]}
-//         $justifyContent={"left"}
-//       >
-//         <Button
-//           $ma={16}
-//           label="Done"
-//           data-testid="mobile-done-thread-modal-button"
-//           icon="arrow-right"
-//           $iconPosition="trailing"
-//           iconBackground="black"
-//           onClick={onOpenModal}
-//         />
-//       </OakFlex>
-//     </OakBox>
-//   );
-// }
+function Modal({
+  data,
+  onOpenModal,
+  filters,
+  onChangeFilters,
+  trackingData,
+}: CurriculumVisualiserFiltersMobileProps) {
+  return (
+    <OakBox
+      $background={"white"}
+      $position="fixed"
+      $top="all-spacing-0"
+      $height={"100%"}
+      $zIndex={"modal-dialog"}
+      $display={["block", "none"]}
+    >
+      <OakFlex $flexDirection={"column"} $height={"100%"}>
+        <OakFlex
+          $width={"100%"}
+          $flexShrink={1}
+          $overflowY={"scroll"}
+          $position={"relative"}
+          $pa={"inner-padding-m"}
+        >
+          <CurriculumVisualiserFiltersDesktop
+            filters={filters}
+            onChangeFilters={onChangeFilters}
+            data={data}
+            trackingData={trackingData}
+            excludeYears={true}
+          />
+        </OakFlex>
+        <OakFlex
+          $width={"100%"}
+          $background={"white"}
+          $bottom={["all-spacing-0"]}
+          $right={["all-spacing-0"]}
+          $ph={"inner-padding-m"}
+          $pv={"inner-padding-s"}
+          $justifyContent={"left"}
+          $bt={"border-solid-s"}
+          $borderColor={"grey30"}
+        >
+          <OakPrimaryButton
+            data-testid="mobile-done-thread-modal-button"
+            onClick={onOpenModal}
+            width={"100%"}
+          >
+            Apply
+          </OakPrimaryButton>
+        </OakFlex>
+      </OakFlex>
+    </OakBox>
+  );
+}
 
 export default function CurriculumVisualiserFiltersMobile({
   filters,
@@ -434,16 +341,16 @@ export default function CurriculumVisualiserFiltersMobile({
   }
 
   return mobileThreadModalOpen ? (
-    <div />
+    <Modal
+      onOpenModal={handleMobileThreadModal}
+      filters={filters}
+      selectedYear={selectedYear}
+      onSelectYear={onSelectYear}
+      onChangeFilters={onChangeFilters}
+      data={data}
+      trackingData={trackingData}
+    />
   ) : (
-    // <Modal
-    //   data={data}
-    //   selectedThread={selectedThread}
-    //   selectedYear={selectedYear}
-    //   yearSelection={yearSelection}
-    //   onOpenModal={handleMobileThreadModal}
-    //   onSelectThread={onSelectThread}
-    // />
     <StickyBit
       onOpenModal={handleMobileThreadModal}
       filters={filters}


### PR DESCRIPTION
## Description
Adds back in mobile modal for filtering

## Issue(s)

Fixes `CUR-1169`

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
