### PR TITLE
Updated gleap to `v14.6.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21384,11 +21384,12 @@
       "license": "ISC"
     },
     "node_modules/gleap": {
-      "version": "14.2.3",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/gleap/-/gleap-14.6.6.tgz",
+      "integrity": "sha512-SPNaFJfvOKSEFf3Xm22IlTkEipDo9qyRI8MjNdeJWJzPyoQEbN2BSSzjpjqFGh2MvZ4xdDxJPEFxB0QBNSQAfQ==",
       "license": "Commercial",
       "dependencies": {
         "@floating-ui/dom": "^1.6.3",
-        "pick-dom-element": "^0.2.3",
         "unique-selector": "^0.5.0"
       }
     },
@@ -33105,10 +33106,6 @@
     },
     "node_modules/periscopic/node_modules/@types/estree": {
       "version": "1.0.6",
-      "license": "MIT"
-    },
-    "node_modules/pick-dom-element": {
-      "version": "0.2.3",
       "license": "MIT"
     },
     "node_modules/picocolors": {


### PR DESCRIPTION
## Description
There are gleap errors being thrown in the frontend for various users in the gleap dependency.

## Issue(s)
hotfix

## How to test
Smoke test gleap still works correctly
