### PR TITLE
Fixes incorrect unit count in hidden aria DOM node

### DIFF
--- a/src/utils/curriculum/getNumberOfSelectedUnits.test.ts
+++ b/src/utils/curriculum/getNumberOfSelectedUnits.test.ts
@@ -1,6 +1,8 @@
 import { getNumberOfSelectedUnits } from "./getNumberOfSelectedUnits";
-import { isVisibleUnit, PartialFilters } from "./isVisibleUnit";
+import { isVisibleUnit } from "./isVisibleUnit";
 import { YearData, Unit, Subject, Tier, SubjectCategory } from "./types";
+
+import { createFilter } from "@/fixtures/curriculum/filters";
 
 jest.mock("./isVisibleUnit");
 
@@ -39,18 +41,22 @@ describe("getNumberOfSelectedUnits", () => {
   });
 
   it("should return 0 when yearData is empty", () => {
-    const result = getNumberOfSelectedUnits({}, "", {
-      years: [],
-      threads: [],
-    });
+    const result = getNumberOfSelectedUnits(
+      {},
+      "",
+      createFilter({
+        years: [],
+        threads: [],
+      }),
+    );
     expect(result).toBe(0);
   });
 
   it("should count visible units for all years when selectedYear is All", () => {
-    const yearSelection: PartialFilters = {
+    const yearSelection = createFilter({
       years: [],
       threads: [],
-    };
+    });
     mockIsVisibleUnit.mockReturnValue(true);
 
     const result = getNumberOfSelectedUnits(yearData, "all", yearSelection);
@@ -59,10 +65,10 @@ describe("getNumberOfSelectedUnits", () => {
   });
 
   it("should count visible units only for the selected year", () => {
-    const yearSelection: PartialFilters = {
+    const yearSelection = createFilter({
       years: [],
       threads: [],
-    };
+    });
     mockIsVisibleUnit.mockReturnValue(true);
 
     const result = getNumberOfSelectedUnits(yearData, "8", yearSelection);
@@ -71,10 +77,10 @@ describe("getNumberOfSelectedUnits", () => {
   });
 
   it("should only count units that are visible according to isVisibleUnit", () => {
-    const yearSelection: PartialFilters = {
+    const yearSelection = createFilter({
       years: [],
       threads: [],
-    };
+    });
     mockIsVisibleUnit
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false)
@@ -88,10 +94,10 @@ describe("getNumberOfSelectedUnits", () => {
   });
 
   it("should return 0 when no units are visible according to isVisibleUnit", () => {
-    const yearSelection: PartialFilters = {
+    const yearSelection = createFilter({
       years: [],
       threads: [],
-    };
+    });
     mockIsVisibleUnit.mockReturnValue(false);
 
     const result = getNumberOfSelectedUnits(yearData, "all", yearSelection);

--- a/src/utils/curriculum/getNumberOfSelectedUnits.ts
+++ b/src/utils/curriculum/getNumberOfSelectedUnits.ts
@@ -1,21 +1,23 @@
-import { isVisibleUnit, PartialFilters } from "./isVisibleUnit";
-import { Unit, YearData } from "./types";
+import { filteringFromYears } from "./filtering";
+import { isVisibleUnit } from "./isVisibleUnit";
+import { CurriculumFilters, Unit, YearData } from "./types";
 
 import { dedupUnits } from "@/components/CurriculumComponents/CurriculumVisualiser";
 
 export function getNumberOfSelectedUnits(
   yearData: YearData,
   selectedYear: string | null,
-  filter: PartialFilters,
+  filters: CurriculumFilters,
 ): number {
   let count = 0;
 
-  Object.keys(yearData).forEach((year) => {
-    const units = yearData[year]?.units;
+  Object.entries(yearData).forEach(([year, yearDataItem]) => {
+    const units = yearDataItem.units;
+    const yearBasedFilters = filteringFromYears(yearDataItem!, filters);
 
     if (units && (selectedYear === "all" || selectedYear === year)) {
       const filteredUnits = units.filter((unit: Unit) => {
-        return isVisibleUnit(filter, year, unit);
+        return isVisibleUnit(yearBasedFilters, year, unit);
       });
 
       const dedupedUnits = dedupUnits(filteredUnits);

--- a/src/utils/curriculum/isVisibleUnit.test.ts
+++ b/src/utils/curriculum/isVisibleUnit.test.ts
@@ -1,5 +1,6 @@
-import { isVisibleUnit, PartialFilters } from "./isVisibleUnit";
+import { isVisibleUnit } from "./isVisibleUnit";
 
+import { createFilter } from "@/fixtures/curriculum/filters";
 import { CombinedCurriculumData } from "@/pages-helpers/curriculum/docx";
 
 const baseUnit = {
@@ -26,10 +27,10 @@ describe("isVisibleUnit", () => {
   it("empty", () => {
     expect(
       isVisibleUnit(
-        {
+        createFilter({
           years: ["10"],
           threads: [],
-        },
+        }),
         "7",
         baseUnit,
       ),
@@ -44,13 +45,11 @@ describe("isVisibleUnit", () => {
       tier_slug: null,
     } as CombinedCurriculumData["units"][number];
 
-    const filters: PartialFilters = {
-      subjectCategories: [],
+    const filters = createFilter({
       childSubjects: ["biology"],
       tiers: ["foundation"],
       years: ["10"],
-      threads: [],
-    };
+    });
     expect(isVisibleUnit(filters, "10", unit)).toEqual(true);
   });
 
@@ -65,13 +64,10 @@ describe("isVisibleUnit", () => {
       ],
     };
 
-    const filters: PartialFilters = {
+    const filters = createFilter({
       subjectCategories: ["1"],
-      childSubjects: [],
-      tiers: [],
       years: ["10"],
-      threads: [],
-    };
+    });
     expect(isVisibleUnit(filters, "10", unit)).toEqual(true);
   });
 
@@ -88,13 +84,12 @@ describe("isVisibleUnit", () => {
       tier_slug: "foundation",
     };
 
-    const filters: PartialFilters = {
+    const filters = createFilter({
       subjectCategories: ["1"],
-      childSubjects: [],
       tiers: ["foundation"],
       years: ["10"],
       threads: [],
-    };
+    });
     expect(isVisibleUnit(filters, "10", unit)).toEqual(true);
   });
 });


### PR DESCRIPTION
## Description
Fixes for the unit count in hidden aria DOM node in the curriculum filters

Also small refactor to use `createFilter` helper

## Issue(s)

Fixes `CUR-1169`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check the accessible highlighted/unit count is correct when different combinations of filtering options are applied

## Screenshots
<img width="1829" alt="Screenshot 2025-03-12 at 16 17 21" src="https://github.com/user-attachments/assets/1f1d495e-03b1-4897-a725-c5eb4f1064c7" />

