### PR TITLE
Added new "all" icons for Science/RE subjects in curriculum filtering

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
@@ -19,6 +19,11 @@ describe("CurricFiltersSubjectCategories", () => {
           years: ["10", "11"],
           threads: [],
         }}
+        slugs={{
+          subjectSlug: "english",
+          phaseSlug: "secondary",
+          ks4OptionSlug: null,
+        }}
         onChangeFilters={() => {}}
         data={ks4Setup}
       />,
@@ -41,6 +46,11 @@ describe("CurricFiltersSubjectCategories", () => {
           tiers: [],
           years: ["7", "8", "9", "10", "11"],
           threads: [],
+        }}
+        slugs={{
+          subjectSlug: "english",
+          phaseSlug: "secondary",
+          ks4OptionSlug: null,
         }}
         onChangeFilters={() => {}}
         data={ks3and4Setup}
@@ -65,6 +75,11 @@ describe("CurricFiltersSubjectCategories", () => {
           tiers: [],
           years: ["10", "11"],
           threads: [],
+        }}
+        slugs={{
+          subjectSlug: "english",
+          phaseSlug: "secondary",
+          ks4OptionSlug: null,
         }}
         onChangeFilters={onChangeFilters}
         data={ks4Setup}

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
@@ -14,17 +14,20 @@ import {
   presentAtKeyStageSlugs,
 } from "@/utils/curriculum/keystage";
 import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 
 export type CurricFiltersSubjectCategoriesProps = {
   filters: CurriculumFilters;
   onChangeFilters: (newFilters: CurriculumFilters) => void;
   data: CurriculumUnitsFormattedData;
+  slugs: CurriculumSelectionSlugs;
 };
 
 export function CurricFiltersSubjectCategories({
   filters,
   onChangeFilters,
   data,
+  slugs,
 }: CurricFiltersSubjectCategoriesProps) {
   const id = useId();
   const { yearData } = data;
@@ -86,7 +89,10 @@ export function CurricFiltersSubjectCategories({
                   value={String(subjectCategory.id)}
                   data-testid={`subject-category-radio-${subjectCategory.id}`}
                   displayValue={subjectCategory.title}
-                  icon={getValidSubjectCategoryIconById(subjectCategory.id)}
+                  icon={getValidSubjectCategoryIconById(
+                    slugs.subjectSlug,
+                    subjectCategory.id,
+                  )}
                 />
               );
             })}

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersDesktop/index.stories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersDesktop/index.stories.tsx
@@ -26,10 +26,10 @@ export const CurricVisualiserFiltersMobile: Story = {
       threads: [],
     },
     onChangeFilters: () => {},
-    trackingData: {
+    slugs: {
       subjectSlug: "english",
-      subjectTitle: "English",
       phaseSlug: "primary",
+      ks4OptionSlug: null,
     },
   },
   render: function Render(args) {

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersDesktop/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersDesktop/index.tsx
@@ -15,23 +15,22 @@ import {
 } from "../CurricVisualiserFilters";
 
 import { CurriculumFilters } from "@/utils/curriculum/types";
-import {
-  CurriculumUnitsFormattedData,
-  CurriculumUnitsTrackingData,
-} from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { shouldDisplayFilter } from "@/utils/curriculum/filtering";
+import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 
 export type CurricVisualiserFiltersProps = {
   filters: CurriculumFilters;
   onChangeFilters: (newFilters: CurriculumFilters) => void;
   data: CurriculumUnitsFormattedData;
-  trackingData: CurriculumUnitsTrackingData;
+  slugs: CurriculumSelectionSlugs;
 };
 
 export function CurricVisualiserFiltersDesktop({
   filters,
   onChangeFilters,
   data,
+  slugs,
 }: CurricVisualiserFiltersProps) {
   return (
     <OakBox $mr={"space-between-s"}>
@@ -58,6 +57,7 @@ export function CurricVisualiserFiltersDesktop({
             filters={filters}
             onChangeFilters={onChangeFilters}
             data={data}
+            slugs={slugs}
           />
           <OakHandDrawnHR hrColor={"grey40"} $mv={"space-between-m2"} />
         </>

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
@@ -7,20 +7,23 @@ import { CurricMobileFilterModal } from "../CurricVisualiserFiltersModal";
 import { OakModalNew } from "../OakComponentsKitchen/OakModalNew";
 
 import { usePrevious } from "@/hooks/usePrevious";
+import { CurriculumUnitsTrackingData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 export type CurricVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {
     selectedYear: string;
     onSelectYear: (newYear: string) => void;
     onOpenModal: () => void;
+    trackingData: CurriculumUnitsTrackingData;
   };
 export default function CurricVisualiserFiltersMobile({
   filters,
   onChangeFilters,
   data,
-  trackingData,
   selectedYear,
   onSelectYear,
+  slugs,
+  trackingData,
 }: CurricVisualiserFiltersMobileProps) {
   const [mobileThreadModalOpen, setMobileThreadModalOpen] =
     useState<boolean>(false);
@@ -59,7 +62,7 @@ export default function CurricVisualiserFiltersMobile({
             onSelectYear={onSelectYear}
             onChangeFilters={onChangeFilters}
             data={data}
-            trackingData={trackingData}
+            slugs={slugs}
           />
         }
         footer={
@@ -79,6 +82,7 @@ export default function CurricVisualiserFiltersMobile({
         onSelectYear={onSelectYear}
         onChangeFilters={onChangeFilters}
         data={data}
+        slugs={slugs}
         trackingData={trackingData}
       />
     </>

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.stories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.stories.tsx
@@ -24,10 +24,10 @@ export const CurricMobileFilterModal: Story = {
       threads: [],
     },
     onChangeFilters: () => {},
-    trackingData: {
+    slugs: {
       subjectSlug: "english",
-      subjectTitle: "English",
       phaseSlug: "primary",
+      ks4OptionSlug: null,
     },
   },
   render: function Render(args) {

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.test.tsx
@@ -8,6 +8,7 @@ import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
 import { createTier } from "@/fixtures/curriculum/tier";
 import { createThread } from "@/fixtures/curriculum/thread";
 import { createChildSubject } from "@/fixtures/curriculum/childSubject";
+import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 
 describe("CurricVisualiserFiltersModal", () => {
   describe("render", () => {
@@ -23,10 +24,10 @@ describe("CurricVisualiserFiltersModal", () => {
         threadOptions: [],
         yearOptions: ["7"],
       };
-      const trackingData = {
-        subjectSlug: "",
-        subjectTitle: "",
-        phaseSlug: "",
+      const slugs: CurriculumSelectionSlugs = {
+        subjectSlug: "english",
+        phaseSlug: "primary",
+        ks4OptionSlug: null,
       };
       const onSelectYear = jest.fn();
       const { getAllByRole } = renderWithTheme(
@@ -34,7 +35,7 @@ describe("CurricVisualiserFiltersModal", () => {
           filters={filters}
           onChangeFilters={() => {}}
           data={data}
-          trackingData={trackingData}
+          slugs={slugs}
           selectedYear={"7"}
           onSelectYear={onSelectYear}
         />,
@@ -59,10 +60,10 @@ describe("CurricVisualiserFiltersModal", () => {
         threadOptions: [],
         yearOptions: ["7"],
       };
-      const trackingData = {
-        subjectSlug: "",
-        subjectTitle: "",
-        phaseSlug: "",
+      const slugs: CurriculumSelectionSlugs = {
+        subjectSlug: "english",
+        phaseSlug: "primary",
+        ks4OptionSlug: null,
       };
       const onSelectYear = jest.fn();
       const { getAllByRole } = renderWithTheme(
@@ -70,7 +71,7 @@ describe("CurricVisualiserFiltersModal", () => {
           filters={filters}
           onChangeFilters={() => {}}
           data={data}
-          trackingData={trackingData}
+          slugs={slugs}
           selectedYear={"7"}
           onSelectYear={onSelectYear}
         />,
@@ -92,10 +93,10 @@ describe("CurricVisualiserFiltersModal", () => {
         threadOptions: [thread1, thread2],
         yearOptions: ["7"],
       };
-      const trackingData = {
-        subjectSlug: "",
-        subjectTitle: "",
-        phaseSlug: "",
+      const slugs: CurriculumSelectionSlugs = {
+        subjectSlug: "english",
+        phaseSlug: "primary",
+        ks4OptionSlug: null,
       };
       const onSelectYear = jest.fn();
       const { container } = renderWithTheme(
@@ -103,7 +104,7 @@ describe("CurricVisualiserFiltersModal", () => {
           filters={filters}
           onChangeFilters={() => {}}
           data={data}
-          trackingData={trackingData}
+          slugs={slugs}
           selectedYear={"7"}
           onSelectYear={onSelectYear}
         />,
@@ -134,10 +135,10 @@ describe("CurricVisualiserFiltersModal", () => {
         threadOptions: [thread1, thread2],
         yearOptions: ["7"],
       };
-      const trackingData = {
-        subjectSlug: "",
-        subjectTitle: "",
-        phaseSlug: "",
+      const slugs: CurriculumSelectionSlugs = {
+        subjectSlug: "english",
+        phaseSlug: "primary",
+        ks4OptionSlug: null,
       };
       const onSelectYear = jest.fn();
       const { getAllByRole, container } = renderWithTheme(
@@ -145,7 +146,7 @@ describe("CurricVisualiserFiltersModal", () => {
           filters={filters}
           onChangeFilters={() => {}}
           data={data}
-          trackingData={trackingData}
+          slugs={slugs}
           selectedYear={"7"}
           onSelectYear={onSelectYear}
         />,
@@ -178,10 +179,10 @@ describe("CurricVisualiserFiltersModal", () => {
         threadOptions: [thread1, thread2],
         yearOptions: ["7"],
       };
-      const trackingData = {
-        subjectSlug: "",
-        subjectTitle: "",
-        phaseSlug: "",
+      const slugs: CurriculumSelectionSlugs = {
+        subjectSlug: "english",
+        phaseSlug: "primary",
+        ks4OptionSlug: null,
       };
       const onSelectYear = jest.fn();
       const { getAllByRole, container } = renderWithTheme(
@@ -189,7 +190,7 @@ describe("CurricVisualiserFiltersModal", () => {
           filters={filters}
           onChangeFilters={() => {}}
           data={data}
-          trackingData={trackingData}
+          slugs={slugs}
           selectedYear={"7"}
           onSelectYear={onSelectYear}
         />,

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersModal/index.tsx
@@ -19,6 +19,7 @@ export function CurricMobileFilterModal({
   data,
   filters,
   onChangeFilters,
+  slugs,
 }: CurricVisualiserFiltersMobileProps) {
   return (
     <OakFlex $flexDirection={"column"} $height={"100%"}>
@@ -38,6 +39,7 @@ export function CurricMobileFilterModal({
               filters={filters}
               onChangeFilters={onChangeFilters}
               data={data}
+              slugs={slugs}
             />
           )}
 

--- a/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.stories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.stories.tsx
@@ -26,10 +26,10 @@ export const CurricMobileStickyHeader: Story = {
       threads: [],
     },
     onChangeFilters: () => {},
-    trackingData: {
+    slugs: {
       subjectSlug: "english",
-      subjectTitle: "English",
       phaseSlug: "primary",
+      ks4OptionSlug: null,
     },
   },
   render: function Render(args) {

--- a/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserMobileHeader/index.tsx
@@ -14,6 +14,7 @@ import {
   highlightedUnitCount,
 } from "@/utils/curriculum/filtering";
 import { buildUnitSequenceRefinedAnalytics } from "@/utils/curriculum/analytics";
+import { CurriculumUnitsTrackingData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 export type CurriculumVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {
@@ -97,7 +98,9 @@ export function CurricMobileStickyHeader({
   trackingData,
   selectedYear,
   onSelectYear,
-}: CurriculumVisualiserFiltersMobileProps) {
+}: CurriculumVisualiserFiltersMobileProps & {
+  trackingData: CurriculumUnitsTrackingData;
+}) {
   const { track } = useAnalytics();
   const { analyticsUseCase } = useAnalyticsPageProps();
   const [lockYear, setLockYear] = useState<string | null>(null);

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -16,12 +16,14 @@ import {
 import { getNumberOfSelectedUnits } from "@/utils/curriculum/getNumberOfSelectedUnits";
 import { highlightedUnitCount } from "@/utils/curriculum/filtering";
 import useMediaQuery from "@/hooks/useMediaQuery";
+import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 
 type UnitsTabProps = {
   trackingData: CurriculumUnitsTrackingData;
   formattedData: CurriculumUnitsFormattedData;
   filters: CurriculumFilters;
   onChangeFilters: (newFilter: CurriculumFilters) => void;
+  slugs: CurriculumSelectionSlugs;
 };
 
 export default function UnitsTab({
@@ -29,6 +31,7 @@ export default function UnitsTab({
   formattedData,
   filters,
   onChangeFilters,
+  slugs,
 }: UnitsTabProps) {
   // Initialize constants
   const isMobile = useMediaQuery("mobile");
@@ -80,8 +83,9 @@ export default function UnitsTab({
             filters={filters}
             onChangeFilters={onChangeFilters}
             data={formattedData}
-            trackingData={trackingData}
+            slugs={slugs}
             onOpenModal={() => {}}
+            trackingData={trackingData}
           />
         )}
         <CurricVisualiserLayout
@@ -91,7 +95,7 @@ export default function UnitsTab({
                 filters={filters}
                 onChangeFilters={onChangeFilters}
                 data={formattedData}
-                trackingData={trackingData}
+                slugs={slugs}
               />
             )
           }

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].tsx
@@ -127,6 +127,7 @@ const CurriculumInfoPage: NextPage<CurriculumInfoPageProps> = ({
           trackingData={curriculumUnitsTrackingData}
           filters={filters}
           onChangeFilters={onChangeFilters}
+          slugs={curriculumSelectionSlugs}
         />
       );
       break;

--- a/src/utils/getValidSubjectCategoryIconById.test.ts
+++ b/src/utils/getValidSubjectCategoryIconById.test.ts
@@ -2,10 +2,20 @@ import { getValidSubjectCategoryIconById } from "./getValidSubjectCategoryIconBy
 
 describe("getValidSubjectCategoryIconById", () => {
   it("valid id", () => {
-    expect(getValidSubjectCategoryIconById(1)).toEqual("subject-biology");
+    expect(getValidSubjectCategoryIconById("english", 1)).toEqual(
+      "subject-biology",
+    );
   });
 
   it("invalid id", () => {
-    expect(getValidSubjectCategoryIconById(99)).toEqual("books");
+    expect(getValidSubjectCategoryIconById("english", 99)).toEqual("books");
+  });
+
+  it("'all' id", () => {
+    expect(getValidSubjectCategoryIconById("english", -1)).toEqual("books");
+    expect(getValidSubjectCategoryIconById("religious-education", -1)).toEqual(
+      "subject-religious-education",
+    );
+    expect(getValidSubjectCategoryIconById("science", -1)).toEqual("rocket");
   });
 });

--- a/src/utils/getValidSubjectCategoryIconById.test.ts
+++ b/src/utils/getValidSubjectCategoryIconById.test.ts
@@ -9,10 +9,13 @@ describe("getValidSubjectCategoryIconById", () => {
 
   it("invalid id", () => {
     expect(getValidSubjectCategoryIconById("english", 99)).toEqual("books");
+    expect(getValidSubjectCategoryIconById("foobar", -1)).toEqual("books");
   });
 
   it("'all' id", () => {
-    expect(getValidSubjectCategoryIconById("english", -1)).toEqual("books");
+    expect(getValidSubjectCategoryIconById("english", -1)).toEqual(
+      "subject-english",
+    );
     expect(getValidSubjectCategoryIconById("religious-education", -1)).toEqual(
       "subject-religious-education",
     );

--- a/src/utils/getValidSubjectCategoryIconById.test.ts
+++ b/src/utils/getValidSubjectCategoryIconById.test.ts
@@ -16,6 +16,8 @@ describe("getValidSubjectCategoryIconById", () => {
     expect(getValidSubjectCategoryIconById("religious-education", -1)).toEqual(
       "subject-religious-education",
     );
-    expect(getValidSubjectCategoryIconById("science", -1)).toEqual("rocket");
+    expect(getValidSubjectCategoryIconById("science", -1)).toEqual(
+      "subject-science",
+    );
   });
 });

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -20,7 +20,7 @@ const subjectCategoryIconMap: Record<number, string> = {
 const allIconMap: Record<string, OakIconName> = {
   "religious-education": "subject-religious-education",
   english: "books",
-  science: "rocket",
+  science: "subject-science",
 };
 
 export function getValidSubjectCategoryIconById(

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -17,8 +17,21 @@ const subjectCategoryIconMap: Record<number, string> = {
   17: "theology",
 };
 
-export function getValidSubjectCategoryIconById(id: number): OakIconName {
-  const subjectSlug = subjectCategoryIconMap[id];
+const allIconMap: Record<string, OakIconName> = {
+  "religious-education": "subject-religious-education",
+  english: "books",
+  science: "rocket",
+};
 
-  return getValidSubjectIconName(subjectSlug ?? null);
+export function getValidSubjectCategoryIconById(
+  subjectSlug: string,
+  id: number,
+): OakIconName {
+  const iconName = subjectCategoryIconMap[id];
+
+  if (id === -1) {
+    return allIconMap[subjectSlug] ?? "books";
+  }
+
+  return getValidSubjectIconName(iconName ?? null);
 }

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -19,7 +19,7 @@ const subjectCategoryIconMap: Record<number, string> = {
 
 const allIconMap: Record<string, OakIconName> = {
   "religious-education": "subject-religious-education",
-  english: "books",
+  english: "subject-english",
   science: "subject-science",
 };
 


### PR DESCRIPTION
## Description
Adds correct "all" icons for Science/RE in new filtering

## Issue(s)

Fixes `CUR-1333`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/
2. Check subject category filters science/english are correct as per `CUR-1333`

## Screenshots

<img width="998" alt="Screenshot 2025-03-31 at 16 00 32" src="https://github.com/user-attachments/assets/7332fd6b-2d15-40fd-b307-272743d60db7" />
<img width="998" alt="Screenshot 2025-03-31 at 16 00 18" src="https://github.com/user-attachments/assets/2f888d2e-b966-4a72-a50a-77849cbae73f" />

