### PR TITLE
Added missing tests for `shouldDisplayFilter` new curric filtering

### DIFF
--- a/src/fixtures/curriculum/filters/index.test.ts
+++ b/src/fixtures/curriculum/filters/index.test.ts
@@ -1,0 +1,79 @@
+import { createFilter } from "./index";
+
+describe("createFilter", () => {
+  it("default filter", () => {
+    const result = createFilter();
+    expect(result).toEqual({
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: [],
+      years: [],
+      threads: [],
+    });
+  });
+
+  it("assign childSubjects to filter", () => {
+    const result = createFilter({
+      childSubjects: ["test1", "test2"],
+    });
+    expect(result).toEqual({
+      childSubjects: ["test1", "test2"],
+      subjectCategories: [],
+      tiers: [],
+      years: [],
+      threads: [],
+    });
+  });
+
+  it("assign subjectCategories to filter", () => {
+    const result = createFilter({
+      subjectCategories: ["test1", "test2"],
+    });
+    expect(result).toEqual({
+      childSubjects: [],
+      subjectCategories: ["test1", "test2"],
+      tiers: [],
+      years: [],
+      threads: [],
+    });
+  });
+
+  it("assign tiers to filter", () => {
+    const result = createFilter({
+      tiers: ["foundation", "higher"],
+    });
+    expect(result).toEqual({
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: ["foundation", "higher"],
+      years: [],
+      threads: [],
+    });
+  });
+
+  it("assign years to filter", () => {
+    const result = createFilter({
+      years: ["9", "10", "11"],
+    });
+    expect(result).toEqual({
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: [],
+      years: ["9", "10", "11"],
+      threads: [],
+    });
+  });
+
+  it("assign threads to filter", () => {
+    const result = createFilter({
+      threads: ["test1", "test2"],
+    });
+    expect(result).toEqual({
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: [],
+      years: [],
+      threads: ["test1", "test2"],
+    });
+  });
+});

--- a/src/fixtures/curriculum/filters/index.ts
+++ b/src/fixtures/curriculum/filters/index.ts
@@ -1,0 +1,16 @@
+import { CurriculumFilters } from "@/utils/curriculum/types";
+
+const BASE_FILTERS: CurriculumFilters = {
+  childSubjects: [],
+  subjectCategories: [],
+  tiers: [],
+  years: [],
+  threads: [],
+};
+
+export function createFilter(partial: Partial<CurriculumFilters> = {}) {
+  return {
+    ...BASE_FILTERS,
+    ...partial,
+  };
+}

--- a/src/fixtures/curriculum/yearData/index.test.ts
+++ b/src/fixtures/curriculum/yearData/index.test.ts
@@ -1,0 +1,91 @@
+import { createChildSubject } from "../childSubject";
+import { createSubjectCategory } from "../subjectCategories";
+import { createTier } from "../tier";
+import { createUnit } from "../unit";
+
+import { createYearData } from "./index";
+
+describe("createSubjectCategory", () => {
+  it("default year data", () => {
+    const result = createYearData();
+    expect(result).toEqual({
+      units: [],
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: [],
+      pathways: [],
+      isSwimming: false,
+      groupAs: null,
+    });
+  });
+
+  it("pass data", () => {
+    const result = createYearData({
+      units: [createUnit({ slug: "test" })],
+      childSubjects: [createChildSubject({ subject_slug: "test" })],
+      subjectCategories: [createSubjectCategory({ id: 2 })],
+      tiers: [createTier({ tier_slug: "test" })],
+      pathways: [],
+      isSwimming: true,
+      groupAs: "testing_group",
+    });
+    expect(result).toEqual({
+      units: [
+        {
+          connection_future_unit_description: null,
+          connection_future_unit_title: null,
+          connection_prior_unit_description: null,
+          connection_prior_unit_title: null,
+          cycle: "1",
+          description: null,
+          domain: null,
+          domain_id: null,
+          examboard: null,
+          examboard_slug: null,
+          keystage_slug: "ks2",
+          lessons: [],
+          order: 0,
+          phase: "Primary",
+          phase_slug: "primary",
+          planned_number_of_lessons: null,
+          slug: "test",
+          state: "published",
+          subject: "Transfiguration",
+          subject_parent: null,
+          subject_parent_slug: null,
+          subject_slug: "transfiguration",
+          subjectcategories: null,
+          tags: null,
+          threads: [],
+          tier: null,
+          tier_slug: null,
+          title: "Test",
+          unit_options: [],
+          why_this_why_now: null,
+          year: "5",
+        },
+      ],
+      childSubjects: [
+        {
+          subject: "Test",
+          subject_slug: "test",
+        },
+      ],
+      subjectCategories: [
+        {
+          id: 2,
+          title: "Foo",
+        },
+      ],
+      tiers: [
+        {
+          tier: "Test",
+          tier_slug: "test",
+        },
+      ],
+      pathways: [],
+      isSwimming: true,
+      groupAs: "testing_group",
+    });
+  });
+});

--- a/src/fixtures/curriculum/yearData/index.ts
+++ b/src/fixtures/curriculum/yearData/index.ts
@@ -1,0 +1,20 @@
+import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+
+const BASE_YEAR_DATA: CurriculumUnitsYearData[number] = {
+  units: [],
+  childSubjects: [],
+  subjectCategories: [],
+  tiers: [],
+  pathways: [],
+  isSwimming: false,
+  groupAs: null,
+};
+
+export function createYearData(
+  partial: Partial<CurriculumUnitsYearData[number]> = {},
+) {
+  return {
+    ...BASE_YEAR_DATA,
+    ...partial,
+  };
+}

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -7,15 +7,21 @@ import {
   getFilterData,
   getNumberOfFiltersApplied,
   isHighlightedUnit,
+  shouldDisplayFilter,
 } from "./filtering";
 import { CurriculumFilters, Unit } from "./types";
 
 import { createUnit } from "@/fixtures/curriculum/unit";
-import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import {
+  CurriculumUnitsFormattedData,
+  CurriculumUnitsYearData,
+} from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { createChildSubject } from "@/fixtures/curriculum/childSubject";
 import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
 import { createTier } from "@/fixtures/curriculum/tier";
 import { createThread } from "@/fixtures/curriculum/thread";
+import { createFilter } from "@/fixtures/curriculum/filters";
+import { createYearData } from "@/fixtures/curriculum/yearData";
 
 describe("filtering", () => {
   describe("getDefaultChildSubjectForYearGroup", () => {
@@ -379,6 +385,235 @@ describe("diffFilters", () => {
       tiers: [tierHigher.tier_slug],
       years: [],
       threads: [thread.slug],
+    });
+  });
+});
+
+describe("shouldDisplayFilter", () => {
+  describe("years", () => {
+    it("with data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test2" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "years",
+      );
+      expect(result).toEqual(true);
+    });
+
+    it("no data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {},
+        threadOptions: [],
+        yearOptions: [],
+      };
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: [] }),
+        "years",
+      );
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe("subjectCategories", () => {
+    it("with data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+            subjectCategories: [createSubjectCategory({ id: 1 })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test2" })],
+            subjectCategories: [createSubjectCategory({ id: 1 })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "subjectCategories",
+      );
+      expect(result).toEqual(true);
+    });
+
+    it("no data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "subjectCategories",
+      );
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe("childSubjects", () => {
+    it("with data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+            childSubjects: [createChildSubject({ subject_slug: "physics" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test2" })],
+            childSubjects: [createChildSubject({ subject_slug: "biology" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "childSubjects",
+      );
+      expect(result).toEqual(true);
+    });
+
+    it("no data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "childSubjects",
+      );
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe("tiers", () => {
+    it("with data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+            tiers: [createTier({ tier_slug: "foundation" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test2" })],
+            tiers: [createTier({ tier_slug: "higher" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "tiers",
+      );
+      expect(result).toEqual(true);
+    });
+
+    it("no data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "tiers",
+      );
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe("threads", () => {
+    it("with data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+        },
+        threadOptions: [
+          createThread({ slug: "test1" }),
+          createThread({ slug: "test2" }),
+        ],
+        yearOptions: ["7", "8"],
+      };
+
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "threads",
+      );
+      expect(result).toEqual(true);
+    });
+
+    it("no data", () => {
+      const data: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+          "8": createYearData({
+            units: [createUnit({ slug: "test1" })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8"],
+      };
+      const result = shouldDisplayFilter(
+        data,
+        createFilter({ years: ["7", "8"] }),
+        "threads",
+      );
+      expect(result).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
## Description
Added missing tests for `shouldDisplayFilter` in new curriculum filtering branch.

Also adds new fixture helpers `createYearData` and `createFilter`


## How to test
No QA required just dev review only tests effected
