### PR TITLE
Change to include core/gcse in year filter

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
@@ -7,7 +7,10 @@ import {
 import { isEqual } from "lodash";
 import { useId } from "react";
 
-import { getYearGroupTitle } from "@/utils/curriculum/formatting";
+import {
+  getPathwaySuffix,
+  getYearGroupTitle,
+} from "@/utils/curriculum/formatting";
 import { CurriculumFilters } from "@/utils/curriculum/types";
 import type { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
@@ -96,20 +99,26 @@ export function CurricFiltersYears({
           displayValue="All"
           data-testid={"all-years-radio"}
         />
-        {yearOptions.map((yearOption, index) => (
-          <OakRadioAsButton
-            key={`${yearOption.year}-${yearOption.pathway}`}
-            value={String(index)}
-            displayValue={getYearGroupTitle(
-              yearData,
-              yearOption.year,
-              shouldDisplayCorePathway && ["10", "11"].includes(yearOption.year)
-                ? `(${yearOption.pathway})`
-                : undefined,
-            )}
-            data-testid={"year-radio"}
-          />
-        ))}
+        {yearOptions.map((yearOption, index) => {
+          const pathwaySuffix = shouldDisplayCorePathway
+            ? getPathwaySuffix(yearOption.year, yearOption.pathway)
+            : undefined;
+          const pathwaySuffixStr = pathwaySuffix
+            ? `(${pathwaySuffix})`
+            : undefined;
+          return (
+            <OakRadioAsButton
+              key={`${yearOption.year}-${yearOption.pathway}`}
+              value={String(index)}
+              displayValue={getYearGroupTitle(
+                yearData,
+                yearOption.year,
+                pathwaySuffixStr,
+              )}
+              data-testid={"year-radio"}
+            />
+          );
+        })}
       </OakRadioGroup>
     </OakBox>
   );

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -10,6 +10,7 @@ import {
   getYearSubheadingText,
   subjectTitleWithCase,
   getPhaseFromCategory,
+  getPathwaySuffix,
 } from "./formatting";
 
 import { createYearData } from "@/fixtures/curriculum/yearData";
@@ -459,5 +460,20 @@ describe("getPhaseFromCategory", () => {
   it("handles default as primary ", () => {
     expect(getPhaseFromCategory("EYFS")).toBe("primary");
     expect(getPhaseFromCategory("Therapies")).toBe("primary");
+  });
+});
+
+describe("getPathwaySuffix", () => {
+  it("should display nothing for non-ks4 years", () => {
+    for (let year = 1; year < 10; year++) {
+      expect(getPathwaySuffix(`${year}`, "core")).toEqual(undefined);
+      expect(getPathwaySuffix(`${year}`, "gcse")).toEqual(undefined);
+    }
+  });
+  it("should display nothing for non-ks4 years", () => {
+    for (const year of ["10", "11"]) {
+      expect(getPathwaySuffix(`${year}`, "core")).toEqual("Core");
+      expect(getPathwaySuffix(`${year}`, "gcse")).toEqual("GCSE");
+    }
   });
 });

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -220,3 +220,13 @@ export function getPhaseFromCategory(input: DownloadCategory) {
   }
   return "primary";
 }
+
+export function getPathwaySuffix(year: string, pathway?: string) {
+  if (["10", "11"].includes(year) && pathway) {
+    if (pathway === "core") {
+      return "Core";
+    } else {
+      return "GCSE";
+    }
+  }
+}


### PR DESCRIPTION
## Description
Changes year filter to include Core/GCSE years in filter

## Issue(s)

Fixes `CUR-1319`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check non-core pathways have additional year filters for core/GCSE

## Screenshots
<img width="309" alt="Screenshot 2025-04-10 at 13 44 09" src="https://github.com/user-attachments/assets/ba9acc1f-fb56-4872-9fc3-48336ab2566d" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
