### PR TITLE
Fix for unit highlighting count when including subject-categories/child-subjects in filter

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersThreads.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersThreads.tsx
@@ -7,7 +7,7 @@ import { RadioGroup, RadioButton } from "../OakComponentsKitchen/SimpleRadio";
 import { Thread, CurriculumFilters } from "@/utils/curriculum/types";
 import { highlightedUnitCount } from "@/utils/curriculum/filtering";
 import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
-import { pluralizeUnits } from "@/utils/curriculum/formatting";
+import { joinWords, pluralizeUnits } from "@/utils/curriculum/formatting";
 
 export type CurricFiltersThreadsProps = {
   filters: CurriculumFilters;
@@ -56,11 +56,9 @@ export function CurricFiltersThreads({
           </OakBox>
           {threadOptions.map((threadOption) => {
             const isSelected = isSelectedThread(threadOption);
-            const highlightedCount = highlightedUnitCount(
-              yearData,
-              filters,
-              filters.threads,
-            );
+            const highlightedCount = !isSelected
+              ? 0
+              : highlightedUnitCount(yearData, filters, filters.threads);
 
             return (
               <OakBox
@@ -87,9 +85,11 @@ export function CurricFiltersThreads({
                     {isSelected && (
                       <>
                         <br />
-                        {highlightedCount}
-                        {pluralizeUnits(highlightedCount)}
-                        highlighted
+                        {joinWords([
+                          highlightedCount,
+                          pluralizeUnits(highlightedCount),
+                          "highlighted",
+                        ])}
                       </>
                     )}
                   </OakSpan>

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -22,6 +22,7 @@ import { isVisibleUnit } from "@/utils/curriculum/isVisibleUnit";
 import { sortYears } from "@/utils/curriculum/sorting";
 import { createTeacherProgrammeSlug } from "@/utils/curriculum/slugs";
 import { CurriculumFilters, Unit, YearData } from "@/utils/curriculum/types";
+import { filteringFromYears } from "@/utils/curriculum/filtering";
 
 const UnitList = styled("ol")`
   margin: 0;
@@ -287,32 +288,19 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
           .filter((year) => filterIncludes("years", [year]))
           .sort(sortYears)
           .map((year, index) => {
-            const {
-              units,
-              isSwimming,
-              childSubjects,
-              tiers,
-              subjectCategories,
-            } = yearData[year] as YearData[string];
+            const { units, isSwimming } = yearData[year] as YearData[string];
 
             const ref = (element: HTMLDivElement) => {
               itemEls.current[index] = element;
             };
 
-            const yearFilters = {
-              childSubjects:
-                childSubjects.length > 0 ? filters.childSubjects : undefined,
-              subjectCategories:
-                childSubjects.length < 1 && subjectCategories.length > 0
-                  ? filters.subjectCategories
-                  : undefined,
-              tiers: tiers.length > 0 ? filters.tiers : undefined,
-              years: filters.years,
-              threads: filters.threads,
-            };
+            const yearBasedFilters = filteringFromYears(
+              yearData[year]!,
+              filters,
+            );
 
             const filteredUnits = units.filter((unit: Unit) =>
-              isVisibleUnit(yearFilters, year, unit),
+              isVisibleUnit(yearBasedFilters, year, unit),
             );
 
             const dedupedUnits = dedupUnits(filteredUnits);

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import {
   diffFilters,
+  filteringFromYears,
   filtersToQuery,
   getDefaultChildSubjectForYearGroup,
   getDefaultFilter,
@@ -873,5 +874,82 @@ describe("highlightedUnitCount", () => {
       thread3.slug,
     ]);
     expect(result).toEqual(2);
+  });
+});
+
+describe("filteringFromYears", () => {
+  const tierHigher = createTier({ tier_slug: "higher" });
+  const subCat1 = createSubjectCategory({ id: 1 });
+  const childSubject = createChildSubject({ subject_slug: "biology" });
+
+  it("no filters", () => {
+    const result = filteringFromYears(
+      createYearData({
+        tiers: [tierHigher],
+        subjectCategories: [subCat1],
+      }),
+      createFilter(),
+    );
+    expect(result).toEqual({
+      childSubjects: undefined,
+      subjectCategories: [],
+      threads: [],
+      tiers: [],
+      years: [],
+    });
+  });
+
+  it("without tiers", () => {
+    const filter = createFilter({
+      tiers: [tierHigher.tier_slug],
+      childSubjects: [childSubject.subject_slug],
+    });
+    const result = filteringFromYears(
+      createYearData({
+        childSubjects: [childSubject],
+      }),
+      filter,
+    );
+    expect(result).toEqual({
+      ...filter,
+      tiers: undefined,
+      subjectCategories: undefined,
+    });
+  });
+
+  it("without child subjects", () => {
+    const filter = createFilter({
+      tiers: [tierHigher.tier_slug],
+      childSubjects: [childSubject.subject_slug],
+    });
+    const result = filteringFromYears(
+      createYearData({
+        tiers: [tierHigher],
+      }),
+      filter,
+    );
+    expect(result).toEqual({
+      ...filter,
+      childSubjects: undefined,
+      subjectCategories: undefined,
+    });
+  });
+
+  it("without subject categories", () => {
+    const filter = createFilter({
+      tiers: [tierHigher.tier_slug],
+      subjectCategories: [String(subCat1.id)],
+    });
+    const result = filteringFromYears(
+      createYearData({
+        tiers: [tierHigher],
+      }),
+      filter,
+    );
+    expect(result).toEqual({
+      ...filter,
+      childSubjects: undefined,
+      subjectCategories: undefined,
+    });
   });
 });

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -139,9 +139,7 @@ export function useFilters(
     }
   });
   const setFilters = (newFilters: CurriculumFilters) => {
-    console.log("isCurricRoutingEnabled()", isCurricRoutingEnabled());
     if (isCurricRoutingEnabled()) {
-      console.log(">>> HERE");
       const url =
         location.pathname +
         "?" +
@@ -204,18 +202,38 @@ export function isHighlightedUnit(
   return unit.threads.some((t) => selectedThreads.includes(t.slug));
 }
 
+export function filteringFromYears(
+  yearData: YearData[number],
+  filters: CurriculumFilters,
+) {
+  const { childSubjects, subjectCategories, tiers } = yearData!;
+  const output = {
+    childSubjects: childSubjects.length > 0 ? filters.childSubjects : undefined,
+    subjectCategories:
+      childSubjects.length < 1 && subjectCategories.length > 0
+        ? filters.subjectCategories
+        : undefined,
+    tiers: tiers.length > 0 ? filters.tiers : undefined,
+    years: filters.years,
+    threads: filters.threads,
+  };
+  return output;
+}
+
 export function highlightedUnitCount(
   yearData: YearData,
   filters: CurriculumFilters,
   selectedThreads: Thread["slug"][] | null,
 ): number {
   let count = 0;
-  Object.keys(yearData).forEach((year) => {
-    const units = yearData[year]?.units;
+  Object.entries(yearData).forEach(([year, yearDataItem]) => {
+    const units = yearDataItem.units;
     if (units && filters.years.includes(year)) {
       units.forEach((unit) => {
+        const yearBasedFilters = filteringFromYears(yearDataItem, filters);
+
         if (
-          isVisibleUnit(filters, year, unit) &&
+          isVisibleUnit(yearBasedFilters, year, unit) &&
           isHighlightedUnit(unit, selectedThreads)
         ) {
           count++;

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -119,7 +119,7 @@ export function buildPageTitle(
   return pageTitle;
 }
 
-export function joinWords(str: string[]) {
+export function joinWords(str: (number | string)[]) {
   return str.filter((str) => str !== "").join(" ");
 }
 


### PR DESCRIPTION
## Description
Fix for unit highlighting count when including `subjectCategories`/`childSubjects` in filter for a given year

## Issue(s)

Fixes `CUR-1169`

## How to test

1. Go to {owa_deployment_url}/teacher/curriculum
2. Check that unit counts for highlighted threads are correct across different filter types.

## Screenshots
Before
<img width="491" alt="Screenshot 2025-03-12 at 15 02 15" src="https://github.com/user-attachments/assets/7317d301-0992-4146-b2f2-542b729e6227" />

After
<img width="491" alt="Screenshot 2025-03-12 at 15 02 21" src="https://github.com/user-attachments/assets/7254df30-e250-4424-86e7-2e5816001d9c" />

