### PR TITLE
Subheadings not displaying correctly for years without subcategories

### DIFF
--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -151,17 +151,7 @@ export function getYearSubheadingText(
         // Try to find subject category in current year
         const subjectCategory = yearData[year]?.subjectCategories.find(
           (sc) => sc.id.toString() === id,
-        ) || {
-          // Fallback: Find any year with this subject category, then get its title
-          // This ensures categories show even in years without matching units
-          // Example: If "Vocabulary" is selected for Primary English, the 'Vocabulary' subheading will still be shown
-          // even if there are no Vocabularly units in that year
-          title: Object.values(yearData)
-            .find((y) =>
-              y?.subjectCategories?.find((sc) => sc.id.toString() === id),
-            )
-            ?.subjectCategories?.find((sc) => sc.id.toString() === id)?.title,
-        };
+        );
         return subjectCategory?.title;
       })
       .filter(Boolean);


### PR DESCRIPTION
## Description

Music year: 1957

- List of changes

## Issue(s)

Fixes `CUR-1329`

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
