### PR TITLE
Remove filter number from mobile filter

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { OakFlex, OakSpan, OakBox } from "@oaknational/oak-components";
 import styled from "styled-components";
 
@@ -12,11 +12,7 @@ import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { Thread } from "@/utils/curriculum/types";
-import {
-  getDefaultFilter,
-  getNumberOfFiltersApplied,
-  highlightedUnitCount,
-} from "@/utils/curriculum/filtering";
+import { highlightedUnitCount } from "@/utils/curriculum/filtering";
 
 export type CurriculumVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {
@@ -164,12 +160,6 @@ export function CurricMobileStickyHeader({
     }
   }
 
-  const dfltFilters = useMemo(() => getDefaultFilter(data), [data]);
-  const numberOfFiltersApplied = getNumberOfFiltersApplied(
-    dfltFilters,
-    filters,
-  );
-
   return (
     <OakBox
       $position={["sticky", "static"]}
@@ -191,7 +181,7 @@ export function CurricMobileStickyHeader({
             $pb={"inner-padding-m"}
           >
             <Button
-              label={`Filter and highlight${numberOfFiltersApplied ? ` (${numberOfFiltersApplied})` : ``}`}
+              label={`Filter and highlight`}
               icon="chevron-right"
               $iconPosition="trailing"
               variant="buttonStyledAsLink"


### PR DESCRIPTION
## Description
Removes the number of filters from mobile filter as shown in the below

<img width="440" alt="Screenshot 2025-03-10 at 15 55 04" src="https://github.com/user-attachments/assets/36a91598-a5dc-4ec8-b0cb-b4758860fb87" />


## Issue(s)
Fixes `CUR-1169`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Go to the visualiser
3. Apply a filter in the mobile viewport
4. Check `(1)` is no longer preset
