### PR TITLE
Added `<OakSecondaryLink/>` as default link in explainer portable text

### DIFF
--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -119,6 +119,12 @@ const blockHeadingComponents: PortableTextComponents["block"] = {
   ),
 };
 
+const markComponents: PortableTextComponents["marks"] = {
+  link: ({ children, value }) => {
+    return <OakSecondaryLink {...value}>{children}</OakSecondaryLink>;
+  },
+};
+
 const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
   const router = useRouter();
   const { track } = useAnalytics();
@@ -286,6 +292,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
                       marks: {
                         strong: basePortableTextComponents.marks!.strong,
                         em: basePortableTextComponents.marks!.em,
+                        link: markComponents.link,
                       },
                     }}
                   />


### PR DESCRIPTION
## Description
Replaced default potable text's link (`<a/>`) with `<OakSecondaryLink/>` in curric explainer.

## Issue(s)

Fixes `CUR-1362`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/
2. Go to english explainer
3. Check the links display correctly

## Screenshots
Before
<img width="603" alt="Screenshot 2025-03-31 at 11 18 04" src="https://github.com/user-attachments/assets/5529a66b-bfb3-4f05-abf7-da5c2a43677e" />

After
<img width="603" alt="Screenshot 2025-03-31 at 11 17 20" src="https://github.com/user-attachments/assets/28d46b2d-9c44-4736-8770-0cdedc6d2395" />

