### PR TITLE
Added subjectcategories slug into filter

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -158,7 +158,7 @@ const unitData = [
     tier: null,
     tier_slug: null,
     tags: [{ id: 5, title: "Biology", category: "Discipline" }],
-    subjectcategories: [{ id: 5, title: "Biology" }],
+    subjectcategories: [{ id: 5, slug: "biology", title: "Biology" }],
     threads: [
       {
         title:
@@ -1303,6 +1303,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
           subjectCategories: [
             {
               id: 5,
+              slug: "biology",
               title: "Biology",
             },
           ],
@@ -1384,7 +1385,7 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
                   title: "Biology",
                 },
               ],
-              subjectcategories: [{ id: 5, title: "Biology" }],
+              subjectcategories: [{ id: 5, slug: "biology", title: "Biology" }],
               threads: [
                 {
                   order: 3,

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.fixtures.ts
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.fixtures.ts
@@ -3,14 +3,17 @@ import { createUnit } from "@/fixtures/curriculum/unit";
 
 const subjectCategoryBiology = createSubjectCategory({
   id: 1,
+  slug: "biology",
   title: "biology",
 });
 const subjectCategoryChemistry = createSubjectCategory({
   id: 2,
+  slug: "chemistry",
   title: "chemistry",
 });
 const subjectCategoryPhysics = createSubjectCategory({
   id: 3,
+  slug: "physics",
   title: "physics",
 });
 

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.test.tsx
@@ -32,9 +32,9 @@ describe("CurricFiltersSubjectCategories", () => {
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
     expect(getByRole("heading").textContent).toEqual("Category (KS4)");
-    expect(elements[0]!.value).toEqual("1");
-    expect(elements[1]!.value).toEqual("2");
-    expect(elements[2]!.value).toEqual("3");
+    expect(elements[0]!.value).toEqual("biology");
+    expect(elements[1]!.value).toEqual("chemistry");
+    expect(elements[2]!.value).toEqual("physics");
   });
 
   it("renders correctly ks3 & ks4", () => {
@@ -60,9 +60,9 @@ describe("CurricFiltersSubjectCategories", () => {
     const elements = getAllByRole("radio") as HTMLInputElement[];
     expect(elements.length).toEqual(3);
     expect(getByRole("heading").textContent).toEqual("Category");
-    expect(elements[0]!.value).toEqual("1");
-    expect(elements[1]!.value).toEqual("2");
-    expect(elements[2]!.value).toEqual("3");
+    expect(elements[0]!.value).toEqual("biology");
+    expect(elements[1]!.value).toEqual("chemistry");
+    expect(elements[2]!.value).toEqual("physics");
   });
 
   it("interacts correctly", () => {
@@ -91,7 +91,7 @@ describe("CurricFiltersSubjectCategories", () => {
 
     act(() => elements[0]!.click());
     expect(onChangeFilters).toHaveBeenCalledWith({
-      subjectCategories: ["1"],
+      subjectCategories: ["biology"],
       childSubjects: [],
       threads: [],
       tiers: [],
@@ -99,7 +99,7 @@ describe("CurricFiltersSubjectCategories", () => {
     });
     act(() => elements[1]!.click());
     expect(onChangeFilters).toHaveBeenCalledWith({
-      subjectCategories: ["2"],
+      subjectCategories: ["chemistry"],
       childSubjects: [],
       threads: [],
       tiers: [],
@@ -107,7 +107,7 @@ describe("CurricFiltersSubjectCategories", () => {
     });
     act(() => elements[2]!.click());
     expect(onChangeFilters).toHaveBeenCalledWith({
-      subjectCategories: ["3"],
+      subjectCategories: ["physics"],
       childSubjects: [],
       threads: [],
       tiers: [],

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
@@ -85,13 +85,13 @@ export function CurricFiltersSubjectCategories({
             {subjectCategories.map((subjectCategory) => {
               return (
                 <OakRadioAsButton
-                  key={String(subjectCategory.id)}
-                  value={String(subjectCategory.id)}
-                  data-testid={`subject-category-radio-${subjectCategory.id}`}
+                  key={String(subjectCategory.slug)}
+                  value={String(subjectCategory.slug)}
+                  data-testid={`subject-category-radio-${subjectCategory.slug}`}
                   displayValue={subjectCategory.title}
                   icon={getValidSubjectCategoryIconById(
                     slugs.subjectSlug,
-                    subjectCategory.id,
+                    subjectCategory.slug,
                   )}
                 />
               );

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -244,7 +244,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -269,7 +269,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7"],
         threads: [],
@@ -294,7 +294,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["8"],
         threads: [],
@@ -319,7 +319,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -351,7 +351,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -379,7 +379,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -407,7 +407,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -441,7 +441,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["7", "8", "9", "10", "11"],
         threads: [],
@@ -468,7 +468,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["1", "2", "3", "4", "5", "6"],
         threads: [],
@@ -495,7 +495,7 @@ describe("Curriculum visualiser filter states", () => {
 
       const filterFixture = {
         childSubjects: [],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         tiers: [],
         years: ["1", "2", "3", "4", "5", "6"],
         threads: [],
@@ -536,7 +536,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays all years - with no subject categories in subheadings for year 7-9, and child subjects and foundation tier in subheading for year 10-11", async () => {
         const filterFixture = {
           childSubjects: ["combined-science"],
-          subjectCategories: ["-1"],
+          subjectCategories: ["all"],
           tiers: ["higher"],
           years: ["7", "8", "9", "10", "11"],
           threads: [],
@@ -574,7 +574,7 @@ describe("Year group filter headings display correctly", () => {
 
       test("displays nothing for 'All' subject category in subheading", async () => {
         const filterFixture = {
-          subjectCategories: ["-1"],
+          subjectCategories: ["all"],
           childSubjects: [],
           tiers: [],
           years: ["7"],
@@ -600,7 +600,7 @@ describe("Year group filter headings display correctly", () => {
 
       test("displays 'Biology' subject category in subheading", async () => {
         const filterFixture = {
-          subjectCategories: ["1"],
+          subjectCategories: ["biology"],
           childSubjects: [],
           tiers: [],
           years: ["7"],
@@ -626,7 +626,7 @@ describe("Year group filter headings display correctly", () => {
 
       test("displays 'Chemistry' subject category in subheading", async () => {
         const filterFixture = {
-          subjectCategories: ["2"],
+          subjectCategories: ["chemistry"],
           childSubjects: [],
           tiers: [],
           years: ["7"],
@@ -652,7 +652,7 @@ describe("Year group filter headings display correctly", () => {
 
       test("displays 'Physics' subject categories in subheading for Year 7", async () => {
         const filterFixture = {
-          subjectCategories: ["3"],
+          subjectCategories: ["physics"],
           childSubjects: [],
           tiers: [],
           years: ["7"],
@@ -817,7 +817,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays subject category in subheading for Year 1, Primary English", async () => {
         const filterFixture = {
           childSubjects: [],
-          subjectCategories: ["4"],
+          subjectCategories: ["reading-writing-and-oracy"],
           tiers: [],
           years: ["1"],
           threads: [],
@@ -849,7 +849,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays Biology subject category in subheading", async () => {
         const filterFixture = {
           childSubjects: [],
-          subjectCategories: ["1"],
+          subjectCategories: ["biology"],
           tiers: [],
           years: ["1"],
           threads: [],
@@ -874,7 +874,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays Chemistry subject category in subheading", async () => {
         const filterFixture = {
           childSubjects: [],
-          subjectCategories: ["2"],
+          subjectCategories: ["chemistry"],
           tiers: [],
           years: ["2"],
           threads: [],
@@ -899,7 +899,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays Physics subject category in subheading", async () => {
         const filterFixture = {
           childSubjects: [],
-          subjectCategories: ["3"],
+          subjectCategories: ["physics"],
           tiers: [],
           years: ["3"],
           threads: [],
@@ -924,7 +924,7 @@ describe("Year group filter headings display correctly", () => {
       test("displays nothing for 'All' subject category in subheading", async () => {
         const filterFixture = {
           childSubjects: [],
-          subjectCategories: ["-1"],
+          subjectCategories: ["all"],
           tiers: [],
           years: ["4"],
           threads: [],

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.tsx
@@ -112,7 +112,7 @@ function getSubjectCategoryMessage(
       years
         .flatMap((yearKey) =>
           yearData[yearKey]?.subjectCategories?.filter((sc) =>
-            subjectCategories.includes(sc.id.toString()),
+            subjectCategories.includes(sc.slug),
           ),
         )
         .filter(Boolean)
@@ -159,7 +159,7 @@ function getSubjectCategoryMessage(
       (yearKey) =>
         yearData[yearKey]?.units?.some((unit) =>
           unit.subjectcategories?.some((sc) =>
-            subjectCategories.includes(sc.id.toString()),
+            subjectCategories.includes(sc.slug.toString()),
           ),
         ),
     );

--- a/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
@@ -3,8 +3,16 @@ import { createChildSubject } from "@/fixtures/curriculum/childSubject";
 import { createUnit } from "@/fixtures/curriculum/unit";
 import { createTier } from "@/fixtures/curriculum/tier";
 
-const subjectCategoryOne = createSubjectCategory({ id: 1, title: "sub-cat-1" });
-const subjectCategoryTwo = createSubjectCategory({ id: 2, title: "sub-cat-2" });
+const subjectCategoryOne = createSubjectCategory({
+  id: 1,
+  slug: "sub-cat-1",
+  title: "sub-cat-1",
+});
+const subjectCategoryTwo = createSubjectCategory({
+  id: 2,
+  slug: "sub-cat-2",
+  title: "sub-cat-2",
+});
 
 // Where M is missing unit and U is a present unit
 // for that subject category in that year
@@ -683,11 +691,15 @@ export const missingUnitForLastYearFixture = {
 // Primary English Fixture
 
 export const primaryEnglishSubjectCategories = [
-  createSubjectCategory({ id: 4, title: "Reading, writing & oracy" }),
-  createSubjectCategory({ id: 5, title: "Grammar" }),
-  createSubjectCategory({ id: 6, title: "Handwriting" }),
-  createSubjectCategory({ id: 7, title: "Spelling" }),
-  createSubjectCategory({ id: 8, title: "Vocabulary" }),
+  createSubjectCategory({
+    slug: "reading-writing-and-oracy",
+    id: 4,
+    title: "Reading, writing & oracy",
+  }),
+  createSubjectCategory({ slug: "grammar", id: 5, title: "Grammar" }),
+  createSubjectCategory({ slug: "handwriting", id: 6, title: "Handwriting" }),
+  createSubjectCategory({ slug: "spelling", id: 7, title: "Spelling" }),
+  createSubjectCategory({ slug: "vocabulary", id: 8, title: "Vocabulary" }),
 ];
 
 export const primaryEnglishYearData = {
@@ -851,10 +863,10 @@ export const primaryEnglishYearData = {
 // Primary Science Fixture
 
 export const primaryScienceSubjectCategories = [
-  createSubjectCategory({ id: -1, title: "All" }),
-  createSubjectCategory({ id: 1, title: "Biology" }),
-  createSubjectCategory({ id: 2, title: "Chemistry" }),
-  createSubjectCategory({ id: 3, title: "Physics" }),
+  createSubjectCategory({ slug: "all", id: -1, title: "All" }),
+  createSubjectCategory({ slug: "biology", id: 1, title: "Biology" }),
+  createSubjectCategory({ slug: "chemistry", id: 2, title: "Chemistry" }),
+  createSubjectCategory({ slug: "physics", id: 3, title: "Physics" }),
 ];
 
 export const primaryScienceYearData = {
@@ -996,10 +1008,10 @@ export const tiers = [
 ];
 
 export const secondaryScienceSubjectCategories = [
-  createSubjectCategory({ id: -1, title: "All" }),
-  createSubjectCategory({ id: 1, title: "Biology" }),
-  createSubjectCategory({ id: 2, title: "Chemistry" }),
-  createSubjectCategory({ id: 3, title: "Physics" }),
+  createSubjectCategory({ slug: "all", id: -1, title: "All" }),
+  createSubjectCategory({ slug: "biology", id: 1, title: "Biology" }),
+  createSubjectCategory({ slug: "chemistry", id: 2, title: "Chemistry" }),
+  createSubjectCategory({ slug: "physics", id: 3, title: "Physics" }),
 ];
 
 const secondaryScienceChildSubjects = [

--- a/src/fixtures/curriculum/subjectCategories/index.test.ts
+++ b/src/fixtures/curriculum/subjectCategories/index.test.ts
@@ -5,6 +5,7 @@ describe("createSubjectCategory", () => {
     const result = createSubjectCategory();
     expect(result).toEqual({
       id: 1,
+      slug: "foo",
       title: "Foo",
     });
   });
@@ -13,6 +14,7 @@ describe("createSubjectCategory", () => {
     const result = createSubjectCategory({ id: 999 });
     expect(result).toEqual({
       id: 999,
+      slug: "foo",
       title: "Foo",
     });
   });
@@ -21,20 +23,21 @@ describe("createSubjectCategory", () => {
     const result = createSubjectCategory({ title: "Badger" });
     expect(result).toEqual({
       id: 1,
+      slug: "foo",
       title: "Badger",
     });
   });
 
   it("create an array of subject categories", () => {
     const result = [
-      createSubjectCategory({ id: 1, title: "Foo" }),
-      createSubjectCategory({ id: 2, title: "Bar" }),
-      createSubjectCategory({ id: 3, title: "Baz" }),
+      createSubjectCategory({ id: 1, slug: "foo", title: "Foo" }),
+      createSubjectCategory({ id: 2, slug: "bar", title: "Bar" }),
+      createSubjectCategory({ id: 3, slug: "baz", title: "Baz" }),
     ];
     expect(result).toEqual([
-      { id: 1, title: "Foo" },
-      { id: 2, title: "Bar" },
-      { id: 3, title: "Baz" },
+      { id: 1, slug: "foo", title: "Foo" },
+      { id: 2, slug: "bar", title: "Bar" },
+      { id: 3, slug: "baz", title: "Baz" },
     ]);
   });
 });

--- a/src/fixtures/curriculum/subjectCategories/index.ts
+++ b/src/fixtures/curriculum/subjectCategories/index.ts
@@ -1,13 +1,17 @@
+import { getTitleFromSlug } from "@/fixtures/shared/helper";
 import { SubjectCategory } from "@/utils/curriculum/types";
 
 const BASE_SUBJECT_CATEGORIES: SubjectCategory = {
   id: 1,
+  slug: "foo",
   title: "Foo",
 };
 
 export function createSubjectCategory(partial: Partial<SubjectCategory> = {}) {
+  const slug = getTitleFromSlug(partial?.slug);
   return {
     ...BASE_SUBJECT_CATEGORIES,
+    ...(slug ? { slug } : {}),
     ...partial,
   };
 }

--- a/src/fixtures/curriculum/yearData/index.test.ts
+++ b/src/fixtures/curriculum/yearData/index.test.ts
@@ -23,7 +23,7 @@ describe("createSubjectCategory", () => {
     const result = createYearData({
       units: [createUnit({ slug: "test" })],
       childSubjects: [createChildSubject({ subject_slug: "test" })],
-      subjectCategories: [createSubjectCategory({ id: 2 })],
+      subjectCategories: [createSubjectCategory({ id: 2, slug: "test" })],
       tiers: [createTier({ tier_slug: "test" })],
       pathways: [],
       isSwimming: true,
@@ -74,6 +74,7 @@ describe("createSubjectCategory", () => {
       subjectCategories: [
         {
           id: 2,
+          slug: "test",
           title: "Foo",
         },
       ],

--- a/src/node-lib/curriculum-api-2023/fixtures/curriculumUnits.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/curriculumUnits.fixture.ts
@@ -90,6 +90,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -183,6 +184,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -258,6 +260,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -1589,6 +1592,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -1692,6 +1696,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -1795,6 +1800,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -3235,6 +3241,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -3339,6 +3346,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -3443,6 +3451,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -4656,6 +4665,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -4729,6 +4739,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -4824,6 +4835,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -6209,6 +6221,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -6289,6 +6302,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -6393,6 +6407,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -7698,6 +7713,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -7802,6 +7818,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -7906,6 +7923,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -9461,6 +9479,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -9564,6 +9583,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -9662,6 +9682,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -10765,6 +10786,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -10858,6 +10880,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -10946,6 +10969,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -11805,6 +11829,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -11908,6 +11933,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -12012,6 +12038,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -12898,6 +12925,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -13002,6 +13030,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -13095,6 +13124,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -13731,6 +13761,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -13829,6 +13860,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -14351,6 +14383,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -14455,6 +14488,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -15066,6 +15100,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],
@@ -15170,6 +15205,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 11,
+            slug: "physics",
             title: "Physics",
           },
         ],
@@ -15783,6 +15819,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 8,
+            slug: "chemistry",
             title: "Chemistry",
           },
         ],
@@ -15877,6 +15914,7 @@ const curriculumUnitsTabFixture = (
         subjectcategories: [
           {
             id: 5,
+            slug: "biology",
             title: "Biology",
           },
         ],

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -21318,6 +21318,512 @@ export type Published_Mv_Curriculum_Sequence_B_13_0_16_Variance_Fields = {
   unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17 = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  national_curriculum_content?: Maybe<Scalars['json']['output']>;
+  non_curriculum?: Maybe<Scalars['Boolean']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  parent_programme_features?: Maybe<Scalars['jsonb']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  subjectcategories?: Maybe<Scalars['jsonb']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17National_Curriculum_ContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17Parent_Programme_FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17SubjectcategoriesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_aggregate';
+  aggregate?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Curriculum_Sequence_B_13_0_17>;
+};
+
+/** aggregate fields of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_aggregate_fields';
+  avg?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Max_Fields>;
+  min?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Min_Fields>;
+  stddev?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Sum_Fields>;
+  var_pop?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Var_Samp_Fields>;
+  variance?: Maybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Avg_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_avg_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_curriculum_sequence_b_13_0_17". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  cross_subject_links?: InputMaybe<String_Comparison_Exp>;
+  cycle?: InputMaybe<String_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<String_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  national_curriculum_content?: InputMaybe<Json_Comparison_Exp>;
+  non_curriculum?: InputMaybe<Boolean_Comparison_Exp>;
+  notes?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  parent_programme_features?: InputMaybe<Jsonb_Comparison_Exp>;
+  pathway?: InputMaybe<String_Comparison_Exp>;
+  pathway_slug?: InputMaybe<String_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  prior_knowledge_requirements?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subjectcategories?: InputMaybe<Jsonb_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  why_this_why_now?: InputMaybe<String_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Max_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Min_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_curriculum_sequence_b_13_0_17". */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  cross_subject_links?: InputMaybe<Order_By>;
+  cycle?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  national_curriculum_content?: InputMaybe<Order_By>;
+  non_curriculum?: InputMaybe<Order_By>;
+  notes?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  parent_programme_features?: InputMaybe<Order_By>;
+  pathway?: InputMaybe<Order_By>;
+  pathway_slug?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  prior_knowledge_requirements?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subjectcategories?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  why_this_why_now?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_curriculum_sequence_b_13_0_17" */
+export enum Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
+  /** column name */
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
+  /** column name */
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
+  /** column name */
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
+  /** column name */
+  CrossSubjectLinks = 'cross_subject_links',
+  /** column name */
+  Cycle = 'cycle',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  Domain = 'domain',
+  /** column name */
+  DomainId = 'domain_id',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  KeystageSlug = 'keystage_slug',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  NationalCurriculumContent = 'national_curriculum_content',
+  /** column name */
+  NonCurriculum = 'non_curriculum',
+  /** column name */
+  Notes = 'notes',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  ParentProgrammeFeatures = 'parent_programme_features',
+  /** column name */
+  Pathway = 'pathway',
+  /** column name */
+  PathwaySlug = 'pathway_slug',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
+  /** column name */
+  PriorKnowledgeRequirements = 'prior_knowledge_requirements',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Subjectcategories = 'subjectcategories',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  WhyThisWhyNow = 'why_this_why_now',
+  /** column name */
+  Year = 'year'
+}
+
+/** aggregate stddev on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_stddev_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Stddev_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_mv_curriculum_sequence_b_13_0_17" */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  cross_subject_links?: InputMaybe<Scalars['String']['input']>;
+  cycle?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['String']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
+  non_curriculum?: InputMaybe<Scalars['Boolean']['input']>;
+  notes?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  parent_programme_features?: InputMaybe<Scalars['jsonb']['input']>;
+  pathway?: InputMaybe<Scalars['String']['input']>;
+  pathway_slug?: InputMaybe<Scalars['String']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  prior_knowledge_requirements?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  why_this_why_now?: InputMaybe<Scalars['String']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Sum_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_sum_fields';
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Var_Pop_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_var_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Var_Samp_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_var_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_Mv_Curriculum_Sequence_B_13_0_17_Variance_Fields = {
+  __typename?: 'published_mv_curriculum_sequence_b_13_0_17_variance_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
 export type Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0 = {
   __typename?: 'published_mv_get_tpc_media_by_lesson_slug_1_0_0';
@@ -35778,6 +36284,512 @@ export type Published_View_Curriculum_Sequence_B_13_0_16_Variance_Fields = {
   unit_id?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17 = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  lessons?: Maybe<Scalars['jsonb']['output']>;
+  national_curriculum_content?: Maybe<Scalars['json']['output']>;
+  non_curriculum?: Maybe<Scalars['Boolean']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  parent_programme_features?: Maybe<Scalars['jsonb']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  subjectcategories?: Maybe<Scalars['jsonb']['output']>;
+  tags?: Maybe<Scalars['jsonb']['output']>;
+  threads?: Maybe<Scalars['jsonb']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  unit_options?: Maybe<Scalars['jsonb']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17LessonsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17National_Curriculum_ContentArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17Parent_Programme_FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17SubjectcategoriesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17TagsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17ThreadsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17Unit_OptionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Aggregate = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_aggregate';
+  aggregate?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Aggregate_Fields>;
+  nodes: Array<Published_View_Curriculum_Sequence_B_13_0_17>;
+};
+
+/** aggregate fields of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Aggregate_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_aggregate_fields';
+  avg?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Max_Fields>;
+  min?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Min_Fields>;
+  stddev?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Fields>;
+  stddev_pop?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Samp_Fields>;
+  sum?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Sum_Fields>;
+  var_pop?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Var_Pop_Fields>;
+  var_samp?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Var_Samp_Fields>;
+  variance?: Maybe<Published_View_Curriculum_Sequence_B_13_0_17_Variance_Fields>;
+};
+
+
+/** aggregate fields of "published.view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Avg_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_avg_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "published.view_curriculum_sequence_b_13_0_17". All fields are combined with a logical 'AND'. */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>>;
+  _not?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  connection_future_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_future_unit_title?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_description?: InputMaybe<String_Comparison_Exp>;
+  connection_prior_unit_title?: InputMaybe<String_Comparison_Exp>;
+  cross_subject_links?: InputMaybe<String_Comparison_Exp>;
+  cycle?: InputMaybe<String_Comparison_Exp>;
+  description?: InputMaybe<String_Comparison_Exp>;
+  domain?: InputMaybe<String_Comparison_Exp>;
+  domain_id?: InputMaybe<String_Comparison_Exp>;
+  examboard?: InputMaybe<String_Comparison_Exp>;
+  examboard_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  keystage_slug?: InputMaybe<String_Comparison_Exp>;
+  lessons?: InputMaybe<Jsonb_Comparison_Exp>;
+  national_curriculum_content?: InputMaybe<Json_Comparison_Exp>;
+  non_curriculum?: InputMaybe<Boolean_Comparison_Exp>;
+  notes?: InputMaybe<String_Comparison_Exp>;
+  order?: InputMaybe<Int_Comparison_Exp>;
+  parent_programme_features?: InputMaybe<Jsonb_Comparison_Exp>;
+  pathway?: InputMaybe<String_Comparison_Exp>;
+  pathway_slug?: InputMaybe<String_Comparison_Exp>;
+  phase?: InputMaybe<String_Comparison_Exp>;
+  phase_slug?: InputMaybe<String_Comparison_Exp>;
+  planned_number_of_lessons?: InputMaybe<Int_Comparison_Exp>;
+  prior_knowledge_requirements?: InputMaybe<String_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  state?: InputMaybe<String_Comparison_Exp>;
+  subject?: InputMaybe<String_Comparison_Exp>;
+  subject_parent?: InputMaybe<String_Comparison_Exp>;
+  subject_parent_slug?: InputMaybe<String_Comparison_Exp>;
+  subject_slug?: InputMaybe<String_Comparison_Exp>;
+  subjectcategories?: InputMaybe<Jsonb_Comparison_Exp>;
+  tags?: InputMaybe<Jsonb_Comparison_Exp>;
+  threads?: InputMaybe<Jsonb_Comparison_Exp>;
+  tier?: InputMaybe<String_Comparison_Exp>;
+  tier_slug?: InputMaybe<String_Comparison_Exp>;
+  title?: InputMaybe<String_Comparison_Exp>;
+  unit_id?: InputMaybe<Int_Comparison_Exp>;
+  unit_options?: InputMaybe<Jsonb_Comparison_Exp>;
+  why_this_why_now?: InputMaybe<String_Comparison_Exp>;
+  year?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Max_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_max_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Min_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_min_fields';
+  connection_future_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_future_unit_title?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_description?: Maybe<Scalars['String']['output']>;
+  connection_prior_unit_title?: Maybe<Scalars['String']['output']>;
+  cross_subject_links?: Maybe<Scalars['String']['output']>;
+  cycle?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  domain?: Maybe<Scalars['String']['output']>;
+  domain_id?: Maybe<Scalars['String']['output']>;
+  examboard?: Maybe<Scalars['String']['output']>;
+  examboard_slug?: Maybe<Scalars['String']['output']>;
+  keystage_slug?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
+  order?: Maybe<Scalars['Int']['output']>;
+  pathway?: Maybe<Scalars['String']['output']>;
+  pathway_slug?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  phase_slug?: Maybe<Scalars['String']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  prior_knowledge_requirements?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  subject?: Maybe<Scalars['String']['output']>;
+  subject_parent?: Maybe<Scalars['String']['output']>;
+  subject_parent_slug?: Maybe<Scalars['String']['output']>;
+  subject_slug?: Maybe<Scalars['String']['output']>;
+  tier?: Maybe<Scalars['String']['output']>;
+  tier_slug?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+  why_this_why_now?: Maybe<Scalars['String']['output']>;
+  year?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.view_curriculum_sequence_b_13_0_17". */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  connection_future_unit_description?: InputMaybe<Order_By>;
+  connection_future_unit_title?: InputMaybe<Order_By>;
+  connection_prior_unit_description?: InputMaybe<Order_By>;
+  connection_prior_unit_title?: InputMaybe<Order_By>;
+  cross_subject_links?: InputMaybe<Order_By>;
+  cycle?: InputMaybe<Order_By>;
+  description?: InputMaybe<Order_By>;
+  domain?: InputMaybe<Order_By>;
+  domain_id?: InputMaybe<Order_By>;
+  examboard?: InputMaybe<Order_By>;
+  examboard_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  keystage_slug?: InputMaybe<Order_By>;
+  lessons?: InputMaybe<Order_By>;
+  national_curriculum_content?: InputMaybe<Order_By>;
+  non_curriculum?: InputMaybe<Order_By>;
+  notes?: InputMaybe<Order_By>;
+  order?: InputMaybe<Order_By>;
+  parent_programme_features?: InputMaybe<Order_By>;
+  pathway?: InputMaybe<Order_By>;
+  pathway_slug?: InputMaybe<Order_By>;
+  phase?: InputMaybe<Order_By>;
+  phase_slug?: InputMaybe<Order_By>;
+  planned_number_of_lessons?: InputMaybe<Order_By>;
+  prior_knowledge_requirements?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  state?: InputMaybe<Order_By>;
+  subject?: InputMaybe<Order_By>;
+  subject_parent?: InputMaybe<Order_By>;
+  subject_parent_slug?: InputMaybe<Order_By>;
+  subject_slug?: InputMaybe<Order_By>;
+  subjectcategories?: InputMaybe<Order_By>;
+  tags?: InputMaybe<Order_By>;
+  threads?: InputMaybe<Order_By>;
+  tier?: InputMaybe<Order_By>;
+  tier_slug?: InputMaybe<Order_By>;
+  title?: InputMaybe<Order_By>;
+  unit_id?: InputMaybe<Order_By>;
+  unit_options?: InputMaybe<Order_By>;
+  why_this_why_now?: InputMaybe<Order_By>;
+  year?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.view_curriculum_sequence_b_13_0_17" */
+export enum Published_View_Curriculum_Sequence_B_13_0_17_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  ConnectionFutureUnitDescription = 'connection_future_unit_description',
+  /** column name */
+  ConnectionFutureUnitTitle = 'connection_future_unit_title',
+  /** column name */
+  ConnectionPriorUnitDescription = 'connection_prior_unit_description',
+  /** column name */
+  ConnectionPriorUnitTitle = 'connection_prior_unit_title',
+  /** column name */
+  CrossSubjectLinks = 'cross_subject_links',
+  /** column name */
+  Cycle = 'cycle',
+  /** column name */
+  Description = 'description',
+  /** column name */
+  Domain = 'domain',
+  /** column name */
+  DomainId = 'domain_id',
+  /** column name */
+  Examboard = 'examboard',
+  /** column name */
+  ExamboardSlug = 'examboard_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  KeystageSlug = 'keystage_slug',
+  /** column name */
+  Lessons = 'lessons',
+  /** column name */
+  NationalCurriculumContent = 'national_curriculum_content',
+  /** column name */
+  NonCurriculum = 'non_curriculum',
+  /** column name */
+  Notes = 'notes',
+  /** column name */
+  Order = 'order',
+  /** column name */
+  ParentProgrammeFeatures = 'parent_programme_features',
+  /** column name */
+  Pathway = 'pathway',
+  /** column name */
+  PathwaySlug = 'pathway_slug',
+  /** column name */
+  Phase = 'phase',
+  /** column name */
+  PhaseSlug = 'phase_slug',
+  /** column name */
+  PlannedNumberOfLessons = 'planned_number_of_lessons',
+  /** column name */
+  PriorKnowledgeRequirements = 'prior_knowledge_requirements',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  State = 'state',
+  /** column name */
+  Subject = 'subject',
+  /** column name */
+  SubjectParent = 'subject_parent',
+  /** column name */
+  SubjectParentSlug = 'subject_parent_slug',
+  /** column name */
+  SubjectSlug = 'subject_slug',
+  /** column name */
+  Subjectcategories = 'subjectcategories',
+  /** column name */
+  Tags = 'tags',
+  /** column name */
+  Threads = 'threads',
+  /** column name */
+  Tier = 'tier',
+  /** column name */
+  TierSlug = 'tier_slug',
+  /** column name */
+  Title = 'title',
+  /** column name */
+  UnitId = 'unit_id',
+  /** column name */
+  UnitOptions = 'unit_options',
+  /** column name */
+  WhyThisWhyNow = 'why_this_why_now',
+  /** column name */
+  Year = 'year'
+}
+
+/** aggregate stddev on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_stddev_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Pop_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_stddev_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Stddev_Samp_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_stddev_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "published_view_curriculum_sequence_b_13_0_17" */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_View_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  connection_future_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_future_unit_title?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_description?: InputMaybe<Scalars['String']['input']>;
+  connection_prior_unit_title?: InputMaybe<Scalars['String']['input']>;
+  cross_subject_links?: InputMaybe<Scalars['String']['input']>;
+  cycle?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  domain_id?: InputMaybe<Scalars['String']['input']>;
+  examboard?: InputMaybe<Scalars['String']['input']>;
+  examboard_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  keystage_slug?: InputMaybe<Scalars['String']['input']>;
+  lessons?: InputMaybe<Scalars['jsonb']['input']>;
+  national_curriculum_content?: InputMaybe<Scalars['json']['input']>;
+  non_curriculum?: InputMaybe<Scalars['Boolean']['input']>;
+  notes?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  parent_programme_features?: InputMaybe<Scalars['jsonb']['input']>;
+  pathway?: InputMaybe<Scalars['String']['input']>;
+  pathway_slug?: InputMaybe<Scalars['String']['input']>;
+  phase?: InputMaybe<Scalars['String']['input']>;
+  phase_slug?: InputMaybe<Scalars['String']['input']>;
+  planned_number_of_lessons?: InputMaybe<Scalars['Int']['input']>;
+  prior_knowledge_requirements?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  subject?: InputMaybe<Scalars['String']['input']>;
+  subject_parent?: InputMaybe<Scalars['String']['input']>;
+  subject_parent_slug?: InputMaybe<Scalars['String']['input']>;
+  subject_slug?: InputMaybe<Scalars['String']['input']>;
+  subjectcategories?: InputMaybe<Scalars['jsonb']['input']>;
+  tags?: InputMaybe<Scalars['jsonb']['input']>;
+  threads?: InputMaybe<Scalars['jsonb']['input']>;
+  tier?: InputMaybe<Scalars['String']['input']>;
+  tier_slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  unit_id?: InputMaybe<Scalars['Int']['input']>;
+  unit_options?: InputMaybe<Scalars['jsonb']['input']>;
+  why_this_why_now?: InputMaybe<Scalars['String']['input']>;
+  year?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Sum_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_sum_fields';
+  order?: Maybe<Scalars['Int']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Int']['output']>;
+  unit_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate var_pop on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Var_Pop_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_var_pop_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Var_Samp_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_var_samp_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Published_View_Curriculum_Sequence_B_13_0_17_Variance_Fields = {
+  __typename?: 'published_view_curriculum_sequence_b_13_0_17_variance_fields';
+  order?: Maybe<Scalars['Float']['output']>;
+  planned_number_of_lessons?: Maybe<Scalars['Float']['output']>;
+  unit_id?: Maybe<Scalars['Float']['output']>;
+};
+
 /** columns and relationships of "published.view_keystages_1_0_0" */
 export type Published_View_Keystages_1_0_0 = {
   __typename?: 'published_view_keystages_1_0_0';
@@ -44076,6 +45088,10 @@ export type Query_Root = {
   published_mv_curriculum_sequence_b_13_0_16: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
   /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_16" */
   published_mv_curriculum_sequence_b_13_0_16_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate;
+  /** fetch data from the table: "published.mv_curriculum_sequence_b_13_0_17" */
+  published_mv_curriculum_sequence_b_13_0_17: Array<Published_Mv_Curriculum_Sequence_B_13_0_17>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_17" */
+  published_mv_curriculum_sequence_b_13_0_17_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate;
   /** fetch data from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
   published_mv_get_tpc_media_by_lesson_slug_1_0_0: Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
@@ -44268,6 +45284,10 @@ export type Query_Root = {
   published_view_curriculum_sequence_b_13_0_16: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
   /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_16" */
   published_view_curriculum_sequence_b_13_0_16_aggregate: Published_View_Curriculum_Sequence_B_13_0_16_Aggregate;
+  /** fetch data from the table: "published.view_curriculum_sequence_b_13_0_17" */
+  published_view_curriculum_sequence_b_13_0_17: Array<Published_View_Curriculum_Sequence_B_13_0_17>;
+  /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_17" */
+  published_view_curriculum_sequence_b_13_0_17_aggregate: Published_View_Curriculum_Sequence_B_13_0_17_Aggregate;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -45365,6 +46385,24 @@ export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_16_AggregateArgs =
 };
 
 
+export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_17Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Curriculum_Sequence_B_13_0_17_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
 export type Query_RootPublished_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -46226,6 +47264,24 @@ export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_16_AggregateArgs
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_16_Order_By>>;
   where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_17Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_View_Curriculum_Sequence_B_13_0_17_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
 };
 
 
@@ -49248,6 +50304,12 @@ export type Subscription_Root = {
   published_mv_curriculum_sequence_b_13_0_16_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_16_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_curriculum_sequence_b_13_0_16" */
   published_mv_curriculum_sequence_b_13_0_16_stream: Array<Published_Mv_Curriculum_Sequence_B_13_0_16>;
+  /** fetch data from the table: "published.mv_curriculum_sequence_b_13_0_17" */
+  published_mv_curriculum_sequence_b_13_0_17: Array<Published_Mv_Curriculum_Sequence_B_13_0_17>;
+  /** fetch aggregated fields from the table: "published.mv_curriculum_sequence_b_13_0_17" */
+  published_mv_curriculum_sequence_b_13_0_17_aggregate: Published_Mv_Curriculum_Sequence_B_13_0_17_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_curriculum_sequence_b_13_0_17" */
+  published_mv_curriculum_sequence_b_13_0_17_stream: Array<Published_Mv_Curriculum_Sequence_B_13_0_17>;
   /** fetch data from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
   published_mv_get_tpc_media_by_lesson_slug_1_0_0: Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0>;
   /** fetch aggregated fields from the table: "published.mv_get_tpc_media_by_lesson_slug_1_0_0" */
@@ -49536,6 +50598,12 @@ export type Subscription_Root = {
   published_view_curriculum_sequence_b_13_0_16_aggregate: Published_View_Curriculum_Sequence_B_13_0_16_Aggregate;
   /** fetch data from the table in a streaming manner: "published.view_curriculum_sequence_b_13_0_16" */
   published_view_curriculum_sequence_b_13_0_16_stream: Array<Published_View_Curriculum_Sequence_B_13_0_16>;
+  /** fetch data from the table: "published.view_curriculum_sequence_b_13_0_17" */
+  published_view_curriculum_sequence_b_13_0_17: Array<Published_View_Curriculum_Sequence_B_13_0_17>;
+  /** fetch aggregated fields from the table: "published.view_curriculum_sequence_b_13_0_17" */
+  published_view_curriculum_sequence_b_13_0_17_aggregate: Published_View_Curriculum_Sequence_B_13_0_17_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.view_curriculum_sequence_b_13_0_17" */
+  published_view_curriculum_sequence_b_13_0_17_stream: Array<Published_View_Curriculum_Sequence_B_13_0_17>;
   /** fetch data from the table: "published.view_keystages_1_0_0" */
   published_view_keystages_1_0_0: Array<Published_View_Keystages_1_0_0>;
   /** fetch aggregated fields from the table: "published.view_keystages_1_0_0" */
@@ -51004,6 +52072,31 @@ export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_16_StreamAr
 };
 
 
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_17Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_17_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Curriculum_Sequence_B_13_0_17_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
 export type Subscription_RootPublished_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0Args = {
   distinct_on?: InputMaybe<Array<Published_Mv_Get_Tpc_Media_By_Lesson_Slug_1_0_0_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -52201,6 +53294,31 @@ export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_16_Stream
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_17Args = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_17_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_View_Curriculum_Sequence_B_13_0_17_Order_By>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_View_Curriculum_Sequence_B_13_0_17_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_View_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
 };
 
 
@@ -60665,6 +61783,8 @@ export type Videos = {
   signed_stream_id?: Maybe<Scalars['String']['output']>;
   text_track_id?: Maybe<Scalars['String']['output']>;
   title?: Maybe<Scalars['String']['output']>;
+  tpc_media_ids?: Maybe<Scalars['jsonb']['output']>;
+  tpc_works_ids?: Maybe<Scalars['jsonb']['output']>;
   updated_at?: Maybe<Scalars['timestamptz']['output']>;
   url?: Maybe<Scalars['String']['output']>;
   video_id: Scalars['Int']['output'];
@@ -60695,6 +61815,18 @@ export type VideosCaption_All_States_AggregateArgs = {
 
 /** columns and relationships of "videos" */
 export type VideosDeprecated_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "videos" */
+export type VideosTpc_Media_IdsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "videos" */
+export type VideosTpc_Works_IdsArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -60779,6 +61911,8 @@ export type Videos_Aggregate_Order_By = {
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Videos_Append_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['jsonb']['input']>;
   video_object?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -60827,6 +61961,8 @@ export type Videos_Bool_Exp = {
   signed_stream_id?: InputMaybe<String_Comparison_Exp>;
   text_track_id?: InputMaybe<String_Comparison_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
+  tpc_media_ids?: InputMaybe<Jsonb_Comparison_Exp>;
+  tpc_works_ids?: InputMaybe<Jsonb_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
   url?: InputMaybe<String_Comparison_Exp>;
   video_id?: InputMaybe<Int_Comparison_Exp>;
@@ -60843,18 +61979,24 @@ export enum Videos_Constraint {
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Videos_Delete_At_Path_Input = {
   deprecated_fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  tpc_media_ids?: InputMaybe<Array<Scalars['String']['input']>>;
+  tpc_works_ids?: InputMaybe<Array<Scalars['String']['input']>>;
   video_object?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Videos_Delete_Elem_Input = {
   deprecated_fields?: InputMaybe<Scalars['Int']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['Int']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['Int']['input']>;
   video_object?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Videos_Delete_Key_Input = {
   deprecated_fields?: InputMaybe<Scalars['String']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['String']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['String']['input']>;
   video_object?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -60884,6 +62026,8 @@ export type Videos_Insert_Input = {
   signed_stream_id?: InputMaybe<Scalars['String']['input']>;
   text_track_id?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   url?: InputMaybe<Scalars['String']['input']>;
   video_id?: InputMaybe<Scalars['Int']['input']>;
@@ -61015,6 +62159,8 @@ export type Videos_Order_By = {
   signed_stream_id?: InputMaybe<Order_By>;
   text_track_id?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
+  tpc_media_ids?: InputMaybe<Order_By>;
+  tpc_works_ids?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
   url?: InputMaybe<Order_By>;
   video_id?: InputMaybe<Order_By>;
@@ -61031,6 +62177,8 @@ export type Videos_Pk_Columns_Input = {
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Videos_Prepend_Input = {
   deprecated_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['jsonb']['input']>;
   video_object?: InputMaybe<Scalars['jsonb']['input']>;
 };
 
@@ -61066,6 +62214,10 @@ export enum Videos_Select_Column {
   TextTrackId = 'text_track_id',
   /** column name */
   Title = 'title',
+  /** column name */
+  TpcMediaIds = 'tpc_media_ids',
+  /** column name */
+  TpcWorksIds = 'tpc_works_ids',
   /** column name */
   UpdatedAt = 'updated_at',
   /** column name */
@@ -61111,6 +62263,8 @@ export type Videos_Set_Input = {
   signed_stream_id?: InputMaybe<Scalars['String']['input']>;
   text_track_id?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   url?: InputMaybe<Scalars['String']['input']>;
   video_id?: InputMaybe<Scalars['Int']['input']>;
@@ -61188,6 +62342,8 @@ export type Videos_Stream_Cursor_Value_Input = {
   signed_stream_id?: InputMaybe<Scalars['String']['input']>;
   text_track_id?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+  tpc_media_ids?: InputMaybe<Scalars['jsonb']['input']>;
+  tpc_works_ids?: InputMaybe<Scalars['jsonb']['input']>;
   updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
   url?: InputMaybe<Scalars['String']['input']>;
   video_id?: InputMaybe<Scalars['Int']['input']>;
@@ -61242,6 +62398,10 @@ export enum Videos_Update_Column {
   TextTrackId = 'text_track_id',
   /** column name */
   Title = 'title',
+  /** column name */
+  TpcMediaIds = 'tpc_media_ids',
+  /** column name */
+  TpcWorksIds = 'tpc_works_ids',
   /** column name */
   UpdatedAt = 'updated_at',
   /** column name */
@@ -61332,11 +62492,11 @@ export type CurriculumPhaseOptionsQueryVariables = Exact<{ [key: string]: never;
 export type CurriculumPhaseOptionsQuery = { __typename?: 'query_root', options: Array<{ __typename?: 'published_mv_curriculum_phase_options_0_3', title?: string | null, slug?: string | null, phases?: any | null, keystages?: any | null, ks4_options?: any | null }> };
 
 export type CurriculumSequenceQueryVariables = Exact<{
-  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_16_Bool_Exp>;
+  where?: InputMaybe<Published_Mv_Curriculum_Sequence_B_13_0_17_Bool_Exp>;
 }>;
 
 
-export type CurriculumSequenceQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_sequence_b_13_0_16', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: string | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, why_this_why_now?: string | null, description?: string | null, cycle?: string | null, features?: any | null, parent_programme_features?: any | null, actions?: any | null, unit_options?: any | null, threads?: any | null, year?: string | null, pathway?: string | null, pathway_slug?: string | null, state?: string | null }> };
+export type CurriculumSequenceQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_curriculum_sequence_b_13_0_17', connection_prior_unit_description?: string | null, connection_future_unit_description?: string | null, connection_future_unit_title?: string | null, connection_prior_unit_title?: string | null, domain?: string | null, domain_id?: string | null, examboard?: string | null, examboard_slug?: string | null, keystage_slug?: string | null, lessons?: any | null, order?: number | null, planned_number_of_lessons?: number | null, phase?: string | null, phase_slug?: string | null, slug?: string | null, subject?: string | null, subject_slug?: string | null, subject_parent?: string | null, subject_parent_slug?: string | null, tags?: any | null, subjectcategories?: any | null, tier?: string | null, tier_slug?: string | null, title?: string | null, why_this_why_now?: string | null, description?: string | null, cycle?: string | null, features?: any | null, parent_programme_features?: any | null, actions?: any | null, unit_options?: any | null, threads?: any | null, year?: string | null, pathway?: string | null, pathway_slug?: string | null, state?: string | null }> };
 
 export type BetaLessonMediaClipsQueryVariables = Exact<{
   lessonSlug: Scalars['String']['input'];
@@ -61634,8 +62794,8 @@ export const CurriculumPhaseOptionsDocument = gql`
 }
     `;
 export const CurriculumSequenceDocument = gql`
-    query curriculumSequence($where: published_mv_curriculum_sequence_b_13_0_16_bool_exp) {
-  units: published_mv_curriculum_sequence_b_13_0_16(where: $where) {
+    query curriculumSequence($where: published_mv_curriculum_sequence_b_13_0_17_bool_exp) {
+  units: published_mv_curriculum_sequence_b_13_0_17(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.gql
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.gql
@@ -1,7 +1,7 @@
 query curriculumSequence(
-  $where: published_mv_curriculum_sequence_b_13_0_16_bool_exp
+  $where: published_mv_curriculum_sequence_b_13_0_17_bool_exp
 ) {
-  units: published_mv_curriculum_sequence_b_13_0_16(where: $where) {
+  units: published_mv_curriculum_sequence_b_13_0_17(where: $where) {
     connection_prior_unit_description
     connection_future_unit_description
     connection_future_unit_title

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.schema.ts
@@ -49,6 +49,7 @@ const curriculumSequenceSchema = z.object({
             id: z.number(),
             title: z.string(),
             category: z.string().optional(),
+            slug: z.string(),
           }),
         )
         .nullable(),

--- a/src/pages-helpers/curriculum/docx/tab-helpers.ts
+++ b/src/pages-helpers/curriculum/docx/tab-helpers.ts
@@ -251,6 +251,7 @@ export function createUnitsListingByYear(
         currentYearData.subjectCategories.push({
           id: subjectCategory.id,
           title: subjectCategory.title,
+          slug: subjectCategory.slug,
         });
       }
     });
@@ -260,7 +261,11 @@ export function createUnitsListingByYear(
     const data = yearData[year]!;
 
     data.isSwimming = data.units[0]?.features?.pe_swimming === true;
-    const allSubjectCategoryTag: SubjectCategory = { id: -1, title: "All" };
+    const allSubjectCategoryTag: SubjectCategory = {
+      id: -1,
+      title: "All",
+      slug: "all",
+    };
     const actions = data.units[0]?.actions;
     // Add an "All" option if there are 2 or more subject categories. Set to -1 id as this shouldn't ever appear in the DB
     if (!actions?.subject_category_actions?.all_disabled) {

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -121,8 +121,8 @@ describe("filtering", () => {
 
   describe("getDefaultSubjectCategoriesForYearGroup", () => {
     it("with data", () => {
-      const subCat1 = createSubjectCategory({ id: 1 });
-      const subCat2 = createSubjectCategory({ id: 2 });
+      const subCat1 = createSubjectCategory({ id: 1, slug: "one" });
+      const subCat2 = createSubjectCategory({ id: 2, slug: "two" });
       const input: CurriculumUnitsYearData = {
         "7": {
           units: [createUnit({ slug: "test1", subjectcategories: [subCat1] })],
@@ -144,7 +144,7 @@ describe("filtering", () => {
         },
       };
       const out = getDefaultSubjectCategoriesForYearGroup(input);
-      expect(out).toEqual(["1"]);
+      expect(out).toEqual(["one"]);
     });
 
     it("without data", () => {
@@ -254,13 +254,17 @@ describe("filtering", () => {
             units: [] as Unit[],
             tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
             childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
-            subjectCategories: [{ id: 2 }],
+            subjectCategories: [
+              createSubjectCategory({ id: 2, slug: "sub-cat-2" }),
+            ],
           } as CurriculumUnitsYearData[number],
           "8": {
             units: [] as Unit[],
             tiers: [{ tier_slug: "higher", tier: "Higher" }],
             childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
-            subjectCategories: [{ id: 1 }],
+            subjectCategories: [
+              createSubjectCategory({ id: 1, slug: "sub-cat-1" }),
+            ],
           } as CurriculumUnitsYearData[number],
         },
         threadOptions: [],
@@ -268,7 +272,7 @@ describe("filtering", () => {
       });
       expect(out).toEqual({
         childSubjects: ["biology"],
-        subjectCategories: ["1"],
+        subjectCategories: ["sub-cat-1"],
         threads: [],
         tiers: ["foundation"],
         years: ["7", "8"],
@@ -285,13 +289,13 @@ test("getFilterData", () => {
       units: [] as Unit[],
       tiers: [{ tier_slug: "foundation", tier: "Foundation" }],
       childSubjects: [{ subject: "Physics", subject_slug: "physics" }],
-      subjectCategories: [{ id: 2 }],
+      subjectCategories: [createSubjectCategory({ id: 2, slug: "sub-cat-2" })],
     } as CurriculumUnitsYearData[number],
     "8": {
       units: [] as Unit[],
       tiers: [{ tier_slug: "higher", tier: "Higher" }],
       childSubjects: [{ subject: "Biology", subject_slug: "biology" }],
-      subjectCategories: [{ id: 1 }],
+      subjectCategories: [createSubjectCategory({ id: 1, slug: "sub-cat-1" })],
     } as CurriculumUnitsYearData[number],
   };
   const allYearOutput = getFilterData(definition, ["7", "8"]);
@@ -309,9 +313,13 @@ test("getFilterData", () => {
     subjectCategories: [
       {
         id: 1,
+        slug: "sub-cat-1",
+        title: "Foo",
       },
       {
         id: 2,
+        slug: "sub-cat-2",
+        title: "Foo",
       },
     ],
     tiers: [
@@ -337,6 +345,8 @@ test("getFilterData", () => {
     subjectCategories: [
       {
         id: 2,
+        slug: "sub-cat-2",
+        title: "Foo",
       },
     ],
     tiers: [
@@ -358,6 +368,8 @@ test("getFilterData", () => {
     subjectCategories: [
       {
         id: 1,
+        slug: "sub-cat-1",
+        title: "Foo",
       },
     ],
     tiers: [

--- a/src/utils/curriculum/filtering.ts
+++ b/src/utils/curriculum/filtering.ts
@@ -49,10 +49,10 @@ export function getDefaultChildSubjectForYearGroup(
 export function getDefaultSubjectCategoriesForYearGroup(
   data: CurriculumUnitsYearData,
 ) {
-  const set = new Set<Pick<SubjectCategory, "id">>();
+  const set = new Set<Pick<SubjectCategory, "slug" | "id">>();
   Object.values(data).forEach((yearData) => {
     yearData.subjectCategories.forEach((subjectCategory) =>
-      set.add({ id: subjectCategory.id }),
+      set.add({ id: subjectCategory.id, slug: subjectCategory.slug }),
     );
   });
   const subjectCategories = [...set]
@@ -63,7 +63,7 @@ export function getDefaultSubjectCategoriesForYearGroup(
         }),
       ),
     )
-    .map((s) => String(s.id));
+    .map((s) => String(s.slug));
   if (subjectCategories.length > 0) {
     return [subjectCategories[0]!];
   }
@@ -174,7 +174,7 @@ export function getFilterData(
   years: string[],
 ) {
   const childSubjects = new Map<string, Subject>();
-  const subjectCategories = new Map<number, SubjectCategory>();
+  const subjectCategories = new Map<string, SubjectCategory>();
   const tiers = new Map<string, Tier>();
   years.forEach((year) => {
     const obj = yearData[year];
@@ -184,7 +184,7 @@ export function getFilterData(
       );
       obj.tiers.forEach((tier) => tiers.set(tier.tier_slug, tier));
       obj.subjectCategories.forEach((subjectCategory) =>
-        subjectCategories.set(subjectCategory.id, subjectCategory),
+        subjectCategories.set(subjectCategory.slug, subjectCategory),
       );
     }
   });

--- a/src/utils/curriculum/fixtures/curriculumunits-english-secondary.fixture.ts
+++ b/src/utils/curriculum/fixtures/curriculumunits-english-secondary.fixture.ts
@@ -1930,6 +1930,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -2056,6 +2057,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -2204,6 +2206,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -2392,6 +2395,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -2482,6 +2486,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -2524,6 +2529,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -2721,6 +2727,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -3138,6 +3145,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -3271,6 +3279,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -3470,6 +3479,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -3755,6 +3765,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -4242,6 +4253,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -5078,6 +5090,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -5324,6 +5337,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -5378,6 +5392,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -5542,6 +5557,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -5776,6 +5792,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -6702,6 +6719,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -6980,6 +6998,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -7028,6 +7047,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -7270,6 +7290,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -7312,6 +7333,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -8559,6 +8581,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -8828,6 +8851,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -9503,6 +9527,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -9603,6 +9628,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -9645,6 +9671,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -10322,6 +10349,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -10370,6 +10398,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -10844,6 +10873,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -11299,6 +11329,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -11408,6 +11439,7 @@ export default {
       subjectcategories: [
         {
           id: 18,
+          slug: "language",
           title: "Language",
         },
       ],
@@ -11450,6 +11482,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -11643,6 +11676,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -11843,6 +11877,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -12279,6 +12314,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],
@@ -12327,6 +12363,7 @@ export default {
       subjectcategories: [
         {
           id: 19,
+          slug: "literature",
           title: "Literature",
         },
       ],

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -374,7 +374,7 @@ describe("getYearSubheadingText", () => {
       "7",
       createFilter({
         years: ["7"],
-        subjectCategories: [String(subCat1.id)],
+        subjectCategories: [subCat1.slug],
       }),
     );
     expect(result).toEqual("SUB_CAT_1");
@@ -410,7 +410,7 @@ describe("getYearSubheadingText", () => {
       "7",
       createFilter({
         years: ["7"],
-        subjectCategories: [String(subCat1.id)],
+        subjectCategories: [subCat1.slug],
         childSubjects: [childSubject1.subject_slug],
         tiers: [tier1.tier_slug],
       }),

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -143,15 +143,15 @@ export function getYearSubheadingText(
   // Handle subject categories (KS1-KS3)
   if (
     filters.subjectCategories.length > 0 &&
-    !filters.subjectCategories.includes("-1") && // Skip if "All" is selected
+    !filters.subjectCategories.includes("all") && // Skip if "All" is selected
     (!isKs4Year || filters.childSubjects.length === 0)
   ) {
     const subjectCategoryTitles = filters.subjectCategories
-      .map((id) => {
+      .map((slug) => {
         // Try to find subject category in current year
-        const subjectCategory = yearData[year]?.subjectCategories.find(
-          (sc) => sc.id.toString() === id,
-        );
+        const subjectCategory = yearData[year]?.subjectCategories.find((sc) => {
+          return sc.slug === slug;
+        });
         return subjectCategory?.title;
       })
       .filter(Boolean);

--- a/src/utils/curriculum/isVisibleUnit.test.ts
+++ b/src/utils/curriculum/isVisibleUnit.test.ts
@@ -59,13 +59,14 @@ describe("isVisibleUnit", () => {
       subjectcategories: [
         {
           id: 1,
+          slug: "biology",
           title: "Biology",
         },
       ],
     };
 
     const filters = createFilter({
-      subjectCategories: ["1"],
+      subjectCategories: ["biology"],
       years: ["10"],
     });
     expect(isVisibleUnit(filters, "10", unit)).toEqual(true);
@@ -77,6 +78,7 @@ describe("isVisibleUnit", () => {
       subjectcategories: [
         {
           id: 1,
+          slug: "biology",
           title: "Biology",
         },
       ],
@@ -85,7 +87,7 @@ describe("isVisibleUnit", () => {
     };
 
     const filters = createFilter({
-      subjectCategories: ["1"],
+      subjectCategories: ["biology"],
       tiers: ["foundation"],
       years: ["10"],
       threads: [],

--- a/src/utils/curriculum/isVisibleUnit.ts
+++ b/src/utils/curriculum/isVisibleUnit.ts
@@ -25,10 +25,10 @@ export function isVisibleUnit(
   const filterBySubjectCategory =
     !filters.subjectCategories?.[0] ||
     (filters.subjectCategories.length > 0 &&
-      filters.subjectCategories?.[0] === "-1") ||
+      filters.subjectCategories?.[0] === "all") ||
     unit.subjectcategories?.findIndex(
       (subjectcategory) =>
-        String(subjectcategory.id) === filters.subjectCategories?.[0],
+        String(subjectcategory.slug) === filters.subjectCategories?.[0],
     ) !== -1;
 
   const filterByTier =

--- a/src/utils/curriculum/keystage.test.ts
+++ b/src/utils/curriculum/keystage.test.ts
@@ -4,6 +4,8 @@ import {
   presentAtKeyStageSlugs,
 } from "./keystage";
 
+import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
+
 test("byKeyStageSlug", () => {
   const output = byKeyStageSlug({
     "7": {
@@ -18,14 +20,14 @@ test("byKeyStageSlug", () => {
       tiers: [],
       childSubjects: [],
       subjectCategories: [
-        {
+        createSubjectCategory({
           id: 3,
-          title: "test1",
-        },
-        {
+          slug: "test1",
+        }),
+        createSubjectCategory({
           id: 4,
-          title: "test2",
-        },
+          slug: "test2",
+        }),
       ],
     },
     "9": {
@@ -75,14 +77,14 @@ test("byKeyStageSlug", () => {
       ],
       childSubjects: [],
       subjectCategories: [
-        {
+        createSubjectCategory({
           id: 3,
-          title: "test1",
-        },
-        {
+          slug: "test1",
+        }),
+        createSubjectCategory({
           id: 4,
-          title: "test2",
-        },
+          slug: "test2",
+        }),
       ],
     },
     ks4: {
@@ -116,14 +118,14 @@ test("presentAtKeyStageSlugs", () => {
       tiers: [],
       childSubjects: [],
       subjectCategories: [
-        {
+        createSubjectCategory({
           id: 3,
-          title: "test1",
-        },
-        {
+          slug: "test1",
+        }),
+        createSubjectCategory({
           id: 4,
-          title: "test2",
-        },
+          slug: "test2",
+        }),
       ],
     },
     ks3: {

--- a/src/utils/curriculum/types.ts
+++ b/src/utils/curriculum/types.ts
@@ -25,6 +25,7 @@ export interface Domain {
 export interface SubjectCategory {
   id: number;
   title: string;
+  slug: string;
 }
 
 export interface Tier {

--- a/src/utils/getValidSubjectCategoryIconById.test.ts
+++ b/src/utils/getValidSubjectCategoryIconById.test.ts
@@ -2,24 +2,25 @@ import { getValidSubjectCategoryIconById } from "./getValidSubjectCategoryIconBy
 
 describe("getValidSubjectCategoryIconById", () => {
   it("valid id", () => {
-    expect(getValidSubjectCategoryIconById("english", 1)).toEqual(
+    expect(getValidSubjectCategoryIconById("english", "biology")).toEqual(
       "subject-biology",
     );
   });
 
   it("invalid id", () => {
-    expect(getValidSubjectCategoryIconById("english", 99)).toEqual("books");
-    expect(getValidSubjectCategoryIconById("foobar", -1)).toEqual("books");
+    expect(getValidSubjectCategoryIconById("english", "FOOBAR")).toEqual(
+      "books",
+    );
   });
 
   it("'all' id", () => {
-    expect(getValidSubjectCategoryIconById("english", -1)).toEqual(
+    expect(getValidSubjectCategoryIconById("english", "all")).toEqual(
       "subject-english",
     );
-    expect(getValidSubjectCategoryIconById("religious-education", -1)).toEqual(
-      "subject-religious-education",
-    );
-    expect(getValidSubjectCategoryIconById("science", -1)).toEqual(
+    expect(
+      getValidSubjectCategoryIconById("religious-education", "all"),
+    ).toEqual("subject-religious-education");
+    expect(getValidSubjectCategoryIconById("science", "all")).toEqual(
       "subject-science",
     );
   });

--- a/src/utils/getValidSubjectCategoryIconById.ts
+++ b/src/utils/getValidSubjectCategoryIconById.ts
@@ -1,37 +1,21 @@
-import { OakIconName } from "@oaknational/oak-components";
-
-import { getValidSubjectIconName } from "./getValidSubjectIconName";
-const subjectCategoryIconMap: Record<number, string> = {
-  1: "biology",
-  2: "chemistry",
-  3: "physics",
-  4: "english-reading-writing-oracy",
-  5: "english-grammar",
-  6: "english-handwriting",
-  7: "english-spelling",
-  8: "english-vocabulary",
-  18: "english-language",
-  19: "english-reading-for-pleasure",
-  15: "philosophy",
-  16: "social-science",
-  17: "theology",
-};
-
-const allIconMap: Record<string, OakIconName> = {
-  "religious-education": "subject-religious-education",
-  english: "subject-english",
-  science: "subject-science",
-};
+import { isValidIconName, OakIconName } from "@oaknational/oak-components";
 
 export function getValidSubjectCategoryIconById(
   subjectSlug: string,
-  id: number,
+  subjectCategorySlug: string,
 ): OakIconName {
-  const iconName = subjectCategoryIconMap[id];
+  const subjectCatKey = `subject-${subjectCategorySlug}`;
+  const subjectAndCatKey = `subject-${subjectSlug}-${subjectCategorySlug}`;
+  const subjectKey = `subject-${subjectSlug}`;
 
-  if (id === -1) {
-    return allIconMap[subjectSlug] ?? "books";
+  if (isValidIconName(subjectCatKey)) {
+    return subjectCatKey;
   }
-
-  return getValidSubjectIconName(iconName ?? null);
+  if (isValidIconName(subjectAndCatKey)) {
+    return subjectAndCatKey;
+  }
+  if (subjectCategorySlug === "all" && isValidIconName(subjectKey)) {
+    return subjectKey;
+  }
+  return "books";
 }


### PR DESCRIPTION
## Description
Adds the recently added `subjectcategories.slug` into the URL filtering

## Issue(s)
Fixes `CUR-1455`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Verify that selecting subject categories from the filter updates the URL with the `slug`, rather than the `id` 
3. Hard refreshing the page should return you to the same filter state 


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [x] Approved by product owner
- [ ] Does this PR update a package with a breaking change
