### PR TITLE
Try to add `Netlify-Vary` to 307 redirect fix netlify cache issue

### DIFF
--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -252,7 +252,9 @@ export default async function handler(
     const newSlugs = new URLSearchParams(slugOb);
 
     const redirectUrl = `/api/curriculum-downloads/?${newSlugs}`;
-    res.redirect(307, redirectUrl);
+
+    // Netlify-Vary is a hack to hopefully resolve
+    res.setHeader("Netlify-Vary", "query").redirect(307, redirectUrl);
     return;
   }
 


### PR DESCRIPTION
## Description
We currently have a caching issue with Netlify caching the first response form the downloads.

## Issue(s)
hotfix

## How to test

1. Go to https://deploy-preview-3357--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Regression test curric downloads
