### PR TITLE
fix: removed feature flag check for teacher notes and use cookie conent for hide/enabled/disabled

### DIFF
--- a/src/__tests__/pages/teachers/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/lessons/[lessonSlug].test.tsx
@@ -1,11 +1,14 @@
 import { GetStaticPropsContext, PreviewData } from "next";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { MockOakConsentClient } from "@oaknational/oak-consent-client";
+import { omit } from "lodash";
 
 import LessonOverviewCanonicalPage, {
   URLParams,
   getStaticProps,
 } from "@/pages/teachers/lessons/[lessonSlug]";
-import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import renderWithProviders, {
+  allProviders,
+} from "@/__tests__/__helpers__/renderWithProviders";
 import lessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/lessonOverview.fixture";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import OakError from "@/errors/OakError";
@@ -54,7 +57,26 @@ jest.mock("posthog-js/react", () => {
   };
 });
 
-const render = renderWithProviders();
+const mockCookieConsent = new MockOakConsentClient({
+  policyConsents: [
+    {
+      policyId: "test-policy",
+      policySlug: "test-policy-slug",
+      consentState: "granted",
+      isStrictlyNecessary: false,
+      policyLabel: "Test Policy",
+      policyDescription: "Test Policy Description",
+      consentedToPreviousVersion: false,
+      policyParties: [],
+    },
+  ],
+  requiresInteraction: false,
+});
+
+const render = renderWithProviders({
+  ...omit(allProviders, "cookieConsent"),
+  cookieConsent: { client: mockCookieConsent },
+});
 
 const lesson = lessonOverviewFixture({
   lessonTitle: "The meaning of time",
@@ -95,29 +117,6 @@ describe("Lesson Overview Canonical Page", () => {
       );
     });
 
-    it("Renders the share button", async () => {
-      window.history.replaceState = jest.fn();
-
-      (useShareExperiment as jest.Mock).mockReturnValueOnce({
-        shareUrl: "http://localhost:3000/teachers/lessons/lesson-1?test=1",
-        browserUrl: "http://localhost:3000/teachers/lessons/lesson-1?test=1",
-        shareActivated: () => {},
-        shareIdRef: { current: "" },
-        shareIdKeyRef: { current: "" },
-      });
-
-      const result = render(
-        <LessonOverviewCanonicalPage
-          lesson={{ ...lesson, pathways: [] }}
-          isSpecialist={false}
-        />,
-      );
-
-      expect(
-        result.getAllByText("Share resources with colleague"),
-      ).toHaveLength(2);
-    });
-
     it("updates the url", async () => {
       const fn = jest.spyOn(window.history, "replaceState");
 
@@ -142,9 +141,7 @@ describe("Lesson Overview Canonical Page", () => {
       );
     });
 
-    it("renders the add teacher note button if teacher notes are enabled", () => {
-      (useFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
-
+    it("renders the add teacher note button if cookies are accepted", () => {
       (useTeacherNotes as jest.Mock).mockReturnValue({
         teacherNote: {},
         isEditable: true,

--- a/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.test.tsx
+++ b/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.test.tsx
@@ -31,6 +31,8 @@ describe("TeacherShareNotesButton", () => {
     noteSaved: false,
     setTeacherNotesOpen: jest.fn(),
     onTeacherNotesOpen: jest.fn(),
+    shareUrl: "https://example.com/share",
+    shareActivated: jest.fn(),
   };
 
   beforeEach(() => {
@@ -139,5 +141,13 @@ describe("TeacherShareNotesButton", () => {
 
     fireEvent.click(screen.getByText("Add teacher note and share"));
     expect(onTeacherNotesOpen).toHaveBeenCalled();
+  });
+
+  it("renders the share button when isEditable is false", () => {
+    render(<TeacherShareNotesButton {...defaultProps} isEditable={false} />);
+
+    expect(
+      screen.queryByText("Share resources with colleague"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.test.tsx
+++ b/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.test.tsx
@@ -20,6 +20,33 @@ jest.mock("@oaknational/oak-components", () => ({
   ),
 }));
 
+jest.mock(
+  "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton",
+  () => ({
+    TeacherShareButton: ({
+      label,
+      shareUrl,
+    }: {
+      label: string;
+      shareUrl: string;
+    }) => (
+      <button data-testid="share-button" data-share-url={shareUrl}>
+        {label}
+      </button>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/components/TeacherComponents/TeacherShareButton/useTeacherShareButton",
+  () => ({
+    useTeacherShareButton: () => ({
+      handleClick: jest.fn(),
+      copiedComponent: <div>Link copied to clipboard</div>,
+    }),
+  }),
+);
+
 const mockUseOakConsent = jest.fn();
 jest.mock("@oaknational/oak-consent-client", () => ({
   useOakConsent: () => mockUseOakConsent(),

--- a/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.tsx
+++ b/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.tsx
@@ -1,46 +1,31 @@
 import { OakSmallSecondaryButton } from "@oaknational/oak-components";
-
-import { useTeacherShareButton } from "../TeacherShareButton/useTeacherShareButton";
-
-import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
+import { useOakConsent } from "@oaknational/oak-consent-client";
 
 export const TeacherShareNotesButton = ({
-  teacherNotesEnabled,
   isEditable,
   noteSaved,
   onTeacherNotesOpen,
-  shareUrl,
-  shareActivated,
 }: {
-  teacherNotesEnabled: boolean;
-  isEditable: boolean;
+  isEditable: boolean | null;
   noteSaved: boolean;
   onTeacherNotesOpen: () => void;
-  shareUrl: string | null;
-  shareActivated?: () => void;
 }) => {
-  const { handleClick, copiedComponent } = useTeacherShareButton({
-    shareUrl,
-    shareActivated,
-  });
+  const { state } = useOakConsent();
+  const cookiesNotAccepted = !!state.policyConsents.find(
+    (policy) =>
+      policy.consentState === "denied" || policy.consentState === "pending",
+  );
 
-  return teacherNotesEnabled && isEditable ? (
+  if (isEditable === null || state.requiresInteraction) return undefined;
+
+  return (
     <OakSmallSecondaryButton
+      disabled={cookiesNotAccepted}
       iconName={noteSaved ? "edit" : "share"}
       isTrailingIcon
       onClick={onTeacherNotesOpen}
     >
       {noteSaved ? "Edit teacher note and share" : "Add teacher note and share"}
     </OakSmallSecondaryButton>
-  ) : (
-    <>
-      <TeacherShareButton
-        label="Share resources with colleague"
-        variant={"secondary"}
-        shareUrl={shareUrl}
-        handleClick={handleClick}
-      />
-      {copiedComponent}
-    </>
   );
 };

--- a/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.tsx
+++ b/src/components/TeacherComponents/TeacherShareNotesButton/TeacherShareNotesButton.tsx
@@ -1,20 +1,46 @@
 import { OakSmallSecondaryButton } from "@oaknational/oak-components";
 import { useOakConsent } from "@oaknational/oak-consent-client";
 
+import { useTeacherShareButton } from "../TeacherShareButton/useTeacherShareButton";
+
+import { TeacherShareButton } from "@/components/TeacherComponents/TeacherShareButton/TeacherShareButton";
+
 export const TeacherShareNotesButton = ({
   isEditable,
   noteSaved,
   onTeacherNotesOpen,
+  shareUrl,
+  shareActivated,
 }: {
   isEditable: boolean | null;
   noteSaved: boolean;
   onTeacherNotesOpen: () => void;
+  shareUrl: string | null;
+  shareActivated?: () => void;
 }) => {
+  const { handleClick, copiedComponent } = useTeacherShareButton({
+    shareUrl,
+    shareActivated,
+  });
   const { state } = useOakConsent();
   const cookiesNotAccepted = !!state.policyConsents.find(
     (policy) =>
       policy.consentState === "denied" || policy.consentState === "pending",
   );
+
+  if (isEditable === false) {
+    return (
+      <>
+        <TeacherShareButton
+          label="Share resources with colleague"
+          variant={"secondary"}
+          shareUrl={shareUrl}
+          handleClick={handleClick}
+        />
+        {copiedComponent}
+      </>
+    );
+  }
 
   if (isEditable === null || state.requiresInteraction) return undefined;
 

--- a/src/pages-helpers/teacher/share-experiments/useTeacherNotes.ts
+++ b/src/pages-helpers/teacher/share-experiments/useTeacherNotes.ts
@@ -40,7 +40,7 @@ export const useTeacherNotes = ({
   );
   const [error, setError] = useState<string | null>(null);
 
-  const [isEditable, setIsEditable] = useState(false);
+  const [isEditable, setIsEditable] = useState<boolean | null>(null);
   const [noteSaved, setNoteSaved] = useState(false);
 
   const coreTrackingProps: CoreProperties = {

--- a/src/pages-helpers/teacher/useLesson/useLesson.tsx
+++ b/src/pages-helpers/teacher/useLesson/useLesson.tsx
@@ -104,6 +104,8 @@ export const useLesson = ({
       isEditable={isEditable}
       noteSaved={noteSaved}
       onTeacherNotesOpen={handleTeacherNotesOpen}
+      shareUrl={shareUrl}
+      shareActivated={shareActivated}
     />
   );
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Removed feature flag check for teacher notes
- Hide teacher notes button when cookies have not been accepted/rejected
- Disabled teacher notes button shows if cookies are rejected
- Enabled teacher notes button shows if cookies are accepted

## Issue(s)

Fixes [https://www.notion.so/oaknationalacademy/Loading-performance-of-teacher-notes-button-lesson-overview-19f26cc4e1b180a29adee94d71511581?pvs=4](https://www.notion.so/oaknationalacademy/Loading-performance-of-teacher-notes-button-lesson-overview-19f26cc4e1b180a29adee94d71511581?pvs=4)

## How to test

1. Go to https://deploy-preview-3401--oak-web-application.netlify.thenational.academy/teachers/programmes/music-secondary-ks3/units/keyboard-fundamentals/lessons/playing-a-melody-in-the-c-position-on-the-keyboard
2. Open in an incognito window
3. Initially you should not see an Add/Edit teacher note button
4. If you accept cookies, the Add button should appear and be enabled
5. If you reject cookies the Add button should appear but be disabled

The feature flag check has also been removed, so we should check that there is no regressions from this. The teacher note should always appear and the legacy Share resources button should never appear.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
- [ ] When cookies have not been accepted/rejected no button is visible
- [ ] When cookies are accepted the button appears and it works as expected (opens notes modal)
- [ ] When cookies are rejected the button appears but is disabled and clicking it performs no action
