### PR TITLE
Fix white gap at top of curric explainer in tablet breakpoint

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloadTab/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/index.tsx
@@ -359,6 +359,7 @@ const CurriculumDownloadTab: FC<CurriculumDownloadTabProps> = ({
         $ph={18}
         $pt={[48, 0]}
         $pb={[48]}
+        $mt={[0, 48, 48]}
         $borderColor="red"
         $width={"100%"}
         role="region"

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -93,7 +93,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
   ];
 
   return (
-    <OakBox $mb={["space-between-none", "space-between-l", "space-between-l"]}>
+    <OakBox>
       {/* @todo replace with OakFlex - colours type needs updating to oak-components colour token */}
       <OakFlex $background={color1} $pv="inner-padding-l">
         <OakBox

--- a/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
+++ b/src/components/CurriculumComponents/OverviewTab/OverviewTab.tsx
@@ -214,12 +214,10 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
   );
 
   return (
-    <>
-      <OakBox
-        $minWidth={"100%"}
-        $display={["block", "block", "none"]}
-        $mt={["space-between-none"]}
-      >
+    <OakBox
+      $mt={["space-between-none", "space-between-none", "space-between-l"]}
+    >
+      <OakBox $minWidth={"100%"} $display={["block", "block", "none"]}>
         <OakBox
           $background={"bg-decorative1-very-subdued"}
           $ph="inner-padding-m"
@@ -448,7 +446,7 @@ const OverviewTab: FC<OverviewTabProps> = (props: OverviewTabProps) => {
           </OakFlex>
         </OakBox>
       </OakBox>
-    </>
+    </OakBox>
   );
 };
 export default OverviewTab;

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.tsx
@@ -66,6 +66,7 @@ export default function UnitsTab({
         $maxWidth={"all-spacing-24"}
         $mh={"auto"}
         $ph={["inner-padding-none", "inner-padding-l"]}
+        $mt={["space-between-none", "space-between-l", "space-between-l"]}
         $width={"100%"}
         role="region"
       >


### PR DESCRIPTION
## Description
Fix margins across curric tabs to fix white gap at top of explainer in tablet breakpoint.

## Issue(s)

Fixes `CUR-1475`

## How to test

1. Go to https://deploy-preview-3440--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Select a sequence from the picker, and
   - Regression test all the tabs layout correctly at all breakpoints
   - Test that the white-gap at the top of the explainer tab is no longer present in tablet layout.

## Screenshots

How it used to look:

<img width="349" alt="Screenshot 2025-05-28 at 11 52 24" src="https://github.com/user-attachments/assets/4c24cf07-3100-4063-920c-c295d85e2cae" />

How it should now look:

<img width="349" alt="Screenshot 2025-05-28 at 11 52 16" src="https://github.com/user-attachments/assets/3850cd51-da22-40c3-856d-6d6a94bd954a" />

## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [x] Design sign-off
- [x] Approved by product owner
- [ ] Does this PR update a package with a breaking change
