### PR TITLE
Background squiggle in curriculum lander

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
@@ -8,6 +8,7 @@ import {
   OakSecondaryLink,
   OakMaxWidth,
   OakBox,
+  OakIcon,
 } from "@oaknational/oak-components";
 
 import Illustration from "@/components/SharedComponents/Illustration";
@@ -19,12 +20,39 @@ import useAnalytics from "@/context/Analytics/useAnalytics";
 type CurriculumDownloadTabProps = {
   curriculumPhaseOptions: SubjectPhasePickerData;
 };
+
 const CurriculumTab: FC<CurriculumDownloadTabProps> = ({
   curriculumPhaseOptions,
 }) => {
   const { track } = useAnalytics();
   return (
-    <OakBox $background={"mint"} $pv="inner-padding-xl" $ph={"inner-padding-m"}>
+    <OakBox
+      $background={"mint"}
+      $pv="inner-padding-xl"
+      $ph={"inner-padding-m"}
+      $position={"relative"}
+    >
+      {/* scroll wrapper */}
+      <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+        {/* force this positioning */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 18,
+            right: "calc(-40rem + 50vw - 200px)",
+            width: 529,
+            height: 420,
+          }}
+        >
+          <OakIcon
+            $display={["none", "none", "block"]}
+            iconName={"looping-line-5"}
+            $colorFilter={"mint30"}
+            $width={"100%"}
+            $height={"100%"}
+          />
+        </div>
+      </div>
       <OakMaxWidth $pv={"inner-padding-xl"}>
         <OakFlex>
           <OakFlex

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -7,8 +7,29 @@ exports[`CurriculumTab renders 1`] = `
       data-overlay-container="true"
     >
       <div
-        class="sc-fqkvVR iKBTzE"
+        class="sc-fqkvVR gZEYWU"
       >
+        <div
+          style="position: absolute; inset: 0; overflow: hidden;"
+        >
+          <div
+            style="position: absolute; bottom: 18px; right: calc(-40rem + 50vw - 200px); width: 529px; height: 420px;"
+          >
+            <div
+              class="sc-fqkvVR gdtuvF"
+            >
+              <img
+                alt="looping-line-5"
+                class="sc-dcJsrY koGnIf"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg"
+                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+              />
+            </div>
+          </div>
+        </div>
         <div
           class="sc-fqkvVR sc-gsFSXq sc-cwHptR itRfeb ibSZJr"
         >


### PR DESCRIPTION
## Description

- Updated design to system to include new colour filter tokens and squiggle icon
- Added squiggle icon behind the teacher illustration
- Updated snapshots

## Issue(s)

Fixes `CUR-1163`

## How to test

1. Go to https://deploy-preview-3340--oak-web-application.netlify.thenational.academy/curriculum
2. You should see that the illustration of the teacher writing on the whiteboard now has a squiggly line behind it

## Screenshots
<img width="1752" alt="Screenshot 2025-04-03 at 12 20 26" src="https://github.com/user-attachments/assets/2001dd7f-baa3-4ad5-b5ba-0356ba3d0f4d" />

<img width="1591" alt="Screenshot 2025-04-03 at 12 20 19" src="https://github.com/user-attachments/assets/7d9d8ef1-0031-45a0-9e5a-e9c70140e34a" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [ ] Does this PR update a package with a breaking change
