### PR TITLE
Mock out error logging in expected error

### DIFF
--- a/src/context/Toast/useToastContext.test.ts
+++ b/src/context/Toast/useToastContext.test.ts
@@ -29,8 +29,32 @@ describe("useToastContext", () => {
   });
 
   test("it should throw an error if called outside of toast provider", () => {
+    console.error = jest.fn();
     expect(() => {
       renderHook(() => useToastContext());
     }).toThrow(Error("useToastContext called outside of toast provider"));
+    expect(console.error).toHaveBeenCalledTimes(3);
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "useToastContext called outside of toast provider",
+        ),
+      }),
+    );
+    expect(console.error).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "useToastContext called outside of toast provider",
+        ),
+      }),
+    );
+    expect(console.error).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(
+        "The above error occurred in the <TestComponent> component",
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Description
Mocks out `console.error` to prevent additional logging in CI.

## How to test
Just dev review required.
