### PR TITLE
Re-enable column breaks in unit detail pages (curric downloads)

### DIFF
--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_detail.ts
@@ -18,8 +18,6 @@ import { createTeacherProgrammeSlug } from "@/utils/curriculum/slugs";
 import { SubjectCategory } from "@/utils/curriculum/types";
 import { getIsUnitDescriptionEnabled } from "@/utils/curriculum/features";
 
-const DISABLE_COLUMN_BREAKS = true;
-
 type Unit = CombinedCurriculumData["units"][number];
 
 async function buildUnitLessons(
@@ -633,16 +631,13 @@ export async function buildUnit(
         </w:pPr>
       </w:p>
       ${unitDescriptions}
-      ${DISABLE_COLUMN_BREAKS ? safeXml` <w:p /> ` : ""}
       <w:p>
         <w:pPr>
           <w:pStyle w:val="Heading4" />
         </w:pPr>
-        ${DISABLE_COLUMN_BREAKS
-          ? ""
-          : `<w:r>
+        <w:r>
           <w:br w:type="column" />
-        </w:r>`}
+        </w:r>
         <w:r>
           <w:rPr>
             <w:rFonts


### PR DESCRIPTION
## Description
Re-enable column breaks now issues have been fixed in office365

## Issue(s)
Fixes `CUR-863`

## How to test

1. Go to https://deploy-preview-3423--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Select various sequences from the picker
3. Check that "Lessons in unit" is in the second column

## Screenshots
How it used to look:
<img width="611" alt="Screenshot 2025-05-20 at 10 35 06" src="https://github.com/user-attachments/assets/adb6a463-6bd8-4cf5-a29a-a02431decc1b" />

How it should now look:
<img width="611" alt="Screenshot 2025-05-20 at 10 32 58" src="https://github.com/user-attachments/assets/9d48b50f-fce5-4a90-9e38-c6d5045fa5fa" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
