### PR TITLE
Feat/lesq 1447/curriculum download banner [LESQ-1447]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/unitListing.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/unitListing.test.tsx
@@ -110,116 +110,141 @@ describe("pages/programmes/[programmeSlug]/units", () => {
     expect(queryAllByTestId("financial-education-banner")).toHaveLength(0);
   });
 
-  describe("SEO", () => {
-    it("renders the correct SEO details for programme", async () => {
-      const { seo } = renderWithSeo()(
-        <UnitListingPage curriculumData={unitListingWithTiers()} />,
-      );
-      expect(seo).toEqual({
-        ...mockSeoResult,
-        ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
-        title:
-          "Free KS4 Computing teaching resources | NEXT_PUBLIC_SEO_APP_NAME",
-        description:
-          "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
-        ogTitle:
-          "Free KS4 Computing teaching resources | NEXT_PUBLIC_SEO_APP_NAME",
-        ogDescription:
-          "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
-        ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-        canonical: "NEXT_PUBLIC_SEO_APP_URL",
-        robots: "index,follow",
-      });
+  it("does not render curriculum download button on non-cycle 2 programmes", () => {
+    render(<UnitListingPage curriculumData={unitListingFixture()} />);
+    const curriculumDownloadButton = screen.queryByRole("button", {
+      name: "Download curriculum plan",
     });
-
-    it("renders the correct SEO details for programmes with pagination", async () => {
-      utilsMock.RESULTS_PER_PAGE = 10;
-      const { seo } = renderWithSeo()(
-        <UnitListingPage
-          curriculumData={{
-            ...unitListingFixture(),
-          }}
-        />,
-      );
-      expect(seo).toEqual({
-        ...mockSeoResult,
-        ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
-        title:
-          "Free KS4 Computing teaching resources | Page 1 of 2 | NEXT_PUBLIC_SEO_APP_NAME",
-        description:
-          "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
-        ogTitle:
-          "Free KS4 Computing teaching resources | Page 1 of 2 | NEXT_PUBLIC_SEO_APP_NAME",
-        ogDescription:
-          "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
-        ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
-        canonical: "NEXT_PUBLIC_SEO_APP_URL",
-        robots: "index,follow",
-      });
-    });
+    expect(curriculumDownloadButton).not.toBeInTheDocument();
   });
-  describe("unit search filters", () => {
-    it("unit filtered by the learningTheme const ", () => {
-      mockRouter.push({
-        pathname: "/teachers/programmes/art-primary-ks1/units",
-        query: {
-          learningTheme: "computer-science-2",
-        },
-      });
-      const { getByRole } = render(
-        <UnitListingPage curriculumData={unitListingFixture()} />,
-      );
-
-      expect(getByRole("heading", { level: 1 })).toHaveTextContent("Computing");
+  it("renders curriculum download button on cycle 2 programmes", () => {
+    render(
+      <UnitListingPage
+        curriculumData={{
+          ...unitListingFixture(),
+          hasCycle2Content: true,
+        }}
+      />,
+    );
+    const curriculumDownloadButton = screen.getByRole("button", {
+      name: "Download curriculum plan",
     });
+    expect(curriculumDownloadButton).toBeInTheDocument();
+    expect(curriculumDownloadButton.closest("a")).toHaveAttribute(
+      "href",
+      "/teachers/curriculum/computing-secondary/downloads",
+    );
+  });
+});
 
-    it("skip filters button becomes visible when focussed", async () => {
-      const { getByText } = render(
-        <UnitListingPage curriculumData={unitListingFixture()} />,
-      );
-
-      const skipUnits = getByText("Skip to units").closest("a");
-
-      if (!skipUnits) {
-        throw new Error("Could not find filter button");
-      }
-
-      act(() => {
-        skipUnits.focus();
-      });
-      expect(skipUnits).toHaveFocus();
-      expect(skipUnits).not.toHaveStyle("position: absolute");
-
-      act(() => {
-        skipUnits.blur();
-      });
-      expect(skipUnits).not.toHaveFocus();
+describe("SEO", () => {
+  it("renders the correct SEO details for programme", async () => {
+    const { seo } = renderWithSeo()(
+      <UnitListingPage curriculumData={unitListingWithTiers()} />,
+    );
+    expect(seo).toEqual({
+      ...mockSeoResult,
+      ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
+      title: "Free KS4 Computing teaching resources | NEXT_PUBLIC_SEO_APP_NAME",
+      description:
+        "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
+      ogTitle:
+        "Free KS4 Computing teaching resources | NEXT_PUBLIC_SEO_APP_NAME",
+      ogDescription:
+        "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
+      ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
+      canonical: "NEXT_PUBLIC_SEO_APP_URL",
+      robots: "index,follow",
     });
   });
 
-  describe("getStaticPaths", () => {
-    it("Should not generate pages at build time", async () => {
-      const res = await getStaticPaths();
-
-      expect(res).toEqual({
-        fallback: "blocking",
-        paths: [],
-      });
+  it("renders the correct SEO details for programmes with pagination", async () => {
+    utilsMock.RESULTS_PER_PAGE = 10;
+    const { seo } = renderWithSeo()(
+      <UnitListingPage
+        curriculumData={{
+          ...unitListingFixture(),
+        }}
+      />,
+    );
+    expect(seo).toEqual({
+      ...mockSeoResult,
+      ogSiteName: "NEXT_PUBLIC_SEO_APP_NAME",
+      title:
+        "Free KS4 Computing teaching resources | Page 1 of 2 | NEXT_PUBLIC_SEO_APP_NAME",
+      description:
+        "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
+      ogTitle:
+        "Free KS4 Computing teaching resources | Page 1 of 2 | NEXT_PUBLIC_SEO_APP_NAME",
+      ogDescription:
+        "Get fully sequenced teaching resources and lesson plans in KS4 Computing",
+      ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
+      canonical: "NEXT_PUBLIC_SEO_APP_URL",
+      robots: "index,follow",
     });
   });
+});
+describe("unit search filters", () => {
+  it("unit filtered by the learningTheme const ", () => {
+    mockRouter.push({
+      pathname: "/teachers/programmes/art-primary-ks1/units",
+      query: {
+        learningTheme: "computer-science-2",
+      },
+    });
+    const { getByRole } = render(
+      <UnitListingPage curriculumData={unitListingFixture()} />,
+    );
 
-  describe("getStaticProps", () => {
-    it("Should fetch the correct data", async () => {
-      await getStaticProps({
-        params: {
-          programmeSlug: "maths-primary-ks1",
-        },
-      });
+    expect(getByRole("heading", { level: 1 })).toHaveTextContent("Computing");
+  });
 
-      expect(curriculumApi.unitListing).toHaveBeenCalledTimes(2);
-      expect(curriculumApi.unitListing).toHaveBeenCalledWith({
-        programmeSlug: "maths-primary-ks1-l",
-      });
+  it("skip filters button becomes visible when focussed", async () => {
+    const { getByText } = render(
+      <UnitListingPage curriculumData={unitListingFixture()} />,
+    );
+
+    const skipUnits = getByText("Skip to units").closest("a");
+
+    if (!skipUnits) {
+      throw new Error("Could not find filter button");
+    }
+
+    act(() => {
+      skipUnits.focus();
+    });
+    expect(skipUnits).toHaveFocus();
+    expect(skipUnits).not.toHaveStyle("position: absolute");
+
+    act(() => {
+      skipUnits.blur();
+    });
+    expect(skipUnits).not.toHaveFocus();
+  });
+});
+
+describe("getStaticPaths", () => {
+  it("Should not generate pages at build time", async () => {
+    const res = await getStaticPaths();
+
+    expect(res).toEqual({
+      fallback: "blocking",
+      paths: [],
+    });
+  });
+});
+
+describe("getStaticProps", () => {
+  it("Should fetch the correct data", async () => {
+    await getStaticProps({
+      params: {
+        programmeSlug: "maths-primary-ks1",
+      },
+    });
+
+    expect(curriculumApi.unitListing).toHaveBeenCalledTimes(2);
+    expect(curriculumApi.unitListing).toHaveBeenCalledWith({
+      programmeSlug: "maths-primary-ks1-l",
     });
   });
 });

--- a/src/node-lib/curriculum-api-2023/__mocks__/index.ts
+++ b/src/node-lib/curriculum-api-2023/__mocks__/index.ts
@@ -2,6 +2,7 @@ import unitListingFixture from "../fixtures/unitListing.fixture";
 import { unitBrowseDataFixture } from "../fixtures/unitBrowseData.fixture";
 import { subjectBrowseDataFixture } from "../fixtures/subjectBrowseData.fixture";
 import { LessonShareQuery } from "../queries/lessonShare/lessonShare.query";
+import { UnitListingQueryReturn } from "../queries/unitListing/unitListing.query";
 
 import { specialistSubjectListingFixture2023 } from "@/node-lib/curriculum-api-2023/fixtures/specialistSubjectListing.fixture";
 import programmeListingFixture from "@/node-lib/curriculum-api-2023/fixtures/programmeListing.fixture";
@@ -145,7 +146,7 @@ const curriculumApi: Pick<
   }) as jest.Mocked<LessonMediaClipsQueryReturn>,
   unitListing: jest.fn(async () => {
     return unitListingFixture();
-  }),
+  }) as jest.Mocked<UnitListingQueryReturn>,
   refreshedMVTime: jest.fn(async () => {
     return refreshedMVTimeFixture();
   }),

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.test.ts
@@ -121,6 +121,7 @@ describe("unitListing()", () => {
       subjectParent: "Maths",
       tierSlug: "foundation",
       phase: "primary",
+      hasCycle2Content: false,
       yearGroups: [{ yearTitle: "Year 1", year: "year-1" }],
       subjectCategories: [
         {

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.query.ts
@@ -64,6 +64,9 @@ const unitListingQuery =
     }
 
     const unitsCamel = keysToCamelCase(parsedUnits);
+    const hasCycle2Content = unitsCamel.some(
+      (u) => u.unitData.Cohort === "2024-2025",
+    );
 
     const programmeFields = unitsCamel.reduce(
       (acc, val) => ({ ...acc, ...val.programmeFields }),
@@ -118,7 +121,10 @@ const unitListingQuery =
       ...(relatedSubjectsSet.size >= 1 && {
         relatedSubjects: Array.from(relatedSubjectsSet),
       }),
+      hasCycle2Content,
     };
   };
 
 export default unitListingQuery;
+
+export type UnitListingQueryReturn = ReturnType<typeof unitListingQuery>;

--- a/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/unitListing/unitListing.schema.ts
@@ -116,6 +116,7 @@ const unitListingData = z.object({
   pathwayTitle: pathways.nullable(),
   relatedSubjects: z.array(subjectSlugs).optional(),
   groupUnitsAs: z.string().optional(),
+  hasCycle2Content: z.boolean().optional(),
 });
 
 export type UnitListingData = z.infer<typeof unitListingData>;

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -15,6 +15,9 @@ import {
   oakDefaultTheme,
   OakFlex,
   OakMaxWidth,
+  OakLinkCard,
+  OakP,
+  OakSmallPrimaryButton,
 } from "@oaknational/oak-components";
 import { examboards, tierSlugs } from "@oaknational/oak-curriculum-schema";
 import { z } from "zod";
@@ -48,6 +51,8 @@ import PaginationHead from "@/components/SharedComponents/Pagination/PaginationH
 import MobileUnitFilters from "@/components/TeacherComponents/MobileUnitFilters";
 import DesktopUnitFilters from "@/components/TeacherComponents/DesktopUnitFilters/DesktopUnitFilters";
 import RelatedSubjectsBanner from "@/components/TeacherComponents/RelatedSubjectsBanner/RelatedSubjectsBanner";
+import { resolveOakHref } from "@/common-lib/urls";
+import { getSubjectPhaseSlug } from "@/components/TeacherComponents/helpers/getSubjectPhaseSlug";
 
 export type UnitListingPageProps = {
   curriculumData: UnitListingData;
@@ -66,6 +71,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
     tiers,
     units,
     examBoardTitle,
+    examBoardSlug,
     hasNewContent,
     subjectCategories,
     yearGroups,
@@ -315,17 +321,58 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
               $colSpan={[12, 12, 9]}
               $mt={"space-between-m2"}
             >
-              <OakFlex
-                $flexDirection={["column-reverse", "column-reverse", "column"]}
-              >
+              <OakFlex $flexDirection="column" $gap="space-between-m2">
+                {!isSlugLegacy(programmeSlug) && (
+                  <OakLinkCard
+                    mainSection={
+                      <OakFlex $flexDirection="column" $gap="space-between-s">
+                        <OakHeading tag="h2">
+                          Fully resourced {subjectTitle.toLocaleLowerCase()}{" "}
+                          curriculum is coming this autumn.
+                        </OakHeading>
+                        <OakP $font="heading-light-7">
+                          We’re busy creating the final lessons and units.
+                          Download the curriculum plan now to explore what’s
+                          coming and the thinking behind our curriculum design.
+                        </OakP>
+                        <OakSmallPrimaryButton
+                          isTrailingIcon
+                          iconName="download"
+                        >
+                          Download curriculum plan
+                        </OakSmallPrimaryButton>
+                      </OakFlex>
+                    }
+                    href={resolveOakHref({
+                      page: "curriculum-downloads",
+                      subjectPhaseSlug: getSubjectPhaseSlug({
+                        subject: subjectSlug,
+                        phaseSlug: phase,
+                        examBoardSlug: examBoardSlug,
+                      }),
+                    })}
+                    iconName="homepage-teacher-map"
+                    iconFill="white"
+                    iconAlt="Curriculum map icon"
+                    showNew={false}
+                  />
+                )}
                 <OakFlex
-                  $justifyContent={"space-between"}
-                  $flexDirection={"row"}
-                  $minWidth={["100%", "auto"]}
-                  $position={"relative"}
+                  $flexDirection={[
+                    "column-reverse",
+                    "column-reverse",
+                    "column",
+                  ]}
                 >
-                  <TierTabsOrUnitCountHeader />
-                  <MobileUnitFilterButton />
+                  <OakFlex
+                    $justifyContent={"space-between"}
+                    $flexDirection={"row"}
+                    $minWidth={["100%", "auto"]}
+                    $position={"relative"}
+                  >
+                    <TierTabsOrUnitCountHeader />
+                    <MobileUnitFilterButton />
+                  </OakFlex>
                 </OakFlex>
               </OakFlex>
 

--- a/src/pages/teachers/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units.tsx
@@ -78,6 +78,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
     pathwayTitle,
     relatedSubjects,
     phase,
+    hasCycle2Content,
   } = curriculumData;
 
   const { track } = useAnalytics();
@@ -322,7 +323,7 @@ const UnitListingPage: NextPage<UnitListingPageProps> = ({
               $mt={"space-between-m2"}
             >
               <OakFlex $flexDirection="column" $gap="space-between-m2">
-                {!isSlugLegacy(programmeSlug) && (
+                {hasCycle2Content && (
                   <OakLinkCard
                     mainSection={
                       <OakFlex $flexDirection="column" $gap="space-between-s">


### PR DESCRIPTION
## Description

Music year: 2021

- Add `hasCycle2Content` flag to unitListing query when any units have the cohort `2024-2025` (it seems this cohort is not fully populated in the data but I think it is widespread enough for this use case)
- Conditionally render a banner on unit listing pages with cycle 2 content
- Banner links to curriculum download page

_Note_: the icon on the card is smaller than the figma designs for this ticket and can't be updated without updating oak components

## How to test

1. Go to https://deploy-preview-3469--oak-web-application.netlify.thenational.academy
2. Go to a unit listing page for a cycle 2 subject, eg. Design and technology
3. You should see the curriculum downloads banner
4. It should link to the curriculum download page
5. Go to a cycle 1 subject and you should not see the banner

## Screenshots

How it should now look:

<img width="1172" alt="Screenshot 2025-06-09 at 11 48 09" src="https://github.com/user-attachments/assets/92984369-9048-471d-aff2-b778575cde3b" />
