### PR TITLE
FEC-115 feat: added extra metadata to getWorksheetInfo error coming up in bugsnag

### DIFF
--- a/src/components/PupilComponents/pupilUtils/getWorksheetInfo.ts
+++ b/src/components/PupilComponents/pupilUtils/getWorksheetInfo.ts
@@ -37,6 +37,9 @@ export const getWorksheetInfo = async (lessonSlug: string) => {
     const oakError = new OakError({
       code: "downloads/failed-to-fetch",
       originalError: error,
+      meta: {
+        lessonSlug,
+      },
     });
     reportError(oakError);
   }


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

Add lessonSlug to the metadata when the getWorksheetInfo error is thrown. Should allow us to narrow down where this error is occurring and we can look for any patterns across the lessons.

## Issue(s)

See [this getWorksheetInfo issue](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/67e2c8c07f772e4ec395b7e0?filters[error.status]=open&filters[event.since]=30d) on bug snag.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
