### PR TITLE
Revert "Only create error boundary once not every render"

### DIFF
--- a/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
@@ -52,9 +52,6 @@ const FallbackComponent: FC<FallbackComponentProps> = () => {
   return <ClientErrorView />;
 };
 
-const BugsnagErrorBoundary =
-  Bugsnag.getPlugin("react")?.createErrorBoundary(React);
-
 export type ErrorBoundaryProps = {
   children?: React.ReactNode;
 };
@@ -63,13 +60,17 @@ export type ErrorBoundaryProps = {
  * and sending a report of the uncaught error to bugsnag.
  */
 const ErrorBoundary: FC<ErrorBoundaryProps> = (props) => {
-  if (bugsnagInitialised() && BugsnagErrorBoundary) {
-    return (
-      <BugsnagErrorBoundary FallbackComponent={FallbackComponent} {...props} />
-    );
+  const BugsnagErrorBoundary =
+    bugsnagInitialised() &&
+    Bugsnag.getPlugin("react")?.createErrorBoundary(React);
+
+  if (!BugsnagErrorBoundary) {
+    return <NonBugsnagErrorBoundary {...props} />;
   }
 
-  return <NonBugsnagErrorBoundary {...props} />;
+  return (
+    <BugsnagErrorBoundary FallbackComponent={FallbackComponent} {...props} />
+  );
 };
 
 export default ErrorBoundary;


### PR DESCRIPTION
Reverts oaknational/Oak-Web-Application#3407

Reverted as it's causing warnings 🤦

```
    console.error
      Bugsnag.getPlugin() was called before Bugsnag.start()
```