### PR TITLE
Typo in test when calling `.completeActivity(...)`

### DIFF
--- a/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
+++ b/src/components/PupilComponents/LessonEngineProvider/LessonEngineProvider.test.tsx
@@ -146,7 +146,7 @@ describe("LessonEngineProvider", () => {
     allLessonReviewSections.forEach((section) => {
       expect(result.current.sectionResults[section]?.isComplete).toBeFalsy();
       act(() => {
-        result.current.completeActivity("intro");
+        result.current.completeActivity(section);
       });
       expect(result.current.sectionResults.intro?.isComplete).toEqual(true);
     });


### PR DESCRIPTION
## Description
I believe this should always be calling

```diff
- result.current.completeActivity("intro")
+ result.current.completeActivity(section)
```


## How to test
@benprotheroe can you confirm the logic in the test

