### PR TITLE
Added error boundary to Mux player

### DIFF
--- a/src/components/SharedComponents/ComponentErrorBoundary/TestingError.tsx
+++ b/src/components/SharedComponents/ComponentErrorBoundary/TestingError.tsx
@@ -1,0 +1,7 @@
+type TestingErrorProps = {
+  error: Error;
+};
+export default function TestingError({ error }: TestingErrorProps) {
+  throw error;
+  return <div />;
+}

--- a/src/components/SharedComponents/ComponentErrorBoundary/index.tsx
+++ b/src/components/SharedComponents/ComponentErrorBoundary/index.tsx
@@ -1,0 +1,39 @@
+import { Component } from "react";
+
+type State = { hasError: boolean };
+type Props = { children: React.ReactNode; fallback: React.ReactNode };
+export class ComponentErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    // Define a state variable to track whether is an error or not
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError(error: Error) {
+    // Update state so the next render will show the fallback UI
+
+    // TODO: Report error here...
+    console.log({ error });
+
+    return { hasError: true };
+  }
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // TODO: Report error here...
+    console.log({ error, errorInfo });
+  }
+  render() {
+    // Check if the error is thrown
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback;
+    }
+
+    // Return children components in case of no error
+
+    return this.props.children;
+  }
+}

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,1 +1,2 @@
 export const ENABLE_OPEN_API = false;
+export const FAKE_MUX_ERRORS = false;


### PR DESCRIPTION
## Description
We recently had some issues with the Mux player which took out the entire page in the global error boundary. Since it's an external component that's lazy loaded we should probably catch that error in an error boundary. This PR adds that

Todo

 - [ ] Design generic error, that we can use for external components, that also works for videos (with @HelenHarlow)
 - [ ] Add in reporting to bugsnag, currently just `console.log`s
 - [ ] Move `FAKE_MUX_ERRORS` into non-curric location
 - [ ] Write tests
 
## Issue(s)

Fixes `FEC-99`

## How to test

1. Enable `FAKE_MUX_ERRORS` in development
2. Go to https://deploy-preview-3267--oak-web-application.netlify.thenational.academy
3. To to a page with a video
4. You should see an error rather than the video

## Screenshots
Without error thrown
<img width="1380" alt="Screenshot 2025-03-10 at 13 20 06" src="https://github.com/user-attachments/assets/507a6540-d013-43fd-8d13-696ad4ed0d40" />

With error thrown

<img width="1380" alt="Screenshot 2025-03-10 at 13 19 48" src="https://github.com/user-attachments/assets/c23f90e8-157f-4d9a-b15b-40fe97617267" />

