### PR TITLE
Added missing tests for `<OakModalNew/>` in curric filtering branch

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
@@ -6,13 +6,7 @@ import { CurricMobileStickyHeader } from "../CurricVisualiserMobileHeader";
 import { CurricMobileFilterModal } from "../CurricVisualiserFiltersModal";
 import { OakModalNew } from "../OakComponentsKitchen/OakModalNew";
 
-export function usePrevious<T>(value: T) {
-  const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref.current;
-}
+import { usePrevious } from "@/hooks/usePrevious";
 
 export type CurricVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {

--- a/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/__snapshots__/index.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakModalNew should match snapshot 1`] = `
+<div>
+  <dialog
+    class="sc-7c25aa5d-0 easTDE"
+    data-testid="modal"
+  >
+    <div
+      class="sc-fqkvVR sc-gsFSXq bXpmro bOTBNE"
+    >
+      <div
+        class="sc-fqkvVR sc-gsFSXq eLuStd dNHjLk"
+      >
+        <h1
+          class="sc-dhKdcB bnPSzI"
+          data-testid="modal-title"
+        >
+          test_title
+        </h1>
+        <div
+          class="sc-fqkvVR RMQib"
+        >
+          <div
+            class="sc-ad0ad6f5-0 sc-952e1041-0 bZaRlP hlZDaV"
+          >
+            <button
+              aria-label="Close"
+              class="sc-ce4d7bd4-0 sc-4362740-0 kYyTPx kgfbIy"
+              data-testid="close-modal-button"
+              title="Close"
+            >
+              <div
+                class="sc-b071a727-0 eQqUiM"
+              >
+                <span
+                  aria-hidden="true"
+                  class="sc-cba1a45e-0 bgbQLJ"
+                >
+                  <span
+                    class="sc-cba1a45e-1 idsnjc"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="sc-86d1d46f-0 eJtvEZ"
+                      height="100%"
+                      name="cross"
+                      width="100%"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <use
+                        xlink:href="/images/sprite/sprite.svg#cross"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="sc-86d1d46f-0 jOBmUC sc-62671a58-0 duckYG"
+                  height="100%"
+                  name="underline-1"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="/images/sprite/sprite.svg#underline-1"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-fqkvVR sc-gsFSXq cqwgvE JfWBw"
+        data-testid="modal-content"
+      >
+        test_content
+      </div>
+      <div
+        class="sc-fqkvVR sc-gsFSXq eGXHla XmDSc"
+        data-testid="modal-footer"
+      >
+        test_footer
+      </div>
+    </div>
+  </dialog>
+</div>
+`;

--- a/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/index.test.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/index.test.tsx
@@ -1,0 +1,107 @@
+import { act } from "@testing-library/react";
+
+import { OakModalNew } from ".";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+describe("OakModalNew", () => {
+  it("should match snapshot", () => {
+    HTMLDialogElement.prototype.close = () => {};
+    HTMLDialogElement.prototype.showModal = () => {};
+    const { container, getByTestId } = renderWithTheme(
+      <OakModalNew
+        title={"test_title"}
+        content={"test_content"}
+        footer={"test_footer"}
+        open={false}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(getByTestId("modal").tagName).toEqual("DIALOG");
+    expect(getByTestId("modal-title")).toHaveTextContent("test_title");
+    expect(getByTestId("modal-content")).toHaveTextContent("test_content");
+    expect(getByTestId("modal-footer")).toHaveTextContent("test_footer");
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should open/close when open state changed", () => {
+    const closeMock = jest.fn();
+    const showModalMock = jest.fn();
+    const onCloseMock = jest.fn();
+    HTMLDialogElement.prototype.close = closeMock;
+    HTMLDialogElement.prototype.showModal = showModalMock;
+    const { rerender } = renderWithTheme(
+      <OakModalNew
+        title={"test_title"}
+        content={"test_content"}
+        footer={"test_footer"}
+        open={false}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const resetMocks = () => {
+      closeMock.mockClear();
+      showModalMock.mockClear();
+      onCloseMock.mockClear();
+    };
+
+    expect(closeMock).not.toHaveBeenCalled();
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+
+    resetMocks();
+    rerender(
+      <OakModalNew
+        title={"test_title"}
+        content={"test_content"}
+        footer={"test_footer"}
+        open={true}
+        onClose={onCloseMock}
+      />,
+    );
+
+    expect(closeMock).not.toHaveBeenCalled();
+    expect(showModalMock).toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+
+    resetMocks();
+    rerender(
+      <OakModalNew
+        title={"test_title"}
+        content={"test_content"}
+        footer={"test_footer"}
+        open={false}
+        onClose={onCloseMock}
+      />,
+    );
+
+    expect(closeMock).toHaveBeenCalled();
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+  });
+
+  it("should open/close when open state changed", () => {
+    const closeMock = jest.fn();
+    const showModalMock = jest.fn();
+    const onCloseMock = jest.fn();
+    HTMLDialogElement.prototype.close = closeMock;
+    HTMLDialogElement.prototype.showModal = showModalMock;
+    const { container } = renderWithTheme(
+      <OakModalNew
+        title={"test_title"}
+        content={"test_content"}
+        footer={"test_footer"}
+        open={false}
+        onClose={onCloseMock}
+      />,
+    );
+
+    act(() => {
+      (container.querySelector('[aria-label="Close"]') as HTMLElement).click();
+    });
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/index.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 
 import { CurriculumModalCloseButton } from "../../CurriculumModalCloseButton";
 
+import { usePrevious } from "@/hooks/usePrevious";
+
 const Dialog = styled("dialog")`
   border: none;
   margin: 0;
@@ -34,21 +36,22 @@ export function OakModalNew({
   onClose,
 }: ModalProps) {
   const ref = useRef<HTMLDialogElement>(null);
+  const prevOpen = usePrevious(open);
 
   useEffect(() => {
     if (ref.current) {
       if (open) {
         document.body.style.overflow = "hidden";
-        ref.current.showModal();
+        if (!prevOpen) ref.current.showModal();
       } else {
         document.body.style.overflow = "";
-        ref.current.close();
+        if (prevOpen) ref.current.close();
       }
     }
-  }, [ref, open]);
+  }, [ref, open, prevOpen]);
 
   return (
-    <Dialog ref={ref}>
+    <Dialog ref={ref} data-testid="modal">
       <OakFlex $flexDirection={"column"} $background={"white"} $height={"100%"}>
         <OakFlex
           $pa={"inner-padding-m"}
@@ -58,7 +61,7 @@ export function OakModalNew({
           $bb={"border-solid-s"}
           $borderColor={"grey30"}
         >
-          <OakHeading tag="h1" $font={"body-1"}>
+          <OakHeading tag="h1" $font={"body-1"} data-testid="modal-title">
             {title}
           </OakHeading>
           <OakBox $position={"absolute"} $right={"all-spacing-4"}>
@@ -69,6 +72,7 @@ export function OakModalNew({
           </OakBox>
         </OakFlex>
         <OakFlex
+          data-testid="modal-content"
           $flexShrink={1}
           $overflowY={"auto"}
           $flexGrow={1}
@@ -77,6 +81,7 @@ export function OakModalNew({
           {content}
         </OakFlex>
         <OakFlex
+          data-testid="modal-footer"
           $width={"100%"}
           $background={"white"}
           $ph={"inner-padding-m"}

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}


### PR DESCRIPTION
## Description
100% test coverage of new `<OakModalNew/>`

FYI: Will add tests for `usePrevious` in another PR as it's not strictly related

```
 .../CurriculumComponents/OakComponentsKitchen/OakModalNew      |     100 |      100 |     100 |     100 | 
  index.tsx                                                     |     100 |      100 |     100 |     100 | 
```


## How to test
No QA required just dev review (only effects tests)
