### PR TITLE
Added `aria-expanded` to `<SubjectPhasePicker/>`

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -138,10 +138,11 @@ exports[`CurriculumTab renders 1`] = `
                           style="width: 50%;"
                         >
                           <div
-                            class="sc-fqkvVR sc-9dfc1bad-0 sc-47b15246-2 jEHEPk fAkCpO evzFxe"
+                            class="sc-fqkvVR sc-9dfc1bad-0 sc-bd3b6d19-2 jEHEPk fAkCpO bqIPtS"
                           >
                             <button
-                              class="sc-47b15246-1 fDOTWT"
+                              aria-expanded="false"
+                              class="sc-bd3b6d19-1 hDLPYn"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
@@ -205,10 +206,11 @@ exports[`CurriculumTab renders 1`] = `
                             class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                           >
                             <div
-                              class="sc-fqkvVR sc-9dfc1bad-0 sc-47b15246-2 eMDDOo fAkCpO evzFxe"
+                              class="sc-fqkvVR sc-9dfc1bad-0 sc-bd3b6d19-2 eMDDOo fAkCpO bqIPtS"
                             >
                               <button
-                                class="sc-47b15246-1 fDOTWT"
+                                aria-expanded="false"
+                                class="sc-bd3b6d19-1 hDLPYn"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
@@ -328,10 +330,11 @@ exports[`CurriculumTab renders 1`] = `
                       style="width: 50%;"
                     >
                       <div
-                        class="sc-fqkvVR sc-9dfc1bad-0 sc-47b15246-2 jEHEPk fAkCpO evzFxe"
+                        class="sc-fqkvVR sc-9dfc1bad-0 sc-bd3b6d19-2 jEHEPk fAkCpO bqIPtS"
                       >
                         <button
-                          class="sc-47b15246-1 fDOTWT"
+                          aria-expanded="false"
+                          class="sc-bd3b6d19-1 hDLPYn"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
@@ -395,10 +398,11 @@ exports[`CurriculumTab renders 1`] = `
                         class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                       >
                         <div
-                          class="sc-fqkvVR sc-9dfc1bad-0 sc-47b15246-2 eMDDOo fAkCpO evzFxe"
+                          class="sc-fqkvVR sc-9dfc1bad-0 sc-bd3b6d19-2 eMDDOo fAkCpO bqIPtS"
                         >
                           <button
-                            class="sc-47b15246-1 fDOTWT"
+                            aria-expanded="false"
+                            class="sc-bd3b6d19-1 hDLPYn"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -667,6 +667,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                   onClick={toggleShowSubjects}
                   title="Subject"
                   data-testid="subject-picker-button"
+                  aria-expanded={isMobileLotPickerModalOpen || showSubjects}
                 >
                   <OakBox
                     $pl="inner-padding-m"
@@ -915,6 +916,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                     data-testid="phase-picker-button"
                     onClick={toggleShowPhases}
                     title="Phase"
+                    aria-expanded={showPhases}
                   >
                     <OakBox
                       $pl="inner-padding-m"


### PR DESCRIPTION
## Description
Accessibility fix added `aria-expanded` to `<SubjectPhasePicker/>`


## Issue(s)
Fixes `CUR-1386`

## How to test

1. Go to https://deploy-preview-3389--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. When the lot picker "pickers" are open the buttons clicked should have `aria-expanded` attribute set to `true`


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
