### PR TITLE
PUPIL-1253 Disable captions on PE practical media clips

### DIFF
--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -45,6 +45,7 @@ export type VideoPlayerProps = {
   pathwayData?: PupilPathwayData;
   isAudioClip?: boolean;
   loadingTextColor?: OakColorToken;
+  defaultHiddenCaptions?: boolean;
 };
 
 export type VideoEventCallbackArgs = {
@@ -66,6 +67,7 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
     pathwayData,
     isAudioClip,
     loadingTextColor = "black",
+    defaultHiddenCaptions = false,
   } = props;
 
   const mediaElRef = useRef<MuxPlayerElement>(null);
@@ -312,6 +314,7 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
             mediaElRef.current?.play();
           }
         }}
+        defaultHiddenCaptions={defaultHiddenCaptions}
         style={{
           aspectRatio: "16/9",
           overflow: "hidden",

--- a/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
+++ b/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
@@ -86,6 +86,7 @@ export const LessonMedia = (props: LessonMediaProps) => {
 
   // construct list of all clips in one array
 
+  const isPEPractical = actions?.isPePractical;
   const isPELesson = actions?.displayPETitle;
   const isMFL = actions?.displayVocabButton;
 
@@ -176,6 +177,7 @@ export const LessonMedia = (props: LessonMediaProps) => {
       isAudioClip={currentClip.mediaObject?.format === "mp3"}
       userEventCallback={handleVideoEvents}
       loadingTextColor="white"
+      defaultHiddenCaptions={isPEPractical}
     />
   );
 


### PR DESCRIPTION
## Description

Disable auto captions on PE practical media clips

## Issue(s)

[PUPIL-1253](https://www.notion.so/oaknationalacademy/Disable-captions-as-default-on-PE-practical-media-clips-1a626cc4e1b180129e79e51531f10ba8)

## How to test

1. Go to https://deploy-preview-3329--oak-web-application.netlify.thenational.academy/teachers/lessons/passing-and-receiving-skills/media
2. Validate that captions are turned off by default for pe practical lesson
3. Validate captions are turn off by default for other lessons

