### PR TITLE
feat: add no index to download and share pages

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -546,7 +546,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
         canonical:
           "NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/combined-science-secondary-ks4-foundation-edexcel/units/measuring-waves/lessons/transverse-waves",
-        robots: "index,follow",
+        robots: "noindex,follow",
       });
     });
   });

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
@@ -392,7 +392,7 @@ describe("pages/teachers/lessons/[lessonSlug]/share", () => {
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
         canonical:
           "NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/maths-higher-ks4-l/units/geometry/lessons/macbeth-lesson-1",
-        robots: "index,follow",
+        robots: "noindex,follow",
       });
     });
   });

--- a/src/pages/teachers/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/downloads.tsx
@@ -41,6 +41,7 @@ const LessonDownloadsCanonicalPage = (
           title: seoTitle,
           description: "Lesson downloads",
         }),
+        noIndex: true,
       }}
     >
       <LessonDownloads isCanonical lesson={curriculumData} />

--- a/src/pages/teachers/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/share.tsx
@@ -33,6 +33,7 @@ const LessonShareCanonicalPage: NextPage<LessonShareCanonicalPageProps> = ({
           description:
             "Share online lesson activities with your students, such as videos, worksheets and quizzes.",
         }),
+        noIndex: true,
       }}
     >
       <LessonShare isCanonical={true} lesson={curriculumData} />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
@@ -36,6 +36,7 @@ const LessonDownloadsPage = ({ curriculumData }: LessonDownloadsPageProps) => {
             curriculumData.lessonSlug
           }`,
         }),
+        noIndex: true,
       }}
     >
       <LessonDownloads isCanonical={false} lesson={curriculumData} />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
@@ -39,6 +39,7 @@ const LessonSharePage: NextPage<LessonSharePageProps> = ({
             curriculumData.lessonSlug
           }`,
         }),
+        noIndex: true,
       }}
     >
       <LessonShare isCanonical={false} lesson={curriculumData} />


### PR DESCRIPTION
## Description

Add no index to download and share pages

## Issue(s)

Fixes [PUPIL-1262](https://www.notion.so/oaknationalacademy/OWA-add-noindex-to-all-downloads-share-pages-1b326cc4e1b18069a566dda2fac210d0)

## How to test

1. Go to https://deploy-preview-3279--oak-web-application.netlify.thenational.academy
2. Check that download and share pages have `<meta name="robots" content="noindex,follow">` in the head


## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
