### PR TITLE
Feat/pupil 1275/primary banner bug

### DIFF
--- a/src/components/PupilComponents/RelatedSubjectsBanner/banners/FinancialEducationBanner.test.tsx
+++ b/src/components/PupilComponents/RelatedSubjectsBanner/banners/FinancialEducationBanner.test.tsx
@@ -55,7 +55,7 @@ describe("FinancialEducationBanner", () => {
     expect(card).toBeInTheDocument();
     expect(card).toHaveAttribute(
       "data-href",
-      "/pupil-unit-index/pupil-unit-index/financial-education-secondary-year-1",
+      "/pupil-unit-index/pupil-unit-index/financial-education-primary-year-1",
     );
 
     expect(screen.getByTestId("icon-name")).toHaveTextContent(

--- a/src/components/PupilComponents/RelatedSubjectsBanner/banners/FinancialEducationBanner.tsx
+++ b/src/components/PupilComponents/RelatedSubjectsBanner/banners/FinancialEducationBanner.tsx
@@ -11,7 +11,7 @@ import { BannerProps } from "../RelatedSubjectsBanner";
 import { resolveOakHref } from "@/common-lib/urls";
 
 function FinancialEducationBanner({ programmeFields }: Readonly<BannerProps>) {
-  const programmeSlug = `financial-education-secondary-${programmeFields.yearSlug}`;
+  const programmeSlug = `financial-education-${programmeFields.phase}-${programmeFields.yearSlug}`;
 
   const href = resolveOakHref({
     page: "pupil-unit-index",


### PR DESCRIPTION
## Description

Music year: 1994

- List of changes
use data to set phase from finance banners on related subjects

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-3331--oak-web-application.netlify.thenational.academy/pupils/programmes/maths-primary-year-1/units
2. Click on finace lesson below
3. You should be linked to primary units

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
