### PR TITLE
Error thrown when switching between primary/secondary science

### DIFF
--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -177,14 +177,16 @@ export function getFilterData(
   const subjectCategories = new Map<number, SubjectCategory>();
   const tiers = new Map<string, Tier>();
   years.forEach((year) => {
-    const obj = yearData[year]!;
-    obj.childSubjects.forEach((childSubject) =>
-      childSubjects.set(childSubject.subject_slug, childSubject),
-    );
-    obj.tiers.forEach((tier) => tiers.set(tier.tier_slug, tier));
-    obj.subjectCategories.forEach((subjectCategory) =>
-      subjectCategories.set(subjectCategory.id, subjectCategory),
-    );
+    const obj = yearData[year];
+    if (obj) {
+      obj.childSubjects.forEach((childSubject) =>
+        childSubjects.set(childSubject.subject_slug, childSubject),
+      );
+      obj.tiers.forEach((tier) => tiers.set(tier.tier_slug, tier));
+      obj.subjectCategories.forEach((subjectCategory) =>
+        subjectCategories.set(subjectCategory.id, subjectCategory),
+      );
+    }
   });
 
   const childSubjectsArray = [...childSubjects.values()].toSorted(


### PR DESCRIPTION
## Description
Error thrown when switching between primary/secondary science

The actual issue is a race condition between, filters being `['1', '2', '3', ...]` and `yearData` containing years 6, 7, 8... for a cycle. This should solve the issue while we work out the race condition though. 

## Issue(s)

Fixes `CUR-1383`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Regression test filtering between different sequences  


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
