### PR TITLE
Remove empty year from the visualiser for core/gcse

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -277,19 +277,26 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7"],
+        years: ["7", "8", "9", "10", "11"],
         threads: [],
       };
 
-      const { findAllByText } = render(
+      const { findAllByTestId, queryByTestId, getByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsForFirstYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-      expect(
-        await findAllByText(/'sub-cat-1' units start in Year 8/i),
-      ).toHaveLength(1);
+
+      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
+
+      const yearsPresent = [8, 9, 10, 11];
+      yearsPresent.forEach((year) => {
+        expect(getByTestId(`year-all-${year}`)).toBeInTheDocument();
+      });
+
+      const unitCards = await findAllByTestId("unit-card");
+      expect(unitCards).toHaveLength(4);
     });
 
     test("No units for subject category in second year of phase", async () => {
@@ -303,19 +310,26 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["8"],
+        years: ["7", "8", "9", "10", "11"],
         threads: [],
       };
 
-      const { findAllByText } = render(
+      const { queryByTestId, findAllByTestId, getByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsForSecondYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-      expect(
-        await findAllByText(/'sub-cat-1' units continue in Year 9/i),
-      ).toHaveLength(1);
+
+      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
+
+      const yearsPresent = [7, 9, 10, 11];
+      yearsPresent.forEach((year) => {
+        expect(getByTestId(`year-all-${year}`)).toBeInTheDocument();
+      });
+
+      const unitCards = await findAllByTestId("unit-card");
+      expect(unitCards).toHaveLength(4);
     });
 
     test("No units for consecutive years at the start of the phase", async () => {
@@ -333,19 +347,18 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findAllByTestId, findAllByText } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtStartFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(
-        await findAllByText(/'sub-cat-1' units start in Year 10/i),
-      ).toHaveLength(1);
-      expect(
-        await findAllByText(/'sub-cat-1' units continue in Year 10/i),
-      ).toHaveLength(2);
+      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-10")).toBeInTheDocument();
+      expect(queryByTestId("year-all-11")).toBeInTheDocument();
 
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
@@ -366,16 +379,19 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findAllByText, findAllByTestId } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsInMiddleFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(
-        await findAllByText(/'sub-cat-1' units continue in Year 11/i),
-      ).toHaveLength(3);
+      expect(queryByTestId("year-all-7")).toBeInTheDocument();
+      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-10")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-11")).toBeInTheDocument();
+
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
     });
@@ -395,18 +411,21 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findAllByText, findAllByTestId } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtEndFixtureWithProps}
           filters={filterFixture}
         />,
       );
+
+      expect(queryByTestId("year-all-7")).toBeInTheDocument();
+      expect(queryByTestId("year-all-8")).toBeInTheDocument();
+      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-10")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
+
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
-      const messages = await findAllByText(
-        /No 'sub-cat-1' units in this year group/i,
-      );
-      expect(messages).toHaveLength(3);
     });
 
     test("No alternate units in the phase", async () => {
@@ -424,24 +443,21 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findByText, findAllByTestId } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingAlternateUnitsFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
+      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-8")).toBeInTheDocument();
+      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-10")).toBeInTheDocument();
+      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
+
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
-      expect(
-        await findByText(/'sub-cat-1' units start in Year 8/i),
-      ).toBeInTheDocument();
-      expect(
-        await findByText(/'sub-cat-1' units continue in Year 10/i),
-      ).toBeInTheDocument();
-      expect(
-        await findByText(/No 'sub-cat-1' units in this year group/i),
-      ).toBeInTheDocument();
     });
 
     test("No unit at the end of the phase", async () => {
@@ -459,15 +475,21 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findByText } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitForLastYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-      expect(
-        await findByText(/No 'sub-cat-1' units in this year group/i),
-      ).toBeInTheDocument();
+
+      expect(queryByTestId("year-all-7")).toBeInTheDocument();
+      expect(queryByTestId("year-all-8")).toBeInTheDocument();
+      expect(queryByTestId("year-all-9")).toBeInTheDocument();
+      expect(queryByTestId("year-all-10")).toBeInTheDocument();
+      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
+
+      const unitCards = await findAllByTestId("unit-card");
+      expect(unitCards).toHaveLength(4);
     });
   });
 
@@ -487,15 +509,19 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findAllByText, findAllByTestId } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsForFirstYearPrimaryFixtureWithProps}
           filters={filterFixture}
         />,
       );
-      expect(
-        await findAllByText(/'sub-cat-1' units start in Year 2/i),
-      ).toHaveLength(1);
+      expect(queryByTestId("year-all-1")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-2")).toBeInTheDocument();
+      expect(queryByTestId("year-all-3")).toBeInTheDocument();
+      expect(queryByTestId("year-all-4")).toBeInTheDocument();
+      expect(queryByTestId("year-all-5")).toBeInTheDocument();
+      expect(queryByTestId("year-all-6")).toBeInTheDocument();
+
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(5);
     });
@@ -515,19 +541,20 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { findAllByText, findAllByTestId } = render(
+      const { queryByTestId, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtStartPrimaryFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(
-        await findAllByText(/'sub-cat-1' units start in Year 4/i),
-      ).toHaveLength(1);
-      expect(
-        await findAllByText(/'sub-cat-1' units continue in Year 4/i),
-      ).toHaveLength(2);
+      expect(queryByTestId("year-all-1")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-2")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-3")).not.toBeInTheDocument();
+      expect(queryByTestId("year-all-4")).toBeInTheDocument();
+      expect(queryByTestId("year-all-5")).toBeInTheDocument();
+      expect(queryByTestId("year-all-6")).toBeInTheDocument();
+
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(3);
     });
@@ -555,7 +582,7 @@ describe("Year group filter headings display correctly", () => {
         const filterFixture = {
           childSubjects: ["combined-science"],
           subjectCategories: ["-1"],
-          tiers: ["higher"],
+          tiers: ["foundation"],
           years: ["7", "8", "9", "10", "11"],
           threads: [],
           pathways: [],
@@ -568,27 +595,39 @@ describe("Year group filter headings display correctly", () => {
           />,
         );
 
-        // Check each year block individually
-        for (const year of ["7", "8", "9", "10", "11"]) {
-          const type = ["10", "11"].includes(year) ? "non_core" : "core";
-          const yearBlock = container.querySelector(
-            `[data-testid="year-${type}-${year}"]`,
-          ) as HTMLElement;
-          expect(yearBlock).not.toBeNull();
-
-          const yearHeading = within(yearBlock).getByTestId("year-heading");
+        for (const year of ["7", "8", "9"]) {
+          const coreBlock = container.querySelector(
+            `[data-testid="year-core-${year}"]`,
+          );
+          expect(coreBlock).not.toBeNull();
+          // Ensure no non_core block exists for KS3
+          expect(
+            container.querySelector(`[data-testid="year-non_core-${year}"]`),
+          ).toBeNull();
+          const yearHeading = within(coreBlock as HTMLElement).getByTestId(
+            "year-heading",
+          );
           expect(yearHeading).toHaveTextContent(`Year ${year}`);
+          const subheading = within(coreBlock as HTMLElement).queryByTestId(
+            "year-subheading",
+          );
+          expect(subheading).toBeNull();
+        }
 
-          if (["7", "8", "9"].includes(year)) {
-            // Years 7-9 should not have subheadings
-            const subheading =
-              within(yearBlock).queryByTestId("year-subheading");
-            expect(subheading).toBeNull();
-          } else {
-            // Years 10-11 should have subheadings with combined science and higher tier
-            const subheading = within(yearBlock).getByTestId("year-subheading");
-            expect(subheading).toHaveTextContent("Combined science, Higher");
-          }
+        for (const year of ["10", "11"]) {
+          const ks4BlockElement = container.querySelector(
+            `[data-testid="year-non_core-${year}"]`,
+          );
+          expect(ks4BlockElement).toBeInTheDocument();
+          const yearHeading = within(
+            ks4BlockElement as HTMLElement,
+          ).getByTestId("year-heading");
+          expect(yearHeading).toHaveTextContent(`Year ${year}`);
+          const subheading = within(
+            ks4BlockElement as HTMLElement,
+          ).queryByTestId("year-subheading");
+          expect(subheading).toBeInTheDocument();
+          expect(subheading).toHaveTextContent("Combined science, Foundation");
         }
       });
 
@@ -766,10 +805,10 @@ describe("Year group filter headings display correctly", () => {
 
       test("Setting KS3 subject category does not affect the KS4 subheading being displayed", async () => {
         const filterFixture = {
-          subjectCategories: ["2"],
+          subjectCategories: ["2"], // KS3 Chemistry
           childSubjects: ["combined-science"],
           tiers: ["higher"],
-          years: ["10"],
+          years: ["11"],
           threads: [],
           pathways: [],
         };
@@ -782,12 +821,13 @@ describe("Year group filter headings display correctly", () => {
         );
 
         const yearBlock = container.querySelector(
-          '[data-testid="year-non_core-10"]',
+          '[data-testid="year-non_core-11"]',
         ) as HTMLElement;
+
         expect(yearBlock).not.toBeNull();
 
         const yearHeading = within(yearBlock).getByTestId("year-heading");
-        expect(yearHeading).toHaveTextContent("Year 10");
+        expect(yearHeading).toHaveTextContent("Year 11");
         const subheading = within(yearBlock).getByTestId("year-subheading");
         expect(subheading).toHaveTextContent("Combined science, Higher");
       });

--- a/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
@@ -1100,6 +1100,14 @@ export const secondaryScienceYearData: YearData = {
         year: "7",
         subjectcategories: [secondaryScienceSubjectCategories[1]!],
       }),
+      createUnit({
+        year: "7",
+        subjectcategories: [secondaryScienceSubjectCategories[3]!],
+      }),
+      createUnit({
+        year: "7",
+        subjectcategories: [secondaryScienceSubjectCategories[2]!],
+      }),
     ],
   },
   "8": {
@@ -1149,7 +1157,6 @@ export const secondaryScienceYearData: YearData = {
     childSubjects: secondaryScienceChildSubjects,
     tiers: [tiers[0]!, tiers[1]!],
     subjectCategories: secondaryScienceSubjectCategories,
-
     groupAs: null,
     isSwimming: false,
     units: [
@@ -1177,6 +1184,13 @@ export const secondaryScienceYearData: YearData = {
         tier: tiers[0]?.tier,
         tier_slug: tiers[0]?.tier_slug,
       }),
+      createUnit({
+        year: "10",
+        subjectcategories: [secondaryScienceSubjectCategories[1]!],
+        tier: tiers[0]?.tier,
+        tier_slug: tiers[0]?.tier_slug,
+        subject_slug: "combined-science",
+      }),
     ],
   },
   "11": {
@@ -1184,7 +1198,6 @@ export const secondaryScienceYearData: YearData = {
     childSubjects: secondaryScienceChildSubjects,
     tiers: [tiers[0]!, tiers[1]!],
     subjectCategories: secondaryScienceSubjectCategories,
-
     groupAs: null,
     isSwimming: false,
     units: [
@@ -1197,8 +1210,29 @@ export const secondaryScienceYearData: YearData = {
       createUnit({
         year: "11",
         subjectcategories: [secondaryScienceSubjectCategories[3]!],
+        tier: tiers[1]?.tier,
+        tier_slug: tiers[1]?.tier_slug,
+      }),
+      createUnit({
+        year: "11",
+        subjectcategories: [secondaryScienceSubjectCategories[1]!],
         tier: tiers[0]?.tier,
         tier_slug: tiers[0]?.tier_slug,
+        subject_slug: "combined-science",
+      }),
+      createUnit({
+        year: "11",
+        subjectcategories: [secondaryScienceSubjectCategories[1]!],
+        tier: tiers[1]?.tier,
+        tier_slug: tiers[1]?.tier_slug,
+        subject_slug: "combined-science",
+      }),
+      createUnit({
+        year: "11",
+        subjectcategories: [secondaryScienceSubjectCategories[2]!],
+        tier: tiers[1]?.tier,
+        tier_slug: tiers[1]?.tier_slug,
+        subject_slug: "combined-science",
       }),
     ],
   },

--- a/src/utils/curriculum/by-pathway.ts
+++ b/src/utils/curriculum/by-pathway.ts
@@ -18,10 +18,11 @@ export function applyFiltering(
     });
   }
 
-  const step1 = Object.values(unitsByYearSelector).filter((item) =>
-    filterIncludes("years", [item.year]),
-  );
-  const step2 = step1
+  const yearDataFilteredBySelectedYear = Object.values(
+    unitsByYearSelector,
+  ).filter((item) => filterIncludes("years", [item.year]));
+
+  return yearDataFilteredBySelectedYear
     .map((item) => {
       return {
         ...item,
@@ -34,7 +35,6 @@ export function applyFiltering(
     .filter((item) => {
       return item.units.length > 0;
     });
-  return step2;
 }
 
 export function getModes(shouldIncludeCore: boolean, ks4Options: Ks4Option[]) {

--- a/src/utils/curriculum/by-pathway.ts
+++ b/src/utils/curriculum/by-pathway.ts
@@ -21,18 +21,19 @@ export function applyFiltering(
   const step1 = Object.values(unitsByYearSelector).filter((item) =>
     filterIncludes("years", [item.year]),
   );
-  const step2 = step1.map((item) => {
-    return {
-      ...item,
-      units: item.units.filter((unit) => {
-        const yearBasedFilters = filteringFromYears(item, filters);
-        return isVisibleUnit(yearBasedFilters, item.year, unit);
-      }),
-    };
-  });
-  // .filter((item) => {
-  //   return item.units.length > 0;
-  // });
+  const step2 = step1
+    .map((item) => {
+      return {
+        ...item,
+        units: item.units.filter((unit) => {
+          const yearBasedFilters = filteringFromYears(item, filters);
+          return isVisibleUnit(yearBasedFilters, item.year, unit);
+        }),
+      };
+    })
+    .filter((item) => {
+      return item.units.length > 0;
+    });
   return step2;
 }
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Remove empty year from the visualiser for core/gcs
- Amended tests and test fixtures to reflect new filtering

## Issue(s)

Fixes #

## How to test

1. Go to https://deploy-preview-3375--oak-web-application.netlify.thenational.academy/teachers/curriculum/computing-secondary-aqa/units?years=10&pathways=core
2. Click on Year 10 (Core)
3. You should see a non-empty year populated with units

## Screenshots

How it used to look (delete if n/a):
![image](https://github.com/user-attachments/assets/797c7cdb-38a8-443e-af2d-d2265d1d5d20)

How it should now look:
<img width="973" alt="image" src="https://github.com/user-attachments/assets/f8e67e8a-f312-46d9-9934-ab64a906e2ab" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
