### PR TITLE
fix: remove superfluous acts from test

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import CurriculumDownloadTab, {
@@ -160,15 +160,12 @@ describe("Component Curriculum Download Tab", () => {
       const childSubjectSelector = await findByTestId("child-subject-selector");
       const tierSelector = await findByTestId("tier-selector");
 
-      await act(async () => {
-        await userEvent.click(childSubjectSelector);
-        await userEvent.click(tierSelector);
-      });
+      await userEvent.click(childSubjectSelector);
+      await userEvent.click(tierSelector);
 
       const nextButton = await findByText("Next");
-      await act(async () => {
-        await userEvent.click(nextButton);
-      });
+
+      await userEvent.click(nextButton);
 
       expect(curriculumResourcesDownloadRefined).toHaveBeenCalledTimes(1);
       expect(curriculumResourcesDownloadRefined).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

I have been getting intermittent test failures when pushing from this test, I'm hoping removing the `act`s from the test will fix it as they're superfluous anyway

## Issue(s)

Fixes #
![Screenshot 2025-05-29 at 09 26 41](https://github.com/user-attachments/assets/4a6e806b-ca7a-4115-8674-a81bfbb59cc2)

