### PR TITLE
fix: set search results pages to noindex

### DIFF
--- a/.github/workflows/post_deployment_actions.yml
+++ b/.github/workflows/post_deployment_actions.yml
@@ -71,7 +71,7 @@ jobs:
     # Filter out storybook deployments and temporarily Netlify deployments
     if: ${{ (github.event.deployment_status.state == 'success') && !startsWith(github.event.deployment_status.environment, 'storybook')}}
     name: Pa11y
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -51,6 +51,9 @@ const config = {
       "CF-Access-Client-Secret": CfAccessClientSecret,
     },
     concurrency: 10,
+    chromeLaunchConfig: {
+      executablePath: "/usr/bin/google-chrome",
+    },
   },
   urls: [],
   // log: {

--- a/src/__tests__/pages/teachers/search.test.tsx
+++ b/src/__tests__/pages/teachers/search.test.tsx
@@ -41,7 +41,7 @@ describe("pages/teachers/search.tsx", () => {
       ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
       ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
       canonical: "NEXT_PUBLIC_SEO_APP_URL",
-      robots: "index,follow",
+      robots: "noindex,follow",
     });
   });
 

--- a/src/pages/teachers/search.tsx
+++ b/src/pages/teachers/search.tsx
@@ -77,6 +77,7 @@ const SearchPage: NextPage<SearchPageProps> = (props) => {
             title: `Search for Free Teaching Resources${paginationTitle}`,
             description: "Search for Free Teaching Resources",
           }),
+          noIndex: true,
         }}
         $background="grey20"
       >


### PR DESCRIPTION
## Description

Music year: 1953

- Changes SEO metadata to noindex on search results pages

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-3347--oak-web-application.netlify.thenational.academy
2. Search using a keyword
3. Check the dev tools elements and you should see `<meta name="robots" content="noindex,follow">` in the head on the search results page

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
