### PR TITLE
fix: preselects and download name

### DIFF
--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/containerTitleToPreselectMap.tsx
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/containerTitleToPreselectMap.tsx
@@ -6,8 +6,14 @@ export const containerTitleToPreselectMap: Omit<
 > = {
   "Lesson guide": { downloadType: "lesson guide", shareType: null },
   "Slide deck": { downloadType: "slide deck", shareType: null },
+  "Lesson slides": { downloadType: "slide deck", shareType: null },
   "Exit quiz": { downloadType: "exit quiz", shareType: "exit quiz" },
   "Starter quiz": { downloadType: "starter quiz", shareType: "starter quiz" },
+  "Prior knowledge starter quiz": {
+    downloadType: "starter quiz",
+    shareType: "starter quiz",
+  },
+  "Assessment exit quiz": { downloadType: "exit quiz", shareType: "exit quiz" },
   "Lesson overview": { downloadType: null, shareType: null },
   "Lesson details": { downloadType: null, shareType: null },
   "Additional material": {

--- a/src/components/TeacherComponents/types/downloadAndShare.types.ts
+++ b/src/components/TeacherComponents/types/downloadAndShare.types.ts
@@ -44,12 +44,7 @@ export type CombinedPreselectedTypeMap = Record<
 >;
 export type DownloadableLessonTitles = Exclude<
   LessonItemTitle,
-  | "Demonstration videos"
-  | "Audio clips"
-  | "Video & audio clips"
-  | "Prior knowledge starter quiz"
-  | "Assessment exit quiz"
-  | "Lesson slides"
+  "Demonstration videos" | "Audio clips" | "Video & audio clips"
 >;
 
 export type ExpandingContainerTitle =

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -119,6 +119,17 @@ export function LessonDownloads(props: LessonDownloadsProps) {
 
   const isDownloadsExperiment =
     useFeatureFlagVariantKey("downloads-grouping-experiement") === "grouping";
+  const isQuizHeader =
+    useFeatureFlagVariantKey("lesson-overview-experiement") === "quiz-header";
+
+  downloads.map((download) => {
+    if (isQuizHeader && download.type === "presentation") {
+      download.label = "Lesson slides";
+      return download;
+    } else {
+      download;
+    }
+  });
 
   const showRiskAssessmentBanner = !!actions?.isPePractical;
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #
preselected for downloads should word for variant b quiz-headers
download header shuld be "Lesson slides"

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
