### PR TITLE
Storybook type fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6398,6 +6398,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.2.tgz",
+      "integrity": "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.2.tgz",
+      "integrity": "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.2.tgz",
+      "integrity": "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.2.tgz",
+      "integrity": "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.2.tgz",
+      "integrity": "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.2.tgz",
+      "integrity": "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.2.tgz",
+      "integrity": "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -41266,111 +41371,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.2.tgz",
-      "integrity": "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.2.tgz",
-      "integrity": "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.2.tgz",
-      "integrity": "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.2.tgz",
-      "integrity": "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.2.tgz",
-      "integrity": "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.2.tgz",
-      "integrity": "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.2.tgz",
-      "integrity": "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.stories.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.stories.tsx
@@ -1,62 +1,64 @@
-// import type { Meta, StoryObj } from "@storybook/react";
-// import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import type { Meta, StoryObj } from "@storybook/react";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
-// import { QuizQuestionStem } from "./QuizQuestionStem";
+import {
+  QuizQuestionStem,
+  type QuizQuestionStemProps,
+} from "./QuizQuestionStem";
 
-// import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
 
-// const meta: Meta<typeof QuizQuestionStem> = {
-//   component: QuizQuestionStem,
-//   decorators: [
-//     (Story) => (
-//       <OakThemeProvider theme={oakDefaultTheme}>
-//         <Story />
-//       </OakThemeProvider>
-//     ),
-//   ],
+const meta = {
+  component: QuizQuestionStem,
+  decorators: [
+    (StoryComponent) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <StoryComponent />
+      </OakThemeProvider>
+    ),
+  ],
+  argTypes: {},
+} satisfies Meta<typeof QuizQuestionStem>;
 
-//   argTypes: {},
-// } as Meta;
+export default meta;
 
-// export default meta;
+type Story = StoryObj<QuizQuestionStemProps>;
 
-// type Story = StoryObj<typeof meta>;
+const starterQuiz = quizQuestions;
+const mcqText = starterQuiz ? starterQuiz[0] : null;
+const mcqStemImage = starterQuiz ? starterQuiz[1] : null;
 
-// const starterQuiz = quizQuestions;
-// const mcqText = starterQuiz ? starterQuiz[0] : null;
-// const mcqStemImage = starterQuiz ? starterQuiz[1] : null;
+/*
+ * This is the view users will see on encountering an expired lesson
+ *
+ */
 
-// /*
-//  * This is the view users will see on encountering an expired lesson
-//  *
-//  */
+export const Default: Story = {
+  render: (args) => {
+    return <QuizQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: mcqText?.questionStem || [],
+    index: 0,
+  },
+};
 
-// export const Default: Story = {
-//   render: (args) => {
-//     return <QuizQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqText?.questionStem || [],
-//     index: 0,
-//   },
-// };
+export const Text: Story = {
+  render: (args) => {
+    return <QuizQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: mcqText?.questionStem || [],
+    index: 0,
+  },
+};
 
-// export const Text: Story = {
-//   render: (args) => {
-//     return <QuizQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqText?.questionStem || [],
-//     index: 0,
-//   },
-// };
-
-// export const Image: Story = {
-//   render: (args) => {
-//     return <QuizQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqStemImage?.questionStem || [],
-//     index: 0,
-//   },
-// };
+export const Image: Story = {
+  render: (args) => {
+    return <QuizQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: mcqStemImage?.questionStem || [],
+    index: 0,
+  },
+};

--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
@@ -18,15 +18,17 @@ import {
   TextItem,
 } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
 
+export interface QuizQuestionStemProps {
+  questionStem: (ImageItem | TextItem)[];
+  index: number;
+  takeFullHeight?: boolean;
+}
+
 export const QuizQuestionStem = ({
   questionStem,
   index,
   takeFullHeight,
-}: {
-  questionStem: (ImageItem | TextItem)[];
-  index: number;
-  takeFullHeight?: boolean;
-}) => {
+}: QuizQuestionStemProps) => {
   const [scaled, setScaled] = useState(false);
   const displayNumber = `Q${index + 1}.`;
   useEffect(() => {

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.stories.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.stories.tsx
@@ -1,62 +1,77 @@
-// import type { Meta, StoryObj } from "@storybook/react";
-// import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import type { Meta, StoryObj } from "@storybook/react";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
-// import { QuizResultQuestionStem } from "./QuizResultQuestionStem";
+import {
+  QuizResultQuestionStem,
+  type QuizQuestionStemProps,
+} from "./QuizResultQuestionStem";
 
-// import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+import type {
+  ImageItem,
+  TextItem,
+} from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { quizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
 
-// const meta: Meta<typeof QuizResultQuestionStem> = {
-//   component: QuizResultQuestionStem,
-//   decorators: [
-//     (Story) => (
-//       <OakThemeProvider theme={oakDefaultTheme}>
-//         <Story />
-//       </OakThemeProvider>
-//     ),
-//   ],
+const meta: Meta<typeof QuizResultQuestionStem> = {
+  component: QuizResultQuestionStem,
+  decorators: [
+    (Story) => (
+      <MathJaxProvider>
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <Story />
+        </OakThemeProvider>
+      </MathJaxProvider>
+    ),
+  ],
 
-//   argTypes: {},
-// } as Meta;
+  argTypes: {},
+};
 
-// export default meta;
+export default meta;
 
-// type Story = StoryObj<typeof meta>;
+type Story = StoryObj<QuizQuestionStemProps>;
 
-// const starterQuiz = quizQuestions;
-// const mcqText = starterQuiz ? starterQuiz[0] : null;
-// const mcqStemImage = starterQuiz ? starterQuiz[1] : null;
+const starterQuiz = quizQuestions;
+const mcqText = starterQuiz ? starterQuiz[0] : null;
+const mcqStemImage = starterQuiz ? starterQuiz[1] : null;
 
-// /*
-//  * This is the view users will see on encountering an expired lesson
-//  *
-//  */
+// Define a sample question stem to ensure type correctness
+const sampleQuestionStem: (ImageItem | TextItem)[] = [
+  { type: "text", text: "This is a sample question text." },
+];
 
-// export const Default: Story = {
-//   render: (args) => {
-//     return <QuizResultQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqText?.questionStem || [],
-//     displayIndex: 1,
-//   },
-// };
+/*
+ * This is the view users will see on encountering an expired lesson
+ *
+ */
 
-// export const Text: Story = {
-//   render: (args) => {
-//     return <QuizResultQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqText?.questionStem || [],
-//     displayIndex: 1,
-//   },
-// };
+export const Default: Story = {
+  render: (args) => {
+    return <QuizResultQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: sampleQuestionStem,
+    displayIndex: 1,
+  },
+};
 
-// export const Image: Story = {
-//   render: (args) => {
-//     return <QuizResultQuestionStem {...args} />;
-//   },
-//   args: {
-//     questionStem: mcqStemImage?.questionStem || [],
-//     displayIndex: 1,
-//   },
-// };
+export const Text: Story = {
+  render: (args) => {
+    return <QuizResultQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: mcqText?.questionStem || sampleQuestionStem,
+    displayIndex: 1,
+  },
+};
+
+export const Image: Story = {
+  render: (args) => {
+    return <QuizResultQuestionStem {...args} />;
+  },
+  args: {
+    questionStem: mcqStemImage?.questionStem || sampleQuestionStem,
+    displayIndex: 1,
+  },
+};

--- a/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizResultQuestionStem/QuizResultQuestionStem.tsx
@@ -17,10 +17,10 @@ import {
 import { getSizes } from "@/components/SharedComponents/CMSImage/getSizes";
 import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
 
-type QuizQuestionStemProps = {
+export interface QuizQuestionStemProps {
   questionStem: (ImageItem | TextItem)[];
   displayIndex: number;
-};
+}
 
 export const QuizResultQuestionStem = (props: QuizQuestionStemProps) => {
   const { questionStem, displayIndex } = props;

--- a/src/components/PupilComponents/QuizResults/QuizResults.stories.tsx
+++ b/src/components/PupilComponents/QuizResults/QuizResults.stories.tsx
@@ -1,41 +1,41 @@
-// import type { Meta, StoryObj } from "@storybook/react";
-// import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import type { Meta, StoryObj } from "@storybook/react";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 
-// import { QuizResults } from "./QuizResults";
+import { QuizResults, type QuizResultsProps } from "./QuizResults";
 
-// import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
-// import { exitQuizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
-// import { sectionResultsFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonSectionResults.fixture";
+import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
+import { exitQuizQuestions } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+import { sectionResultsFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonSectionResults.fixture";
 
-// const meta: Meta<typeof QuizResults> = {
-//   component: QuizResults,
-//   decorators: [
-//     (Story) => (
-//       <MathJaxProvider>
-//         <OakThemeProvider theme={oakDefaultTheme}>
-//           <Story />
-//         </OakThemeProvider>
-//       </MathJaxProvider>
-//     ),
-//   ],
-// };
+const meta: Meta<typeof QuizResults> = {
+  component: QuizResults,
+  decorators: [
+    (StoryComponent) => (
+      <MathJaxProvider>
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <StoryComponent />
+        </OakThemeProvider>
+      </MathJaxProvider>
+    ),
+  ],
+};
 
-// export default meta;
+export default meta;
 
-// type Story = StoryObj<typeof meta>;
+type Story = StoryObj<QuizResultsProps>;
 
-// /*
-//  * This is the view for the quiz results
-//  *
-//  */
+/*
+ * This is the view for the quiz results
+ *
+ */
 
-// export const Default: Story = {
-//   render: (args) => {
-//     return <QuizResults {...args} />;
-//   },
-//   args: {
-//     quizArray: exitQuizQuestions,
-//     sectionResults: sectionResultsFixture,
-//     lessonSection: "exit-quiz",
-//   },
-// } as Story; // Add the type definition here
+export const Default: Story = {
+  render: (args) => {
+    return <QuizResults {...args} />;
+  },
+  args: {
+    quizArray: exitQuizQuestions,
+    sectionResults: sectionResultsFixture,
+    lessonSection: "exit-quiz",
+  },
+};

--- a/src/components/PupilViews/PupilResults/PupilResults.stories.tsx
+++ b/src/components/PupilViews/PupilResults/PupilResults.stories.tsx
@@ -1,62 +1,62 @@
-// import type { Meta, StoryObj } from "@storybook/react";
-// import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
-// import { LessonAttemptCamelCase } from "@oaknational/oak-pupil-client";
+import type { Meta, StoryObj } from "@storybook/react";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+import { LessonAttemptCamelCase } from "@oaknational/oak-pupil-client";
 
-// import { PupilViewsResults } from "./PupilResults.view";
+import { PupilViewsResults } from "./PupilResults.view";
 
-// import {
-//   exitQuizQuestions,
-//   quizQuestions,
-// } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
-// import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
-// import { sectionResultsFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonSectionResults.fixture";
-// import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import {
+  exitQuizQuestions,
+  quizQuestions,
+} from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+import { MathJaxProvider } from "@/browser-lib/mathjax/MathJaxProvider";
+import { sectionResultsFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonSectionResults.fixture";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
 
-// const meta: Meta<typeof PupilViewsResults> = {
-//   component: PupilViewsResults,
-//   decorators: [
-//     (Story) => (
-//       <OakThemeProvider theme={oakDefaultTheme}>
-//         <Story />
-//       </OakThemeProvider>
-//     ),
-//   ],
+const meta = {
+  component: PupilViewsResults,
+  decorators: [
+    (StoryComponent) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <StoryComponent />
+      </OakThemeProvider>
+    ),
+  ],
 
-//   argTypes: {},
-//   parameters: {
-//     controls: {},
-//   },
-// } satisfies Meta<typeof PupilViewsResults>;
+  argTypes: {},
+  parameters: {
+    controls: {},
+  },
+} satisfies Meta<typeof PupilViewsResults>;
 
-// export default meta;
+export default meta;
 
-// type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof meta>;
 
-// export const Default: Story = {
-//   render: (args) => {
-//     return (
-//       <MathJaxProvider>
-//         <PupilViewsResults {...args} />
-//       </MathJaxProvider>
-//     );
-//   },
-//   args: {
-//     browseData: lessonBrowseDataFixture({}),
-//     starterQuizQuestionsArray: quizQuestions,
-//     exitQuizQuestionsArray: exitQuizQuestions,
-//     attemptData: {
-//       attemptId: "efwef",
-//       createdAt: "efwef",
-//       browseData: {
-//         subject: "ewfw",
-//         yearDescription: "efwef",
-//       },
-//       lessonData: {
-//         slug: "efwef",
-//         title: "efwef",
-//       },
-//       sectionResults:
-//         sectionResultsFixture as LessonAttemptCamelCase["sectionResults"],
-//     },
-//   },
-// };
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <MathJaxProvider>
+        <PupilViewsResults {...args} />
+      </MathJaxProvider>
+    );
+  },
+  args: {
+    browseData: lessonBrowseDataFixture({}),
+    starterQuizQuestionsArray: quizQuestions,
+    exitQuizQuestionsArray: exitQuizQuestions,
+    attemptData: {
+      attemptId: "efwef",
+      createdAt: "efwef",
+      browseData: {
+        subject: "ewfw",
+        yearDescription: "efwef",
+      },
+      lessonData: {
+        slug: "efwef",
+        title: "efwef",
+      },
+      sectionResults:
+        sectionResultsFixture as LessonAttemptCamelCase["sectionResults"],
+    },
+  },
+};


### PR DESCRIPTION
## Description

Music year: 2015

Resolved prop type inference in stories by:
- Making Storybook 'Story' type aliases specific to component props.
- Using 'satisfies' operator for typing the `meta` object.

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
