### PR TITLE
Added `data-percy-hide` attribute to prevent race condition in video content

### DIFF
--- a/percy.config.js
+++ b/percy.config.js
@@ -27,6 +27,10 @@ module.exports = {
     minHeight: 1024,
     percyCSS: `
     #mtm-root-container { display: none!important; }
+    
+    *[data-percy-hide="contents"] > * {
+      display: none;
+    }
     `,
   },
   discovery: {

--- a/percy.config.js
+++ b/percy.config.js
@@ -29,7 +29,7 @@ module.exports = {
     #mtm-root-container { display: none!important; }
     
     *[data-percy-hide="contents"] > * {
-      display: none;
+      visibility: hidden;
     }
     `,
   },

--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -55,6 +55,28 @@ export type VideoEventCallbackArgs = {
   muted: boolean;
 };
 
+function VideoContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <OakFlex
+      // NOTE: Hiding video contents because otherwise we get some percy
+      // snapshots loaded and some pending load depending on the timing
+      // (race condition)
+      data-percy-hide="contents"
+      $alignItems={"center"}
+      $justifyContent={"center"}
+      $ba={"border-solid-m"}
+      $minWidth={"100%"}
+      $borderColor={"black"}
+      style={{
+        aspectRatio: "16/9",
+        boxSizing: "content-box",
+      }}
+    >
+      {children}
+    </OakFlex>
+  );
+}
+
 const VideoPlayer: FC<VideoPlayerProps> = (props) => {
   const {
     thumbnailTime: thumbTime,
@@ -241,21 +263,11 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
 
   if (videoToken.loading || thumbnailToken.loading || storyboardToken.loading) {
     return (
-      <OakFlex
-        $alignItems={"center"}
-        $justifyContent={"center"}
-        $ba={"border-solid-m"}
-        $minWidth={"100%"}
-        $borderColor={"black"}
-        style={{
-          aspectRatio: "16/9",
-          boxSizing: "content-box",
-        }}
-      >
+      <VideoContainer>
         <OakP $color={loadingTextColor} $textAlign="center">
           Loading...
         </OakP>
-      </OakFlex>
+      </VideoContainer>
     );
   }
 
@@ -279,15 +291,7 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
   }
 
   return (
-    <OakFlex
-      $flexDirection={"column"}
-      $ba={"border-solid-l"}
-      $minWidth={"100%"}
-      $borderColor={"black"}
-      style={{
-        boxSizing: "content-box",
-      }}
-    >
+    <VideoContainer>
       <MuxPlayer
         key={reloadOnErrors.length}
         preload="metadata"
@@ -320,7 +324,7 @@ const VideoPlayer: FC<VideoPlayerProps> = (props) => {
           overflow: "hidden",
         }}
       />
-    </OakFlex>
+    </VideoContainer>
   );
 };
 

--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -64,7 +64,7 @@ function VideoContainer({ children }: { children: React.ReactNode }) {
       data-percy-hide="contents"
       $alignItems={"center"}
       $justifyContent={"center"}
-      $ba={"border-solid-m"}
+      $ba={"border-solid-l"}
       $minWidth={"100%"}
       $borderColor={"black"}
       style={{


### PR DESCRIPTION
## Description
In the percy tests we end up in a state where sometimes videos are loaded and sometimes they aren't. Rather than adding hacks in to disable videos in the code, I've instead just added a `data-percy-hide="contents"` to allow the disabling anything we like in the percy tests

> Why not stop the video from loading entirely

Because we use the preview URL to do the testing against, we'd need a conditional in the querystring (or something like that) to disable loading entirely. This seems like a much simpler and robust solution.  Also `data-percy-hide="contents"` is very easy to identify during development.

## Issue(s)

Fixes `FEC-82`

## How to test
To test OWA

1. Go to https://deploy-preview-3402--oak-web-application.netlify.thenational.academy
2. Check videos still work as expects and still looks correct

To test percy: Rerun the tests a couple of time check that we don't get a video race condition

