### PR TITLE
[PUPIL-1225] Adds the related subjects data to the FE from the overrides table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mux/mux-player-react": "3.1.0",
         "@oaknational/oak-components": "^1.93.0",
         "@oaknational/oak-consent-client": "^2.1.1",
-        "@oaknational/oak-curriculum-schema": "^1.52.2",
+        "@oaknational/oak-curriculum-schema": "^1.53.1",
         "@oaknational/oak-pupil-client": "^2.14.0",
         "@portabletext/react": "^3.2.0",
         "@react-aria/aria-modal-polyfill": "^3.7.13",
@@ -7128,9 +7128,9 @@
       }
     },
     "node_modules/@oaknational/oak-curriculum-schema": {
-      "version": "1.52.2",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-curriculum-schema/-/oak-curriculum-schema-1.52.2.tgz",
-      "integrity": "sha512-PWiKmDpHwn5YwSX/dpBDr5VdVzBHsjaCfj8NsMo0//iXShoVIjvl0cYmnkDZHK8SHDByO7fQ7jE+K7XWjp5Y7A==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-curriculum-schema/-/oak-curriculum-schema-1.53.1.tgz",
+      "integrity": "sha512-/ZYZ8V09imHe0rwQjT4KtSZY/Vkon4QXJ/aklaWzRxAzqsSaHPfWqEQOQBYP17mg7ab4f9wZPYd8BGwj2i6+TA==",
       "license": "MIT",
       "peerDependencies": {
         "zod": "^3.22.4"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mux/mux-player-react": "3.1.0",
     "@oaknational/oak-components": "^1.93.0",
     "@oaknational/oak-consent-client": "^2.1.1",
-    "@oaknational/oak-curriculum-schema": "^1.52.2",
+    "@oaknational/oak-curriculum-schema": "^1.53.1",
     "@oaknational/oak-pupil-client": "^2.14.0",
     "@portabletext/react": "^3.2.0",
     "@react-aria/aria-modal-polyfill": "^3.7.13",

--- a/src/components/PupilViews/PupilUnitListing/PupilUnitListing.view.tsx
+++ b/src/components/PupilViews/PupilUnitListing/PupilUnitListing.view.tsx
@@ -16,6 +16,7 @@ import { PupilUnitsSection } from "@/components/PupilComponents/PupilUnitsSectio
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { UnitListingBrowseData } from "@/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.schema";
 import { generateKeyStageTitle } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import { SubjectSlugs } from "@/node-lib/curriculum-api-2023/queries/pupilSubjectListing/pupilSubjectListing.schema";
 
 export type PupilViewsUnitListingProps = {
   unitSections: UnitsSectionData[];
@@ -23,6 +24,7 @@ export type PupilViewsUnitListingProps = {
   backHrefSlugs: UseBackHrefProps;
   subjectCategories: string[];
   programmeFields: UnitListingBrowseData[number]["programmeFields"];
+  relatedSubjects?: SubjectSlugs[];
 };
 
 export const PupilViewsUnitListing = ({

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.test.ts
@@ -52,6 +52,9 @@ jest.mock("../../sdk", () => {
               }),
               unit_slug: "unit-slug-1",
               supplementary_data: { unit_order: 1 },
+              actions: {
+                related_subject_slugs: ["physics"],
+              },
             },
           }),
           rawFixture({
@@ -162,6 +165,9 @@ describe("unitListing()", () => {
             cohort: "2023-2024",
             subjectCategories: null,
             learningThemes: null,
+            actions: {
+              relatedSubjectSlugs: ["physics"],
+            },
           },
         ],
         [

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
@@ -1,3 +1,7 @@
+import { subjectSlugs } from "@oaknational/oak-curriculum-schema";
+
+import { SubjectSlugs } from "../pupilSubjectListing/pupilSubjectListing.schema";
+
 import { reshapeUnitData } from "./helpers/reshapeUnitData";
 import { getAllLearningThemes } from "./helpers/getAllLearningThemes";
 import {
@@ -86,6 +90,17 @@ const unitListingQuery =
       .flatMap((unit) => unit.flatMap((u) => u.cohort ?? "2020-2023"))
       .includes(NEW_COHORT);
 
+    const relatedSubjectsSet = new Set<SubjectSlugs>();
+    parsedUnits.forEach((unit) => {
+      if (unit.actions && unit.actions.related_subject_slugs) {
+        unit.actions.related_subject_slugs.forEach((subject) => {
+          if (subjectSlugs.safeParse(subject).success) {
+            relatedSubjectsSet.add(subject);
+          }
+        });
+      }
+    });
+
     return {
       programmeSlug: args.programmeSlug,
       keyStageSlug: programmeFields.keystageSlug,
@@ -104,6 +119,9 @@ const unitListingQuery =
       subjectCategories,
       yearGroups,
       pathwayTitle: programmeFields.pathway,
+      ...(relatedSubjectsSet.size > 1 && {
+        relatedSubjects: Array.from(relatedSubjectsSet),
+      }),
     };
   };
 

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
@@ -1,5 +1,3 @@
-import { subjectSlugs } from "@oaknational/oak-curriculum-schema";
-
 import { SubjectSlugs } from "../pupilSubjectListing/pupilSubjectListing.schema";
 
 import { reshapeUnitData } from "./helpers/reshapeUnitData";
@@ -94,9 +92,7 @@ const unitListingQuery =
     parsedUnits.forEach((unit) => {
       if (unit.actions && unit.actions.related_subject_slugs) {
         unit.actions.related_subject_slugs.forEach((subject) => {
-          if (subjectSlugs.safeParse(subject).success) {
-            relatedSubjectsSet.add(subject);
-          }
+          relatedSubjectsSet.add(subject);
         });
       }
     });

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
@@ -109,6 +109,7 @@ const unitListingData = z.object({
   yearGroups: yearGroupsSchema,
   subjectCategories: z.array(subjectCategorySchema),
   pathwayTitle: pathways.nullable(),
+  relatedSubjects: z.array(subjectSlugs).optional(),
 });
 
 export type UnitListingData = z.infer<typeof unitListingData>;

--- a/src/pages/pupils/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units.tsx
@@ -6,6 +6,7 @@ import {
   isValidIconName,
   oakDefaultTheme,
 } from "@oaknational/oak-components";
+import { subjectSlugs } from "@oaknational/oak-curriculum-schema";
 
 import { UnitListingBrowseData } from "@/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.schema";
 import getPageProps from "@/node-lib/getPageProps";
@@ -18,6 +19,7 @@ import { extractBaseSlug } from "@/pages-helpers/pupil";
 import { UseBackHrefProps } from "@/components/PupilViews/PupilUnitListing/useBackHref";
 import { getSecondUnitSection } from "@/pages-helpers/pupil/units-page/units-page-helper";
 import OakError from "@/errors/OakError";
+import { SubjectSlugs } from "@/node-lib/curriculum-api-2023/queries/pupilSubjectListing/pupilSubjectListing.schema";
 
 export type UnitsSectionData = {
   title: string | null;
@@ -38,6 +40,7 @@ export type UnitListingPageProps = {
   unitSections: UnitsSectionData[];
   subjectCategories: string[];
   programmeFields: UnitListingBrowseData[number]["programmeFields"];
+  relatedSubjects: SubjectSlugs[];
 };
 
 type PupilUnitListingPageURLParams = {
@@ -52,6 +55,7 @@ const PupilUnitListingPage = ({
   unitSections,
   subjectCategories,
   programmeFields,
+  relatedSubjects,
 }: UnitListingPageProps) => {
   return (
     <OakThemeProvider theme={oakDefaultTheme}>
@@ -69,6 +73,7 @@ const PupilUnitListingPage = ({
           backHrefSlugs={backHrefSlugs}
           subjectCategories={subjectCategories}
           programmeFields={programmeFields}
+          relatedSubjects={relatedSubjects}
         />
       </AppLayout>
     </OakThemeProvider>
@@ -234,6 +239,18 @@ export const getStaticProps: GetStaticProps<
         examboardSlug,
       };
 
+      const relatedSubjectsSet = new Set<SubjectSlugs>();
+
+      curriculumData.forEach((unit) => {
+        if (unit.actions && unit.actions.relatedSubjectSlugs) {
+          unit.actions.relatedSubjectSlugs.forEach((subject) => {
+            if (subjectSlugs.safeParse(subject).success) {
+              relatedSubjectsSet.add(subject);
+            }
+          });
+        }
+      });
+
       const results: GetStaticPropsResult<UnitListingPageProps> = {
         props: {
           subject,
@@ -243,6 +260,7 @@ export const getStaticProps: GetStaticProps<
           subjectCategories,
           unitSections: [firstUnitSection, secondUnitSection],
           programmeFields,
+          relatedSubjects: Array.from(relatedSubjectsSet),
         },
       };
 


### PR DESCRIPTION
## Description

Music year: 2022

[Ticket here](https://www.notion.so/Overrides-for-cross-reference-of-finance-from-both-unit-listing-pages-1a026cc4e1b1803a8e01f002f16d910f?pvs=8&n=github_linkback)

## List of changes

This PR adds the schema and associated changes required to access related subjects from within the teachers and pupils unit listing views (**Note**: no visual changes).

## How to test

1. Go to https://deploy-preview-3296--oak-web-application.netlify.thenational.academy
2. The site should operate normally

## Screenshots

N/A

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility (N/A)
- [x] Design sign-off (N/A)
- [x] Approved by product owner (N/A)
- [x] Does this PR update a package with a breaking change
