### PR TITLE
feat: dont show save buttons on legacy units [LESQ-1435]

### DIFF
--- a/src/components/TeacherComponents/UnitList/UnitList.test.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.test.tsx
@@ -20,6 +20,11 @@ const render = (children: React.ReactNode) =>
     <OakThemeProvider theme={oakDefaultTheme}>{children}</OakThemeProvider>,
   );
 
+const mockFeatureFlagEnabled = jest.fn(() => false);
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFeatureFlagEnabled(),
+}));
+
 describe("components/UnitList", () => {
   test("renders the list items", () => {
     render(
@@ -243,6 +248,22 @@ describe("components/UnitList", () => {
 
     const unitCards = screen.getAllByTestId("unit-list-item");
     expect(unitCards).toHaveLength(6);
+  });
+  test("renders save buttons for new units and not for legacy", () => {
+    mockFeatureFlagEnabled.mockReturnValue(true);
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <UnitList
+          {...combinedUnitListingFixture()}
+          paginationProps={mockPaginationProps}
+          currentPageItems={combinedUnitListingFixture().units}
+          onClick={onClick}
+        />
+      </OakThemeProvider>,
+    );
+
+    const saveButtons = screen.getAllByText("Save");
+    expect(saveButtons).toHaveLength(6); // 3 new units rendered twice
   });
 });
 

--- a/src/components/TeacherComponents/UnitList/UnitList.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.tsx
@@ -224,7 +224,8 @@ const UnitList: FC<UnitListProps> = (props) => {
       const isItemLegacy = isSlugLegacy(item[0]!.programmeSlug);
 
       const isSpecialistUnit = !isUnitListData(props);
-      const showSave = isSaveEnabled && !isSpecialistUnit;
+      const getShowSave = (ps: string) =>
+        isSaveEnabled && !isSpecialistUnit && !isSlugLegacy(ps);
 
       if (isItemLegacy) {
         if (newAndLegacyUnitsOnPage) {
@@ -268,7 +269,9 @@ const UnitList: FC<UnitListProps> = (props) => {
               : null
           }
           optionalityUnits={getOptionalityUnits(item, onClick, router)}
-          onSave={showSave ? onSaveToggle : undefined}
+          onSave={
+            getShowSave(item[0]!.programmeSlug) ? onSaveToggle : undefined
+          }
           getIsSaved={isUnitSaved}
         />
       ) : (
@@ -317,7 +320,9 @@ const UnitList: FC<UnitListProps> = (props) => {
                 programmeSlug: unitOption.programmeSlug,
               })}
               onSave={
-                showSave ? () => onSaveToggle(unitOption.slug) : undefined
+                getShowSave(unitOption.programmeSlug)
+                  ? () => onSaveToggle(unitOption.slug)
+                  : undefined
               }
               isSaved={isUnitSaved(unitOption.slug)}
             />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons.tsx
@@ -303,7 +303,11 @@ const LessonListPage: NextPage<LessonListingPageProps> = ({
           showRiskAssessmentBanner={showRiskAssessmentBanner}
           isIncompleteUnit={unpublishedLessonCount > 0}
           isUnitSaved={isUnitSaved(unitSlug)}
-          onSave={() => onSaveToggle(unitSlug)}
+          onSave={
+            isSlugLegacy(programmeSlug)
+              ? undefined
+              : () => onSaveToggle(unitSlug)
+          }
         />
         <OakMaxWidth $ph={"inner-padding-m"}>
           <OakGrid>


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Hide save button on legacy units on unit listing page
- Hide save button on legacy unit lesson listing page

## How to test

1. Go to {owa_deployment_url}
2. Go to a unit with only legacy content, eg ks2 music
3. You should not see any save buttons
4. Go to a unit with both new and legacy units
5. You should see save buttons on new units but not o legacy units
6. You should still be able to save new units as normal, see them in my library etc

Note: if you previously saved legacy units they will appear in my library until they are unsaved at which point you shouldn't be able to save them again.

## Screenshots
How it used to look (delete if n/a):
<img width="700" alt="Screenshot 2025-06-03 at 14 24 04" src="https://github.com/user-attachments/assets/af73051a-0e15-4f97-816b-4593bcc9f605" />


How it should now look:
<img width="700" alt="Screenshot 2025-06-03 at 14 23 46" src="https://github.com/user-attachments/assets/686d1425-3444-46ca-9dae-f50aa05d0257" />
