### PR TITLE
Disable curriculum downloads while waiting on a fix from netlify

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -25,6 +25,7 @@ import {
   fetchSubjectPhasePickerData,
   formatCurriculumUnitsData,
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { DISABLE_DOWNLOADS } from "@/utils/curriculum/constants";
 
 const render = renderWithProviders();
 
@@ -703,27 +704,29 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
       expect(queryAllByTestId("unit-cards")[0]).toBeInTheDocument();
     });
 
-    it("renders the Curriculum Downloads Tab (with prerelease)", () => {
-      mockPrerelease("curriculum.downloads");
-      (useRouter as jest.Mock).mockReturnValue({
-        query: { tab: "downloads" },
-        isPreview: false,
-        pathname: "/teachers-2023/curriculum/english-secondary-aqa/downloads",
+    if (!DISABLE_DOWNLOADS) {
+      it("renders the Curriculum Downloads Tab (with prerelease)", () => {
+        mockPrerelease("curriculum.downloads");
+        (useRouter as jest.Mock).mockReturnValue({
+          query: { tab: "downloads" },
+          isPreview: false,
+          pathname: "/teachers-2023/curriculum/english-secondary-aqa/downloads",
+        });
+        const slugs = parseSubjectPhaseSlug("english-secondary-aqa")!;
+        const { queryByTestId } = render(
+          <CurriculumInfoPage
+            mvRefreshTime={1721314874829}
+            curriculumUnitsFormattedData={curriculumUnitsFormattedData}
+            curriculumSelectionSlugs={slugs}
+            curriculumPhaseOptions={curriculumPhaseOptions}
+            curriculumOverviewSanityData={curriculumOverviewCMSFixture()}
+            curriculumOverviewTabData={curriculumOverviewMVFixture()}
+            curriculumDownloadsTabData={{ tiers: [], child_subjects: [] }}
+          />,
+        );
+        expect(queryByTestId("download-heading")).toBeInTheDocument();
       });
-      const slugs = parseSubjectPhaseSlug("english-secondary-aqa")!;
-      const { queryByTestId } = render(
-        <CurriculumInfoPage
-          mvRefreshTime={1721314874829}
-          curriculumUnitsFormattedData={curriculumUnitsFormattedData}
-          curriculumSelectionSlugs={slugs}
-          curriculumPhaseOptions={curriculumPhaseOptions}
-          curriculumOverviewSanityData={curriculumOverviewCMSFixture()}
-          curriculumOverviewTabData={curriculumOverviewMVFixture()}
-          curriculumDownloadsTabData={{ tiers: [], child_subjects: [] }}
-        />,
-      );
-      expect(queryByTestId("download-heading")).toBeInTheDocument();
-    });
+    }
   });
 
   describe("getStaticProps", () => {

--- a/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
@@ -10,6 +10,7 @@ import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { mockPrerelease } from "@/utils/mocks";
 import { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { DISABLE_DOWNLOADS } from "@/utils/curriculum/constants";
 
 const render = renderWithProviders();
 const mvRefreshTime = 1721314874829;
@@ -72,15 +73,17 @@ describe("Component Curriculum Download Tab", () => {
     return render(<CurriculumDownloadTab {...defaultProps} />);
   };
 
-  test("user can see download form", async () => {
-    // NOTE: This is only active during testing.
-    mockPrerelease("curriculum.downloads");
-    const { findByText, findAllByTestId } = renderComponent();
-    const formHeading = await findByText("Your details");
-    const formInputs = await findAllByTestId("input");
-    expect(formHeading).toBeInTheDocument();
-    expect(formInputs).toHaveLength(1);
-  });
+  if (!DISABLE_DOWNLOADS) {
+    test("user can see download form", async () => {
+      // NOTE: This is only active during testing.
+      mockPrerelease("curriculum.downloads");
+      const { findByText, findAllByTestId } = renderComponent();
+      const formHeading = await findByText("Your details");
+      const formInputs = await findAllByTestId("input");
+      expect(formHeading).toBeInTheDocument();
+      expect(formInputs).toHaveLength(1);
+    });
+  }
 
   describe("Curriculum Downloads Tab: Secondary Maths", () => {
     test("user can see the tier selector for secondary maths", async () => {

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
@@ -55,7 +55,9 @@ describe("CurriculumDownloadView", () => {
           isSubmitting={false}
         />,
       );
-      expect(baseElement).toHaveTextContent("currently disabled");
+      expect(baseElement).toHaveTextContent(
+        "won't be able to download curriculum documents right now",
+      );
     });
   }
   if (!DISABLE_DOWNLOADS) {

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
@@ -4,6 +4,7 @@ import { act, waitFor } from "@testing-library/react";
 import CurriculumDownloadView, { CurriculumDownloadViewData } from ".";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { DISABLE_DOWNLOADS } from "@/utils/curriculum/constants";
 
 const render = renderWithProviders();
 
@@ -28,113 +29,144 @@ jest.mock(
 );
 
 describe("CurriculumDownloadView", () => {
-  test("with data", async () => {
-    const initialData: CurriculumDownloadViewData = {
-      schoolId: undefined,
-      schools: [
-        {
-          urn: "",
-          la: "",
-          name: "Test",
-          postcode: "TEST",
-          fullInfo: "test",
-          status: "",
-        },
-      ],
-      email: "test@example.com",
-      downloadType: "word",
-      schoolNotListed: true,
-      termsAndConditions: true,
-    } as const;
-    const { getByTestId } = render(
-      <CurriculumDownloadView
-        data={initialData}
-        schools={[]}
-        isSubmitting={false}
-      />,
-    );
-    const completeElement = getByTestId("details-completed");
-    expect(completeElement).toContainHTML("My school isn’t listed");
-    expect(completeElement).toContainHTML("test@example.com");
-  });
-
-  test("no data", async () => {
-    const initialData: CurriculumDownloadViewData = {
-      schoolId: undefined,
-      schools: [
-        {
-          urn: "",
-          la: "",
-          name: "Test",
-          postcode: "TEST",
-          fullInfo: "test",
-          status: "",
-        },
-      ],
-      email: undefined,
-      downloadType: "word",
-      schoolNotListed: false,
-      termsAndConditions: true,
-    } as const;
-    const { getByTestId } = render(
-      <CurriculumDownloadView
-        data={initialData}
-        schools={[]}
-        isSubmitting={false}
-      />,
-    );
-    expect(getByTestId("download-school-isnt-listed")).toBeVisible();
-    expect(getByTestId("download-email")).toBeVisible();
-    expect(getByTestId("download-accept-terms")).toBeVisible();
-  });
-
-  test("logged in", async () => {
-    (useUser as jest.Mock).mockReturnValue({
-      isLoaded: true,
-      isSignedIn: true,
-    });
-
-    const onSubmit = jest.fn();
-
-    const initialData: CurriculumDownloadViewData = {
-      schoolId: undefined,
-      schools: [
-        {
-          urn: "",
-          la: "",
-          name: "Test",
-          postcode: "TEST",
-          fullInfo: "test",
-          status: "",
-        },
-      ],
-      email: undefined,
-      downloadType: "word",
-      schoolNotListed: false,
-      termsAndConditions: true,
-    } as const;
-    const { getByTestId } = render(
-      <CurriculumDownloadView
-        data={initialData}
-        schools={[]}
-        isSubmitting={false}
-        onSubmit={onSubmit}
-      />,
-    );
-    act(() => {
-      getByTestId("download").click();
-    });
-
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({
+  if (DISABLE_DOWNLOADS) {
+    test("with data", async () => {
+      const initialData: CurriculumDownloadViewData = {
+        schoolId: undefined,
+        schools: [
+          {
+            urn: "",
+            la: "",
+            name: "Test",
+            postcode: "TEST",
+            fullInfo: "test",
+            status: "",
+          },
+        ],
+        email: "test@example.com",
         downloadType: "word",
-        email: "EMAIL",
-        schoolId: "SCHOOL_ID-SCHOOL_NAME",
-        schoolName: "SCHOOL_NAME",
-        schoolNotListed: false,
-        schools: [],
+        schoolNotListed: true,
         termsAndConditions: true,
+      } as const;
+      const { baseElement } = render(
+        <CurriculumDownloadView
+          data={initialData}
+          schools={[]}
+          isSubmitting={false}
+        />,
+      );
+      expect(baseElement).toHaveTextContent("currently disabled");
+    });
+  }
+  if (!DISABLE_DOWNLOADS) {
+    test("with data", async () => {
+      const initialData: CurriculumDownloadViewData = {
+        schoolId: undefined,
+        schools: [
+          {
+            urn: "",
+            la: "",
+            name: "Test",
+            postcode: "TEST",
+            fullInfo: "test",
+            status: "",
+          },
+        ],
+        email: "test@example.com",
+        downloadType: "word",
+        schoolNotListed: true,
+        termsAndConditions: true,
+      } as const;
+      const { getByTestId } = render(
+        <CurriculumDownloadView
+          data={initialData}
+          schools={[]}
+          isSubmitting={false}
+        />,
+      );
+      const completeElement = getByTestId("details-completed");
+      expect(completeElement).toContainHTML("My school isn’t listed");
+      expect(completeElement).toContainHTML("test@example.com");
+    });
+
+    test("no data", async () => {
+      const initialData: CurriculumDownloadViewData = {
+        schoolId: undefined,
+        schools: [
+          {
+            urn: "",
+            la: "",
+            name: "Test",
+            postcode: "TEST",
+            fullInfo: "test",
+            status: "",
+          },
+        ],
+        email: undefined,
+        downloadType: "word",
+        schoolNotListed: false,
+        termsAndConditions: true,
+      } as const;
+      const { getByTestId } = render(
+        <CurriculumDownloadView
+          data={initialData}
+          schools={[]}
+          isSubmitting={false}
+        />,
+      );
+      expect(getByTestId("download-school-isnt-listed")).toBeVisible();
+      expect(getByTestId("download-email")).toBeVisible();
+      expect(getByTestId("download-accept-terms")).toBeVisible();
+    });
+
+    test("logged in", async () => {
+      (useUser as jest.Mock).mockReturnValue({
+        isLoaded: true,
+        isSignedIn: true,
+      });
+
+      const onSubmit = jest.fn();
+
+      const initialData: CurriculumDownloadViewData = {
+        schoolId: undefined,
+        schools: [
+          {
+            urn: "",
+            la: "",
+            name: "Test",
+            postcode: "TEST",
+            fullInfo: "test",
+            status: "",
+          },
+        ],
+        email: undefined,
+        downloadType: "word",
+        schoolNotListed: false,
+        termsAndConditions: true,
+      } as const;
+      const { getByTestId } = render(
+        <CurriculumDownloadView
+          data={initialData}
+          schools={[]}
+          isSubmitting={false}
+          onSubmit={onSubmit}
+        />,
+      );
+      act(() => {
+        getByTestId("download").click();
+      });
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({
+          downloadType: "word",
+          email: "EMAIL",
+          schoolId: "SCHOOL_ID-SCHOOL_NAME",
+          schoolName: "SCHOOL_NAME",
+          schoolNotListed: false,
+          schools: [],
+          termsAndConditions: true,
+        });
       });
     });
-  });
+  }
 });

--- a/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
@@ -1,4 +1,4 @@
-import { OakBox } from "@oaknational/oak-components";
+import { OakBox, OakInlineBanner } from "@oaknational/oak-components";
 import { FC, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 
@@ -7,6 +7,7 @@ import SignedOutFlow from "./SignedOutFlow";
 import SignedInFlow from "./SignedInFlow";
 
 import Button from "@/components/SharedComponents/Button";
+import { DISABLE_DOWNLOADS } from "@/utils/curriculum/constants";
 
 export type CurriculumDownloadViewData = {
   schools: School[];
@@ -32,28 +33,39 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = (props) => {
 
   return (
     <OakBox $color="black">
-      {props.onBackToKs4Options && (
-        <OakBox $mb="space-between-m">
-          <Button
-            variant={"buttonStyledAsLink"}
-            icon="chevron-left"
-            data-testid="back-to-downloads-link"
-            size="small"
-            label="Back to KS4 options"
-            onClick={props.onBackToKs4Options}
-          />
-        </OakBox>
+      {DISABLE_DOWNLOADS && (
+        <OakInlineBanner
+          type="alert"
+          isOpen={true}
+          message="Curriculum downloads are currently disabled due to ongoing issues"
+        />
       )}
-      {user.isLoaded && (
+      {!DISABLE_DOWNLOADS && (
         <>
-          {!user.isSignedIn && (
-            <SignedOutFlow
-              {...props}
-              onChangeDownloadType={setDownloadType}
-              downloadType={downloadType}
-            />
+          {props.onBackToKs4Options && (
+            <OakBox $mb="space-between-m">
+              <Button
+                variant={"buttonStyledAsLink"}
+                icon="chevron-left"
+                data-testid="back-to-downloads-link"
+                size="small"
+                label="Back to KS4 options"
+                onClick={props.onBackToKs4Options}
+              />
+            </OakBox>
           )}
-          {user.isSignedIn && <SignedInFlow {...props} user={user} />}
+          {user.isLoaded && (
+            <>
+              {!user.isSignedIn && (
+                <SignedOutFlow
+                  {...props}
+                  onChangeDownloadType={setDownloadType}
+                  downloadType={downloadType}
+                />
+              )}
+              {user.isSignedIn && <SignedInFlow {...props} user={user} />}
+            </>
+          )}
         </>
       )}
     </OakBox>

--- a/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
@@ -37,7 +37,7 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = (props) => {
         <OakInlineBanner
           type="alert"
           isOpen={true}
-          message="Curriculum downloads are currently disabled due to ongoing issues"
+          message="Sorry, we've found a problem which means you won't be able to download curriculum documents right now. We're working hard to get it fixed as soon as possible."
         />
       )}
       {!DISABLE_DOWNLOADS && (

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,2 +1,3 @@
 export const ENABLE_OPEN_API = false;
 export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;
+export const DISABLE_DOWNLOADS = true;


### PR DESCRIPTION
## Description
Disable curriculum downloads in the UI while we wait for a fix from netlify

## Issue(s)
hotfix

## How to test

1. Go to https://deploy-preview-3361--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check downloads shows the following message, both when logged in an logged out.

## Screenshots
<img width="1322" alt="Screenshot 2025-04-14 at 13 21 15" src="https://github.com/user-attachments/assets/1f513dba-2ada-4b9f-b980-e11443c91ba7" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
