### PR TITLE
Curric filters more test coverage

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.fixtures.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.fixtures.tsx
@@ -68,7 +68,7 @@ export const ks3and4Setup = {
       ],
     },
     "8": {
-      childSubjects: [childSubjectBiology],
+      childSubjects: [childSubjectPhysics],
       pathways: [],
       tiers: [],
       groupAs: null,
@@ -78,7 +78,7 @@ export const ks3and4Setup = {
         createUnit({
           year: "8",
           subjectcategories: [],
-          subject_slug: childSubjectBiology.subject_slug,
+          subject_slug: childSubjectPhysics.subject_slug,
         }),
       ],
     },

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.test.tsx
@@ -23,7 +23,7 @@ describe("CurricFiltersChildSubjects", () => {
 
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
-    expect(getByRole("heading")).toHaveTextContent("Exam subject (KS4)");
+    expect(getByRole("heading").textContent).toEqual("Exam subject (KS4)");
     expect(elements[0]!.value).toEqual("biology");
     expect(elements[1]!.value).toEqual("chemistry");
     expect(elements[2]!.value).toEqual("physics");
@@ -36,7 +36,7 @@ describe("CurricFiltersChildSubjects", () => {
           childSubjects: [],
           subjectCategories: [],
           tiers: [],
-          years: ["10", "11"],
+          years: ["7", "8", "9", "10", "11"],
           threads: [],
         }}
         onChangeFilters={() => {}}
@@ -46,7 +46,7 @@ describe("CurricFiltersChildSubjects", () => {
 
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
-    expect(getByRole("heading")).toHaveTextContent("Exam subject");
+    expect(getByRole("heading").textContent).toEqual("Exam subject");
     expect(elements[0]!.value).toEqual("biology");
     expect(elements[1]!.value).toEqual("chemistry");
     expect(elements[2]!.value).toEqual("physics");

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.tsx
@@ -52,9 +52,9 @@ export function CurricFiltersChildSubjects({
             $font={"heading-6"}
             $mb="space-between-s"
           >
-            Exam subject{" "}
+            Exam subject
             {childSubjectsAt.length === 1
-              ? `(${childSubjectsAt[0]?.toUpperCase()})`
+              ? ` (${childSubjectsAt[0]?.toUpperCase()})`
               : ""}
           </OakHeading>
           <OakRadioGroup

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.fixtures.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.fixtures.tsx
@@ -64,11 +64,7 @@ export const ks3and4Setup = {
       tiers: [],
       groupAs: null,
       isSwimming: false,
-      subjectCategories: [
-        subjectCategoryBiology,
-        subjectCategoryChemistry,
-        subjectCategoryPhysics,
-      ],
+      subjectCategories: [subjectCategoryBiology],
       units: [
         createUnit({
           year: "7",
@@ -82,11 +78,7 @@ export const ks3and4Setup = {
       tiers: [],
       groupAs: null,
       isSwimming: false,
-      subjectCategories: [
-        subjectCategoryBiology,
-        subjectCategoryChemistry,
-        subjectCategoryPhysics,
-      ],
+      subjectCategories: [subjectCategoryBiology],
       units: [
         createUnit({
           year: "8",
@@ -100,11 +92,7 @@ export const ks3and4Setup = {
       tiers: [],
       groupAs: null,
       isSwimming: false,
-      subjectCategories: [
-        subjectCategoryBiology,
-        subjectCategoryChemistry,
-        subjectCategoryPhysics,
-      ],
+      subjectCategories: [subjectCategoryBiology],
       units: [
         createUnit({
           year: "9",

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
@@ -26,7 +26,7 @@ describe("CurricFiltersSubjectCategories", () => {
 
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
-    expect(getByRole("heading")).toHaveTextContent("Category (KS4)");
+    expect(getByRole("heading").textContent).toEqual("Category (KS4)");
     expect(elements[0]!.value).toEqual("1");
     expect(elements[1]!.value).toEqual("2");
     expect(elements[2]!.value).toEqual("3");
@@ -39,7 +39,7 @@ describe("CurricFiltersSubjectCategories", () => {
           childSubjects: [],
           subjectCategories: [],
           tiers: [],
-          years: ["10", "11"],
+          years: ["7", "8", "9", "10", "11"],
           threads: [],
         }}
         onChangeFilters={() => {}}
@@ -49,7 +49,7 @@ describe("CurricFiltersSubjectCategories", () => {
 
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
-    expect(getByRole("heading")).toHaveTextContent("Category");
+    expect(getByRole("heading").textContent).toEqual("Category");
     expect(elements[0]!.value).toEqual("1");
     expect(elements[1]!.value).toEqual("2");
     expect(elements[2]!.value).toEqual("3");

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
@@ -61,9 +61,9 @@ export function CurricFiltersSubjectCategories({
             $font={"heading-6"}
             $mb="space-between-s"
           >
-            Category{" "}
+            Category
             {subjectCategoriesAt.length === 1
-              ? `(${subjectCategoriesAt[0]?.toUpperCase()})`
+              ? ` (${subjectCategoriesAt[0]?.toUpperCase()})`
               : ""}
           </OakHeading>
 

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersThreads.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersThreads.tsx
@@ -7,6 +7,7 @@ import { RadioGroup, RadioButton } from "../OakComponentsKitchen/SimpleRadio";
 import { Thread, CurriculumFilters } from "@/utils/curriculum/types";
 import { highlightedUnitCount } from "@/utils/curriculum/filtering";
 import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { pluralizeUnits } from "@/utils/curriculum/formatting";
 
 export type CurricFiltersThreadsProps = {
   filters: CurriculumFilters;
@@ -87,7 +88,7 @@ export function CurricFiltersThreads({
                       <>
                         <br />
                         {highlightedCount}
-                        {highlightedCount === 1 ? " unit " : " units "}
+                        {pluralizeUnits(highlightedCount)}
                         highlighted
                       </>
                     )}

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -7,7 +7,14 @@ import {
   formatKeystagesShort,
   joinWords,
   pluralizeUnits,
+  getYearSubheadingText,
 } from "./formatting";
+
+import { createYearData } from "@/fixtures/curriculum/yearData";
+import { createFilter } from "@/fixtures/curriculum/filters";
+import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
+import { createChildSubject } from "@/fixtures/curriculum/childSubject";
+import { createTier } from "@/fixtures/curriculum/tier";
 
 describe("getYearGroupTitle", () => {
   describe("no suffix", () => {
@@ -326,9 +333,86 @@ describe("pluralizeUnits", () => {
     expect(pluralizeUnits(1)).toEqual("unit");
   });
   it("many", () => {
-    expect(pluralizeUnits(0)).toEqual("units");
+    expect(pluralizeUnits(2)).toEqual("units");
   });
   it("none", () => {
     expect(pluralizeUnits(0)).toEqual("");
+  });
+});
+
+describe("getYearSubheadingText", () => {
+  const subCat1 = createSubjectCategory({ id: 1, title: "SUB_CAT_1" });
+  const childSubject1 = createChildSubject({ subject_slug: "CHILD_SUBJECT_1" });
+  const tier1 = createTier({ tier_slug: "TIER_1" });
+  const data = {
+    "7": createYearData({
+      childSubjects: [childSubject1],
+      subjectCategories: [subCat1],
+      tiers: [tier1],
+    }),
+  };
+
+  it("all year", () => {
+    const result = getYearSubheadingText(
+      data,
+      "all",
+      createFilter({
+        years: ["7"],
+        subjectCategories: [String(subCat1.id)],
+        childSubjects: [childSubject1.subject_slug],
+        tiers: [tier1.tier_slug],
+      }),
+    );
+    expect(result).toEqual(null);
+  });
+
+  it("subjectCategories", () => {
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        subjectCategories: [String(subCat1.id)],
+      }),
+    );
+    expect(result).toEqual("SUB_CAT_1");
+  });
+
+  it("sortChildSubjects", () => {
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        childSubjects: [childSubject1.subject_slug],
+      }),
+    );
+    expect(result).toEqual("CHILD_SUBJECT_1");
+  });
+
+  it("tiers", () => {
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        tiers: [tier1.tier_slug],
+      }),
+    );
+    expect(result).toEqual("TIER_1");
+  });
+
+  it("all", () => {
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        subjectCategories: [String(subCat1.id)],
+        childSubjects: [childSubject1.subject_slug],
+        tiers: [tier1.tier_slug],
+      }),
+    );
+    expect(result).toEqual("SUB_CAT_1, CHILD_SUBJECT_1, TIER_1");
   });
 });

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -6,6 +6,7 @@ import {
   buildPageTitle,
   formatKeystagesShort,
   joinWords,
+  pluralizeUnits,
 } from "./formatting";
 
 describe("getYearGroupTitle", () => {
@@ -317,5 +318,17 @@ describe("joinWords", () => {
 
   it("with empty words", () => {
     expect(joinWords(["one", "", "two", "", "three"])).toEqual("one two three");
+  });
+});
+
+describe("pluralizeUnits", () => {
+  it("one", () => {
+    expect(pluralizeUnits(1)).toEqual("unit");
+  });
+  it("many", () => {
+    expect(pluralizeUnits(0)).toEqual("units");
+  });
+  it("none", () => {
+    expect(pluralizeUnits(0)).toEqual("");
   });
 });

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -1,4 +1,5 @@
-import { YearData } from "./types";
+import { CurriculumFilters, YearData } from "./types";
+import { keystageFromYear } from "./keystage";
 
 import { Actions } from "@/node-lib/curriculum-api-2023/shared.schema";
 import { Phase } from "@/node-lib/curriculum-api-2023";
@@ -125,11 +126,10 @@ export function joinWords(str: string[]) {
 export function getYearSubheadingText(
   yearData: YearData,
   year: string,
-  filters: {
-    childSubjects: string[];
-    subjectCategories: string[];
-    tiers: string[];
-  },
+  filters: Pick<
+    CurriculumFilters,
+    "childSubjects" | "subjectCategories" | "tiers"
+  >,
 ): string | null {
   // Don't show subheading for "All" years view
   if (year === "all") {
@@ -137,7 +137,7 @@ export function getYearSubheadingText(
   }
 
   const parts: string[] = [];
-  const isKs4Year = year === "10" || year === "11";
+  const isKs4Year = keystageFromYear(year) === "ks4";
 
   // Handle subject categories (KS1-KS3)
   if (

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -203,3 +203,12 @@ export function getYearSubheadingText(
 
   return parts.length > 0 ? parts.join(", ") : null;
 }
+
+export function pluralizeUnits(count: number) {
+  if (count > 1) {
+    return "units";
+  } else if (count === 1) {
+    return "unit";
+  }
+  return "";
+}

--- a/src/utils/curriculum/keystage.test.ts
+++ b/src/utils/curriculum/keystage.test.ts
@@ -1,4 +1,8 @@
-import { byKeyStageSlug, presentAtKeyStageSlugs } from "./keystage";
+import {
+  byKeyStageSlug,
+  keystageFromYear,
+  presentAtKeyStageSlugs,
+} from "./keystage";
 
 test("byKeyStageSlug", () => {
   const output = byKeyStageSlug({
@@ -150,4 +154,18 @@ test("presentAtKeyStageSlugs", () => {
   expect(presentAtKeyStageSlugs(definition, "subjectCategories")).toEqual([
     "ks2",
   ]);
+});
+
+it("keystageFromYear", () => {
+  expect(keystageFromYear("1")).toEqual("ks1");
+  expect(keystageFromYear("2")).toEqual("ks1");
+  expect(keystageFromYear("3")).toEqual("ks2");
+  expect(keystageFromYear("4")).toEqual("ks2");
+  expect(keystageFromYear("5")).toEqual("ks2");
+  expect(keystageFromYear("6")).toEqual("ks2");
+  expect(keystageFromYear("7")).toEqual("ks3");
+  expect(keystageFromYear("8")).toEqual("ks3");
+  expect(keystageFromYear("9")).toEqual("ks3");
+  expect(keystageFromYear("10")).toEqual("ks4");
+  expect(keystageFromYear("11")).toEqual("ks4");
 });

--- a/src/utils/curriculum/keystage.ts
+++ b/src/utils/curriculum/keystage.ts
@@ -71,6 +71,14 @@ export function byKeyStageSlug(
   return output;
 }
 
+export function keystageFromYear(year: string) {
+  for (const [keystage, years] of Object.entries(keystageYearMappings)) {
+    if (years.includes(year)) {
+      return keystage;
+    }
+  }
+}
+
 export function presentAtKeyStageSlugs(
   KeyStageSlugData: Record<KeyStageSlug, YearDataPartialYearDataArray>,
   key: keyof YearDataPartialYearDataArray,


### PR DESCRIPTION
## Description
More code coverage for curric filtering
```
  CurricFiltersChildSubjects.fixtures.tsx                                                       |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersChildSubjects.tsx                                                                |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersSubjectCategories.fixtures.tsx                                                   |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersSubjectCategories.tsx                                                            |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersThreads.fixtures.tsx                                                             |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersThreads.tsx                                                                      |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersTiers.fixtures.tsx                                                               |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersTiers.tsx                                                                        |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersYears.fixtures.tsx                                                               |     100 |      100 |     100 |     100 |                                                                          
  CurricFiltersYears.tsx                                                                        |     100 |      100 |     100 |     100 |      
  keystage.ts                                                                                   |     100 |      100 |     100 |     100 |      
  formatting.ts                                                                                 |     100 |    98.66 |     100 |     100 | 149                
```

## How to test
Minor change to `getYearSubheadingText` probably only needs dev review as we're merging into feature branch anyway.
