### PR TITLE
Re-enable curriculum downloads after netlify fix

### DIFF
--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,3 +1,3 @@
 export const ENABLE_OPEN_API = false;
 export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;
-export const DISABLE_DOWNLOADS = true;
+export const DISABLE_DOWNLOADS = false;


### PR DESCRIPTION
## Description
Re-enable curriculum downloads after netlify fix

## Issue(s)
hotfix

## How to test

1. Go to https://deploy-preview-3363--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Test curric downloads work as expected


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
