### PR TITLE
Fix regression when trying to remove empty year in the visualiser

### DIFF
--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -277,26 +277,19 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7", "8", "9", "10", "11"],
+        years: ["7"],
         threads: [],
       };
 
-      const { findAllByTestId, queryByTestId, getByTestId } = render(
+      const { findAllByText } = render(
         <CurriculumVisualiser
           {...missingUnitsForFirstYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-
-      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
-
-      const yearsPresent = [8, 9, 10, 11];
-      yearsPresent.forEach((year) => {
-        expect(getByTestId(`year-all-${year}`)).toBeInTheDocument();
-      });
-
-      const unitCards = await findAllByTestId("unit-card");
-      expect(unitCards).toHaveLength(4);
+      expect(
+        await findAllByText(/'sub-cat-1' units start in Year 8/i),
+      ).toHaveLength(1);
     });
 
     test("No units for subject category in second year of phase", async () => {
@@ -310,26 +303,19 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7", "8", "9", "10", "11"],
+        years: ["8"],
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId, getByTestId } = render(
+      const { findAllByText } = render(
         <CurriculumVisualiser
           {...missingUnitsForSecondYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-
-      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
-
-      const yearsPresent = [7, 9, 10, 11];
-      yearsPresent.forEach((year) => {
-        expect(getByTestId(`year-all-${year}`)).toBeInTheDocument();
-      });
-
-      const unitCards = await findAllByTestId("unit-card");
-      expect(unitCards).toHaveLength(4);
+      expect(
+        await findAllByText(/'sub-cat-1' units continue in Year 9/i),
+      ).toHaveLength(1);
     });
 
     test("No units for consecutive years at the start of the phase", async () => {
@@ -347,18 +333,19 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findAllByTestId, findAllByText } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtStartFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-10")).toBeInTheDocument();
-      expect(queryByTestId("year-all-11")).toBeInTheDocument();
+      expect(
+        await findAllByText(/'sub-cat-1' units start in Year 10/i),
+      ).toHaveLength(1);
+      expect(
+        await findAllByText(/'sub-cat-1' units continue in Year 10/i),
+      ).toHaveLength(2);
 
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
@@ -379,19 +366,16 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findAllByText, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsInMiddleFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(queryByTestId("year-all-7")).toBeInTheDocument();
-      expect(queryByTestId("year-all-8")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-10")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-11")).toBeInTheDocument();
-
+      expect(
+        await findAllByText(/'sub-cat-1' units continue in Year 11/i),
+      ).toHaveLength(3);
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
     });
@@ -411,21 +395,18 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findAllByText, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtEndFixtureWithProps}
           filters={filterFixture}
         />,
       );
-
-      expect(queryByTestId("year-all-7")).toBeInTheDocument();
-      expect(queryByTestId("year-all-8")).toBeInTheDocument();
-      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-10")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
-
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
+      const messages = await findAllByText(
+        /No 'sub-cat-1' units in this year group/i,
+      );
+      expect(messages).toHaveLength(3);
     });
 
     test("No alternate units in the phase", async () => {
@@ -443,21 +424,24 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findByText, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingAlternateUnitsFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(queryByTestId("year-all-7")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-8")).toBeInTheDocument();
-      expect(queryByTestId("year-all-9")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-10")).toBeInTheDocument();
-      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
-
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(2);
+      expect(
+        await findByText(/'sub-cat-1' units start in Year 8/i),
+      ).toBeInTheDocument();
+      expect(
+        await findByText(/'sub-cat-1' units continue in Year 10/i),
+      ).toBeInTheDocument();
+      expect(
+        await findByText(/No 'sub-cat-1' units in this year group/i),
+      ).toBeInTheDocument();
     });
 
     test("No unit at the end of the phase", async () => {
@@ -475,21 +459,15 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findByText } = render(
         <CurriculumVisualiser
           {...missingUnitForLastYearFixtureWithProps}
           filters={filterFixture}
         />,
       );
-
-      expect(queryByTestId("year-all-7")).toBeInTheDocument();
-      expect(queryByTestId("year-all-8")).toBeInTheDocument();
-      expect(queryByTestId("year-all-9")).toBeInTheDocument();
-      expect(queryByTestId("year-all-10")).toBeInTheDocument();
-      expect(queryByTestId("year-all-11")).not.toBeInTheDocument();
-
-      const unitCards = await findAllByTestId("unit-card");
-      expect(unitCards).toHaveLength(4);
+      expect(
+        await findByText(/No 'sub-cat-1' units in this year group/i),
+      ).toBeInTheDocument();
     });
   });
 
@@ -509,19 +487,15 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findAllByText, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingUnitsForFirstYearPrimaryFixtureWithProps}
           filters={filterFixture}
         />,
       );
-      expect(queryByTestId("year-all-1")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-2")).toBeInTheDocument();
-      expect(queryByTestId("year-all-3")).toBeInTheDocument();
-      expect(queryByTestId("year-all-4")).toBeInTheDocument();
-      expect(queryByTestId("year-all-5")).toBeInTheDocument();
-      expect(queryByTestId("year-all-6")).toBeInTheDocument();
-
+      expect(
+        await findAllByText(/'sub-cat-1' units start in Year 2/i),
+      ).toHaveLength(1);
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(5);
     });
@@ -541,20 +515,19 @@ describe("Curriculum visualiser filter states", () => {
         threads: [],
       };
 
-      const { queryByTestId, findAllByTestId } = render(
+      const { findAllByText, findAllByTestId } = render(
         <CurriculumVisualiser
           {...missingConsecutiveUnitsAtStartPrimaryFixtureWithProps}
           filters={filterFixture}
         />,
       );
 
-      expect(queryByTestId("year-all-1")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-2")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-3")).not.toBeInTheDocument();
-      expect(queryByTestId("year-all-4")).toBeInTheDocument();
-      expect(queryByTestId("year-all-5")).toBeInTheDocument();
-      expect(queryByTestId("year-all-6")).toBeInTheDocument();
-
+      expect(
+        await findAllByText(/'sub-cat-1' units start in Year 4/i),
+      ).toHaveLength(1);
+      expect(
+        await findAllByText(/'sub-cat-1' units continue in Year 4/i),
+      ).toHaveLength(2);
       const unitCards = await findAllByTestId("unit-card");
       expect(unitCards).toHaveLength(3);
     });
@@ -582,7 +555,7 @@ describe("Year group filter headings display correctly", () => {
         const filterFixture = {
           childSubjects: ["combined-science"],
           subjectCategories: ["-1"],
-          tiers: ["foundation"],
+          tiers: ["higher"],
           years: ["7", "8", "9", "10", "11"],
           threads: [],
           pathways: [],
@@ -595,39 +568,27 @@ describe("Year group filter headings display correctly", () => {
           />,
         );
 
-        for (const year of ["7", "8", "9"]) {
-          const coreBlock = container.querySelector(
-            `[data-testid="year-core-${year}"]`,
-          );
-          expect(coreBlock).not.toBeNull();
-          // Ensure no non_core block exists for KS3
-          expect(
-            container.querySelector(`[data-testid="year-non_core-${year}"]`),
-          ).toBeNull();
-          const yearHeading = within(coreBlock as HTMLElement).getByTestId(
-            "year-heading",
-          );
-          expect(yearHeading).toHaveTextContent(`Year ${year}`);
-          const subheading = within(coreBlock as HTMLElement).queryByTestId(
-            "year-subheading",
-          );
-          expect(subheading).toBeNull();
-        }
+        // Check each year block individually
+        for (const year of ["7", "8", "9", "10", "11"]) {
+          const type = ["10", "11"].includes(year) ? "non_core" : "core";
+          const yearBlock = container.querySelector(
+            `[data-testid="year-${type}-${year}"]`,
+          ) as HTMLElement;
+          expect(yearBlock).not.toBeNull();
 
-        for (const year of ["10", "11"]) {
-          const ks4BlockElement = container.querySelector(
-            `[data-testid="year-non_core-${year}"]`,
-          );
-          expect(ks4BlockElement).toBeInTheDocument();
-          const yearHeading = within(
-            ks4BlockElement as HTMLElement,
-          ).getByTestId("year-heading");
+          const yearHeading = within(yearBlock).getByTestId("year-heading");
           expect(yearHeading).toHaveTextContent(`Year ${year}`);
-          const subheading = within(
-            ks4BlockElement as HTMLElement,
-          ).queryByTestId("year-subheading");
-          expect(subheading).toBeInTheDocument();
-          expect(subheading).toHaveTextContent("Combined science, Foundation");
+
+          if (["7", "8", "9"].includes(year)) {
+            // Years 7-9 should not have subheadings
+            const subheading =
+              within(yearBlock).queryByTestId("year-subheading");
+            expect(subheading).toBeNull();
+          } else {
+            // Years 10-11 should have subheadings with combined science and higher tier
+            const subheading = within(yearBlock).getByTestId("year-subheading");
+            expect(subheading).toHaveTextContent("Combined science, Higher");
+          }
         }
       });
 
@@ -805,10 +766,10 @@ describe("Year group filter headings display correctly", () => {
 
       test("Setting KS3 subject category does not affect the KS4 subheading being displayed", async () => {
         const filterFixture = {
-          subjectCategories: ["2"], // KS3 Chemistry
+          subjectCategories: ["2"],
           childSubjects: ["combined-science"],
           tiers: ["higher"],
-          years: ["11"],
+          years: ["10"],
           threads: [],
           pathways: [],
         };
@@ -821,13 +782,12 @@ describe("Year group filter headings display correctly", () => {
         );
 
         const yearBlock = container.querySelector(
-          '[data-testid="year-non_core-11"]',
+          '[data-testid="year-non_core-10"]',
         ) as HTMLElement;
-
         expect(yearBlock).not.toBeNull();
 
         const yearHeading = within(yearBlock).getByTestId("year-heading");
-        expect(yearHeading).toHaveTextContent("Year 11");
+        expect(yearHeading).toHaveTextContent("Year 10");
         const subheading = within(yearBlock).getByTestId("year-subheading");
         expect(subheading).toHaveTextContent("Combined science, Higher");
       });

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -277,7 +277,7 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7"],
+        years: ["7", "8", "9", "10", "11"],
         threads: [],
       };
 
@@ -287,6 +287,7 @@ describe("Curriculum visualiser filter states", () => {
           filters={filterFixture}
         />,
       );
+
       expect(
         await findAllByText(/'sub-cat-1' units start in Year 8/i),
       ).toHaveLength(1);
@@ -303,7 +304,7 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["8"],
+        years: ["7", "8", "9", "10", "11"],
         threads: [],
       };
 
@@ -771,7 +772,7 @@ describe("Year group filter headings display correctly", () => {
           tiers: ["higher"],
           years: ["10"],
           threads: [],
-          pathways: [],
+          pathways: ["non_core"],
         };
 
         const { container } = render(

--- a/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/CurriculumVisualiser.test.tsx
@@ -277,7 +277,7 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7", "8", "9", "10", "11"],
+        years: ["7"],
         threads: [],
       };
 
@@ -287,7 +287,6 @@ describe("Curriculum visualiser filter states", () => {
           filters={filterFixture}
         />,
       );
-
       expect(
         await findAllByText(/'sub-cat-1' units start in Year 8/i),
       ).toHaveLength(1);
@@ -304,7 +303,7 @@ describe("Curriculum visualiser filter states", () => {
         pathways: [],
         subjectCategories: ["1"],
         tiers: [],
-        years: ["7", "8", "9", "10", "11"],
+        years: ["8"],
         threads: [],
       };
 
@@ -772,7 +771,7 @@ describe("Year group filter headings display correctly", () => {
           tiers: ["higher"],
           years: ["10"],
           threads: [],
-          pathways: ["non_core"],
+          pathways: [],
         };
 
         const { container } = render(

--- a/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
@@ -1191,13 +1191,6 @@ export const secondaryScienceYearData: YearData = {
         tier_slug: tiers[0]?.tier_slug,
         subject_slug: "combined-science",
       }),
-      createUnit({
-        year: "10",
-        subjectcategories: [secondaryScienceSubjectCategories[1]!],
-        tier: tiers[1]?.tier,
-        tier_slug: tiers[1]?.tier_slug,
-        subject_slug: "combined-science",
-      }),
     ],
   },
   "11": {

--- a/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/fixtures.ts
@@ -1191,6 +1191,13 @@ export const secondaryScienceYearData: YearData = {
         tier_slug: tiers[0]?.tier_slug,
         subject_slug: "combined-science",
       }),
+      createUnit({
+        year: "10",
+        subjectcategories: [secondaryScienceSubjectCategories[1]!],
+        tier: tiers[1]?.tier,
+        tier_slug: tiers[1]?.tier_slug,
+        subject_slug: "combined-science",
+      }),
     ],
   },
   "11": {

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -65,7 +65,6 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
   const { analyticsUseCase } = useAnalyticsPageProps();
 
   const shouldIncludeCore = ks4OptionSlug !== "core";
-
   const unitsByYearSelector = applyFiltering(
     filters,
     groupUnitsByPathway({

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -68,7 +68,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
   const unitsByYearSelector = applyFiltering(
     filters,
     groupUnitsByPathway({
-      modes: getModes(shouldIncludeCore, ks4Options),
+      modes: getModes(shouldIncludeCore, ks4Options, filters.pathways[0]),
       yearData,
     }),
   );

--- a/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumVisualiser/index.tsx
@@ -65,6 +65,7 @@ const CurriculumVisualiser: FC<CurriculumVisualiserProps> = ({
   const { analyticsUseCase } = useAnalyticsPageProps();
 
   const shouldIncludeCore = ks4OptionSlug !== "core";
+
   const unitsByYearSelector = applyFiltering(
     filters,
     groupUnitsByPathway({

--- a/src/utils/curriculum/by-pathway.ts
+++ b/src/utils/curriculum/by-pathway.ts
@@ -18,9 +18,14 @@ export function applyFiltering(
     });
   }
 
+  // HACK: If we're filtering by more than one year assume "all"
+  const selectingAll = filters.years.length > 1;
+
   const yearDataFilteredBySelectedYear = Object.values(
     unitsByYearSelector,
-  ).filter((item) => filterIncludes("years", [item.year]));
+  ).filter((item) => {
+    return selectingAll || filterIncludes("years", [item.year]);
+  });
 
   return yearDataFilteredBySelectedYear
     .map((item) => {
@@ -33,7 +38,7 @@ export function applyFiltering(
       };
     })
     .filter((item) => {
-      return item.units.length > 0;
+      return selectingAll || item.units.length > 0;
     });
 }
 

--- a/src/utils/curriculum/by-pathway.ts
+++ b/src/utils/curriculum/by-pathway.ts
@@ -1,4 +1,4 @@
-import { CurriculumFilters, Unit, YearData } from "./types";
+import { CurriculumFilters, Pathway, Unit, YearData } from "./types";
 import { sortYears } from "./sorting";
 import { isVisibleUnit } from "./isVisibleUnit";
 import { filteringFromYears } from "./filtering";
@@ -27,30 +27,34 @@ export function applyFiltering(
     return selectingAll || filterIncludes("years", [item.year]);
   });
 
-  return yearDataFilteredBySelectedYear
-    .map((item) => {
-      return {
-        ...item,
-        units: item.units.filter((unit) => {
-          const yearBasedFilters = filteringFromYears(item, filters);
-          return isVisibleUnit(yearBasedFilters, item.year, unit);
-        }),
-      };
-    })
-    .filter((item) => {
-      return selectingAll || item.units.length > 0;
-    });
+  return yearDataFilteredBySelectedYear.map((item) => {
+    return {
+      ...item,
+      units: item.units.filter((unit) => {
+        const yearBasedFilters = filteringFromYears(item, filters);
+        return isVisibleUnit(yearBasedFilters, item.year, unit);
+      }),
+    };
+  });
 }
 
-export function getModes(shouldIncludeCore: boolean, ks4Options: Ks4Option[]) {
+export function getModes(
+  shouldIncludeCore: boolean,
+  ks4Options: Ks4Option[],
+  onlyPathway?: Pathway["pathway_slug"],
+) {
   const yearTypes: MODES[] = [];
   if (!ks4Options?.find((opt) => opt.slug === "core")) {
     yearTypes.push("all");
   } else {
-    if (!shouldIncludeCore || ks4Options?.find((opt) => opt.slug === "core")) {
+    if (
+      !shouldIncludeCore ||
+      (ks4Options?.find((opt) => opt.slug === "core") &&
+        onlyPathway !== "non_core")
+    ) {
       yearTypes.push("core");
     }
-    if (shouldIncludeCore) {
+    if (shouldIncludeCore && onlyPathway !== "core") {
       yearTypes.push("non_core");
     }
   }


### PR DESCRIPTION
## Description
Fixes regression introduced in https://github.com/oaknational/Oak-Web-Application/commit/3abe6747e87fed940a82f6fb89c2605719f70591

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Regression test filtering in visualiser
3. Test "continue at" logic in the visualiser works as expected


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
