### PR TITLE
Store curric filter in the URLs querystring

### DIFF
--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,2 +1,2 @@
 export const ENABLE_OPEN_API = false;
-export const ENABLE_FILTERS_IN_SEARCH_PARAMS = false;
+export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -681,7 +681,13 @@ describe("getNumberOfFiltersApplied", () => {
 
 describe("filtersToQuery", () => {
   it("with default", () => {
-    const result = filtersToQuery(createFilter());
+    const result = filtersToQuery(createFilter(), {
+      childSubjects: [],
+      subjectCategories: [],
+      tiers: [],
+      years: [],
+      threads: [],
+    });
     expect(result).toEqual({});
   });
 
@@ -707,11 +713,18 @@ describe("filtersToQuery", () => {
         years: ["7", "8"],
         threads: [thread1.slug, thread2.slug],
       }),
+      {
+        childSubjects: [],
+        subjectCategories: [],
+        tiers: [],
+        years: [],
+        threads: [],
+      },
     );
 
     expect(result).toEqual({
-      childSubjects: "child_subject_1,child_subject_2",
-      subjectCategories: "1,2",
+      child_subjects: "child_subject_1,child_subject_2",
+      subject_categories: "1,2",
       threads: "thread_1,thread_2",
       tiers: "tier_1,tier_2",
       years: "7,8",
@@ -732,7 +745,7 @@ describe("mergeInFilterParams", () => {
     const result = mergeInFilterParams(
       filter,
       new URLSearchParams(
-        "?childSubjects=child_subject_1&subjectCategories=1&tiers=tier_1&years=1&threads=thread1",
+        "?child_subjects=child_subject_1&subject_categories=1&tiers=tier_1&years=1&threads=thread1",
       ),
     );
     expect(result).toEqual({
@@ -756,7 +769,7 @@ describe("mergeInFilterParams", () => {
     const result = mergeInFilterParams(
       filter,
       new URLSearchParams(
-        "?childSubjects=child_subject_1,child_subject_2&subjectCategories=1,2&tiers=tier_1,tier_2&years=1,2&threads=thread1,thread2",
+        "?child_subjects=child_subject_1,child_subject_2&subject_categories=1,2&tiers=tier_1,tier_2&years=1,2&threads=thread1,thread2",
       ),
     );
     expect(result).toEqual({

--- a/src/utils/curriculum/flags.test.ts
+++ b/src/utils/curriculum/flags.test.ts
@@ -1,6 +1,6 @@
 import { isCurricRoutingEnabled } from "./flags";
 
 it("isCurricRoutingEnabled", () => {
-  // We don't want this enabled until release
-  expect(isCurricRoutingEnabled()).toEqual(false);
+  // Enabled on release
+  expect(isCurricRoutingEnabled()).toEqual(true);
 });


### PR DESCRIPTION
## Description
Initial branch of storing the curriculum filter in the URLs querystring

**Note**: This doesn't "build time" / "server side", render which is inline with other squads, for example you'll note that https://www.thenational.academy/teachers/programmes/art-primary-ks1/units?year=year-2&learning-theme=draw gets a flash of "initial state" prior to JavaScript kicking in.

## Issue(s)

Fixes `CUR-1294`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check that filtering modifies the querystring in the correct way
3. Check that refreshing the browser, or opening the URL in a different browser restores the correct state
