### PR TITLE
Feat/curepic 131 core in gcse non core fix

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
@@ -95,14 +95,14 @@ export function CurricFiltersYears({
     if (data.yearOptions.includes("10")) {
       yearOptions.push({
         year: "10",
-        queryString: "!core",
+        queryString: "non_core",
         pathway: "non_core",
       });
     }
     if (data.yearOptions.includes("11")) {
       yearOptions.push({
         year: "11",
-        queryString: "!core",
+        queryString: "non_core",
         pathway: "non_core",
       });
     }

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersYears.tsx
@@ -26,7 +26,7 @@ export type CurricFiltersYearsProps = {
   slugs: CurriculumSelectionSlugs;
 };
 
-type YearOption = { year: string; pathway?: string };
+type YearOption = { year: string; pathway?: string; queryString?: string };
 
 const filterToIndex = (
   filters: CurriculumFilters,
@@ -46,7 +46,7 @@ const filterToIndex = (
         if (shouldDisplayCorePathway) {
           return (
             yearOption.year === currentYear &&
-            yearOption.pathway === currentPathway
+            yearOption.queryString === currentPathway
           );
         } else {
           return yearOption.year === currentYear;
@@ -73,29 +73,38 @@ export function CurricFiltersYears({
       return {
         year,
         pathway: keystageFromYear(year) === "ks4" ? "core" : undefined,
+        queryString: "core",
       };
     } else {
       return { year };
     }
   });
-  function addAllToFilter(target: { year: string; pathway?: string }) {
+  function addAllToFilter(target: YearOption) {
     if (target.year === "all") {
       onChangeFilters({ ...filters, years: data.yearOptions, pathways: [] });
     } else {
       onChangeFilters({
         ...filters,
         years: [target.year],
-        pathways: target.pathway ? [target.pathway] : [],
+        pathways: target.queryString ? [target.queryString] : [],
       });
     }
   }
 
   if (shouldDisplayCorePathway) {
     if (data.yearOptions.includes("10")) {
-      yearOptions.push({ year: "10", pathway: "non_core" });
+      yearOptions.push({
+        year: "10",
+        queryString: "!core",
+        pathway: "non_core",
+      });
     }
     if (data.yearOptions.includes("11")) {
-      yearOptions.push({ year: "11", pathway: "non_core" });
+      yearOptions.push({
+        year: "11",
+        queryString: "!core",
+        pathway: "non_core",
+      });
     }
   }
 

--- a/src/utils/curriculum/analytics.test.ts
+++ b/src/utils/curriculum/analytics.test.ts
@@ -181,7 +181,7 @@ describe("buildUnitSequenceRefinedAnalytics", () => {
   it("should set pathway to GCSE when selected", () => {
     const filtersWithHigherTier: CurriculumFilters = {
       ...baseFilters,
-      pathways: ["!core"],
+      pathways: ["non_core"],
     };
 
     const result = buildUnitSequenceRefinedAnalytics(

--- a/src/utils/curriculum/analytics.ts
+++ b/src/utils/curriculum/analytics.ts
@@ -20,7 +20,7 @@ function assertValidPathway(
   if (pathway === "core") {
     return "Core";
   }
-  if (pathway === "!core") {
+  if (pathway === "non_core") {
     return "GCSE";
   }
   return null;

--- a/src/utils/curriculum/isVisibleUnit.test.ts
+++ b/src/utils/curriculum/isVisibleUnit.test.ts
@@ -1,4 +1,4 @@
-import { evalCondition, isVisibleUnit } from "./isVisibleUnit";
+import { evalPathwayCondition, isVisibleUnit } from "./isVisibleUnit";
 
 import { createFilter } from "@/fixtures/curriculum/filters";
 import { CombinedCurriculumData } from "@/pages-helpers/curriculum/docx";
@@ -94,9 +94,9 @@ describe("isVisibleUnit", () => {
   });
 });
 
-it("evalCondition", () => {
-  expect(evalCondition("!foo", "foo")).toEqual(false);
-  expect(evalCondition("!foo", "bar")).toEqual(true);
-  expect(evalCondition("foo", "foo")).toEqual(true);
-  expect(evalCondition("foo", "bar")).toEqual(false);
+it("evalPathwayCondition", () => {
+  expect(evalPathwayCondition("non_core", "core")).toEqual(false);
+  expect(evalPathwayCondition("non_core", "gcse")).toEqual(true);
+  expect(evalPathwayCondition("core", "core")).toEqual(true);
+  expect(evalPathwayCondition("core", "gcse")).toEqual(false);
 });

--- a/src/utils/curriculum/isVisibleUnit.ts
+++ b/src/utils/curriculum/isVisibleUnit.ts
@@ -11,15 +11,12 @@ export type PartialFilters = {
   pathways: CurriculumFilters["pathways"];
 };
 
-export function evalCondition(query: string, slug: string) {
-  const isNot = query.match(/^!/);
-  const target = query.replace(/^!/, "");
-
+export function evalPathwayCondition(query: string, slug: string) {
   let ret = false;
-  if (isNot) {
-    ret = slug !== target;
+  if (query === "non_core") {
+    ret = "core" !== slug;
   } else {
-    ret = slug === target;
+    ret = "core" === slug;
   }
 
   return ret;
@@ -55,7 +52,7 @@ export function isVisibleUnit(
   const filterByPathways =
     !filters.pathways?.[0] ||
     !unit.pathway_slug ||
-    evalCondition(filters.pathways[0], unit.pathway_slug);
+    evalPathwayCondition(filters.pathways[0], unit.pathway_slug);
 
   return (
     filterBySubject &&


### PR DESCRIPTION
## Description
Fixes for `non_core` filtering in the sidebar of the curric visualiser


## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Verify changing pathway core/gcse updates the URL correctly 
3. Verify the visualiser shows the correct output for the pathway selected.


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
