### PR TITLE
Fix mobile filtering closing bug

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
@@ -8,7 +8,6 @@ import { OakModalNew } from "../OakComponentsKitchen/OakModalNew";
 
 import { usePrevious } from "@/hooks/usePrevious";
 import { CurriculumUnitsTrackingData } from "@/pages-helpers/curriculum/docx/tab-helpers";
-import { CurriculumFilters } from "@/utils/curriculum/types";
 
 export type CurricVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {
@@ -33,24 +32,16 @@ export default function CurricVisualiserFiltersMobile({
     return filters;
   });
 
-  const [tempFilters, setTempFilters] = useState<CurriculumFilters>(filters);
-
   // Only change `initialFilterState` when opening the modal
   const prevMobileThreadModalOpen = usePrevious(mobileThreadModalOpen);
   useEffect(() => {
     if (mobileThreadModalOpen && !prevMobileThreadModalOpen) {
       setInitialFilterState(filters);
-      setTempFilters(filters);
     }
   }, [filters, mobileThreadModalOpen, prevMobileThreadModalOpen]);
 
   function handleMobileThreadModal(): void {
     setMobileThreadModalOpen(!mobileThreadModalOpen);
-  }
-
-  function handleApply() {
-    onChangeFilters(tempFilters);
-    setMobileThreadModalOpen(false);
   }
 
   function onClose() {
@@ -66,10 +57,10 @@ export default function CurricVisualiserFiltersMobile({
         title={<OakBox $font={"heading-6"}>Filter and highlight</OakBox>}
         content={
           <CurricMobileFilterModal
-            filters={tempFilters}
+            filters={filters}
             selectedYear={selectedYear}
             onSelectYear={onSelectYear}
-            onChangeFilters={setTempFilters}
+            onChangeFilters={onChangeFilters}
             data={data}
             slugs={slugs}
           />
@@ -77,7 +68,7 @@ export default function CurricVisualiserFiltersMobile({
         footer={
           <OakPrimaryButton
             data-testid="mobile-done-thread-modal-button"
-            onClick={handleApply}
+            onClick={() => setMobileThreadModalOpen(false)}
             width={"100%"}
           >
             Apply

--- a/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFiltersMobile/index.tsx
@@ -8,6 +8,7 @@ import { OakModalNew } from "../OakComponentsKitchen/OakModalNew";
 
 import { usePrevious } from "@/hooks/usePrevious";
 import { CurriculumUnitsTrackingData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { CurriculumFilters } from "@/utils/curriculum/types";
 
 export type CurricVisualiserFiltersMobileProps =
   CurricVisualiserFiltersProps & {
@@ -32,16 +33,24 @@ export default function CurricVisualiserFiltersMobile({
     return filters;
   });
 
+  const [tempFilters, setTempFilters] = useState<CurriculumFilters>(filters);
+
   // Only change `initialFilterState` when opening the modal
   const prevMobileThreadModalOpen = usePrevious(mobileThreadModalOpen);
   useEffect(() => {
     if (mobileThreadModalOpen && !prevMobileThreadModalOpen) {
       setInitialFilterState(filters);
+      setTempFilters(filters);
     }
   }, [filters, mobileThreadModalOpen, prevMobileThreadModalOpen]);
 
   function handleMobileThreadModal(): void {
     setMobileThreadModalOpen(!mobileThreadModalOpen);
+  }
+
+  function handleApply() {
+    onChangeFilters(tempFilters);
+    setMobileThreadModalOpen(false);
   }
 
   function onClose() {
@@ -57,10 +66,10 @@ export default function CurricVisualiserFiltersMobile({
         title={<OakBox $font={"heading-6"}>Filter and highlight</OakBox>}
         content={
           <CurricMobileFilterModal
-            filters={filters}
+            filters={tempFilters}
             selectedYear={selectedYear}
             onSelectYear={onSelectYear}
-            onChangeFilters={onChangeFilters}
+            onChangeFilters={setTempFilters}
             data={data}
             slugs={slugs}
           />
@@ -68,7 +77,7 @@ export default function CurricVisualiserFiltersMobile({
         footer={
           <OakPrimaryButton
             data-testid="mobile-done-thread-modal-button"
-            onClick={() => setMobileThreadModalOpen(false)}
+            onClick={handleApply}
             width={"100%"}
           >
             Apply

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -1,6 +1,5 @@
 import { useSearchParams } from "next/navigation";
 import { renderHook } from "@testing-library/react";
-import { useRouter } from "next/router";
 
 import {
   buildTextDescribingFilter,
@@ -828,8 +827,9 @@ describe("useFilters", () => {
 
     it("updating state", () => {
       (isCurricRoutingEnabled as jest.Mock).mockReturnValue(true);
-      const replaceMock = jest.fn();
-      (useRouter as jest.Mock).mockReturnValue({ replace: replaceMock });
+      const replaceStateMock = jest.fn();
+      const originalReplaceState = window.history.replaceState;
+      window.history.replaceState = replaceStateMock;
 
       const defaultFilter = createFilter();
       const updateFilterValue = createFilter({
@@ -842,11 +842,13 @@ describe("useFilters", () => {
       const [, setFilters] = result.current;
       setFilters(updateFilterValue);
 
-      expect(replaceMock).toHaveBeenCalledWith(
+      expect(replaceStateMock).toHaveBeenCalledWith(
+        {},
+        "",
         "/?tiers=foundation",
-        undefined,
-        { shallow: true },
       );
+
+      window.history.replaceState = originalReplaceState;
 
       rerender();
       const [filters] = result.current;

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -1,6 +1,5 @@
 import { ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
-import { useRouter } from "next/router";
-import { useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useState, useCallback } from "react";
 import { isEqual } from "lodash";
 
 import { findFirstMatchingFeatures } from "./features";
@@ -141,7 +140,6 @@ export function mergeInFilterParams(
 export function useFilters(
   defaultFilter: CurriculumFilters,
 ): [CurriculumFilters, (newFilters: CurriculumFilters) => void] {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const [filters, setLocalFilters] = useState<CurriculumFilters>(defaultFilter);
@@ -153,18 +151,22 @@ export function useFilters(
     }
   }, [searchParams, defaultFilter]);
 
-  const setFilters = (newFilters: CurriculumFilters) => {
-    if (isCurricRoutingEnabled()) {
-      const url =
-        location.pathname +
-        "?" +
-        new URLSearchParams(
-          Object.entries(filtersToQuery(newFilters, defaultFilter)),
-        ).toString();
-      router.replace(url, undefined, { shallow: true });
-    }
-    setLocalFilters(newFilters);
-  };
+  const setFilters = useCallback(
+    (newFilters: CurriculumFilters) => {
+      if (isCurricRoutingEnabled()) {
+        const url =
+          location.pathname +
+          "?" +
+          new URLSearchParams(
+            Object.entries(filtersToQuery(newFilters, defaultFilter)),
+          ).toString();
+        // Use replaceState directly to avoid triggering router events
+        window.history.replaceState({}, "", url);
+      }
+      setLocalFilters(newFilters);
+    },
+    [defaultFilter],
+  );
 
   return [filters, setFilters];
 }

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -160,14 +160,12 @@ export function useFilters(
           new URLSearchParams(
             Object.entries(filtersToQuery(newFilters, defaultFilter)),
           ).toString();
-        // Use replaceState directly to avoid triggering router events
         window.history.replaceState({}, "", url);
       }
       setLocalFilters(newFilters);
     },
     [defaultFilter],
   );
-
   return [filters, setFilters];
 }
 


### PR DESCRIPTION
## Description

Music year: 2010

- Fix mobile filtering closing bug

## Issue(s)

Fixes #[1371](https://www.notion.so/oaknationalacademy/Mobile-filtering-closing-after-each-selection-1ca26cc4e1b180beaf37fedd33cf2c44?pvs=4)

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/english-secondary-edexcel
2. Switch to responsive mobile view in Chrome
3. Click the mobile filter
4. Select options within the filter
5. The filter should only close when you click apply

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
