### PR TITLE
Add config to allow WTWN to be enabled via flag

### DIFF
--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -16,6 +16,7 @@ import { notUndefined, Unit, YearData, Lesson } from "@/utils/curriculum/types";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { ComponentTypeValueType } from "@/browser-lib/avo/Avo";
 import { getTitleFromSlug } from "@/fixtures/shared/helper";
+import { getIsUnitDescriptionEnabled } from "@/utils/curriculum/features";
 
 type UnitModalProps = {
   unitData: Unit | null;
@@ -101,6 +102,8 @@ const UnitModal: FC<UnitModalProps> = ({
     }
   };
 
+  const isUnitDescriptionEnabled = getIsUnitDescriptionEnabled(unitData);
+
   return (
     <>
       {unitData && (
@@ -164,10 +167,7 @@ const UnitModal: FC<UnitModalProps> = ({
                     handleUnitOverviewExploredAnalytics
                   }
                   threads={unitData.threads}
-                  isUnitDescriptionEnabled={
-                    unitData.parent_programme_features?.unit_description ===
-                    true
-                  }
+                  isUnitDescriptionEnabled={isUnitDescriptionEnabled}
                   whyThisWhyNow={unitData.why_this_why_now}
                   description={unitData.description}
                   lessons={unitData.lessons}
@@ -246,8 +246,7 @@ const UnitModal: FC<UnitModalProps> = ({
                                 description: optionalUnit.description,
                                 whyThisWhyNow: optionalUnit.why_this_why_now,
                                 isUnitDescriptionEnabled:
-                                  unitData.parent_programme_features
-                                    ?.unit_description === true,
+                                  isUnitDescriptionEnabled,
                                 handleUnitOverviewExploredAnalytics:
                                   handleUnitOverviewExploredAnalytics,
                               });

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -16,6 +16,7 @@ import { createUnitsListingByYear } from "../../tab-helpers";
 import { getYearGroupTitle } from "@/utils/curriculum/formatting";
 import { createProgrammeSlug } from "@/utils/curriculum/slugs";
 import { SubjectCategory } from "@/utils/curriculum/types";
+import { getIsUnitDescriptionEnabled } from "@/utils/curriculum/features";
 
 const DISABLE_COLUMN_BREAKS = true;
 
@@ -227,8 +228,7 @@ export async function buildUnit(
     )}/units/${resolvedUnitSlug}/lessons`,
   });
 
-  const isUnitDescriptionEnabled =
-    unit.parent_programme_features?.unit_description === true;
+  const isUnitDescriptionEnabled = getIsUnitDescriptionEnabled(unit);
 
   let unitDescriptions: string = "";
   if (!isUnitDescriptionEnabled) {

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -1,3 +1,4 @@
 export const ENABLE_OPEN_API = false;
 export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;
 export const DISABLE_DOWNLOADS = true;
+export const ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE = false;

--- a/src/utils/curriculum/features.test.ts
+++ b/src/utils/curriculum/features.test.ts
@@ -1,0 +1,68 @@
+import { getIsUnitDescriptionEnabled } from "./features";
+import { Unit } from "./types";
+
+const ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE_GETTER = jest.fn();
+jest.mock("@/utils/curriculum/constants", () => ({
+  __esModule: true,
+  get ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE() {
+    return ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE_GETTER();
+  },
+}));
+
+describe("getIsUnitDescriptionEnabled", () => {
+  it("when false", () => {
+    ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE_GETTER.mockReturnValue(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        parent_programme_features: {
+          unit_description: true,
+        },
+      } as Unit),
+    ).toEqual(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        parent_programme_features: {
+          unit_description: false,
+        },
+      } as Unit),
+    ).toEqual(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        cycle: "1",
+      } as Unit),
+    ).toEqual(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        cycle: "2",
+      } as Unit),
+    ).toEqual(true);
+  });
+
+  it("when true", () => {
+    ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE_GETTER.mockReturnValue(true);
+    expect(
+      getIsUnitDescriptionEnabled({
+        parent_programme_features: {
+          unit_description: true,
+        },
+      } as Unit),
+    ).toEqual(true);
+    expect(
+      getIsUnitDescriptionEnabled({
+        parent_programme_features: {
+          unit_description: false,
+        },
+      } as Unit),
+    ).toEqual(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        cycle: "1",
+      } as Unit),
+    ).toEqual(false);
+    expect(
+      getIsUnitDescriptionEnabled({
+        cycle: "2",
+      } as Unit),
+    ).toEqual(false);
+  });
+});

--- a/src/utils/curriculum/features.ts
+++ b/src/utils/curriculum/features.ts
@@ -1,3 +1,4 @@
+import { ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE } from "./constants";
 import { Unit } from "./types";
 
 import { CurriculumUnitsYearData } from "@/pages-helpers/curriculum/docx/tab-helpers";
@@ -11,4 +12,12 @@ export function findFirstMatchingFeatures(
     .flatMap((a) => a.units)
     .find(fn)?.features;
   return features;
+}
+
+export function getIsUnitDescriptionEnabled(unit?: Unit | null) {
+  if (ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE) {
+    return unit?.parent_programme_features?.unit_description === true;
+  } else {
+    return unit?.cycle === "2";
+  }
 }


### PR DESCRIPTION
## Description
Add config to allow WTWN to be enabled via flag

## How to test

1. Go to https://deploy-preview-3365--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check all cycle 1 subjects use prior/future units rather than WTWN and unit-description. 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
