### PR TITLE
Fix `Error: Not implemented:` errors

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -155,6 +155,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
     expect(screen.queryByText("Exit quiz questions")).not.toBeInTheDocument();
   });
   it("tracks download event with correct args", async () => {
+    window.scrollTo = jest.fn();
     const { result } = renderHook(() => useLocalStorageForDownloads());
 
     result.current.setEmailInLocalStorage("test@test.com");
@@ -168,6 +169,11 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       name: "Download .zip",
     });
     await userEvent.click(downloadButton);
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 0,
+    });
     expect(lessonDownloaded).toHaveBeenCalledWith({
       analyticsUseCase: "Teacher",
       componentType: "lesson_download_button",
@@ -198,6 +204,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
     });
   });
   it("tracks download event with correct args for lessons without pfs", async () => {
+    window.scrollTo = jest.fn();
     const { result } = renderHook(() => useLocalStorageForDownloads());
 
     result.current.setEmailInLocalStorage("test@test.com");
@@ -218,6 +225,11 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
       name: "Download .zip",
     });
     await userEvent.click(downloadButton);
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 0,
+    });
     expect(lessonDownloaded).toHaveBeenCalledWith({
       analyticsUseCase: "Teacher",
       componentType: "lesson_download_button",

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
@@ -940,7 +940,7 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
   });
 
   test("mobile: anchor links for year group filters match", async () => {
-    window.HTMLElement.prototype.scrollIntoView = function () {};
+    window.scrollTo = jest.fn();
     resizeWindow(390, 844);
 
     const { findAllByTestId } = render(
@@ -955,6 +955,9 @@ describe("components/pages/CurriculumInfo/tabs/UnitsTab", () => {
     const year2Button = yearFilterButtons[1];
     if (year2Button) {
       await userEvent.click(year2Button);
+
+      expect(window.scrollTo).toHaveBeenCalledTimes(1);
+
       // Selected button background colour should change
       waitFor(() => {
         expect(year2Button).toHaveStyle("background-color: rgb(34, 34, 34);");

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.test.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.test.tsx
@@ -36,10 +36,20 @@ jest.mock("@oaknational/oak-consent-client", () => ({
   })),
 }));
 
+window.scrollTo = jest.fn();
+
 describe("DownloadConfirmation component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
+  const expectScrollTopOnRender = () => {
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 0,
+    });
+  };
 
   const curriculumTrackingProps: CurriculumTrackingProps = {
     lessonName: "Test lesson",
@@ -64,6 +74,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     expect(getByText("Thanks for downloading")).toBeInTheDocument();
   });
 
@@ -79,6 +90,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     const link = getByTestId("back-to-lesson-link");
 
     expect(link).toHaveAttribute(
@@ -99,6 +111,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     const link = getByTestId("back-to-lesson-link");
 
     expect(link).toHaveAttribute(
@@ -118,6 +131,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     const link = getByTestId("back-to-lesson-link");
 
     expect(link).toHaveAttribute("href", "/teachers/lessons/test-lesson");
@@ -136,6 +150,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     const lessonLink = getByRole("link", { name: "Back to lesson" });
 
     await user.click(lessonLink);
@@ -162,6 +177,7 @@ describe("DownloadConfirmation component", () => {
       />,
     );
 
+    expectScrollTopOnRender();
     const lessonLink = getByRole("link", { name: "Back to lesson" });
 
     await user.click(lessonLink);


### PR DESCRIPTION
## Description
Fix `Error: Not implemented:` errors

I can't seem to work out how to fix `Error: Not implemented: navigation` errors. So those can be left for another PR.

## How to test
Run the tests, check `Error: Not implemented:` doesn't appear in the logs

Note: See above `Error: Not implemented: navigation` will still appear others should not.

