### PR TITLE
chore: made the QuizQuestionStem titles full width to ensure code blocks always go full width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.101.0",
+        "@oaknational/oak-components": "^1.102.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.60.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.101.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.101.1.tgz",
-      "integrity": "sha512-Y3qD036R6Du/B8czUsqockacfQt5YjXmqcgGsj3as/uhbwGWm4R5Et76u+1Ai4QZjILwU2kWKct4R7sjiZ2l5A==",
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.102.0.tgz",
+      "integrity": "sha512-C0RAyvqvw6drU6NceAVCLavDtNWoLK8amT/51tBA+kIggjCDEOuCTqpqd4nIcxx2E142zajCKnYJQZXEx2vu2Q==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.102.0",
+        "@oaknational/oak-components": "^1.102.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.60.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.102.0.tgz",
-      "integrity": "sha512-C0RAyvqvw6drU6NceAVCLavDtNWoLK8amT/51tBA+kIggjCDEOuCTqpqd4nIcxx2E142zajCKnYJQZXEx2vu2Q==",
+      "version": "1.102.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.102.1.tgz",
+      "integrity": "sha512-kAI1aGkYtjJJI6JpNjHkvVb/NEgbSGBmDonI5RR0P2PODOUyyxcwpCKQ0GfthJCZCjxVzQb+GNZWNZlenu4ADQ==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.101.0",
+    "@oaknational/oak-components": "^1.102.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.60.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.102.0",
+    "@oaknational/oak-components": "^1.102.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.60.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
@@ -3,7 +3,7 @@ import {
   OakCloudinaryImage,
   OakFlex,
   OakScaleImageButton,
-  OakSpan,
+  OakBox,
 } from "@oaknational/oak-components";
 
 import { CodeRenderWrapper } from "../CodeRendererWrapper/CodeRendererWrapper";
@@ -51,24 +51,26 @@ export const QuizQuestionStem = ({
           }
         >
           {questionStem[0]?.type === "text" && (
-            <OakSpan
+            <OakBox
               key={`q-${displayNumber}-stem-element-0`}
               $font={["heading-6", "heading-4", "heading-4"]}
+              $width={"100%"}
             >
               {shortAnswerTitleFormatter(removeMarkdown(questionStem[0].text))}
-            </OakSpan>
+            </OakBox>
           )}
         </OakFlex>
 
         {questionStem.map((stemItem, i) => {
           if (stemItem.type === "text" && i > 0) {
             return (
-              <OakSpan
+              <OakBox
                 key={`q-${displayNumber}-stem-element-${i}`}
                 $font={["body-2-bold", "body-1-bold"]}
+                $width={"100%"}
               >
                 {shortAnswerTitleFormatter(removeMarkdown(stemItem.text))}
-              </OakSpan>
+              </OakBox>
             );
           } else if (stemItem.type === "image") {
             return (


### PR DESCRIPTION
## Description

- Updated oak components to use latest OakCodeRenderer with Code colour tooltip
- Made QuizQuestionStem text span full available width

## Issue(s)

When code blocks were being rendered in code in quizzes the width of the code block would match the width of the question text and not span all available space.

## How to test

1. Go to [quiz in preview deploy](https://deploy-preview-3368--oak-web-application.netlify.thenational.academy/pupils/programmes/computing-secondary-year-9/units/python-programming-with-sequences-of-data/lessons/creating-lists-in-python/exit-quiz)
2. Example of the code block quiz is question 5 here: [`/pupils/programmes/computing-secondary-year-9/units/python-programming-with-sequences-of-data/lessons/creating-lists-in-python/exit-quiz`](https://deploy-preview-3368--oak-web-application.netlify.thenational.academy/pupils/programmes/computing-secondary-year-9/units/python-programming-with-sequences-of-data/lessons/creating-lists-in-python/exit-quiz)
3. Check that the code block is spanning the full width of the quiz question stem

Important to note that this change has been applied to the overall quiz question stem component, meaning that the full width stems will apply to various question types. So it will be worth testing a variety of question types, and also questions with different lengths of text.

## Screenshots

How it should now look:
[Designs here](https://www.figma.com/design/XMr2P0ZaLW0dDq5SMzcLoX/Cycle-2-requirements---Pupils?node-id=2015-10786&m=dev)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
