### PR TITLE
A11y fixes

### DIFF
--- a/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetails/CurriculumUnitDetails.tsx
@@ -77,14 +77,18 @@ export const CurriculumUnitDetails: FC<CurriculumUnitDetailsProps> = ({
             $gap="all-spacing-2"
             $alignItems={"flex-start"}
           >
-            {uniqueThreadsArray.map((thread) => (
-              <TagFunctional
-                key={thread}
-                text={thread}
-                color={"lavender"}
-                data-testid="thread-tag"
-              />
-            ))}
+            <ul style={{ display: "contents" }}>
+              {uniqueThreadsArray.map((thread) => (
+                <li style={{ display: "contents" }}>
+                  <TagFunctional
+                    key={thread}
+                    text={thread}
+                    color={"lavender"}
+                    data-testid="thread-tag"
+                  />
+                </li>
+              ))}
+            </ul>
           </OakFlex>
         </OakBox>
       )}

--- a/src/components/CurriculumComponents/CurriculumUnitDetailsAccordion/CurriculumUnitDetailsAccordion.tsx
+++ b/src/components/CurriculumComponents/CurriculumUnitDetailsAccordion/CurriculumUnitDetailsAccordion.tsx
@@ -59,28 +59,30 @@ const CurriculumUnitDetailsAccordion: FC<
         $justifyContent={"space-between"}
         $ph={0}
       >
-        <Button
-          {...focusWithinProps}
-          {...primaryTargetProps}
-          data-testid={"expand-accordian-button"}
-          variant="buttonStyledAsLink"
-          aria-expanded={isToggleOpen}
-          label={title}
-          isCurrent={isHovered}
-          currentStyles={["underline"]}
-          onClick={() => {
-            setIsToggleOpen(!isToggleOpen);
-            handleUnitOverviewExploredAnalytics(
-              snakeCase(title) as ComponentTypeValueType,
-            );
-          }}
-          $font={"heading-6"}
-        />
-        <OakIcon
-          iconName={isToggleOpen ? "chevron-up" : "chevron-down"}
-          $width={"all-spacing-6"}
-          $height={"all-spacing-6"}
-        />
+        <h3 style={{ display: "contents" }}>
+          <Button
+            {...focusWithinProps}
+            {...primaryTargetProps}
+            data-testid={"expand-accordian-button"}
+            variant="buttonStyledAsLink"
+            aria-expanded={isToggleOpen}
+            label={title}
+            isCurrent={isHovered}
+            currentStyles={["underline"]}
+            onClick={() => {
+              setIsToggleOpen(!isToggleOpen);
+              handleUnitOverviewExploredAnalytics(
+                snakeCase(title) as ComponentTypeValueType,
+              );
+            }}
+            $font={"heading-6"}
+          />
+          <OakIcon
+            iconName={isToggleOpen ? "chevron-up" : "chevron-down"}
+            $width={"all-spacing-6"}
+            $height={"all-spacing-6"}
+          />
+        </h3>
       </Card>
       {/* @todo replace with OakFlex - work out $maxHeight, why is it Flex if it has display set to either block or none? */}
       <Flex


### PR DESCRIPTION
## Description
Add the following

 - Add headings to unit modal accordions — `CUR-1387`
 - Mark up unit modal threads as unordered list — `CUR-1389`


## Issue(s)
Fixes `CUR-1387` and `CUR-1389`

## How to test
`CUR-1387`

1. Go to https://deploy-preview-3380--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Accordian modal titles should be marked up as `<h3/>`

`CUR-1389`

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check threads in the unit modals are marked up as a list

## Screenshots
`CUR-1387`
<img width="1573" alt="Screenshot 2025-04-28 at 15 04 37" src="https://github.com/user-attachments/assets/1309202a-2900-4846-b7ec-0e103a25ddb4" />

`CUR-1389`
<img width="1573" alt="Screenshot 2025-04-28 at 15 05 01" src="https://github.com/user-attachments/assets/36edfc83-2975-4fa0-a1a3-0086fca9b6ad" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
