### PR TITLE
feat: added logs for vercel to datadog as part of terraform config

### DIFF
--- a/infrastructure/web/monitoring.tf
+++ b/infrastructure/web/monitoring.tf
@@ -9,6 +9,16 @@ locals {
 locals {
   monitors = var.env == "prod" ? [
     {
+      name    = "OWA log errors (Vercel)"
+      type    = "log alert"
+      message = "Errors detected in the OWA logs @slack-Oak_National_Academy-dev-general-alerts"
+      query   = "logs(\"source:vercel @http.url:(${local.url_string}) status:error\").index(\"*\").rollup(\"count\")"
+
+      evaluate_period    = "5m"
+      warning_threshold  = 3
+      critical_threshold = 10
+    },
+    {
       name    = "OWA log errors"
       type    = "log alert"
       message = "Errors detected in the OWA logs @slack-Oak_National_Academy-dev-general-alerts"

--- a/infrastructure/web/monitoring.tf
+++ b/infrastructure/web/monitoring.tf
@@ -19,7 +19,17 @@ locals {
       critical_threshold = 10
     },
     {
-      name    = "OWA log errors"
+      name    = "OWA page timeouts (Vercel)"
+      type    = "log alert"
+      message = "Timeouts detected on Vercel @slack-Oak_National_Academy-dev-general-alerts"
+      query   = "logs(\"source:vercel service:oak-web-application @branch:main @duration:>3s\").index(\"*\").rollup(\"count\")"
+
+      evaluate_period    = "5m"
+      warning_threshold  = 3
+      critical_threshold = 10
+    },
+    {
+      name    = "OWA log errors (Netlify)"
       type    = "log alert"
       message = "Errors detected in the OWA logs @slack-Oak_National_Academy-dev-general-alerts"
       query   = "logs(\"source:netlify @http.url:(${local.url_string}) status:error\").index(\"*\").rollup(\"count\")"
@@ -29,7 +39,7 @@ locals {
       critical_threshold = 10
     },
     {
-      name    = "OWA page timeouts"
+      name    = "OWA page timeouts (Netlify)"
       type    = "log alert"
       message = "Netlify has several process that are timing out @slack-Oak_National_Academy-dev-general-alerts"
       query   = "logs(\"source:netlify service:oak-web-application @branch:main @duration:>3s\").index(\"*\").rollup(\"count\")"


### PR DESCRIPTION
## Description

Music year: 1966

Updated terraform monitoring to additionally send OWA error logs to datadog log drain for Vercel source. 

## Issue(s)

[Notion Ticket Here](https://www.notion.so/oaknationalacademy/Datadog-monitoring-20626cc4e1b180eca362e59942a9164b?source=copy_link)

## How to test

After a terraform deployment, we should see a new monitor on datadog for the vercel errors. [Datadog Montiors](https://app.datadoghq.eu/monitors/manage)

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
