### PR TITLE
PUPIL-1280 refactor: updated expiring banner for teacher and pupil lesson overview and listing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.102.1",
+        "@oaknational/oak-components": "^1.103.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.60.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.102.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.102.1.tgz",
-      "integrity": "sha512-kAI1aGkYtjJJI6JpNjHkvVb/NEgbSGBmDonI5RR0P2PODOUyyxcwpCKQ0GfthJCZCjxVzQb+GNZWNZlenu4ADQ==",
+      "version": "1.103.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.103.0.tgz",
+      "integrity": "sha512-+qAxLXtm5ZZ8rDKPNHtOh5/KHh3JW6/hopic8/7wV4WKQg6ElhyWSnL0V97CKoi8sG1mpwAsb07CnWxBhlTNRA==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.103.0",
+        "@oaknational/oak-components": "1.104.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.60.0",
         "@oaknational/oak-pupil-client": "^2.14.0",
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.103.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.103.0.tgz",
-      "integrity": "sha512-+qAxLXtm5ZZ8rDKPNHtOh5/KHh3JW6/hopic8/7wV4WKQg6ElhyWSnL0V97CKoi8sG1mpwAsb07CnWxBhlTNRA==",
+      "version": "1.104.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.104.1.tgz",
+      "integrity": "sha512-qVT3MY9/KAf70E2z2KXxjhHZe4FfbadxD8r0lCL+W14YRpsdvZSVsqnzcqcfnECRnF5v9ADHivoEVX0FrFY0uw==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.103.0",
+    "@oaknational/oak-components": "1.104.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.60.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.102.1",
+    "@oaknational/oak-components": "^1.103.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.60.0",
     "@oaknational/oak-pupil-client": "^2.14.0",

--- a/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
+++ b/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
@@ -12,7 +12,6 @@ import {
   OakBox,
   isValidIconName,
 } from "@oaknational/oak-components";
-import { useState } from "react";
 
 import { resolveOakHref } from "@/common-lib/urls";
 import { LessonListingBrowseData } from "@/node-lib/curriculum-api-2023/queries/pupilLessonListing/pupilLessonListing.schema";
@@ -40,12 +39,6 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
     examboard,
     phaseSlug,
   } = programmeFields;
-
-  const [showExpiredLessonsBanner, setShowExpiredLessonsBanner] =
-    useState<boolean>(
-      unitData.expirationDate !== null ||
-        orderedCurriculumData.some((c) => c.actions?.displayExpiringBanner),
-    );
 
   const baseSlug = `${subjectSlug}-${phaseSlug}-${yearSlug}`;
   const unitListingHref = `/pupils/programmes/${baseSlug}/options`; // NB. options will forward to units if no options available
@@ -109,12 +102,12 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
       </OakFlex>
 
       <ExpiringBanner
-        isOpen={showExpiredLessonsBanner}
+        isOpen={
+          unitData.expirationDate !== null ||
+          orderedCurriculumData.some((c) => c.actions?.displayExpiringBanner)
+        }
         isResourcesMessage={false}
         onwardHref={unitListingHref}
-        onClose={() => {
-          setShowExpiredLessonsBanner(false);
-        }}
       />
     </OakFlex>
   );

--- a/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
+++ b/src/components/PupilViews/PupilLessonOverview/PupilLessonOverview.view.tsx
@@ -77,11 +77,6 @@ export const PupilViewsLessonOverview = ({
   useEffect(() => {
     setIsMounted(true);
   }, []);
-  const [showExpiredLessonsBanner, setShowExpiredLessonsBanner] =
-    useState<boolean>(
-      expirationDate !== null ||
-        browseData.actions?.displayExpiringBanner === true,
-    );
 
   const baseSlug = `${browseData.programmeFields.subjectSlug}-${browseData.programmeFields.phaseSlug}-${browseData.programmeFields.yearSlug}`;
   const unitListingHref = `/pupils/programmes/${baseSlug}/options`; // NB. options will forward to units if no options available
@@ -117,13 +112,13 @@ export const PupilViewsLessonOverview = ({
 
   const expiringBanner = (
     <ExpiringBanner
-      isOpen={showExpiredLessonsBanner}
+      isOpen={
+        expirationDate !== null ||
+        browseData.actions?.displayExpiringBanner === true
+      }
       isResourcesMessage={false}
       isSingular={true}
       onwardHref={unitListingHref}
-      onClose={() => {
-        setShowExpiredLessonsBanner(false);
-      }}
     />
   );
 

--- a/src/components/SharedComponents/ExpiringBanner/ExpiringBanner.test.tsx
+++ b/src/components/SharedComponents/ExpiringBanner/ExpiringBanner.test.tsx
@@ -49,12 +49,6 @@ describe("ExpiringBanner", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call onClose when the dismiss button is clicked", () => {
-    const screen = render(<ExpiringBanner {...defaultProps} />);
-    screen.getByRole("button", { name: /dismiss/i }).click();
-    expect(defaultProps.onClose).toHaveBeenCalled();
-  });
-
   it("should call onViewNewLessons when the View new lessons button is clicked", () => {
     const screen = render(<ExpiringBanner {...defaultProps} />);
     screen.getByRole("link", { name: /view new lessons/i }).click();

--- a/src/components/SharedComponents/ExpiringBanner/ExpiringBanner.tsx
+++ b/src/components/SharedComponents/ExpiringBanner/ExpiringBanner.tsx
@@ -1,7 +1,8 @@
 import {
   OakBox,
   OakInlineBanner,
-  OakSecondaryButton,
+  OakPrimaryButton,
+  OakP,
 } from "@oaknational/oak-components";
 
 export type ExpiringBannerProps = {
@@ -9,7 +10,6 @@ export type ExpiringBannerProps = {
   isResourcesMessage?: boolean;
   isSingular?: boolean;
   onwardHref: string;
-  onClose: () => void;
   onViewNewLessons?: () => void;
 };
 
@@ -18,7 +18,6 @@ export const ExpiringBanner = ({
   isResourcesMessage,
   isSingular,
   onwardHref,
-  onClose,
   onViewNewLessons,
 }: ExpiringBannerProps) => {
   const title = (() => {
@@ -32,16 +31,26 @@ export const ExpiringBanner = ({
     }
   })();
 
-  const message = isResourcesMessage
-    ? "Switch to our new teaching resources now - designed by teachers and leading subject experts, and tested in classrooms."
-    : `We've made brand-new and improved lessons for you.`;
+  const message = isResourcesMessage ? (
+    <>
+      <OakP>
+        Switch to our new teaching resources now - designed by teachers and
+        leading subject experts, and tested in classrooms.
+      </OakP>
+      <OakP $mt={"space-between-m"}>
+        These resources were created for remote use during the pandemic and are
+        not designed for classroom teaching.
+      </OakP>
+    </>
+  ) : (
+    `We've made brand-new and improved lessons for you.`
+  );
 
   return (
     <OakInlineBanner
-      canDismiss
       cta={
-        <OakBox $pt="inner-padding-s">
-          <OakSecondaryButton
+        <OakBox>
+          <OakPrimaryButton
             element="a"
             iconName="arrow-right"
             isTrailingIcon
@@ -49,14 +58,14 @@ export const ExpiringBanner = ({
             onClick={onViewNewLessons}
           >
             {`View new ${isResourcesMessage ? "resources" : "lessons"}`}
-          </OakSecondaryButton>
+          </OakPrimaryButton>
         </OakBox>
       }
       isOpen={isOpen}
       message={message}
-      onDismiss={onClose}
       title={title}
-      type="alert"
+      type="warning"
+      variant="large"
     />
   );
 };

--- a/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
+++ b/src/components/TeacherViews/LessonOverview/LessonOverview.view.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, Fragment, useState } from "react";
+import React, { useRef, Fragment } from "react";
 import {
   OakGrid,
   OakGridArea,
@@ -138,9 +138,6 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
     : "Video & audio clips";
 
   const MathJaxLessonProvider = isMathJaxLesson ? MathJaxProvider : Fragment;
-
-  const [showExpiredLessonsBanner, setShowExpiredLessonsBanner] =
-    useState<boolean>(actions?.displayExpiringBanner);
 
   const unitListingHref = `/teachers/key-stages/${keyStageSlug}/subjects/${subjectSlug}/programmes`;
 
@@ -310,12 +307,9 @@ export function LessonOverview({ lesson }: LessonOverviewProps) {
               <OakFlex $flexDirection={"column"} $position={"relative"}>
                 <OakBox $pb={"inner-padding-m"}>
                   <ExpiringBanner
-                    isOpen={showExpiredLessonsBanner}
+                    isOpen={actions?.displayExpiringBanner}
                     isResourcesMessage={true}
                     onwardHref={unitListingHref}
-                    onClose={() => {
-                      setShowExpiredLessonsBanner(false);
-                    }}
                   />
                 </OakBox>
 

--- a/src/pages/teachers/beta/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/beta/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import {
   NextPage,
   GetStaticProps,
@@ -87,9 +87,6 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
     subjectSlug,
     actions,
   } = curriculumData;
-
-  const [showExpiredLessonsBanner, setShowExpiredLessonsBanner] =
-    useState<boolean>(actions?.displayExpiringBanner ?? false);
 
   const unitListingHref = `/teachers/key-stages/${keyStageSlug}/subjects/${subjectSlug}/programmes`;
   const { shareUrl, browserUrl, shareActivated } = useShareExperiment({
@@ -325,12 +322,9 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
                 onClick={trackLessonSelected}
                 expiringBanner={
                   <ExpiringBanner
-                    isOpen={showExpiredLessonsBanner}
+                    isOpen={actions?.displayExpiringBanner ?? false}
                     isResourcesMessage={true}
                     onwardHref={unitListingHref}
-                    onClose={() => {
-                      setShowExpiredLessonsBanner(false);
-                    }}
                   />
                 }
               />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import {
   NextPage,
   GetStaticProps,
@@ -88,9 +88,6 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
     subjectSlug,
     actions,
   } = curriculumData;
-
-  const [showExpiredLessonsBanner, setShowExpiredLessonsBanner] =
-    useState<boolean>(actions?.displayExpiringBanner ?? false);
 
   const unitListingHref = `/teachers/key-stages/${keyStageSlug}/subjects/${subjectSlug}/programmes`;
   const { shareUrl, browserUrl, shareActivated } = useShareExperiment({
@@ -330,12 +327,9 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
                 onClick={trackLessonSelected}
                 expiringBanner={
                   <ExpiringBanner
-                    isOpen={showExpiredLessonsBanner}
+                    isOpen={actions?.displayExpiringBanner ?? false}
                     isResourcesMessage={true}
                     onwardHref={unitListingHref}
-                    onClose={() => {
-                      setShowExpiredLessonsBanner(false);
-                    }}
                   />
                 }
               />


### PR DESCRIPTION
## Description

Music year: 1953

- Updated oak component version to utilise new OakInlineBanners
- Updated Expiring Lesson Banners new large variant and warning type
- Updated existing inline banners so that they are no longer dismissable

[Link to designs](https://www.figma.com/design/dGO9erL0b0kpYxmv6Jku4f/Lessons-takedown-banners?node-id=2177-4655&p=f&m=dev)

## How to test

### Teacher Lesson Overview
1. Go to https://deploy-preview-3372--oak-web-application.netlify.thenational.academy/teachers/programmes/geography-primary-ks2-l/units/mountains-volcanoes-and-earthquakes-e02a/lessons/what-is-the-earth-made-of-6hk3ec
2. You should see the updated alert banner in a warning style (same as designs)

### Teacher Lesson Listing
1. Go to https://deploy-preview-3372--oak-web-application.netlify.thenational.academy/teachers/programmes/geography-primary-ks2-l/units/mountains-volcanoes-and-earthquakes-e02a/lessons
2. You should see the updated alert banner in a warning style (same as designs)

### Pupil Lesson Overview
1. Go to https://deploy-preview-3372--oak-web-application.netlify.thenational.academy/pupils/programmes/geography-primary-year-3-l/units/mountains-volcanoes-and-earthquakes-e02a/lessons/what-is-the-earth-made-of-6hk3ec/overview
2. You should see the updated alert banner in a warning style (same as designs)

### Pupil Lesson Listing
1. Go to https://deploy-preview-3372--oak-web-application.netlify.thenational.academy/pupils/programmes/geography-primary-year-3-l/units/mountains-volcanoes-and-earthquakes-e02a/lessons
2. You should see the updated alert banner in a warning style (same as designs)

### Other
There has been an update to the usage of react state for displaying the banners, due to the fact that it is no longer dismissable. Therefore we should verify that the banners are not showing on non-legacy lessons too.

We should also check that any other usages of the OakInlineBanner have not changed in unexpected ways since updating to use the new component.

## Screenshots

How it used to look (delete if n/a):
![image](https://github.com/user-attachments/assets/8d63f0a4-a4ce-4905-9b6a-65fd2b191ec8)


How it should now look:
![image](https://github.com/user-attachments/assets/d12ad7f3-281a-49c1-8732-2c5f689e6419)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
