### PR TITLE
Re-enable bugsnag / sentry behind env-variable

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { withSentryConfig } from "@sentry/nextjs";
-// import { sentryWebpackPlugin } from "@sentry/webpack-plugin";
+import { sentryWebpackPlugin } from "@sentry/webpack-plugin";
 import buildWithBundleAnalyzer from "@next/bundle-analyzer";
 import StatoscopeWebpackPlugin from "@statoscope/webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
@@ -257,18 +257,19 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
         config.plugins?.push(bugsnagSourcemapUploaderPlugin);
 
         // // Upload production sourcemaps to Sentry
-        // config.plugins?.push(
-        //   sentryWebpackPlugin({
-        //     authToken: oakConfig.sentry.authToken,
-        //     org: oakConfig.sentry.organisationIdentifier,
-        //     project: oakConfig.sentry.projectIdentifier,
-        //     release: appVersion,
-        //     widenClientFileUpload: true,
-        //     reactComponentAnnotation: {
-        //       enabled: true,
-        //     },
-        //   }) as unknown as WebpackPluginInstance,
-        // );
+        config.plugins?.push(
+          sentryWebpackPlugin({
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            org: oakConfig.sentry.organisationIdentifier,
+            project: oakConfig.sentry.projectIdentifier,
+            release: {
+              name: appVersion,
+            },
+            reactComponentAnnotation: {
+              enabled: true,
+            },
+          }) as unknown as WebpackPluginInstance,
+        );
       }
 
       return config;

--- a/next.config.ts
+++ b/next.config.ts
@@ -250,26 +250,28 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
           overwrite: true,
         };
 
-        const bugsnagSourcemapUploaderPlugin =
-          new BugsnagSourceMapUploaderPlugin(
-            bugsnagSourcemapInfo,
-          ) as unknown as WebpackPluginInstance;
-        config.plugins?.push(bugsnagSourcemapUploaderPlugin);
-
-        // // Upload production sourcemaps to Sentry
-        config.plugins?.push(
-          sentryWebpackPlugin({
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            org: oakConfig.sentry.organisationIdentifier,
-            project: oakConfig.sentry.projectIdentifier,
-            release: {
-              name: appVersion,
-            },
-            reactComponentAnnotation: {
-              enabled: true,
-            },
-          }) as unknown as WebpackPluginInstance,
-        );
+        if (process.env.SENTRY_ENABLED === "true") {
+          // Upload production sourcemaps to Sentry
+          config.plugins?.push(
+            sentryWebpackPlugin({
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+              org: oakConfig.sentry.organisationIdentifier,
+              project: oakConfig.sentry.projectIdentifier,
+              release: {
+                name: appVersion,
+              },
+              reactComponentAnnotation: {
+                enabled: true,
+              },
+            }) as unknown as WebpackPluginInstance,
+          );
+        } else {
+          const bugsnagSourcemapUploaderPlugin =
+            new BugsnagSourceMapUploaderPlugin(
+              bugsnagSourcemapInfo,
+            ) as unknown as WebpackPluginInstance;
+          config.plugins?.push(bugsnagSourcemapUploaderPlugin);
+        }
       }
 
       return config;

--- a/src/components/AppComponents/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/AppComponents/ErrorBoundary/ErrorBoundary.test.tsx
@@ -39,7 +39,7 @@ const WithThemeProvider: FC = (props) => {
   return <ThemeProvider theme={theme} {...props} />;
 };
 
-describe.skip("ErrorBoundary.tsx", () => {
+describe("ErrorBoundary.tsx", () => {
   beforeEach(() => {
     consoleErrorSpy.mockImplementation(noop);
     consoleLogSpy.mockImplementation(noop);

--- a/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/AppComponents/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { ErrorInfo, FC, useMemo } from "react";
 import Bugsnag from "@bugsnag/js";
-// import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/nextjs";
 
 import ErrorView from "@/components/AppComponents/ErrorView";
 import { bugsnagInitialised } from "@/browser-lib/bugsnag/useBugsnag";
@@ -37,7 +37,7 @@ export type ErrorBoundaryProps = {
  * send error reports if the service has been initialised, which only happens
  * if the user has consented.
  */
-const ErrorBoundary: FC<ErrorBoundaryProps> = (props) => {
+function BugsnagErrorBoundary(props: ErrorBoundaryProps) {
   const isBugsnagInitialised = bugsnagInitialised();
   const BugsnagErrorBoundary = useMemo(() => {
     if (isBugsnagInitialised) {
@@ -47,7 +47,6 @@ const ErrorBoundary: FC<ErrorBoundaryProps> = (props) => {
 
   return (
     <>
-      {/* <Sentry.ErrorBoundary fallback={<ClientErrorView />}> */}
       {BugsnagErrorBoundary ? (
         <BugsnagErrorBoundary
           FallbackComponent={FallbackComponent}
@@ -56,9 +55,22 @@ const ErrorBoundary: FC<ErrorBoundaryProps> = (props) => {
       ) : (
         props.children
       )}
-      {/* </Sentry.ErrorBoundary> */}
     </>
   );
-};
+}
 
-export default ErrorBoundary;
+function SentryErrorBoundry({ children }: ErrorBoundaryProps) {
+  return (
+    <Sentry.ErrorBoundary fallback={<ClientErrorView />}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
+}
+
+export default function ErrorBoundary({ children }: ErrorBoundaryProps) {
+  if (process.env.SENTRY_ENABLED === "true") {
+    return <SentryErrorBoundry>{children}</SentryErrorBoundry>;
+  } else {
+    return <BugsnagErrorBoundary>{children}</BugsnagErrorBoundary>;
+  }
+}

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
@@ -1,8 +1,4 @@
-import {
-  OakFlex,
-  OakHeading,
-  OakPrimaryButton,
-} from "@oaknational/oak-components";
+import { OakFlex, OakHeading } from "@oaknational/oak-components";
 
 import {
   DOWNLOAD_TYPES,
@@ -70,13 +66,6 @@ export function CurriculumResourcesSelector({
               />
             );
           })}
-          <OakPrimaryButton
-            onClick={() => {
-              throw new Error("HERE");
-            }}
-          >
-            Test error
-          </OakPrimaryButton>
         </OakFlex>
       </RadioGroup>
     </OakFlex>

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
@@ -1,4 +1,8 @@
-import { OakFlex, OakHeading } from "@oaknational/oak-components";
+import {
+  OakFlex,
+  OakHeading,
+  OakPrimaryButton,
+} from "@oaknational/oak-components";
 
 import {
   DOWNLOAD_TYPES,
@@ -66,6 +70,13 @@ export function CurriculumResourcesSelector({
               />
             );
           })}
+          <OakPrimaryButton
+            onClick={() => {
+              throw new Error("HERE");
+            }}
+          >
+            Test error
+          </OakPrimaryButton>
         </OakFlex>
       </RadioGroup>
     </OakFlex>


### PR DESCRIPTION
## Description
Re-enable bugsnag / sentry behind env-variable


## Issue(s)
Fixes https://www.notion.so/oaknationalacademy/Disable-sentry-in-vercel-PR-1fa26cc4e1b18089bc5efdddb1be3300

## How to test
Dev code review, test that errors are getting through to bugsnag


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
