### PR TITLE
fix: reset saved units count on sign out [LESQ-1431]

### DIFF
--- a/src/components/TeacherComponents/SaveCount/SaveCount.test.tsx
+++ b/src/components/TeacherComponents/SaveCount/SaveCount.test.tsx
@@ -3,8 +3,10 @@ import { screen } from "@testing-library/dom";
 import { SaveCount } from "./SaveCount";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
+import { mockLoggedIn, mockLoggedOut } from "@/__tests__/__helpers__/mockUser";
 
-const mockUseFeatureFlagEnabled = jest.fn().mockReturnValue(false);
+const mockUseFeatureFlagEnabled = jest.fn();
 jest.mock("posthog-js/react", () => ({
   ...jest.requireActual("posthog-js/react"),
   useFeatureFlagEnabled: () => mockUseFeatureFlagEnabled(),
@@ -14,28 +16,41 @@ jest.mock("@/node-lib/educator-api/helpers/useGetEducatorData", () => ({
   useGetEducatorData: jest.fn(() => ({
     data: 10,
     isLoading: false,
+    mutate: jest.fn(),
   })),
 }));
 
 describe("SaveCount", () => {
+  beforeEach(() => {
+    setUseUserReturn(mockLoggedIn);
+    mockUseFeatureFlagEnabled.mockReturnValue(true);
+  });
   it("renders nothing when the feature flag is disabled", () => {
+    mockUseFeatureFlagEnabled.mockReturnValue(false);
     renderWithProviders()(<SaveCount />);
     const saveCount = screen.queryByTestId("save-count");
     expect(saveCount).not.toBeInTheDocument();
   });
   it("renders the save count when the feature flag is enabled", () => {
-    mockUseFeatureFlagEnabled.mockReturnValue(true);
     renderWithProviders()(<SaveCount />);
     const saveCount = screen.getByText("10");
     expect(saveCount).toBeInTheDocument();
   });
   it('links to the "my-library" page', () => {
-    mockUseFeatureFlagEnabled.mockReturnValue(true);
     renderWithProviders()(<SaveCount />);
     const saveCount = screen.getByText("10");
     expect(saveCount.closest("a")).toHaveAttribute(
       "href",
       "/teachers/my-library",
     );
+  });
+  it("resets count to 0 when a user signs out", () => {
+    const { rerender } = renderWithProviders()(<SaveCount />);
+    const saveCount = screen.getByText("10");
+    expect(saveCount).toBeInTheDocument();
+    setUseUserReturn(mockLoggedOut);
+    rerender(<SaveCount />);
+    const resetSaveCount = screen.queryByText("0");
+    expect(resetSaveCount).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- listen for sign out in SaveCount component and set count to 0 on sign out
- call `mutate` on sign in to update unit count

## Issue(s)

Fixes #
https://www.notion.so/oaknationalacademy/Save-icon-and-count-does-not-return-to-zero-when-user-signs-out-20326cc4e1b180e2a174e0248a0807b5?pvs=4

## How to test

1. Go to {owa_deployment_url} and sign in
2. Go to a unit listing page and save some units so your save count is above 0
3. Sign out
4. You should see your save count reset to 0
5. Sign in again
6. You should see a loading state (grey save count) and then your count should update to the correct number
