### PR TITLE
A11y fix adding `<ul/>`/`<li/>` to curriculum heading nav

### DIFF
--- a/src/components/CurriculumComponents/CurriculumHeaderTabNav/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeaderTabNav/index.tsx
@@ -46,32 +46,36 @@ const CurriculumHeaderTabNav = ({
       $overflowX={"auto"}
       {...flexProps}
     >
-      {links.map((link, i) => (
-        <ButtonAsLink
-          {...link}
-          size="large"
-          variant={variant}
-          aria-current={link.isCurrent ? "page" : undefined}
-          key={`CurriculumHeaderTabNav-${link.page}-${i}`}
-          $font={["heading-7", "heading-6"]}
-          $pt={[3, 0]}
-          $ph={20}
-          data-testid="header-nav-tab"
-          onClick={() => {
-            track.curriculumVisualiserTabAccessed({
-              subjectTitle: subjectTitle,
-              subjectSlug: subjectSlug,
-              platform: "owa",
-              product: "curriculum visualiser",
-              engagementIntent: "explore",
-              componentType: getComponentType(link.page),
-              eventVersion: "2.0.0",
-              analyticsUseCase: "Teacher",
-              phase: phaseSlug,
-            });
-          }}
-        />
-      ))}
+      <ul style={{ display: "contents" }}>
+        {links.map((link, i) => (
+          <li style={{ display: "contents" }}>
+            <ButtonAsLink
+              {...link}
+              size="large"
+              variant={variant}
+              aria-current={link.isCurrent ? "page" : undefined}
+              key={`CurriculumHeaderTabNav-${link.page}-${i}`}
+              $font={["heading-7", "heading-6"]}
+              $pt={[3, 0]}
+              $ph={20}
+              data-testid="header-nav-tab"
+              onClick={() => {
+                track.curriculumVisualiserTabAccessed({
+                  subjectTitle: subjectTitle,
+                  subjectSlug: subjectSlug,
+                  platform: "owa",
+                  product: "curriculum visualiser",
+                  engagementIntent: "explore",
+                  componentType: getComponentType(link.page),
+                  eventVersion: "2.0.0",
+                  analyticsUseCase: "Teacher",
+                  phase: phaseSlug,
+                });
+              }}
+            />
+          </li>
+        ))}
+      </ul>
     </Flex>
   );
 };


### PR DESCRIPTION
## Description
Adding missing `<ul/>`/`<li/>` to curriculum heading nav


## Issue(s)
Fixes `CUR-1391`

## How to test

1. Go to https://deploy-preview-3379--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Nav should be marked up with `<ul>`/`<li>`

## Screenshots
<img width="1573" alt="Screenshot 2025-04-28 at 13 53 34" src="https://github.com/user-attachments/assets/3b23a33e-ea8a-47aa-a03b-8e991e56f45d" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
