### PR TITLE
Add Computer Science to year group subheading

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -12,7 +12,6 @@ import AnchorTarget from "@/components/SharedComponents/AnchorTarget";
 import UnitModal from "@/components/CurriculumComponents/UnitModal/UnitModal";
 import UnitsTabSidebar from "@/components/CurriculumComponents/UnitsTabSidebar";
 import {
-  getSuffixFromFeatures,
   getYearGroupTitle,
   getYearSubheadingText,
 } from "@/utils/curriculum/formatting";
@@ -42,8 +41,6 @@ type CurriculumVisualiserProps = {
   threadOptions: Thread[];
   ks4Options: SubjectPhasePickerData["subjects"][number]["ks4_options"];
 };
-
-// Function component
 
 const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
   unitData,
@@ -223,17 +220,14 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
 
         const actions = units[0]?.actions;
 
-        const yearTitle = getYearGroupTitle(
-          yearData,
-          year,
-          getSuffixFromFeatures(actions),
-        );
+        const yearTitle = getYearGroupTitle(yearData, year, undefined);
 
         const yearSubheadingText = getYearSubheadingText(
           yearData,
           year,
           filters,
           type,
+          actions,
         );
 
         return (

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -157,8 +157,6 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
     }
   }
 
-  console.log({ yearTypes });
-
   const yearSelectors = yearTypes.flatMap((type) => {
     return Object.keys(yearData)
       .map((year) => ({ year, type }))
@@ -236,9 +234,8 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
           yearData,
           year,
           filters,
-          type,
-          actions,
           shouldDisplayCorePathway ? type : null,
+          actions,
         );
 
         return (

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -238,7 +238,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
           filters,
           type,
           actions,
-          shouldDisplayCorePathway ? type : null
+          shouldDisplayCorePathway ? type : null,
         );
 
         return (

--- a/src/pages-helpers/curriculum/docx/builder/8_units/8_units.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/8_units.ts
@@ -26,10 +26,7 @@ import {
 
 import { buildUnit } from "./unit_detail";
 
-import {
-  getSuffixFromFeatures,
-  getYearGroupTitle,
-} from "@/utils/curriculum/formatting";
+import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import { sortYears } from "@/utils/curriculum/sorting";
 import { Unit } from "@/utils/curriculum/types";
 
@@ -503,9 +500,7 @@ async function buildYear(
     }
   }
 
-  const yearTitleSuffix = [getSuffixFromFeatures(firstUnit?.actions), "units"]
-    .filter(Boolean)
-    .join(" ");
+  const yearTitleSuffix = "units";
   const yearTitle = getYearGroupTitle(
     formattedData.yearData,
     year,

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -2,7 +2,6 @@ import {
   getYearGroupTitle,
   getPhaseText,
   getShortPhaseText,
-  getSuffixFromFeatures,
   buildPageTitle,
   formatKeystagesShort,
   joinWords,
@@ -239,10 +238,6 @@ describe("getSuffixFromFeatures", () => {
   //     }),
   //   ).toBe("(test)");
   // });
-
-  it("undefined if override not present", () => {
-    expect(getSuffixFromFeatures(undefined)).toBe(undefined);
-  });
 });
 
 describe("buildPageTitle", () => {
@@ -372,6 +367,51 @@ describe("getYearSubheadingText", () => {
       null,
     );
     expect(result).toEqual(null);
+  });
+
+  it("displays subject from programme_field_overrides when it exists", () => {
+    const actions = {
+      programme_field_overrides: {
+        subject: "Overridden Subject",
+      },
+    };
+
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+      }),
+      null,
+      actions,
+    );
+
+    expect(result).toEqual("Overridden Subject");
+  });
+
+  it("combines programme_field_overrides subject with other filters", () => {
+    const actions = {
+      programme_field_overrides: {
+        subject: "Overridden Subject",
+      },
+    };
+
+    const result = getYearSubheadingText(
+      data,
+      "7",
+      createFilter({
+        years: ["7"],
+        subjectCategories: [String(subCat1.id)],
+        childSubjects: [childSubject1.subject_slug],
+        tiers: [tier1.tier_slug],
+      }),
+      null,
+      actions,
+    );
+
+    expect(result).toEqual(
+      "Overridden Subject, SUB_CAT_1, CHILD_SUBJECT_1, TIER_1",
+    );
   });
 
   it("subjectCategories", () => {

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -125,7 +125,7 @@ export function getYearSubheadingText(
     "childSubjects" | "subjectCategories" | "tiers"
   >,
   type: "core" | "non_core" | "all" | null,
-  actions?: Actions
+  actions?: Actions,
 ): string | null {
   // Don't show subheading for "All" years view
   if (year === "all") {

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -83,15 +83,6 @@ export function formatKeystagesShort(keyStages: string[]) {
   return keyStagesItems.length > 0 ? `KS${keyStagesItems.join("-")}` : ``;
 }
 
-export function getSuffixFromFeatures(_features: Actions): undefined {
-  _features;
-  // TODO: Remove me from programme_field_overrides
-  // if (features?.programme_field_overrides?.subject) {
-  //   return `(${features.programme_field_overrides?.subject})`;
-  // }
-  return;
-}
-
 export function subjectTitleWithCase(title: string) {
   if (
     ["english", "french", "spanish", "german"].includes(title.toLowerCase())
@@ -134,6 +125,7 @@ export function getYearSubheadingText(
     "childSubjects" | "subjectCategories" | "tiers"
   >,
   type: "core" | "non_core" | null,
+  actions?: Actions,
 ): string | null {
   // Don't show subheading for "All" years view
   if (year === "all") {
@@ -141,6 +133,12 @@ export function getYearSubheadingText(
   }
 
   const parts: string[] = [];
+
+  // Add subject from programme_field_overrides if it exists
+  if (actions?.programme_field_overrides?.subject) {
+    parts.push(actions.programme_field_overrides.subject);
+  }
+
   const isKs4Year = keystageFromYear(year) === "ks4";
 
   if (keystageFromYear(year) === "ks4") {


### PR DESCRIPTION
## Description

Music year: 2008

- Moved the subject override from year group title to subheading
- Removed getSuffixFromFeatures function

@HelenHarlow is it okay if there's a comma between the subject title and GCSE in the subheading? (Refer to screenshot below)

## Issue(s)

Fixes #[1320](https://www.notion.so/oaknationalacademy/Change-computer-science-exception-for-new-style-1b326cc4e1b180509c91d2b8f47b3e90?pvs=4)

## How to test

1. Go to https://deploy-preview-3360--oak-web-application.netlify.thenational.academy/teachers/curriculum/computing-secondary-aqa/units
2. Navigate to Year 10 & 11
3. Refer to the below screenshot for what you should see

## Screenshots

How it used to look:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/7237f29e-15f5-4855-bedc-1b0b2cc3cb9f" />

How it should now look:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/3bf00785-40e7-4405-9a99-5cc717a7e79c" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
