### PR TITLE
fix: unskip and resolve lesson planning and listing tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.117.0",
+        "@oaknational/oak-components": "^1.120.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.62.0",
         "@oaknational/oak-pupil-client": "^2.15.0",
@@ -7045,9 +7045,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.117.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.117.0.tgz",
-      "integrity": "sha512-1qIDT08KqygLLhNG1zqF2/+cPIbSjH0T1ww3ZsdXJbbxCvi4jMAyl5g0dTIlBGxbxV5wWcnWCc3bKqh45AMvGw==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.120.0.tgz",
+      "integrity": "sha512-igchFjTk940tmS6qPwJI0FT8B3RtnF0InEkw00hDpi1Cb51uovpvr1Y5Cx0TP72HsDhqDQ5qSbqxSr1yKQDgiA==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.117.0",
+    "@oaknational/oak-components": "^1.120.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.62.0",
     "@oaknational/oak-pupil-client": "^2.15.0",

--- a/src/__tests__/pages/lesson-planning.test.tsx
+++ b/src/__tests__/pages/lesson-planning.test.tsx
@@ -105,7 +105,7 @@ describe("pages/lesson-planning.tsx", () => {
       screen.getByAltText(testPlanALessonPageData.hero.image?.altText ?? ""),
     ).toBeInTheDocument();
   });
-  it.skip("Renders the header hero without author", () => {
+  it("Renders the header hero without author", () => {
     render(
       <PlanALesson
         pageData={{
@@ -120,12 +120,12 @@ describe("pages/lesson-planning.tsx", () => {
     );
 
     expect(
+      screen.queryByText(testPlanALessonPageData.hero.author.name),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByAltText(
         `${testPlanALessonPageData.hero.author.name} profile picture`,
       ),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByAltText(testPlanALessonPageData.hero.image?.altText ?? ""),
     ).not.toBeInTheDocument();
   });
 
@@ -172,12 +172,24 @@ describe("pages/lesson-planning.tsx", () => {
   });
 
   describe("SEO", () => {
-    it.skip("renders the correct SEO details", () => {
+    it("renders the correct SEO details", () => {
       const { seo } = renderWithSeo()(
         <PlanALesson pageData={testPlanningPageData} posts={mockPosts} />,
       );
 
-      expect(seo).toEqual({});
+      expect(seo).toEqual({
+        title: "test | NEXT_PUBLIC_SEO_APP_NAME",
+        description: "test",
+        ogTitle: "test | NEXT_PUBLIC_SEO_APP_NAME",
+        ogDescription: "test",
+        ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
+        ogImage:
+          "NEXT_PUBLIC_SEO_APP_URL/images/sharing/default-social-sharing-2022.png?" +
+          new Date().getFullYear(),
+        ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
+        canonical: "NEXT_PUBLIC_SEO_APP_URL",
+        robots: "index,follow",
+      });
     });
   });
 

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessonListing.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessonListing.test.tsx
@@ -72,7 +72,7 @@ describe("Lesson listing page", () => {
     expect(pageHeading).toBeInTheDocument();
   });
 
-  test.skip("it renders the correct number of lessons", () => {
+  test("it renders the correct number of lessons", () => {
     const { getByText } = render(
       <LessonListPage curriculumData={lessonListingFixture()} />,
     );
@@ -108,7 +108,7 @@ describe("Lesson listing page", () => {
   });
 
   describe("SEO", () => {
-    it.skip("renders the correct SEO details", async () => {
+    it("renders the correct SEO details", async () => {
       const { seo } = renderWithSeo()(
         <LessonListPage curriculumData={lessonListingFixture()} />,
       );
@@ -127,7 +127,7 @@ describe("Lesson listing page", () => {
         robots: "index,follow",
       });
     });
-    it.skip("renders the correct SEO details with pagination", async () => {
+    it("renders the correct SEO details with pagination", async () => {
       utilsMock.RESULTS_PER_PAGE = 2;
       const { seo } = renderWithSeo()(
         <LessonListPage curriculumData={lessonListingFixture()} />,
@@ -198,7 +198,7 @@ describe("Lesson listing page", () => {
     });
   });
   describe("tracking", () => {
-    test.skip("It calls tracking.lessonSelected with correct props when clicked", async () => {
+    test("It calls tracking.lessonSelected with correct props when clicked", async () => {
       const { getByText } = render(
         <LessonListPage curriculumData={lessonListingFixture()} />,
       );

--- a/src/pages/lesson-planning.tsx
+++ b/src/pages/lesson-planning.tsx
@@ -50,20 +50,22 @@ const PlanALesson: NextPage<PlanALessonProps> = ({ pageData, posts }) => {
       $background={"white"}
     >
       <OakHeaderHero
-        authorImageAlt={`${pageData.hero.author.name} profile picture`}
         heroImageAlt={pageData.hero.image?.altText ?? ""}
         data-testid="header-hero"
         headingTitle={pageData.hero.heading}
         authorName={pageData.hero.author.name}
         authorTitle={pageData.hero.author.role ?? ""}
+        authorImageSrc={
+          pageData.hero.author.image?.asset
+            ? imageBuilder.image(pageData.hero.author.image.asset).url()
+            : undefined
+        }
+        authorImageAlt={`${pageData.hero.author.name} profile picture`}
         subHeadingText={
           pageData.hero.summaryPortableText?.[0]?.children?.[0]?.text
         }
         heroImageSrc={imageBuilder
           .image(pageData.hero.image?.asset?.url ?? {})
-          .url()}
-        authorImageSrc={imageBuilder
-          .image(pageData.hero.author.image?.asset?.url ?? {})
           .url()}
         breadcrumbs={
           <Breadcrumbs


### PR DESCRIPTION
## Description

Music year: 2016

Fixed the issue where the `OakHeaderHero` component was rendering an author image element even when `authorImageSrc` was undefined, because it was always receiving an `authorImageAlt` prop. Tests were updated to account for this.

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
