### PR TITLE
Migrate away from `defaultProps`

### DIFF
--- a/src/components/CurriculumComponents/Banners/__snapshots__/Banners.test.tsx.snap
+++ b/src/components/CurriculumComponents/Banners/__snapshots__/Banners.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Banners when cycle 2 enabled 1`] = `
           </div>
         </div>
         <a
-          class="sc-20316575-0 bMaumR"
+          class="sc-f63c4ba9-0 gXtJUS"
           href="/teachers/curriculum"
           role="link"
           title="See curriculum plans"

--- a/src/components/SharedComponents/Button/ButtonAsLink/ButtonAsLink.tsx
+++ b/src/components/SharedComponents/Button/ButtonAsLink/ButtonAsLink.tsx
@@ -38,6 +38,10 @@ export type ButtonAsLinkProps = CommonButtonProps &
   };
 
 const ButtonAsLink: FC<ButtonAsLinkProps> = (props) => {
+  props = {
+    ...defaultButtonProps,
+    ...props,
+  };
   const { nextLinkProps, ...transformedProps } = transformOwaLinkProps(props);
   const {
     label,
@@ -110,7 +114,5 @@ const ButtonAsLink: FC<ButtonAsLinkProps> = (props) => {
     </Link>
   );
 };
-
-ButtonAsLink.defaultProps = defaultButtonProps;
 
 export default ButtonAsLink;

--- a/src/components/SharedComponents/Card/SummaryCard.tsx
+++ b/src/components/SharedComponents/Card/SummaryCard.tsx
@@ -38,7 +38,7 @@ const SummaryCard: FC<SummaryCardProps> = ({
   heading,
   summaryPortableText,
   summaryCardImage,
-  background,
+  background = "lemon50",
   imageContainerProps,
   children,
 }) => {
@@ -114,10 +114,6 @@ const SummaryCard: FC<SummaryCardProps> = ({
       <BrushBorders hideOnMobileH color={background || "inherit"} />
     </Card>
   );
-};
-
-SummaryCard.defaultProps = {
-  background: "lemon50",
 };
 
 export default SummaryCard;

--- a/src/components/SharedComponents/Circle/Circle.tsx
+++ b/src/components/SharedComponents/Circle/Circle.tsx
@@ -17,7 +17,12 @@ export type CircleProps = FlexProps & {
  * Use it where you need a container which is a circle.
  */
 const Circle: FC<CircleProps> = (props) => {
-  const { size, ...flexProps } = props;
+  const { size, ...flexProps } = {
+    $alignItems: "center",
+    $justifyContent: "center",
+    $borderRadius: "50%",
+    ...props,
+  };
 
   return (
     <Flex
@@ -28,12 +33,6 @@ const Circle: FC<CircleProps> = (props) => {
       $minHeight={size}
     />
   );
-};
-
-Circle.defaultProps = {
-  $alignItems: "center",
-  $justifyContent: "center",
-  $borderRadius: "50%",
 };
 
 export default Circle;

--- a/src/components/SharedComponents/Circle/Circle.tsx
+++ b/src/components/SharedComponents/Circle/Circle.tsx
@@ -17,12 +17,13 @@ export type CircleProps = FlexProps & {
  * Use it where you need a container which is a circle.
  */
 const Circle: FC<CircleProps> = (props) => {
-  const { size, ...flexProps } = {
+  props = {
     $alignItems: "center",
     $justifyContent: "center",
     $borderRadius: "50%",
     ...props,
   };
+  const { size, ...flexProps } = props;
 
   return (
     <Flex

--- a/src/components/SharedComponents/SocialButtons/SocialButtons.tsx
+++ b/src/components/SharedComponents/SocialButtons/SocialButtons.tsx
@@ -71,6 +71,11 @@ type SocialButtonsProps = FlexProps &
     spaceBetween?: ResponsiveValues<PixelSpacing>;
   };
 const SocialButtons: FC<SocialButtonsProps> = (props) => {
+  props = {
+    size: "large",
+    spaceBetween: 16,
+    ...props,
+  };
   const { size, spaceBetween, for: accountHolder, ...flexProps } = props;
   const id = useId();
   const socialsToShow = SOCIAL_NETWORKS.filter((network) => props[network]);
@@ -106,11 +111,6 @@ const SocialButtons: FC<SocialButtonsProps> = (props) => {
       })}
     </Flex>
   );
-};
-
-SocialButtons.defaultProps = {
-  size: "large",
-  spaceBetween: 16,
 };
 
 export default SocialButtons;


### PR DESCRIPTION
## Description
Migrate away from `defaultProps` in the components

In a few component we previously used something like the following

```tsx
Circle.defaultProps = {
  $alignItems: "center",
  $justifyContent: "center",
  $borderRadius: "50%",
};
```

We've changed that into

```tsx
const Circle: FC<CircleProps> = (props) => {
  props = {
    $alignItems: "center",
    $justifyContent: "center",
    $borderRadius: "50%",
    ...props,
  };

  // ...
}
```

## How to test
Dev QA the following components are effected

 - `ButtonAsLink`
 - `SummaryCard`
 - `SocialButtons`
 - `Circle`
