### PR TITLE
Datatype has changed for all-years swimming

### DIFF
--- a/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
+++ b/src/components/CurriculumComponents/UnitModal/UnitModal.tsx
@@ -75,7 +75,7 @@ const UnitModal: FC<UnitModalProps> = ({
   const yearTitle = unitData
     ? getYearGroupTitle(
         yearData,
-        unitData.actions?.programme_field_overrides?.Year ?? unitData.year,
+        unitData.actions?.programme_field_overrides?.year_slug ?? unitData.year,
       )
     : "";
 

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -451,7 +451,7 @@ export async function buildUnit(
   const yearData = createUnitsListingByYear([unit]);
   const yearTitle = getYearGroupTitle(
     yearData,
-    unit.actions?.programme_field_overrides?.Year ?? unit.year,
+    unit.actions?.programme_field_overrides?.year_slug ?? unit.year,
   );
 
   const xml = safeXml`

--- a/src/pages-helpers/curriculum/docx/builder/helper.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.ts
@@ -76,7 +76,8 @@ export function threadUnitByYear(units: Unit[], threadSlug: string) {
   const output = {} as Record<string, Unit[]>;
 
   units.forEach((unit: Unit) => {
-    const year = unit.actions?.programme_field_overrides?.Year ?? unit.year;
+    const year =
+      unit.actions?.programme_field_overrides?.year_slug ?? unit.year;
     unit.threads.forEach((thread) => {
       if (thread.slug === threadSlug) {
         output[year] = output[year] ?? [];
@@ -98,7 +99,8 @@ export function unitsByYear(units: Unit[]) {
   const output = {} as Record<string, Unit[]>;
 
   units.forEach((unit: Unit) => {
-    const year = unit.actions?.programme_field_overrides?.Year ?? unit.year;
+    const year =
+      unit.actions?.programme_field_overrides?.year_slug ?? unit.year;
     output[year] = output[year] ?? [];
     if (
       output[year] &&

--- a/src/pages-helpers/curriculum/docx/tab-helpers.ts
+++ b/src/pages-helpers/curriculum/docx/tab-helpers.ts
@@ -116,7 +116,8 @@ export function createYearOptions(units: Unit[]): string[] {
 
   units.forEach((unit: Unit) => {
     // Populate years object
-    const year = unit.actions?.programme_field_overrides?.Year ?? unit.year;
+    const year =
+      unit.actions?.programme_field_overrides?.year_slug ?? unit.year;
     if (yearOptions.every((yo) => yo !== year)) {
       yearOptions.push(year);
     }
@@ -179,7 +180,8 @@ export function createUnitsListingByYear(
     // Check if the yearData object has an entry for the unit's year
     // If not, initialize it with default values
 
-    const year = unit.actions?.programme_field_overrides?.Year ?? unit.year;
+    const year =
+      unit.actions?.programme_field_overrides?.year_slug ?? unit.year;
 
     let currentYearData = yearData[year];
     if (!currentYearData) {

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -24,7 +24,7 @@ describe("getYearGroupTitle", () => {
       expect(
         getYearGroupTitle(
           {
-            ["All years"]: {
+            ["all-years"]: {
               units: [],
               childSubjects: [],
               tiers: [],
@@ -33,7 +33,7 @@ describe("getYearGroupTitle", () => {
               groupAs: "Swimming",
             },
           },
-          "All years",
+          "all-years",
         ),
       ).toEqual("Swimming (all years)");
     });
@@ -62,7 +62,7 @@ describe("getYearGroupTitle", () => {
       expect(
         getYearGroupTitle(
           {
-            ["All years"]: {
+            ["all-years"]: {
               units: [],
               childSubjects: [],
               tiers: [],
@@ -71,7 +71,7 @@ describe("getYearGroupTitle", () => {
               groupAs: "Swimming",
             },
           },
-          "All years",
+          "all-years",
           "units",
         ),
       ).toEqual("Swimming units (all years)");

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -13,7 +13,7 @@ export function getYearGroupTitle(
   const suffixStr = suffix ? ` ${suffix}` : "";
   if (year in yearData) {
     const { groupAs } = yearData[year]!;
-    if (groupAs && year === "All years") {
+    if (groupAs && year === "all-years") {
       return `${groupAs}${suffixStr} (all years)`;
     }
   }

--- a/src/utils/curriculum/sorting.test.ts
+++ b/src/utils/curriculum/sorting.test.ts
@@ -13,8 +13,8 @@ describe("sortYears", () => {
   });
 
   it("with all years", () => {
-    expect(["8", "7", "All years", "9", "11", "10"].sort(sortYears)).toEqual([
-      "All years",
+    expect(["8", "7", "all-years", "9", "11", "10"].sort(sortYears)).toEqual([
+      "all-years",
       "7",
       "8",
       "9",

--- a/src/utils/curriculum/sorting.ts
+++ b/src/utils/curriculum/sorting.ts
@@ -3,7 +3,7 @@ import { Subject, SubjectCategory, Tier, Unit } from "./types";
 import { Actions } from "@/node-lib/curriculum-api-2023/shared.schema";
 
 export function sortYears(a: string, b: string) {
-  if (a === "All years") {
+  if (a === "all-years") {
     return -1;
   }
   return parseInt(a) - parseInt(b);


### PR DESCRIPTION
## Description
Datatype has changed for all-years swimming, this PR makes the changes required to fix that

## Issue(s)

Fixes `CUR-1384`

## How to test

1. Go to https://deploy-preview-3367--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Go to physical education -> primary
3. Check filtering and "all years" works as expected


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
