### PR TITLE
`pointer-events: none` to fix text selection issue

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.tsx
@@ -33,7 +33,14 @@ const CurriculumTab: FC<CurriculumDownloadTabProps> = ({
       $position={"relative"}
     >
       {/* scroll wrapper */}
-      <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          overflow: "hidden",
+          pointerEvents: "none",
+        }}
+      >
         {/* force this positioning */}
         <div
           style={{

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`CurriculumTab renders 1`] = `
         class="sc-fqkvVR gZEYWU"
       >
         <div
-          style="position: absolute; inset: 0; overflow: hidden;"
+          style="position: absolute; inset: 0; overflow: hidden; pointer-events: none;"
         >
           <div
             style="position: absolute; bottom: 18px; right: calc(-40rem + 50vw - 200px); width: 529px; height: 420px;"


### PR DESCRIPTION
## Description
Fixes text selection issue on curric lander.

## How to test

1. Go to https://deploy-preview-3341--oak-web-application.netlify.thenational.academy/curriculum
2. Check text selection and picker works as expected.
