### PR TITLE
Use `features` of parent programme to determine whether to show unit-description/WTWN

### DIFF
--- a/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.test.tsx
@@ -18,6 +18,7 @@ const testCurriculumUnitDetails = {
   whyThisWhyNow: "test why this why now",
   description: "test description",
   handleUnitOverviewExploredAnalytics: () => jest.fn(),
+  isUnitDescriptionEnabled: false,
 };
 
 describe("CurriculumUnitDetails component", () => {
@@ -55,7 +56,10 @@ describe("CurriculumUnitDetails component", () => {
 
     test("it should render all accordion components (cycle 2)", () => {
       const { getAllByTestId, getByText } = renderWithTheme(
-        <CurriculumUnitDetails {...testCurriculumUnitDetails} cycle="2" />,
+        <CurriculumUnitDetails
+          {...testCurriculumUnitDetails}
+          isUnitDescriptionEnabled={true}
+        />,
       );
 
       expect(getAllByTestId("accordion-component")).toHaveLength(2);

--- a/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
@@ -23,7 +23,7 @@ export type CurriculumUnitDetailsProps = {
   futureUnitTitle: string | null;
   whyThisWhyNow: string | null;
   description: string | null;
-  cycle: string;
+  isUnitDescriptionEnabled: boolean;
   handleUnitOverviewExploredAnalytics: (
     componentType: ComponentTypeValueType,
   ) => void;
@@ -38,7 +38,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
   futureUnitTitle,
   whyThisWhyNow,
   description,
-  cycle,
+  isUnitDescriptionEnabled,
   handleUnitOverviewExploredAnalytics,
 }) => {
   const threadTitleSet = new Set<string>(threads.map((thread) => thread.title));
@@ -89,7 +89,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
         </OakBox>
       )}
       <OakFlex $flexDirection={"column"}>
-        {cycle === "2" && (
+        {isUnitDescriptionEnabled && (
           <>
             {description && (
               <OakBox $mb={"space-between-m2"}>
@@ -122,7 +122,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
         {numberOfLessons >= 1 && (
           <CurriculumUnitDetailsAccordion
             title="Lessons in unit"
-            lastAccordion={cycle === "2"}
+            lastAccordion={isUnitDescriptionEnabled}
             handleUnitOverviewExploredAnalytics={
               handleUnitOverviewExploredAnalytics
             }
@@ -136,7 +136,7 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
           </CurriculumUnitDetailsAccordion>
         )}
 
-        {cycle === "1" && (
+        {!isUnitDescriptionEnabled && (
           <>
             {priorUnitDescription && (
               <CurriculumUnitDetailsAccordion

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -164,7 +164,9 @@ const UnitModal: FC<UnitModalProps> = ({
                     handleUnitOverviewExploredAnalytics
                   }
                   threads={unitData.threads}
-                  cycle={unitData.cycle}
+                  isUnitDescriptionEnabled={
+                    unitData.parent_programme_features.unit_description === true
+                  }
                   whyThisWhyNow={unitData.why_this_why_now}
                   description={unitData.description}
                   lessons={unitData.lessons}
@@ -242,7 +244,9 @@ const UnitModal: FC<UnitModalProps> = ({
                                   optionalUnit.connection_future_unit_title,
                                 description: optionalUnit.description,
                                 whyThisWhyNow: optionalUnit.why_this_why_now,
-                                cycle: unitData.cycle,
+                                isUnitDescriptionEnabled:
+                                  unitData.parent_programme_features
+                                    .unit_description === true,
                                 handleUnitOverviewExploredAnalytics:
                                   handleUnitOverviewExploredAnalytics,
                               });

--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -165,7 +165,8 @@ const UnitModal: FC<UnitModalProps> = ({
                   }
                   threads={unitData.threads}
                   isUnitDescriptionEnabled={
-                    unitData.parent_programme_features.unit_description === true
+                    unitData.parent_programme_features?.unit_description ===
+                    true
                   }
                   whyThisWhyNow={unitData.why_this_why_now}
                   description={unitData.description}
@@ -246,7 +247,7 @@ const UnitModal: FC<UnitModalProps> = ({
                                 whyThisWhyNow: optionalUnit.why_this_why_now,
                                 isUnitDescriptionEnabled:
                                   unitData.parent_programme_features
-                                    .unit_description === true,
+                                    ?.unit_description === true,
                                 handleUnitOverviewExploredAnalytics:
                                   handleUnitOverviewExploredAnalytics,
                               });

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -1974,6 +1974,7 @@ export type Cat_Subjectcategories = {
   /** A computed field, executes function "function__cat_subjectcategories__permitted_programme_fields" */
   permitted_programme_fields?: Maybe<Array<Templates_Permitted_Programme_Fields>>;
   programme_fields: Scalars['jsonb']['output'];
+  slug?: Maybe<Scalars['String']['output']>;
   subjectcategory_id: Scalars['Int']['output'];
   title?: Maybe<Scalars['String']['output']>;
   /** A computed field, executes function "function__cat_subjectcategories__units" */
@@ -2095,6 +2096,7 @@ export type Cat_Subjectcategories_Bool_Exp = {
   description?: InputMaybe<String_Comparison_Exp>;
   permitted_programme_fields?: InputMaybe<Templates_Permitted_Programme_Fields_Bool_Exp>;
   programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
   subjectcategory_id?: InputMaybe<Int_Comparison_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
   units_with_subjectcategory?: InputMaybe<Units_Bool_Exp>;
@@ -2142,6 +2144,7 @@ export type Cat_Subjectcategories_Insert_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   subjectcategory_id?: InputMaybe<Scalars['Int']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -2155,6 +2158,7 @@ export type Cat_Subjectcategories_Max_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
   subjectcategory_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
   /** A computed field, executes function "function__cat_subjectcategories__units__count" */
@@ -2169,6 +2173,7 @@ export type Cat_Subjectcategories_Max_Order_By = {
   _state?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
   subjectcategory_id?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
@@ -2182,6 +2187,7 @@ export type Cat_Subjectcategories_Min_Fields = {
   _state?: Maybe<Scalars['String']['output']>;
   created_at?: Maybe<Scalars['timestamptz']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
   subjectcategory_id?: Maybe<Scalars['Int']['output']>;
   title?: Maybe<Scalars['String']['output']>;
   /** A computed field, executes function "function__cat_subjectcategories__units__count" */
@@ -2196,6 +2202,7 @@ export type Cat_Subjectcategories_Min_Order_By = {
   _state?: InputMaybe<Order_By>;
   created_at?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
   subjectcategory_id?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
@@ -2228,6 +2235,7 @@ export type Cat_Subjectcategories_Order_By = {
   description?: InputMaybe<Order_By>;
   permitted_programme_fields_aggregate?: InputMaybe<Templates_Permitted_Programme_Fields_Aggregate_Order_By>;
   programme_fields?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
   subjectcategory_id?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
   units_with_subjectcategory_aggregate?: InputMaybe<Units_Aggregate_Order_By>;
@@ -2266,6 +2274,8 @@ export enum Cat_Subjectcategories_Select_Column {
   /** column name */
   ProgrammeFields = 'programme_fields',
   /** column name */
+  Slug = 'slug',
+  /** column name */
   SubjectcategoryId = 'subjectcategory_id',
   /** column name */
   Title = 'title',
@@ -2283,6 +2293,7 @@ export type Cat_Subjectcategories_Set_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   subjectcategory_id?: InputMaybe<Scalars['Int']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -2351,6 +2362,7 @@ export type Cat_Subjectcategories_Stream_Cursor_Value_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
   subjectcategory_id?: InputMaybe<Scalars['Int']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -2389,6 +2401,8 @@ export enum Cat_Subjectcategories_Update_Column {
   Description = 'description',
   /** column name */
   ProgrammeFields = 'programme_fields',
+  /** column name */
+  Slug = 'slug',
   /** column name */
   SubjectcategoryId = 'subjectcategory_id',
   /** column name */

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -20756,6 +20756,512 @@ export type Published_Mv_Curriculum_Sequence_B_13_0_15_Variance_Fields = {
   unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16 = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  national_curriculum_content?: Maybe<Scalars['json']['output']>;
+  non_curriculum?: Maybe<Scalars['Boolean']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  parent_programme_features?: Maybe<Scalars['jsonb']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  subjectcategories?: Maybe<Scalars['jsonb']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16National_Curriculum_ContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16Parent_Programme_FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16SubjectcategoriesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_aggregate';
+  aggregate?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
+};
+
+/** aggregate fields of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_aggregate_fields';
+  avg?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Max_Fields>;
+  min?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Avg_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_avg_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_curriculum_sequence_b_13_0_16". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  cross_subject_links?: InputMaybe<String_Comparison_Exp>;
+  cycle?: InputMaybe<String_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<String_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  national_curriculum_content?: InputMaybe<Json_Comparison_Exp>;
+  non_curriculum?: InputMaybe<Boolean_Comparison_Exp>;
+  notes?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  parent_programme_features?: InputMaybe<Jsonb_Comparison_Exp>;
+  pathway?: InputMaybe<String_Comparison_Exp>;
+  pathway_slug?: InputMaybe<String_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  prior_knowledge_requirements?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subjectcategories?: InputMaybe<Jsonb_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  why_this_why_now?: InputMaybe<String_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Max_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Min_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_curriculum_sequence_b_13_0_16". */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  cross_subject_links?: InputMaybe<Order_By>;
+  cycle?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  national_curriculum_content?: InputMaybe<Order_By>;
+  non_curriculum?: InputMaybe<Order_By>;
+  notes?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  parent_programme_features?: InputMaybe<Order_By>;
+  pathway?: InputMaybe<Order_By>;
+  pathway_slug?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  prior_knowledge_requirements?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subjectcategories?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  why_this_why_now?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_curriculum_sequence_b_13_0_16" */
+export enum Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
+  /** column name */
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
+  /** column name */
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
+  /** column name */
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
+  /** column name */
+  CrossSubjectLinks = 'cross_subject_links',
+  /** column name */
+  Cycle = 'cycle',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  Domain = 'domain',
+  /** column name */
+  DomainId = 'domain_id',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  KeystageSlug = 'keystage_slug',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  NationalCurriculumContent = 'national_curriculum_content',
+  /** column name */
+  NonCurriculum = 'non_curriculum',
+  /** column name */
+  Notes = 'notes',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  ParentProgrammeFeatures = 'parent_programme_features',
+  /** column name */
+  Pathway = 'pathway',
+  /** column name */
+  PathwaySlug = 'pathway_slug',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
+  /** column name */
+  PriorKnowledgeRequirements = 'prior_knowledge_requirements',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Subjectcategories = 'subjectcategories',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  WhyThisWhyNow = 'why_this_why_now',
+  /** column name */
+  Year = 'year'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_stddev_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_curriculum_sequence_b_13_0_16" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  cross_subject_links?: InputMaybe<Scalars['String']['input']>;
+  cycle?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['String']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
+  non_curriculum?: InputMaybe<Scalars['Boolean']['input']>;
+  notes?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  parent_programme_features?: InputMaybe<Scalars['jsonb']['input']>;
+  pathway?: InputMaybe<Scalars['String']['input']>;
+  pathway_slug?: InputMaybe<Scalars['String']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  prior_knowledge_requirements?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  why_this_why_now?: InputMaybe<Scalars['String']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Sum_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_sum_fields';
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Var_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_var_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Var_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_var_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_16_Variance_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_16_variance_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
 export type Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0 = {
   __typename?: 'published_mv_get_tpc_media_by_lesson_slug_1_0_0';
@@ -32154,6 +32660,512 @@ export type Published_View_Curriculum_Sequence_B_13_0_15_Variance_Fields = {
   unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16 = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  national_curriculum_content?: Maybe<Scalars['json']['output']>;
+  non_curriculum?: Maybe<Scalars['Boolean']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  parent_programme_features?: Maybe<Scalars['jsonb']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  subjectcategories?: Maybe<Scalars['jsonb']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16National_Curriculum_ContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16Parent_Programme_FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16SubjectcategoriesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Aggregate = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_aggregate';
+  aggregate?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Aggregate_Fields>;
+  nodes: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
+};
+
+/** aggregate fields of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Aggregate_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_aggregate_fields';
+  avg?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Max_Fields>;
+  min?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Min_Fields>;
+  stddev?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Curriculum_Sequence_B_13_0_16_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Avg_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_avg_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_curriculum_sequence_b_13_0_16". All fields are combined with a logical 'AND'. */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  cross_subject_links?: InputMaybe<String_Comparison_Exp>;
+  cycle?: InputMaybe<String_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<String_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  national_curriculum_content?: InputMaybe<Json_Comparison_Exp>;
+  non_curriculum?: InputMaybe<Boolean_Comparison_Exp>;
+  notes?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  parent_programme_features?: InputMaybe<Jsonb_Comparison_Exp>;
+  pathway?: InputMaybe<String_Comparison_Exp>;
+  pathway_slug?: InputMaybe<String_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  prior_knowledge_requirements?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subjectcategories?: InputMaybe<Jsonb_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  why_this_why_now?: InputMaybe<String_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Max_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Min_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_curriculum_sequence_b_13_0_16". */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  cross_subject_links?: InputMaybe<Order_By>;
+  cycle?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  national_curriculum_content?: InputMaybe<Order_By>;
+  non_curriculum?: InputMaybe<Order_By>;
+  notes?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  parent_programme_features?: InputMaybe<Order_By>;
+  pathway?: InputMaybe<Order_By>;
+  pathway_slug?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  prior_knowledge_requirements?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subjectcategories?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  why_this_why_now?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_curriculum_sequence_b_13_0_16" */
+export enum Published_View_Curriculum_Sequence_B_13_0_16_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
+  /** column name */
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
+  /** column name */
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
+  /** column name */
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
+  /** column name */
+  CrossSubjectLinks = 'cross_subject_links',
+  /** column name */
+  Cycle = 'cycle',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  Domain = 'domain',
+  /** column name */
+  DomainId = 'domain_id',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  KeystageSlug = 'keystage_slug',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  NationalCurriculumContent = 'national_curriculum_content',
+  /** column name */
+  NonCurriculum = 'non_curriculum',
+  /** column name */
+  Notes = 'notes',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  ParentProgrammeFeatures = 'parent_programme_features',
+  /** column name */
+  Pathway = 'pathway',
+  /** column name */
+  PathwaySlug = 'pathway_slug',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
+  /** column name */
+  PriorKnowledgeRequirements = 'prior_knowledge_requirements',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Subjectcategories = 'subjectcategories',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  WhyThisWhyNow = 'why_this_why_now',
+  /** column name */
+  Year = 'year'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_stddev_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Pop_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Stddev_Samp_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_curriculum_sequence_b_13_0_16" */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  cross_subject_links?: InputMaybe<Scalars['String']['input']>;
+  cycle?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['String']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
+  non_curriculum?: InputMaybe<Scalars['Boolean']['input']>;
+  notes?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  parent_programme_features?: InputMaybe<Scalars['jsonb']['input']>;
+  pathway?: InputMaybe<Scalars['String']['input']>;
+  pathway_slug?: InputMaybe<Scalars['String']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  prior_knowledge_requirements?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  why_this_why_now?: InputMaybe<Scalars['String']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Sum_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_sum_fields';
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Var_Pop_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_var_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Var_Samp_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_var_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_16_Variance_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_16_variance_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.view_keystages_1_0_0" */
 export type Published_View_Keystages_1_0_0 = {
   __typename?: 'published_view_keystages_1_0_0';
@@ -38576,6 +39588,10 @@ export type Query_Root = {
   published_mv_curriculum_sequence_b_13_0_15: Array<Published_Mv_Curriculum_Sequence_B_13_0_15>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_15" */
   published_mv_curriculum_sequence_b_13_0_15_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_15_Aggregate;
+  /** fetch data from the table: "published.mv_curriculum_sequence_b_13_0_16" */
+  published_mv_curriculum_sequence_b_13_0_16: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_16" */
+  published_mv_curriculum_sequence_b_13_0_16_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate;
   /** fetch data from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
   published_mv_get_tpc_media_by_lesson_slug_1_0_0: Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
@@ -38728,6 +39744,10 @@ export type Query_Root = {
   published_view_curriculum_sequence_b_13_0_15: Array<Published_View_Curriculum_Sequence_B_13_0_15>;
   /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_15" */
   published_view_curriculum_sequence_b_13_0_15_aggregate: Published_View_Curriculum_Sequence_B_13_0_15_Aggregate;
+  /** fetch data from the table: "published.view_curriculum_sequence_b_13_0_16" */
+  published_view_curriculum_sequence_b_13_0_16: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
+  /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_16" */
+  published_view_curriculum_sequence_b_13_0_16_aggregate: Published_View_Curriculum_Sequence_B_13_0_16_Aggregate;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -39787,6 +40807,24 @@ export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_15_AggregateArgs =
 };
 
 
+export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_16Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_16_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -40468,6 +41506,24 @@ export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_15_AggregateArgs
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_15_Order_By>>;
   where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_15_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_16Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_16_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
 };
 
 
@@ -43394,6 +44450,12 @@ export type Subscription_Root = {
   published_mv_curriculum_sequence_b_13_0_15_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_15_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_curriculum_sequence_b_13_0_15" */
   published_mv_curriculum_sequence_b_13_0_15_stream: Array<Published_Mv_Curriculum_Sequence_B_13_0_15>;
+  /** fetch data from the table: "published.mv_curriculum_sequence_b_13_0_16" */
+  published_mv_curriculum_sequence_b_13_0_16: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_16" */
+  published_mv_curriculum_sequence_b_13_0_16_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_curriculum_sequence_b_13_0_16" */
+  published_mv_curriculum_sequence_b_13_0_16_stream: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
   /** fetch data from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
   published_mv_get_tpc_media_by_lesson_slug_1_0_0: Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
@@ -43622,6 +44684,12 @@ export type Subscription_Root = {
   published_view_curriculum_sequence_b_13_0_15_aggregate: Published_View_Curriculum_Sequence_B_13_0_15_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_curriculum_sequence_b_13_0_15" */
   published_view_curriculum_sequence_b_13_0_15_stream: Array<Published_View_Curriculum_Sequence_B_13_0_15>;
+  /** fetch data from the table: "published.view_curriculum_sequence_b_13_0_16" */
+  published_view_curriculum_sequence_b_13_0_16: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
+  /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_16" */
+  published_view_curriculum_sequence_b_13_0_16_aggregate: Published_View_Curriculum_Sequence_B_13_0_16_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_curriculum_sequence_b_13_0_16" */
+  published_view_curriculum_sequence_b_13_0_16_stream: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -45035,6 +46103,31 @@ export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_15_StreamAr
 };
 
 
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_16Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_16_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_16_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -45982,6 +47075,31 @@ export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_15_Stream
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_View_Curriculum_Sequence_B_13_0_15_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_15_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_16Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_16_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_16_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
 };
 
 
@@ -54988,11 +56106,11 @@ export type CurriculumPhaseOptionsQueryVariables = Exact<{ [key: string]: never;
 export type CurriculumPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_curriculum_phase_options_0_3', title?: string | null, slug?: string | null, phases?: any | null, keystages?: any | null, ks4_options?: any | null }> };
 
 export type CurriculumSequenceQueryVariables = Exact<{
-  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_15_Bool_Exp>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
 }>;
 
 
-export type CurriculumSequenceQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_sequence_b_13_0_15', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: string | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, why_this_why_now?: string | null, description?: string | null, cycle?: string | null, features?: any | null, actions?: any | null, unit_options?: any | null, threads?: any | null, year?: string | null, pathway?: string | null, pathway_slug?: string | null, state?: string | null }> };
+export type CurriculumSequenceQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_sequence_b_13_0_16', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: string | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, why_this_why_now?: string | null, description?: string | null, cycle?: string | null, features?: any | null, parent_programme_features?: any | null, actions?: any | null, unit_options?: any | null, threads?: any | null, year?: string | null, pathway?: string | null, pathway_slug?: string | null, state?: string | null }> };
 
 export type BetaLessonMediaClipsQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -55275,8 +56393,8 @@ export const CurriculumPhaseOptionsDocument = gql`
 }
     `;
 export const CurriculumSequenceDocument = gql`
-    query curriculumSequence($where: published_mv_curriculum_sequence_b_13_0_15_bool_exp) {
-  units: published_mv_curriculum_sequence_b_13_0_15(where: $where) {
+    query curriculumSequence($where: published_mv_curriculum_sequence_b_13_0_16_bool_exp) {
+  units: published_mv_curriculum_sequence_b_13_0_16(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title
@@ -55305,6 +56423,7 @@ export const CurriculumSequenceDocument = gql`
     description
     cycle
     features
+    parent_programme_features
     actions
     unit_options
     threads

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.gql
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.gql
@@ -1,7 +1,7 @@
 query curriculumSequence(
-  $where: published_mv_curriculum_sequence_b_13_0_15_bool_exp
+  $where: published_mv_curriculum_sequence_b_13_0_16_bool_exp
 ) {
-  units: published_mv_curriculum_sequence_b_13_0_15(where: $where) {
+  units: published_mv_curriculum_sequence_b_13_0_16(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title
@@ -30,6 +30,7 @@ query curriculumSequence(
     description
     cycle
     features
+    parent_programme_features
     actions
     unit_options
     threads

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
@@ -64,7 +64,7 @@ const curriculumSequenceSchema = z.object({
       why_this_why_now: z.string().nullable(),
       cycle: z.string(),
       features: z.any(),
-      parent_programme_features: z.any(),
+      parent_programme_features: z.any().nullable(),
       actions: z.any(),
       unit_options: z.array(
         z.object({

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
@@ -64,6 +64,7 @@ const curriculumSequenceSchema = z.object({
       why_this_why_now: z.string().nullable(),
       cycle: z.string(),
       features: z.any(),
+      parent_programme_features: z.any(),
       actions: z.any(),
       unit_options: z.array(
         z.object({

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -227,8 +227,11 @@ export async function buildUnit(
     )}/units/${resolvedUnitSlug}/lessons`,
   });
 
+  const isUnitDescriptionEnabled =
+    unit.parent_programme_features.unit_description === true;
+
   let unitDescriptions: string = "";
-  if (unit.cycle === "1") {
+  if (!isUnitDescriptionEnabled) {
     const priorUnitTitle = unitOptionIfAvailable.connection_prior_unit_title
       ? unitOptionIfAvailable.connection_prior_unit_title
       : "-";

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -228,7 +228,7 @@ export async function buildUnit(
   });
 
   const isUnitDescriptionEnabled =
-    unit.parent_programme_features.unit_description === true;
+    unit.parent_programme_features?.unit_description === true;
 
   let unitDescriptions: string = "";
   if (!isUnitDescriptionEnabled) {

--- a/src/utils/curriculum/fixtures/curriculumunits-english-primary.fixture.ts
+++ b/src/utils/curriculum/fixtures/curriculumunits-english-primary.fixture.ts
@@ -138,6 +138,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -251,6 +252,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -371,6 +373,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -473,6 +476,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -587,6 +591,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -783,6 +788,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -917,6 +923,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1015,6 +1022,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1107,6 +1115,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1206,6 +1215,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1290,6 +1300,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1378,6 +1389,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1456,6 +1468,7 @@ export default {
         "In this unit, pupils retell the fairy tale 'Goldilocks and the Three Bears', learning to sequence events and use precise, descriptive vocabulary to enhance their storytelling. They practise techniques to tell the story with charisma, culminating in an expressive retelling to an audience.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1576,6 +1589,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1629,6 +1643,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -1929,6 +1944,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2079,6 +2095,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2162,6 +2179,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2241,6 +2259,7 @@ export default {
         "In this unit, pupils read, engage with, analyse and act from play scripts for the first time. They learn about conventions of scripts, they learn about directors and actors' roles within a cast and they learn to improvise at the end of the unit. Pupils also build their performance and oracy skills. ",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "3",
@@ -2341,6 +2360,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2482,6 +2502,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2623,6 +2644,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2721,6 +2743,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2813,6 +2836,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2945,6 +2969,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3065,6 +3090,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3163,6 +3189,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3261,6 +3288,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3343,6 +3371,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3485,6 +3514,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3586,6 +3616,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3681,6 +3712,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3753,6 +3785,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3935,6 +3968,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4037,6 +4071,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4218,6 +4253,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4290,6 +4326,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4389,6 +4426,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4500,6 +4538,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4622,6 +4661,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4693,6 +4733,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4784,6 +4825,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4912,6 +4954,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5102,6 +5145,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5191,6 +5235,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5301,6 +5346,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5386,6 +5432,7 @@ export default {
         "In this unit, pupils recap on the features of a debate and use the PEPs structure to deliver a speech. They learn what makes an effective debate motion and design their own. Pupils then prepare for and participate in a full debate, scoring their performances and reflecting on their speech delivery.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5471,6 +5518,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5570,6 +5618,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5684,6 +5733,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5762,6 +5812,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5847,6 +5898,7 @@ export default {
         "In this unit, pupils practise speaking and listening skills to turn take, agree and disagree respectfully and share opinions about the transition of leaving primary school to go to secondary school. Pupils develop their ability to listen without judgement to their peers' opinions and feelings.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5918,6 +5970,7 @@ export default {
         "In this unit, pupils develop speaking and listening skills by answering questions about themselves, giving and following instructions and retelling a story. They focus on clear speech, attentive listening, maintaining eye contact and responding in full sentences with relevant answers.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6023,6 +6076,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6122,6 +6176,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6205,6 +6260,7 @@ export default {
         "In this unit, pupils practise their speaking and listening skills in a performative way. Pupils learn the importance of speaking 'loud and proud' by standing up and using their voice for a range of purposes; show and tell, performing a poem, expressing an opinion.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6438,6 +6494,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6536,6 +6593,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6615,6 +6673,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6722,6 +6781,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6850,6 +6910,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6945,6 +7006,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7080,6 +7142,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7178,6 +7241,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7270,6 +7334,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7347,6 +7412,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7472,6 +7538,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7564,6 +7631,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7691,6 +7759,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7806,6 +7875,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7898,6 +7968,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8083,6 +8154,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8136,6 +8208,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -8365,6 +8438,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8456,6 +8530,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8534,6 +8609,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8605,6 +8681,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8686,6 +8763,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8799,6 +8877,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8901,6 +8980,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8973,6 +9053,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9071,6 +9152,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9171,6 +9253,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9268,6 +9351,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9366,6 +9450,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9457,6 +9542,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9556,6 +9642,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9633,6 +9720,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9753,6 +9841,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9831,6 +9920,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9932,6 +10022,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10019,6 +10110,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10155,6 +10247,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10287,6 +10380,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10444,6 +10538,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10541,6 +10636,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10717,6 +10813,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10826,6 +10923,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10899,6 +10997,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10994,6 +11093,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11079,6 +11179,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11238,6 +11339,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11391,6 +11493,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11521,6 +11624,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11618,6 +11722,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11752,6 +11857,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11829,6 +11935,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11928,6 +12035,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12020,6 +12128,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12073,6 +12182,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -12424,6 +12534,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12537,6 +12648,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12688,6 +12800,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12833,6 +12946,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12992,6 +13106,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13137,6 +13252,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13236,6 +13352,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13330,6 +13447,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13426,6 +13544,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13550,6 +13669,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "3",
@@ -13629,6 +13749,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13717,6 +13838,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13831,6 +13953,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13907,6 +14030,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -13999,6 +14123,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -14140,6 +14265,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -14224,6 +14350,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -14388,6 +14515,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -14486,6 +14614,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -14610,6 +14739,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "4",
@@ -14657,6 +14787,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -14925,6 +15056,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15024,6 +15156,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15164,6 +15297,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15310,6 +15444,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15398,6 +15533,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15576,6 +15712,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15688,6 +15825,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15783,6 +15921,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15867,6 +16006,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -15954,6 +16094,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16066,6 +16207,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16177,6 +16319,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16355,6 +16498,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16432,6 +16576,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16540,6 +16685,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "6",
@@ -16639,6 +16785,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16773,6 +16920,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -16890,6 +17038,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17029,6 +17178,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17140,6 +17290,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17211,6 +17362,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17328,6 +17480,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17467,6 +17620,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17604,6 +17758,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17736,6 +17891,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17850,6 +18006,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17927,6 +18084,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -17980,6 +18138,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -18155,6 +18314,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -18449,6 +18609,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -18533,6 +18694,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -18660,6 +18822,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -18776,6 +18939,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -18879,6 +19043,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -18949,6 +19114,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19026,6 +19192,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19109,6 +19276,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19180,6 +19348,7 @@ export default {
         "In this unit, pupils learn how to share their opinions and have conversations. They learn the difference between agreeing and disagreeing with others and how to do this respectfully and politely. Pupils also build on their listening skills, practising paying close attention to the person speaking.  ",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19293,6 +19462,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19433,6 +19603,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19573,6 +19744,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19722,6 +19894,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19854,6 +20027,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -19980,6 +20154,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20117,6 +20292,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20196,6 +20372,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20294,6 +20471,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20382,6 +20560,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20520,6 +20699,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20596,6 +20776,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20703,6 +20884,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -20808,6 +20990,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "4",
@@ -20929,6 +21112,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21030,6 +21214,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21102,6 +21287,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21182,6 +21368,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21294,6 +21481,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21406,6 +21594,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21500,6 +21689,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -21553,6 +21743,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -21888,6 +22079,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22022,6 +22214,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "5",
@@ -22163,6 +22356,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22265,6 +22459,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22349,6 +22544,7 @@ export default {
         "In this unit, pupils analyse abridged, rewritten versions of famous speeches made by Greta Thunberg, Emma Watson and Malala Yousafzai. They learn the techniques that the writer of each speech has used to ensure it meets its purpose.",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22463,6 +22659,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22636,6 +22833,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22779,6 +22977,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22873,6 +23072,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -22995,6 +23195,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -23086,6 +23287,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -23259,6 +23461,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -23351,6 +23554,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -23485,6 +23689,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -23557,6 +23762,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {

--- a/src/utils/curriculum/fixtures/curriculumunits-english-secondary.fixture.ts
+++ b/src/utils/curriculum/fixtures/curriculumunits-english-secondary.fixture.ts
@@ -141,6 +141,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -419,6 +420,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -545,6 +547,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -686,6 +689,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -916,6 +920,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1141,6 +1146,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1216,6 +1222,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "9",
@@ -1432,6 +1439,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1507,6 +1515,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "7",
@@ -1802,6 +1811,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1930,6 +1940,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2055,6 +2066,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2202,6 +2214,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2389,6 +2402,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2478,6 +2492,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "11",
@@ -2519,6 +2534,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -2715,6 +2731,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -3131,6 +3148,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3263,6 +3281,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3463,6 +3482,7 @@ export default {
         "In this unit, pupils read extracts from four novels from around the world, and use them to develop their narrative writing. In particular, pupils explore writers' use of structure. At the end of the unit, pupils consider their own use of paragraphs for effect and write an engaging narrative. ",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3692,6 +3712,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3744,6 +3765,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -4230,6 +4252,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -5065,6 +5088,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -5310,6 +5334,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5363,6 +5388,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -5526,6 +5552,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -5759,6 +5786,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6039,6 +6067,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6199,6 +6228,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6278,6 +6308,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "8",
@@ -6416,6 +6447,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6528,6 +6560,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6626,6 +6659,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6678,6 +6712,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -6955,6 +6990,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7002,6 +7038,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -7243,6 +7280,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "11",
@@ -7284,6 +7322,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -7620,6 +7659,7 @@ export default {
         "In this unit, pupils read and explore two famous Sherlock Holmes stories. They start by reading and analysing 'The Speckled Band' before using it as inspiration to write a newspaper article. They then read and analyse 'The Boscombe Valley Murder' before writing a comparison of the two stories. ",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "7",
@@ -7875,6 +7915,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8142,6 +8183,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8244,6 +8286,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8477,6 +8520,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8525,6 +8569,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -8793,6 +8838,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -9467,6 +9513,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9566,6 +9613,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "10",
@@ -9607,6 +9655,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -10283,6 +10332,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -10330,6 +10380,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -10803,6 +10854,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -11257,6 +11309,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -11365,6 +11418,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [],
       year: "10",
@@ -11406,6 +11460,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -11598,6 +11653,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -11797,6 +11853,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -12232,6 +12289,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12279,6 +12337,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [
         {
           state: "published",
@@ -12682,6 +12741,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -12873,6 +12933,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {

--- a/src/utils/curriculum/fixtures/curriculumunits-science-secondary.fixture.ts
+++ b/src/utils/curriculum/fixtures/curriculumunits-science-secondary.fixture.ts
@@ -64,6 +64,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -161,6 +162,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -262,6 +264,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -362,6 +365,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -440,6 +444,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -542,6 +547,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -645,6 +651,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -742,6 +749,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -819,6 +827,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -929,6 +938,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1039,6 +1049,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1141,6 +1152,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1235,6 +1247,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1323,6 +1336,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1410,6 +1424,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1495,6 +1510,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1588,6 +1604,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1681,6 +1698,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1787,6 +1805,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -1898,6 +1917,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2037,6 +2057,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2176,6 +2197,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2337,6 +2359,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2436,6 +2459,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2571,6 +2595,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2739,6 +2764,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2850,6 +2876,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -2961,6 +2988,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3093,6 +3121,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3218,6 +3247,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3364,6 +3394,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3510,6 +3541,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3612,6 +3644,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3715,6 +3748,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3803,6 +3837,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -3896,6 +3931,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4038,6 +4074,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4152,6 +4189,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4268,6 +4306,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4361,6 +4400,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4454,6 +4494,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4582,6 +4623,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4729,6 +4771,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -4875,6 +4918,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5021,6 +5065,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5137,6 +5182,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5251,6 +5297,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5330,6 +5377,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5409,6 +5457,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5504,6 +5553,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5592,6 +5642,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5660,6 +5711,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5719,6 +5771,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5833,6 +5886,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -5933,6 +5987,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6048,6 +6103,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6139,6 +6195,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6222,6 +6279,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6335,6 +6393,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6447,6 +6506,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6579,6 +6639,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6656,6 +6717,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6726,6 +6788,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6838,6 +6901,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -6957,6 +7021,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7075,6 +7140,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7160,6 +7226,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7274,6 +7341,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7379,6 +7447,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7478,6 +7547,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7563,6 +7633,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7646,6 +7717,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7751,6 +7823,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7850,6 +7923,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -7920,6 +7994,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8002,6 +8077,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8106,6 +8182,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8233,6 +8310,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8353,6 +8431,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8473,6 +8552,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8608,6 +8688,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8742,6 +8823,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8829,6 +8911,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -8916,6 +8999,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9020,6 +9104,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9148,6 +9233,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9261,6 +9347,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9333,6 +9420,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9461,6 +9549,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9586,6 +9675,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9691,6 +9781,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {
@@ -9812,6 +9903,7 @@ export default {
       description: "",
       cycle: "1",
       features: null,
+      parent_programme_features: {},
       unit_options: [],
       threads: [
         {


### PR DESCRIPTION
## Description
This PR changes from using `cycle` to determine wether to show unit-description/WTWN to using the parent programmes `features.unit_description`

## Issue(s)

Fixes `CUR-1351` & `CUR-1355`

## How to test

1. Go to https://deploy-preview-3332--oak-web-application.netlify.thenational.academy/teachers/curriculum/
2. Check that units that previously used prior/future units still display those in the unit modals
3. Check that units that previously used unit-description/WTWN still display those in the unit modals


