### PR TITLE
Fix bottom heading margin `<CurriculumHeader/>` with medium width viewport

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -93,9 +93,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   ];
 
   return (
-    <OakBox
-      $mb={["space-between-none", "space-between-none", "space-between-l"]}
-    >
+    <OakBox $mb={["space-between-none", "space-between-l", "space-between-l"]}>
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
       <OakFlex $background={color1} $pv="inner-padding-l">
         <OakBox


### PR DESCRIPTION
## Description
Fixes bottom heading margin `<CurriculumHeader/> with medium width viewport

## Issue(s)
hotfix

## How to test

1. Go to https://deploy-preview-3355--oak-web-application.netlify.thenational.academy/teachers/curriculum/computing-secondary-core/units
2. Verify spacing is correct with a medium width viewport

## Screenshots
Before

<img width="322" alt="Screenshot 2025-04-10 at 17 37 52" src="https://github.com/user-attachments/assets/71dd5b24-9775-45d2-bd9b-5a822dfcbef6" />

After

How it used to look (de
<img width="322" alt="Screenshot 2025-04-10 at 17 38 14" src="https://github.com/user-attachments/assets/43b3e1dd-e29a-4425-81eb-b193550d3c39" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
