### PR TITLE
fix: unit download button height

### DIFF
--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -20,7 +20,11 @@ const UnitDownloadOnboardButton = ({
 }: {
   onClick: () => Promise<boolean>;
 }) => (
-  <OakPrimaryButton width="fit-content" onClick={onClick}>
+  <OakPrimaryButton
+    width="fit-content"
+    onClick={onClick}
+    pv={["inner-padding-s", "inner-padding-ssx"]}
+  >
     <OakFlex $alignItems="center" $gap="space-between-xs">
       <OakTagFunctional label="New" $background="mint" $color="text-primary" />
       Complete sign up to download this unit
@@ -31,7 +35,12 @@ const UnitDownloadOnboardButton = ({
 // Used when a user is not signed in
 const UnitDownloadSignInButton = ({ redirectUrl }: { redirectUrl: string }) => (
   <SignUpButton forceRedirectUrl={redirectUrl}>
-    <OakPrimaryButton iconName={"download"} isTrailingIcon width="fit-content">
+    <OakPrimaryButton
+      iconName={"download"}
+      isTrailingIcon
+      width="fit-content"
+      pv={["inner-padding-s", "inner-padding-ssx"]}
+    >
       <OakFlex $alignItems="center" $gap="space-between-xs">
         <OakTagFunctional
           label="New"


### PR DESCRIPTION
## Description

Music year: 1962

- Fixes unit download button being taller than share button

## Issue(s)

Fixes LESQ-1265

## How to test

1. Go to https://deploy-preview-3317--oak-web-application.netlify.thenational.academy
2. Go to lesson listing page (example: [https://deploy-preview-3317--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks3/units/lord-of-the-flies/lessons?sid-93727c=jdjn9KdJmp&sm=0&src=3](https://deploy-preview-3317--oak-web-application.netlify.thenational.academy/teachers/programmes/english-secondary-ks3/units/lord-of-the-flies/lessons?sid-93727c=jdjn9KdJmp&sm=0&src=3))
3. You should see unit download button with the same height as share button

## Screenshots

How it used to look (delete if n/a):
<img width="786" alt="image" src="https://github.com/user-attachments/assets/923bbd2a-471d-45ad-9034-e3e16f4e486d" />

How it should now look:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/340f68ac-d43b-45fe-b87d-98d656b06957" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
