### PR TITLE
Fixes for new curriculum filtering data issues

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -286,14 +286,32 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
           .filter((year) => filterIncludes("years", [year]))
           .sort(sortYears)
           .map((year, index) => {
-            const { units, isSwimming } = yearData[year] as YearData[string];
+            const {
+              units,
+              isSwimming,
+              childSubjects,
+              tiers,
+              subjectCategories,
+            } = yearData[year] as YearData[string];
 
             const ref = (element: HTMLDivElement) => {
               itemEls.current[index] = element;
             };
 
+            const yearFilters = {
+              childSubjects:
+                childSubjects.length > 0 ? filters.childSubjects : undefined,
+              subjectCategories:
+                childSubjects.length < 1 && subjectCategories.length > 0
+                  ? filters.subjectCategories
+                  : undefined,
+              tiers: tiers.length > 0 ? filters.tiers : undefined,
+              years: filters.years,
+              threads: filters.threads,
+            };
+
             const filteredUnits = units.filter((unit: Unit) =>
-              isVisibleUnit(filters, year, unit),
+              isVisibleUnit(yearFilters, year, unit),
             );
 
             const dedupedUnits = dedupUnits(filteredUnits);


### PR DESCRIPTION
## Description
Fixes for various data issues in the new filtering branch.

I turns out when I told @assadk88 to ah yeah just remove that code in https://github.com/oaknational/Oak-Web-Application/commit/be20ecfcf35da30582bbf5b1ecd7403808936dd3#diff-f5088875e98c3f1cda69461182f7cb387c881b0fe15b374868d107ef82132948L75-L172 yeah we kind of needed that code.


## Issue(s)
Fixes `CUR-1291`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/science-secondary-aqa/units
2. Check data is correct
3. Check for regressions

