### PR TITLE
Added subheading for core/gsce to years in curric visualiser

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
@@ -14,6 +14,7 @@ import {
 import { CurriculumFilters } from "@/utils/curriculum/types";
 import type { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
+import { getShouldDisplayCorePathway } from "@/utils/curriculum/pathways";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 
 export type CurricFiltersYearsProps = {
@@ -29,14 +30,11 @@ export function CurricFiltersYears({
   onChangeFilters,
   data,
   ks4Options,
-  slugs,
 }: CurricFiltersYearsProps) {
   const id = useId();
   const { yearData } = data;
 
-  const hasCorePathway = !!ks4Options?.find((opt) => opt.slug === "core");
-  const shouldDisplayCorePathway =
-    hasCorePathway && slugs.ks4OptionSlug !== "core";
+  const shouldDisplayCorePathway = getShouldDisplayCorePathway(ks4Options);
   const yearOptions = data.yearOptions.map<{ year: string; pathway?: string }>(
     (year) => {
       if (shouldDisplayCorePathway) {

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/utils/curriculum/types";
 import { CurriculumUnit } from "@/node-lib/curriculum-api-2023";
 import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
+import { getShouldDisplayCorePathway } from "@/utils/curriculum/pathways";
 
 type CurriculumVisualiserProps = {
   unitData: Unit | null;
@@ -211,6 +212,8 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
       return units.length > 0;
     });
 
+  const shouldDisplayCorePathway = getShouldDisplayCorePathway(ks4Options);
+
   return (
     <OakBox id="content" data-testid="curriculum-visualiser">
       {unitsByYearSelector.flatMap((data, index) => {
@@ -233,7 +236,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
           yearData,
           year,
           filters,
-          type,
+          shouldDisplayCorePathway ? type : null,
         );
 
         return (

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -148,7 +148,10 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
     setCurrentUnitLessons([]);
   };
 
-  const yearTypes: ("core" | "non_core")[] = [];
+  const yearTypes: ("core" | "non_core" | "all")[] = [];
+  if (!ks4Options?.find((opt) => opt.slug === "core")) {
+    yearTypes.push("all");
+  }
   if (!ks4OptionSlug || ks4Options?.find((opt) => opt.slug === "core")) {
     yearTypes.push("core");
   }

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -357,6 +357,11 @@ describe("getYearSubheadingText", () => {
       subjectCategories: [subCat1],
       tiers: [tier1],
     }),
+    "10": createYearData({
+      childSubjects: [childSubject1],
+      subjectCategories: [subCat1],
+      tiers: [tier1],
+    }),
   };
 
   it("all year", () => {
@@ -426,6 +431,53 @@ describe("getYearSubheadingText", () => {
       null,
     );
     expect(result).toEqual("SUB_CAT_1, CHILD_SUBJECT_1, TIER_1");
+  });
+
+  it("all", () => {
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        subjectCategories: [String(subCat1.id)],
+        childSubjects: [childSubject1.subject_slug],
+        tiers: [tier1.tier_slug],
+      }),
+      null,
+    );
+    expect(result).toEqual("SUB_CAT_1, CHILD_SUBJECT_1, TIER_1");
+  });
+
+  describe("core/non-core", () => {
+    it("core", () => {
+      const result = getYearSubheadingText(
+        data,
+        "10",
+        createFilter({
+          years: ["10"],
+          subjectCategories: [String(subCat1.id)],
+          childSubjects: [childSubject1.subject_slug],
+          tiers: [tier1.tier_slug],
+        }),
+        "core",
+      );
+      expect(result).toEqual("Core, CHILD_SUBJECT_1, TIER_1");
+    });
+
+    it("non-core", () => {
+      const result = getYearSubheadingText(
+        data,
+        "10",
+        createFilter({
+          years: ["10"],
+          subjectCategories: [String(subCat1.id)],
+          childSubjects: [childSubject1.subject_slug],
+          tiers: [tier1.tier_slug],
+        }),
+        "non_core",
+      );
+      expect(result).toEqual("GCSE, CHILD_SUBJECT_1, TIER_1");
+    });
   });
 });
 

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -133,7 +133,7 @@ export function getYearSubheadingText(
     CurriculumFilters,
     "childSubjects" | "subjectCategories" | "tiers"
   >,
-  type: "core" | "non_core" | null,
+  type: "core" | "non_core" | "all" | null,
 ): string | null {
   // Don't show subheading for "All" years view
   if (year === "all") {

--- a/src/utils/curriculum/pathways.test.ts
+++ b/src/utils/curriculum/pathways.test.ts
@@ -1,0 +1,27 @@
+import { getShouldDisplayCorePathway } from "./pathways";
+
+describe("getShouldDisplayCorePathway", () => {
+  it("has core slug", () => {
+    const out = getShouldDisplayCorePathway([
+      {
+        slug: "core",
+        title: "Core",
+      },
+      {
+        slug: "gcse",
+        title: "GCSE",
+      },
+    ]);
+    expect(out).toEqual(true);
+  });
+
+  it("does not have core slug", () => {
+    const out = getShouldDisplayCorePathway([
+      {
+        slug: "gcse",
+        title: "GCSE",
+      },
+    ]);
+    expect(out).toEqual(false);
+  });
+});

--- a/src/utils/curriculum/pathways.ts
+++ b/src/utils/curriculum/pathways.ts
@@ -1,0 +1,19 @@
+import { CurriculumSelectionSlugs } from "./slugs";
+
+import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
+
+export function getShouldDisplayCorePathway(
+  ks4Options: SubjectPhasePickerData["subjects"][number]["ks4_options"],
+) {
+  const hasCorePathway = !!ks4Options?.find((opt) => opt.slug === "core");
+  return hasCorePathway;
+}
+
+export function getShouldDisplayGCSEPathway(
+  slugs: CurriculumSelectionSlugs,
+  ks4Options: SubjectPhasePickerData["subjects"][number]["ks4_options"],
+) {
+  return (
+    getShouldDisplayCorePathway(ks4Options) && slugs.ks4OptionSlug !== "core"
+  );
+}

--- a/src/utils/curriculum/pathways.ts
+++ b/src/utils/curriculum/pathways.ts
@@ -1,5 +1,3 @@
-import { CurriculumSelectionSlugs } from "./slugs";
-
 import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
 
 export function getShouldDisplayCorePathway(
@@ -7,13 +5,4 @@ export function getShouldDisplayCorePathway(
 ) {
   const hasCorePathway = !!ks4Options?.find((opt) => opt.slug === "core");
   return hasCorePathway;
-}
-
-export function getShouldDisplayGCSEPathway(
-  slugs: CurriculumSelectionSlugs,
-  ks4Options: SubjectPhasePickerData["subjects"][number]["ks4_options"],
-) {
-  return (
-    getShouldDisplayCorePathway(ks4Options) && slugs.ks4OptionSlug !== "core"
-  );
 }


### PR DESCRIPTION
## Description
Added subheading for core/gsce to years in curric visualiser.

Note: This is just the missing tests, the work was completed in the main branch as a part of the initial spike.

## Issue(s)

Fixes `CUR-1322`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check non-core pathways have Core/GCSE sub-heading

## Screenshots
<img width="967" alt="Screenshot 2025-04-10 at 13 54 42" src="https://github.com/user-attachments/assets/abc002d1-f1f0-40df-9010-d77c22927ff5" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
