### PR TITLE
Fix unit count in curric-visualiser

### DIFF
--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -13,7 +13,10 @@ import {
   CurriculumUnitsFormattedData,
   CurriculumUnitsTrackingData,
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
-import { highlightedUnitCount } from "@/utils/curriculum/filtering";
+import {
+  getNumberOfSelectedUnits,
+  highlightedUnitCount,
+} from "@/utils/curriculum/filtering";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import { CurriculumSelectionSlugs } from "@/utils/curriculum/slugs";
 import { Ks4Option } from "@/node-lib/curriculum-api-2023/queries/curriculumPhaseOptions/curriculumPhaseOptions.schema";
@@ -43,7 +46,7 @@ export default function UnitsTab({
 
   const [mobileSelectedYear, setMobileSelectedYear] = useState<string>("");
 
-  const unitCount = highlightedUnitCount(yearData, filters, []);
+  const unitCount = getNumberOfSelectedUnits(yearData, filters);
 
   const highlightedUnits = highlightedUnitCount(
     yearData,

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -13,6 +13,7 @@ import {
   getDefaultTiersForYearGroup,
   getFilterData,
   getNumberOfFiltersApplied,
+  getNumberOfSelectedUnits,
   highlightedUnitCount,
   isHighlightedUnit,
   mergeInFilterParams,
@@ -22,7 +23,7 @@ import {
   tierForFilter,
   useFilters,
 } from "./filtering";
-import { CurriculumFilters, Unit } from "./types";
+import { CurriculumFilters, YearData, Unit } from "./types";
 import { isCurricRoutingEnabled } from "./flags";
 
 import { createUnit } from "@/fixtures/curriculum/unit";
@@ -1190,5 +1191,92 @@ describe("buildTextDescribingFilter", () => {
       "Tier1 (KS3)",
       "Thread1",
     ]);
+  });
+});
+
+describe("getNumberOfSelectedUnits", () => {
+  const foundationTier = createTier({ tier_slug: "foundation" });
+  const higherTier = createTier({ tier_slug: "higher" });
+  const yearData: YearData = {
+    "7": {
+      units: [
+        createUnit({ slug: "unit1", tier_slug: foundationTier.tier_slug }),
+        createUnit({ slug: "unit2", tier_slug: foundationTier.tier_slug }),
+      ],
+      childSubjects: [],
+      tiers: [foundationTier],
+      subjectCategories: [],
+      isSwimming: false,
+      groupAs: null,
+      pathways: [],
+    },
+    "8": {
+      units: [
+        createUnit({ slug: "unit3", tier_slug: foundationTier.tier_slug }),
+        createUnit({ slug: "unit4", tier_slug: higherTier.tier_slug }),
+        createUnit({ slug: "unit5", tier_slug: higherTier.tier_slug }),
+      ],
+      childSubjects: [],
+      tiers: [foundationTier, higherTier],
+      subjectCategories: [],
+      isSwimming: false,
+      groupAs: null,
+      pathways: [],
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 0 when yearData is empty", () => {
+    const result = getNumberOfSelectedUnits(
+      {},
+      createFilter({
+        years: [],
+        threads: [],
+      }),
+    );
+    expect(result).toBe(0);
+  });
+
+  it("should count visible units for all years when selectedYear is All", () => {
+    const yearSelection = createFilter({
+      years: ["7", "8"],
+      threads: [],
+    });
+
+    const result = getNumberOfSelectedUnits(yearData, yearSelection);
+    expect(result).toBe(5);
+  });
+
+  it("should count visible units only for the selected year", () => {
+    const yearSelection = createFilter({
+      years: ["8"],
+      threads: [],
+    });
+
+    const result = getNumberOfSelectedUnits(yearData, yearSelection);
+    expect(result).toBe(3);
+  });
+
+  it("should only count units that are visible", () => {
+    const yearSelection = createFilter({
+      years: ["7", "8"],
+      tiers: ["foundation"],
+    });
+
+    const result = getNumberOfSelectedUnits(yearData, yearSelection);
+    expect(result).toBe(3);
+  });
+
+  it("should return 0 when no units are visible", () => {
+    const yearSelection = createFilter({
+      years: ["7", "8"],
+      tiers: ["foo"],
+    });
+
+    const result = getNumberOfSelectedUnits(yearData, yearSelection);
+    expect(result).toBe(0);
   });
 });

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -510,3 +510,26 @@ export function keystageSuffixForFilter(
 
   return undefined;
 }
+
+export function getNumberOfSelectedUnits(
+  yearData: YearData,
+  filters: CurriculumFilters,
+): number {
+  let count = 0;
+
+  Object.entries(yearData).forEach(([year, yearDataItem]) => {
+    const units = yearDataItem.units;
+    const yearBasedFilters = filteringFromYears(yearDataItem!, filters);
+    console.log({ yearBasedFilters, filters });
+
+    if (units && filters.years.includes(year)) {
+      const filteredUnits = units.filter((unit: Unit) => {
+        return isVisibleUnit(yearBasedFilters, year, unit);
+      });
+
+      count += filteredUnits.length;
+    }
+  });
+
+  return count;
+}


### PR DESCRIPTION
## Description
Fix unit count in curric-visualiser and refactored `getNumberOfSelectedUnits(...)`, which was previously removed accidentally.


## Issue(s)
Fixes `CUR-1394`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Check unit count is correct and no longer displays zero 


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
