### PR TITLE
Feat/lesq 1308/promote registration layout ff [LESQ-1308]

### DIFF
--- a/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(registration)/sign-in/[[...sign-in]]/page.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { SignIn } from "@clerk/nextjs";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { OakBox } from "@oaknational/oak-components";
 
 import { formAppearanceStyles } from "../../formAppearanceStyles";
@@ -12,9 +11,6 @@ import RegistrationLayout from "@/components/TeacherComponents/RegistrationLayou
 import { getIllustrationAsset } from "@/image-data";
 
 function SignInPage() {
-  const featureFlagVariant = useFeatureFlagVariantKey("teacher-sign-up-page");
-  const newLayoutEnabled = featureFlagVariant === "new-layout";
-
   return (
     <RegistrationLayout
       asideSlot={
@@ -26,7 +22,6 @@ function SignInPage() {
           />
         </OakBox>
       }
-      useAlternateLayout={newLayoutEnabled}
     >
       <SignIn appearance={formAppearanceStyles} />
     </RegistrationLayout>

--- a/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(registration)/sign-up/[[...sign-up]]/page.tsx
@@ -3,7 +3,6 @@
 
 import { SignUp } from "@clerk/nextjs";
 import { useState, useCallback, useEffect } from "react";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 import {
   OakBox,
   OakFlex,
@@ -18,18 +17,10 @@ import RegistrationAside from "@/components/TeacherComponents/RegistrationAside/
 import RegistrationLayout from "@/components/TeacherComponents/RegistrationLayout/RegistrationLayout";
 import { resolveOakHref } from "@/common-lib/urls";
 
-const TermsAndConditions = ({
-  newLayoutEnabled,
-}: {
-  newLayoutEnabled: boolean;
-}) => {
+const TermsAndConditions = () => {
   return (
-    <OakBox $ph={newLayoutEnabled ? "inner-padding-xl3" : "inner-padding-none"}>
-      <OakP
-        $font="body-2"
-        color="text-primary"
-        $textAlign={newLayoutEnabled ? "left" : "center"}
-      >
+    <OakBox $ph={"inner-padding-xl3"}>
+      <OakP $font="body-2" color="text-primary" $textAlign={"left"}>
         By continuing you are agreeing to Oak's{" "}
         <OakLink
           href={resolveOakHref({
@@ -58,8 +49,8 @@ const TermsAndConditions = ({
   );
 };
 
-const Banner = ({ newLayoutEnabled }: { newLayoutEnabled: boolean }) => {
-  return newLayoutEnabled ? (
+const Banner = () => {
+  return (
     <OakInlineBanner
       isOpen
       $background="bg-decorative1-very-subdued"
@@ -79,25 +70,11 @@ const Banner = ({ newLayoutEnabled }: { newLayoutEnabled: boolean }) => {
         </OakFlex>
       }
     />
-  ) : (
-    <OakInlineBanner
-      isOpen
-      $width="100%"
-      message={
-        <>
-          No <strong>pupil accounts</strong>, sorry.
-        </>
-      }
-      $mt={["space-between-m", "space-between-none"]}
-      $mb={["space-between-none", "space-between-m"]}
-    />
   );
 };
 
 function SignUpPage() {
   const [clerkRendered, setClerkRendered] = useState(false);
-  const featureFlagVariant = useFeatureFlagVariantKey("teacher-sign-up-page");
-  const newLayoutEnabled = featureFlagVariant === "new-layout";
 
   const checkForClerkElement = useCallback(() => {
     // Clerk docs say these classnames are stable
@@ -120,16 +97,9 @@ function SignUpPage() {
 
   return (
     <RegistrationLayout
-      termsSlot={
-        clerkRendered ? (
-          <TermsAndConditions newLayoutEnabled={newLayoutEnabled} />
-        ) : null
-      }
-      asideSlot={<RegistrationAside useNew={newLayoutEnabled} />}
-      useAlternateLayout={newLayoutEnabled}
-      bannerSlot={
-        clerkRendered ? <Banner newLayoutEnabled={newLayoutEnabled} /> : null
-      }
+      termsSlot={clerkRendered ? <TermsAndConditions /> : null}
+      asideSlot={<RegistrationAside />}
+      bannerSlot={clerkRendered ? <Banner /> : null}
     >
       <SignUp
         appearance={formAppearanceStyles}

--- a/src/components/TeacherComponents/OnboardingLayout/OnboardingLayout.tsx
+++ b/src/components/TeacherComponents/OnboardingLayout/OnboardingLayout.tsx
@@ -8,7 +8,6 @@ import { PropsWithChildren, ReactNode } from "react";
 
 import CMSImage from "@/components/SharedComponents/CMSImage";
 import { getIllustrationAsset } from "@/image-data";
-import RegistrationLayout from "@/components/TeacherComponents/RegistrationLayout/RegistrationLayout";
 import { resolveOakHref } from "@/common-lib/urls";
 
 type OnboardingLayoutProps = PropsWithChildren<{
@@ -22,55 +21,88 @@ export const OnboardingLayout = ({
   promptBody,
 }: OnboardingLayoutProps) => {
   return (
-    <RegistrationLayout
-      useAlternateLayout={false}
-      termsSlot={
-        <OakBox
-          as="p"
-          $font="body-2"
-          color="text-primary"
-          $textAlign="center"
-          $pb="inner-padding-s"
-          $width="max-content"
-        >
-          Need help?{" "}
-          <OakLink
-            href={resolveOakHref({
-              page: "contact",
-            })}
-          >
-            Contact us
-          </OakLink>
-          .
-        </OakBox>
-      }
-      asideSlot={
-        <OakBox
-          $textAlign="center"
-          $width="min-content"
-          $minWidth="all-spacing-21"
-          $mb="space-between-xl"
-        >
-          <OakFlex $mb="space-between-m" $maxHeight="all-spacing-19">
-            <CMSImage
-              image={getIllustrationAsset("auth-acorn")}
-              $objectFit="contain"
-            />
-          </OakFlex>
-          <OakHeading tag="h1" $font="heading-1" $mb="space-between-m">
-            {promptHeading}
-          </OakHeading>
-          <OakBox
-            $display="inline-flex"
-            $font="body-1"
-            $maxWidth="all-spacing-20"
-          >
-            {promptBody}
-          </OakBox>
-        </OakBox>
-      }
+    <OakFlex
+      $background={["white", "bg-decorative1-main"]}
+      $overflow="auto"
+      $color="black"
     >
-      {children}
-    </RegistrationLayout>
+      <OakFlex
+        $justifyContent={"center"}
+        $minHeight={"100vh"}
+        $alignItems={["flex-start", "center"]}
+        $flexDirection="row"
+        $pv={["inner-padding-none", "inner-padding-xl3"]}
+        $maxWidth={["all-spacing-21", "all-spacing-24"]}
+        $ph={["inner-padding-none", "inner-padding-s"]}
+        $flexGrow={1}
+        $width={"100%"}
+        $mh={"auto"}
+      >
+        <OakFlex
+          $display={["none", "none", "flex"]}
+          $flexGrow={1}
+          $justifyContent="flex-end"
+          $order={2}
+        >
+          <OakBox
+            $textAlign="center"
+            $width="min-content"
+            $minWidth="all-spacing-21"
+            $mb="space-between-xl"
+          >
+            <OakFlex $mb="space-between-m" $maxHeight="all-spacing-19">
+              <CMSImage
+                image={getIllustrationAsset("auth-acorn")}
+                $objectFit="contain"
+              />
+            </OakFlex>
+            <OakHeading tag="h1" $font="heading-1" $mb="space-between-m">
+              {promptHeading}
+            </OakHeading>
+            <OakBox
+              $display="inline-flex"
+              $font="body-1"
+              $maxWidth="all-spacing-20"
+            >
+              {promptBody}
+            </OakBox>
+          </OakBox>
+        </OakFlex>
+        <OakFlex $display="block" $order={1} style={{ width: "400px" }}>
+          <OakFlex
+            $flexDirection="column"
+            $alignItems="center"
+            $justifyContent="center"
+          >
+            <OakBox
+              $dropShadow={[null, "drop-shadow-standard"]}
+              $borderRadius="border-radius-m2"
+              $mb={["space-between-none", "space-between-m"]}
+              $width="100%"
+            >
+              {children}
+            </OakBox>
+            <OakBox
+              as="p"
+              $font="body-2"
+              color="text-primary"
+              $textAlign="center"
+              $pb="inner-padding-s"
+              $width="max-content"
+            >
+              Need help?{" "}
+              <OakLink
+                href={resolveOakHref({
+                  page: "contact",
+                })}
+              >
+                Contact us
+              </OakLink>
+              .
+            </OakBox>
+          </OakFlex>
+        </OakFlex>
+      </OakFlex>
+    </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/RegistrationAside/RegistrationAside.stories.tsx
+++ b/src/components/TeacherComponents/RegistrationAside/RegistrationAside.stories.tsx
@@ -15,22 +15,10 @@ export const RegistrationAside: Story = {
   args: {
     useNew: false,
   },
-  render: (args) => {
+  render: () => {
     return (
       <OakThemeProvider theme={oakDefaultTheme}>
-        <Component {...args} />
-      </OakThemeProvider>
-    );
-  },
-};
-export const NewRegistrationAside: Story = {
-  args: {
-    useNew: true,
-  },
-  render: (args) => {
-    return (
-      <OakThemeProvider theme={oakDefaultTheme}>
-        <Component {...args} />
+        <Component />
       </OakThemeProvider>
     );
   },

--- a/src/components/TeacherComponents/RegistrationAside/ResgistrationAside.test.tsx
+++ b/src/components/TeacherComponents/RegistrationAside/ResgistrationAside.test.tsx
@@ -5,15 +5,8 @@ import RegistrationAside from "./ResgistrationAside";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 describe("RegistrationAside", () => {
-  it("renders the original component", () => {
-    renderWithProviders()(<RegistrationAside useNew={false} />);
-    const headerText = screen.getByRole("heading", {
-      name: "Our resources will always be free. Creating an account gives you:",
-    });
-    expect(headerText).toBeInTheDocument();
-  });
-  it("renders the new component", () => {
-    renderWithProviders()(<RegistrationAside useNew={true} />);
+  it("renders the component", () => {
+    renderWithProviders()(<RegistrationAside />);
     const headerText1 = screen.getByRole("heading", {
       name: "Our resources will",
     });
@@ -24,7 +17,7 @@ describe("RegistrationAside", () => {
     expect(headerText2).toBeInTheDocument();
   });
   it("renders a list of items", () => {
-    renderWithProviders()(<RegistrationAside useNew={true} />);
+    renderWithProviders()(<RegistrationAside />);
     const listItems = screen.getAllByRole("listitem");
     expect(listItems).toHaveLength(4);
   });

--- a/src/components/TeacherComponents/RegistrationAside/ResgistrationAside.tsx
+++ b/src/components/TeacherComponents/RegistrationAside/ResgistrationAside.tsx
@@ -32,8 +32,8 @@ function ListItem({ children }: PropsWithChildren) {
   );
 }
 
-const RegistrationAside = ({ useNew }: { useNew: boolean }) => {
-  return useNew ? (
+const RegistrationAside = () => {
+  return (
     <OakFlex
       $flexDirection="column"
       $maxWidth="all-spacing-21"
@@ -82,32 +82,6 @@ const RegistrationAside = ({ useNew }: { useNew: boolean }) => {
         </OakFlex>
       </OakFlex>
     </OakFlex>
-  ) : (
-    <OakBox
-      $width="min-content"
-      $minWidth="all-spacing-21"
-      $mb="space-between-xl"
-    >
-      <OakFlex $mb="space-between-m2" $maxHeight="all-spacing-19">
-        <CMSImage
-          image={getIllustrationAsset("auth-acorn")}
-          $objectFit="contain"
-        />
-      </OakFlex>
-      <OakHeading
-        tag="h2"
-        $font="heading-5"
-        $mb="space-between-l"
-        $textAlign="center"
-      >
-        Our resources will always be free. Creating an account gives you:
-      </OakHeading>
-      <OakUL $font="heading-light-7" $reset $mh="space-between-xl">
-        <ListItem>Full unit downloads</ListItem>
-        <ListItem>Instant access to Aila, our AI lesson assistant</ListItem>
-        <ListItem>Priority access to new products and features</ListItem>
-      </OakUL>
-    </OakBox>
   );
 };
 

--- a/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.stories.tsx
+++ b/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.stories.tsx
@@ -12,23 +12,15 @@ import Component from "./RegistrationLayout";
 
 const meta: Meta<typeof Component> = {
   component: Component,
-  argTypes: {
-    useAlternateLayout: {
-      control: {
-        type: "boolean",
-      },
-    },
-  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Component>;
 
-export const AlternateRegistrationLayout: Story = {
+export const RegistrationLayout: Story = {
   args: {
-    useAlternateLayout: true,
-    asideSlot: <RegistrationAside useNew={true} />,
+    asideSlot: <RegistrationAside />,
     termsSlot: (
       <OakBox>
         <OakP>Terms and conditions</OakP>
@@ -37,25 +29,6 @@ export const AlternateRegistrationLayout: Story = {
     children: (
       <OakBox $width="all-spacing-18" $ba="border-solid-m">
         Sign up form
-      </OakBox>
-    ),
-  },
-  render: (args) => {
-    return (
-      <OakThemeProvider theme={oakDefaultTheme}>
-        <Component {...args} />
-      </OakThemeProvider>
-    );
-  },
-};
-
-export const RegistrationLayout: Story = {
-  args: {
-    useAlternateLayout: false,
-    asideSlot: <RegistrationAside useNew={false} />,
-    termsSlot: (
-      <OakBox>
-        <OakP>Terms and conditions</OakP>
       </OakBox>
     ),
   },

--- a/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.test.tsx
+++ b/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.test.tsx
@@ -6,47 +6,18 @@ import RegistrationLayout from "./RegistrationLayout";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 describe("RegistrationLayout", () => {
-  it("renders an aside in the default layout", () => {
+  it("renders an aside", () => {
     renderWithProviders()(
-      <RegistrationLayout
-        useAlternateLayout={false}
-        asideSlot={<OakP>Aside</OakP>}
-      >
+      <RegistrationLayout asideSlot={<OakP>Aside</OakP>}>
         Child
       </RegistrationLayout>,
     );
     const aside = screen.getByText("Aside");
     expect(aside).toBeInTheDocument();
   });
-  it("renders an aside in the alternate layout", () => {
-    renderWithProviders()(
-      <RegistrationLayout
-        useAlternateLayout={true}
-        asideSlot={<OakP>Aside</OakP>}
-      >
-        Child
-      </RegistrationLayout>,
-    );
-    const aside = screen.getByText("Aside");
-    expect(aside).toBeInTheDocument;
-  });
   it("renders a banner", () => {
     renderWithProviders()(
       <RegistrationLayout
-        useAlternateLayout={false}
-        asideSlot={<OakP>Aside</OakP>}
-        bannerSlot={<OakP>Banner</OakP>}
-      >
-        Child
-      </RegistrationLayout>,
-    );
-    const banner = screen.getByText("Banner");
-    expect(banner).toBeInTheDocument;
-  });
-  it("renders a banner in an alternate layout", () => {
-    renderWithProviders()(
-      <RegistrationLayout
-        useAlternateLayout={true}
         asideSlot={<OakP>Aside</OakP>}
         bannerSlot={<OakP>Banner</OakP>}
       >
@@ -56,23 +27,9 @@ describe("RegistrationLayout", () => {
     const banner = screen.getAllByText("Banner");
     expect(banner).toHaveLength(2); // 1 each for mobile and desktop visible in test
   });
-  it("renders terms ", () => {
+  it("renders terms", () => {
     renderWithProviders()(
       <RegistrationLayout
-        useAlternateLayout={false}
-        asideSlot={<OakP>Aside</OakP>}
-        termsSlot={<OakP>Terms</OakP>}
-      >
-        Child
-      </RegistrationLayout>,
-    );
-    const terms = screen.getByText("Terms");
-    expect(terms).toBeInTheDocument();
-  });
-  it("renders terms in an alternate layout", () => {
-    renderWithProviders()(
-      <RegistrationLayout
-        useAlternateLayout={true}
         asideSlot={<OakP>Aside</OakP>}
         termsSlot={<OakP>Terms</OakP>}
       >

--- a/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.tsx
+++ b/src/components/TeacherComponents/RegistrationLayout/RegistrationLayout.tsx
@@ -10,8 +10,6 @@ type RegistrationLayoutProps = PropsWithChildren<{
   asideSlot: ReactNode;
   termsSlot?: ReactNode;
   bannerSlot?: ReactNode;
-  // A/B testing an alternate layout for registration pages
-  useAlternateLayout: boolean;
 }>;
 
 const RegistrationLayout = ({
@@ -19,9 +17,8 @@ const RegistrationLayout = ({
   asideSlot,
   termsSlot,
   bannerSlot,
-  useAlternateLayout,
 }: RegistrationLayoutProps) => {
-  return useAlternateLayout ? (
+  return (
     <OakGrid $width="100%" $height="100%">
       <OakGridArea
         $colSpan={[0, 0, 6]}
@@ -64,52 +61,6 @@ const RegistrationLayout = ({
         </OakFlex>
       </OakGridArea>
     </OakGrid>
-  ) : (
-    <OakFlex
-      $background={["white", "bg-decorative1-main"]}
-      $overflow="auto"
-      $color="black"
-    >
-      <OakFlex
-        $justifyContent={"center"}
-        $minHeight={"100vh"}
-        $alignItems={["flex-start", "center"]}
-        $flexDirection="row"
-        $pv={["inner-padding-none", "inner-padding-xl3"]}
-        $maxWidth={["all-spacing-21", "all-spacing-24"]}
-        $ph={["inner-padding-none", "inner-padding-s"]}
-        $flexGrow={1}
-        $width={"100%"}
-        $mh={"auto"}
-      >
-        <OakFlex
-          $display={["none", "none", "flex"]}
-          $flexGrow={1}
-          $justifyContent="flex-end"
-          $order={2}
-        >
-          {asideSlot}
-        </OakFlex>
-        <OakFlex $display="block" $order={1} style={{ width: "400px" }}>
-          <OakFlex
-            $flexDirection="column"
-            $alignItems="center"
-            $justifyContent="center"
-          >
-            {bannerSlot}
-            <OakBox
-              $dropShadow={[null, "drop-shadow-standard"]}
-              $borderRadius="border-radius-m2"
-              $mb={["space-between-none", "space-between-m"]}
-              $width="100%"
-            >
-              {children}
-            </OakBox>
-            {termsSlot}
-          </OakFlex>
-        </OakFlex>
-      </OakFlex>
-    </OakFlex>
   );
 };
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Remove feature flag from sign up and in pages
- Use the alternate layout as default
- move the previous default layout to OnboardingLayout as it's still used there

## How to test

1. Go to {owa_deployment_url}
2. Go to sign up
3. You should see the new layout
4. Go to sign in
5. You should see the new layout
6. Onboarding journey should be unchanged in layout

## Screenshots

How it used to look (delete if n/a):
Sign up:  
<img width="800" alt="Screenshot 2025-06-04 at 10 48 50" src="https://github.com/user-attachments/assets/bd137668-a993-4d0c-8e34-0d51eb5e9441" />
  
Sign in:  
<img width="800" alt="Screenshot 2025-06-04 at 10 48 59" src="https://github.com/user-attachments/assets/b976bbc0-ec20-4293-af65-effbc9234fd6" />


How it should now look:
Sign up:  
<img width="800" alt="Screenshot 2025-06-04 at 10 48 30" src="https://github.com/user-attachments/assets/e341b3ff-3c80-4514-9834-6be2d7de6940" />
    
Sign in:
<img width="800" alt="Screenshot 2025-06-04 at 10 49 50" src="https://github.com/user-attachments/assets/f6544066-b275-4b6d-ad1e-d5cbe0901fe2" />. 