### PR TITLE
fix: add logic to ensure GCSE is correctly appended to a year in TOC

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/2_tableOfContents.ts
+++ b/src/pages-helpers/curriculum/docx/builder/2_tableOfContents.ts
@@ -45,7 +45,11 @@ export default async function generate(
     ...Object.values(yearData).map((item) => {
       let typeSuffix = "";
       if (["10", "11"].includes(item.year)) {
-        typeSuffix = `(${item.type === "core" ? "Core" : "GCSE"})`;
+        if (item.type === "core") {
+          typeSuffix = "(Core)";
+        } else if (item.type === "non_core") {
+          typeSuffix = "(GCSE)";
+        }
       }
 
       const anchorId = `section_year_${item.type}-${item.year}`;

--- a/src/pages-helpers/curriculum/docx/builder/__snapshots__/2_tableOfContents.test.ts.snap
+++ b/src/pages-helpers/curriculum/docx/builder/__snapshots__/2_tableOfContents.test.ts.snap
@@ -4848,7 +4848,7 @@ exports[`2_tableOfContents without pathways 1`] = `
               w:val="28"
             ></w:sz>
           </w:rPr>
-          <w:t><![CDATA[Year 10 units (GCSE)]]></w:t>
+          <w:t><![CDATA[Year 10 units ]]></w:t>
         </w:r>
       </w:hyperlink>
     </w:p>
@@ -4880,7 +4880,7 @@ exports[`2_tableOfContents without pathways 1`] = `
               w:val="28"
             ></w:sz>
           </w:rPr>
-          <w:t><![CDATA[Year 11 units (GCSE)]]></w:t>
+          <w:t><![CDATA[Year 11 units ]]></w:t>
         </w:r>
       </w:hyperlink>
     </w:p>


### PR DESCRIPTION
## Description

Music year: 1981

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/english-secondary-edexcel/downloads
2. Click on dowload and inspect the generated .docx file

## Screenshots

How it used to look (delete if n/a):
![image](https://github.com/user-attachments/assets/1e7bc425-29a4-41d4-b8af-25c75d966389)

How it should now look:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/b877c57e-aa4f-4c6b-a8b9-cedc889dc93b" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [ ] Does this PR update a package with a breaking change
