### PR TITLE
Add new RE subject category icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.93.1",
+        "@oaknational/oak-components": "^1.95.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.52.2",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7102,9 +7102,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.94.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.94.0.tgz",
-      "integrity": "sha512-ZOeC8tYYXyD2eyaTWmQT5H0eRpWPeiZ45Br8mzNqEFR/f/2Qq9G03dOTzOcwt7Le4jyjiVpohOlEbb6ceeqK0g==",
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.95.0.tgz",
+      "integrity": "sha512-+egopT9/UPQKAo/Xm9UE4LYrx8dG4TXaq9NJI5Mi/6p4YdBU7tdeK/fYH0b4oYc8p+8dVZjyxiwq4MP2NFwYdw==",
       "peerDependencies": {
         "next": "^14.2.12",
         "next-cloudinary": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.93.1",
+    "@oaknational/oak-components": "^1.95.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.52.2",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -12,10 +12,9 @@ const subjectCategoryIconMap: Record<number, string> = {
   8: "english-vocabulary",
   18: "english-language",
   19: "english-reading-for-pleasure",
-  // TODO: Implement RE icons once they're added to Oak Components image map
-  // ?: "rshe-philosophy"
-  // ?: "rshe-theology"
-  // ?: "rshe-social-sciences"
+  15: "philosophy",
+  16: "social-science",
+  17: "theology",
 };
 
 export function getValidSubjectCategoryIconById(id: number): OakIconName {


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Added RE subject category icons

## Issue(s)

Fixes #[1246](https://www.notion.so/oaknationalacademy/Add-missing-icons-to-oak-components-filtering-19d26cc4e1b1803692c2d8d2cf33fb06)

## How to test

1. Naviate to RE Primary to https://deploy-preview-3283--oak-web-application.netlify.thenational.academy/teachers/curriculum/religious-education-primary/units
2. You should see the recently added subject category icons for Theology, Philosophy and Social Science

## Screenshots

How it should now look:
<img width="304" alt="image" src="https://github.com/user-attachments/assets/6bd703e9-415a-46b6-b5b1-308427ae9583" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [X] Does this PR update a package with a breaking change
