### PR TITLE
fix: overflow causes bottom of close button to not be clickable

### DIFF
--- a/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/Content.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/Content.tsx
@@ -34,6 +34,7 @@ export function ModalContent({
           $position={"absolute"}
           $right={"all-spacing-4"}
           $top={"all-spacing-4"}
+          $zIndex={"in-front"}
         >
           <CurriculumModalCloseButton
             ariaLabel="Close"

--- a/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/__snapshots__/index.test.tsx.snap
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/OakModalNew/__snapshots__/index.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`OakModalNew should match snapshot 1`] = `
             test_title
           </h3>
           <div
-            class="sc-fqkvVR jvA-Dea"
+            class="sc-fqkvVR ioiQyz"
           >
             <div
               class="sc-ad0ad6f5-0 sc-952e1041-0 bZaRlP hlZDaV"


### PR DESCRIPTION
## Description
Fixes bottom half of mobile close button isn't clickable

<img width="1199" alt="Screenshot 2025-05-29 at 17 10 20" src="https://github.com/user-attachments/assets/c46cf5fb-bd0b-4bb4-a20a-65301a26356e" />

## Issue(s)
hotfix

## How to test

1. Go to https://deploy-preview-3449--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Test closing of curriculum modals


## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
