### PR TITLE
Only create error boundary once not every render

### DIFF
--- a/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
@@ -52,6 +52,9 @@ const FallbackComponent: FC<FallbackComponentProps> = () => {
   return <ClientErrorView />;
 };
 
+const BugsnagErrorBoundary =
+  Bugsnag.getPlugin("react")?.createErrorBoundary(React);
+
 export type ErrorBoundaryProps = {
   children?: React.ReactNode;
 };
@@ -60,17 +63,13 @@ export type ErrorBoundaryProps = {
  * and sending a report of the uncaught error to bugsnag.
  */
 const ErrorBoundary: FC<ErrorBoundaryProps> = (props) => {
-  const BugsnagErrorBoundary =
-    bugsnagInitialised() &&
-    Bugsnag.getPlugin("react")?.createErrorBoundary(React);
-
-  if (!BugsnagErrorBoundary) {
-    return <NonBugsnagErrorBoundary {...props} />;
+  if (bugsnagInitialised() && BugsnagErrorBoundary) {
+    return (
+      <BugsnagErrorBoundary FallbackComponent={FallbackComponent} {...props} />
+    );
   }
 
-  return (
-    <BugsnagErrorBoundary FallbackComponent={FallbackComponent} {...props} />
-  );
+  return <NonBugsnagErrorBoundary {...props} />;
 };
 
 export default ErrorBoundary;


### PR DESCRIPTION
## Description
Only create error boundary once not every render

This prevents aggressive rei-rendering of the entire tree, and is the recommended usage, see <https://docs.bugsnag.com/platforms/javascript/react/capturing-render-errors/>

**Note**: Although this is true for lots of parts of the application, the testing steps below if for my particular usecase.

## Issue(s)
hotfix

## How to test
Test the app locally (with `npm run dev`) as it doesn't appear to be an issue in production.
 
### Load the app in locally
1. Go to http://localhost:3000/teachers/curriculum/english-primary/overview
2. Select the `<h1/>` ("KS1 & KS2 English curriculum") in dev tools
<img width="442" alt="Screenshot 2025-05-12 at 16 36 19" src="https://github.com/user-attachments/assets/304cbcda-b634-4f99-8fe7-bad59effbb61" />

3. Navigate to the explainer
<img width="442" alt="Screenshot 2025-05-12 at 16 36 26" src="https://github.com/user-attachments/assets/07aabd08-710b-4dd9-821e-a55694971893" />

4. The same DOM node should remain present, if the selection gets reset it means that the DOM node was recycled.

Also verify on the `main` branch that the above does indeed fail.


