### PR TITLE
PUPIL-1242: order media clips according to order in CAT

### DIFF
--- a/src/components/TeacherComponents/LessonOverviewMediaClips/LessonOverviewMediaClips.tsx
+++ b/src/components/TeacherComponents/LessonOverviewMediaClips/LessonOverviewMediaClips.tsx
@@ -52,7 +52,9 @@ const LessonOverviewMediaClips: FC<LessonOverviewMediaClipsProps> = ({
           const learningCycleTitleToDisplay =
             learningCycleVideosTitleMap[learningCycleTitle];
 
-          const firstCycleVideo = learningCycleVideos[0];
+          const firstCycleVideo = learningCycleVideos.find(
+            (video) => video.order === "1" || video.order === 1,
+          );
           if (!firstCycleVideo) return null;
 
           const isAudioClip = firstCycleVideo.mediaObject?.format === "mp3";

--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
@@ -763,21 +763,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 2",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -799,7 +794,6 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 1",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
@@ -810,10 +804,7 @@ describe("sortMediaClipsByOrder", () => {
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -839,21 +830,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 1",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -875,21 +861,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 2",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -916,7 +897,6 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 2",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
@@ -927,10 +907,7 @@ describe("sortMediaClipsByOrder", () => {
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -952,21 +929,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -993,7 +965,6 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 2",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
@@ -1004,10 +975,7 @@ describe("sortMediaClipsByOrder", () => {
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -1029,21 +997,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -1078,21 +1041,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -1114,21 +1072,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -1155,21 +1108,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {
@@ -1191,21 +1139,16 @@ describe("sortMediaClipsByOrder", () => {
         mediaType: "video",
         customTitle: "Intro Video 3",
         mediaObject: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video3.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
           duration: 7.601633,
-
           displayName: "8_task_C1_2",
           resourceType: "video",
         },
         videoObject: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playbackIds: [
             {

--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
@@ -1,3 +1,5 @@
+import { mediaClipsFixture } from "@oaknational/oak-curriculum-schema";
+
 import {
   createAttributionObject,
   getCommonPathway,
@@ -6,11 +8,13 @@ import {
   getLessonMediaBreadCrumb,
   getMediaClipLabel,
   convertBytesToMegabytes,
+  sortMediaClipsByOrder,
 } from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
 import {
   quizQuestions,
   quizQuestionsNoImages,
 } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.fixture";
+import type { MediaClip } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
 
 describe("getCommonPathway()", () => {
   it("returns the intersection of a single LessonPathway", () => {
@@ -748,5 +752,87 @@ describe("convertBytesToMegabytes", () => {
   it("doesn't convert bytes if the size is too small to be converted", () => {
     const result = convertBytesToMegabytes(876);
     expect(result).toBe("876 B");
+  });
+});
+
+describe("sortMediaClipsByOrder", () => {
+  it("sorts media clips by order", () => {
+    const mediaClips = mediaClipsFixture().media_clips["intro"] as MediaClip[];
+    const result = mediaClips.toSorted(sortMediaClipsByOrder);
+
+    expect(result).toEqual([
+      {
+        order: "1",
+        media_id: "191188",
+        video_id: 29844,
+        media_type: "video",
+        custom_title: "Intro Video 1",
+        media_object: {
+          id: "4de4d70775b95bbc722d4d259fb033ad",
+          url: "http://example.com/video1.mp3",
+          type: "upload",
+          bytes: 81127,
+          format: "mp3",
+          duration: 5.041633,
+
+          display_name: "9_task_C1_3",
+          resource_type: "video",
+        },
+        video_object: {
+          id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
+
+          duration: 5.055667,
+
+          mux_asset_id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
+          playback_ids: [
+            {
+              id: "mVkKUtOfoD1100012GNC1pCO6RvUgyGwqGoq01pYsy7WeA",
+              policy: "signed",
+            },
+            {
+              id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
+              policy: "public",
+            },
+          ],
+          mux_playback_id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
+        },
+      },
+      {
+        order: "2",
+        media_id: "191189",
+        video_id: 29845,
+        media_type: "video",
+        custom_title: "Intro Video 2",
+        media_object: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          display_name: "8_task_C1_2",
+          resource_type: "video",
+        },
+        video_object: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          mux_asset_id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playback_ids: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          mux_playback_id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ]);
   });
 });

--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.test.ts
@@ -1,5 +1,3 @@
-import { mediaClipsFixture } from "@oaknational/oak-curriculum-schema";
-
 import {
   createAttributionObject,
   getCommonPathway,
@@ -756,54 +754,15 @@ describe("convertBytesToMegabytes", () => {
 });
 
 describe("sortMediaClipsByOrder", () => {
-  it("sorts media clips by order", () => {
-    const mediaClips = mediaClipsFixture().media_clips["intro"] as MediaClip[];
-    const result = mediaClips.toSorted(sortMediaClipsByOrder);
-
-    expect(result).toEqual([
-      {
-        order: "1",
-        media_id: "191188",
-        video_id: 29844,
-        media_type: "video",
-        custom_title: "Intro Video 1",
-        media_object: {
-          id: "4de4d70775b95bbc722d4d259fb033ad",
-          url: "http://example.com/video1.mp3",
-          type: "upload",
-          bytes: 81127,
-          format: "mp3",
-          duration: 5.041633,
-
-          display_name: "9_task_C1_3",
-          resource_type: "video",
-        },
-        video_object: {
-          id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
-
-          duration: 5.055667,
-
-          mux_asset_id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
-          playback_ids: [
-            {
-              id: "mVkKUtOfoD1100012GNC1pCO6RvUgyGwqGoq01pYsy7WeA",
-              policy: "signed",
-            },
-            {
-              id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
-              policy: "public",
-            },
-          ],
-          mux_playback_id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
-        },
-      },
+  it("sorts media clips in ascending order based on the 'order' property", () => {
+    const mediaClips = [
       {
         order: "2",
-        media_id: "191189",
-        video_id: 29845,
-        media_type: "video",
-        custom_title: "Intro Video 2",
-        media_object: {
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 2",
+        mediaObject: {
           id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
@@ -811,16 +770,16 @@ describe("sortMediaClipsByOrder", () => {
           format: "mp3",
           duration: 7.601633,
 
-          display_name: "8_task_C1_2",
-          resource_type: "video",
+          displayName: "8_task_C1_2",
+          resourceType: "video",
         },
-        video_object: {
+        videoObject: {
           id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
 
           duration: 7.603667,
 
-          mux_asset_id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-          playback_ids: [
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
             {
               id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
               policy: "public",
@@ -830,7 +789,435 @@ describe("sortMediaClipsByOrder", () => {
               policy: "signed",
             },
           ],
-          mux_playback_id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "1",
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 1",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ];
+    const result = mediaClips.toSorted(sortMediaClipsByOrder);
+
+    expect(result).toEqual([
+      {
+        order: "1",
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 1",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "2",
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 2",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ]);
+  });
+
+  it("returns 0 when two media clips have the same 'order' property", () => {
+    const mediaClips: MediaClip[] = [
+      {
+        order: "2",
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 2",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "2",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ];
+
+    const result = mediaClips.toSorted(sortMediaClipsByOrder);
+
+    expect(result).toEqual([
+      {
+        order: "2",
+        mediaId: "191189",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 2",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video2.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "2",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ]);
+  });
+
+  it("handles empty arrays without errors", () => {
+    const mediaClips: MediaClip[] = [];
+
+    const result = mediaClips.toSorted(sortMediaClipsByOrder);
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles media clips with non-numeric 'order' values gracefully", () => {
+    const mediaClips: MediaClip[] = [
+      {
+        order: "2",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "ab",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+    ];
+
+    const result = mediaClips.toSorted(sortMediaClipsByOrder);
+
+    expect(result).toEqual([
+      {
+        order: "2",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+        },
+      },
+      {
+        order: "ab",
+        mediaId: "191134489",
+        videoId: 29845,
+        mediaType: "video",
+        customTitle: "Intro Video 3",
+        mediaObject: {
+          id: "e3331a6ee856256933cee73f7a62041b",
+          url: "http://example.com/video3.mp3",
+          type: "upload",
+          bytes: 122087,
+          format: "mp3",
+          duration: 7.601633,
+
+          displayName: "8_task_C1_2",
+          resourceType: "video",
+        },
+        videoObject: {
+          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+
+          duration: 7.603667,
+
+          muxAssetId: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
+          playbackIds: [
+            {
+              id: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
+              policy: "public",
+            },
+            {
+              id: "02mDhMdHMs4MOCAMutPLWzylp00NQgDYfiydlLQPDWI3M",
+              policy: "signed",
+            },
+          ],
+          muxPlaybackId: "9a02PY7PivjOBUHyH4N2mAwJH00aJoZeybWyy9hiwXVQY",
         },
       },
     ]);

--- a/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
+++ b/src/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers.ts
@@ -15,6 +15,7 @@ import {
   LessonOverviewQuizData,
   StemImageObject,
 } from "@/node-lib/curriculum-api-2023/shared.schema";
+import type { MediaClip } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
 import removeLegacySlugSuffix from "@/utils/slugModifiers/removeLegacySlugSuffix";
 import isSlugEYFS from "@/utils/slugModifiers/isSlugEYFS";
 import { LessonItemTitle } from "@/components/TeacherComponents/LessonItemContainer";
@@ -616,6 +617,15 @@ export const getMediaClipLabel = (subjectSlug: string): LessonItemTitle => {
     default:
       return "Video & audio clips";
   }
+};
+
+export const sortMediaClipsByOrder = (a: MediaClip, b: MediaClip) => {
+  if (Number(a.order) < Number(b.order)) {
+    return -1;
+  } else if (Number(a.order) > Number(b.order)) {
+    return 1;
+  }
+  return 0;
 };
 
 export function convertBytesToMegabytes(bytes: number): string {

--- a/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
+++ b/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import {
   OakTertiaryButton,
@@ -97,22 +97,24 @@ export const LessonMedia = (props: LessonMediaProps) => {
     lessonOutlines: lessonOutline,
   });
 
-  const listOfAllClips = mediaClips
-    ? Object.keys(mediaClips)
-        .map((learningCycle) => {
-          return (
-            mediaClips[learningCycle]
-              ?.toSorted(sortMediaClipsByOrder)
-              .map((mediaClip: MediaClip) => {
-                return {
-                  ...mediaClip,
-                  learningCycle,
-                };
-              }) || []
-          );
-        })
-        .flat()
-    : [];
+  const listOfAllClips = useMemo(() => {
+    return mediaClips
+      ? Object.keys(mediaClips)
+          .map((learningCycle) => {
+            return (
+              mediaClips[learningCycle]
+                ?.toSorted(sortMediaClipsByOrder)
+                .map((mediaClip: MediaClip) => {
+                  return {
+                    ...mediaClip,
+                    learningCycle,
+                  };
+                }) || []
+            );
+          })
+          .flat()
+      : [];
+  }, [mediaClips]);
 
   const [currentClip, setCurrentClip] = useState(
     getInitialCurrentClip(listOfAllClips, query.video),
@@ -140,6 +142,10 @@ export const LessonMedia = (props: LessonMediaProps) => {
       );
     }
   };
+
+  useEffect(() => {
+    setCurrentClip(getInitialCurrentClip(listOfAllClips, query.video));
+  }, [listOfAllClips, query.video]);
 
   const handleVideoChange = (clip: MediaClip & { learningCycle: string }) => {
     goToTheNextClip(String(clip.mediaId));

--- a/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
+++ b/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
@@ -114,8 +114,6 @@ export const LessonMedia = (props: LessonMediaProps) => {
         .flat()
     : [];
 
-  console.log("listOfAllClips", listOfAllClips);
-
   const [currentClip, setCurrentClip] = useState(
     getInitialCurrentClip(listOfAllClips, query.video),
   );

--- a/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
+++ b/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
@@ -20,6 +20,7 @@ import {
   getBreadcrumbsForLessonPathway,
   getCommonPathway,
   getLessonMediaBreadCrumb,
+  sortMediaClipsByOrder,
 } from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
 import { LessonPathway } from "@/components/TeacherComponents/types/lesson.types";
 import { LessonMediaClipInfo } from "@/components/TeacherComponents/LessonMediaClipInfo";
@@ -100,16 +101,20 @@ export const LessonMedia = (props: LessonMediaProps) => {
     ? Object.keys(mediaClips)
         .map((learningCycle) => {
           return (
-            mediaClips[learningCycle]?.map((mediaClip: MediaClip) => {
-              return {
-                ...mediaClip,
-                learningCycle,
-              };
-            }) || []
+            mediaClips[learningCycle]
+              ?.toSorted(sortMediaClipsByOrder)
+              .map((mediaClip: MediaClip) => {
+                return {
+                  ...mediaClip,
+                  learningCycle,
+                };
+              }) || []
           );
         })
         .flat()
     : [];
+
+  console.log("listOfAllClips", listOfAllClips);
 
   const [currentClip, setCurrentClip] = useState(
     getInitialCurrentClip(listOfAllClips, query.video),


### PR DESCRIPTION
## Description

-  Order media clips according to order in CAT
- Go to the correct clip when clicking on a learning cycle on the lesson overview page

Testing link:
https://deploy-preview-3325--oak-web-application.netlify.thenational.academy/teachers/lessons/what-is-it-naming-belongings-with-un-and-une

## Issue(s)

Fixes [PUPIL-1242](https://www.notion.so/oaknationalacademy/Media-clip-bugs-Lesson-media-page-some-clips-are-not-in-the-correct-order-19a26cc4e1b18050a2f8d2aa374fa067)
Also fixes [PUPIL-1252](https://www.notion.so/oaknationalacademy/Clicking-on-a-learning-cycle-on-the-lesson-page-always-displays-the-first-video-clip-18a26cc4e1b1808f98fed647d9b1ec76)