### PR TITLE
Display unit-option details when showing modal for options

### DIFF
--- a/src/components/CurriculumComponents/CurricUnitDetails/CurricUnitDetails.tsx
+++ b/src/components/CurriculumComponents/CurricUnitDetails/CurricUnitDetails.tsx
@@ -9,11 +9,12 @@ import {
 
 import { TagFunctional } from "@/components/SharedComponents/TagFunctional";
 import CurricUnitDetailsAccordion from "@/components/CurriculumComponents/CurricUnitDetailsAccordion";
-import { Unit } from "@/utils/curriculum/types";
+import { Unit, UnitOption } from "@/utils/curriculum/types";
 import { ComponentTypeValueType } from "@/browser-lib/avo/Avo";
 
 export type CurricUnitDetailsProps = {
   unit: Unit;
+  unitOption?: UnitOption;
   isUnitDescriptionEnabled: boolean;
   handleUnitOverviewExploredAnalytics: (
     componentType: ComponentTypeValueType,
@@ -22,11 +23,12 @@ export type CurricUnitDetailsProps = {
 
 export default function CurricUnitDetails({
   unit,
+  unitOption,
   isUnitDescriptionEnabled,
   handleUnitOverviewExploredAnalytics,
 }: CurricUnitDetailsProps) {
+  const threads = unit.threads;
   const {
-    threads,
     lessons,
     connection_prior_unit_description: priorUnitDescription,
     connection_future_unit_description: futureUnitDescription,
@@ -34,7 +36,8 @@ export default function CurricUnitDetails({
     connection_future_unit_title: futureUnitTitle,
     why_this_why_now: whyThisWhyNow,
     description,
-  } = unit;
+  } = unitOption ?? unit;
+
   const threadTitleSet = new Set<string>(threads.map((thread) => thread.title));
 
   const lessonTitleSet = new Set<string>(

--- a/src/components/CurriculumComponents/CurricUnitModalContent/CurricUnitModalContent.tsx
+++ b/src/components/CurriculumComponents/CurricUnitModalContent/CurricUnitModalContent.tsx
@@ -117,12 +117,13 @@ export default function CurricUnitModalContent({
             </OakFlex>
 
             <OakHeading tag="h2" $font={"heading-5"}>
-              {unitData.title}
+              {unitOptionData?.title ?? unitData.title}
             </OakHeading>
             {!unitOptionsAvailable && (
               <OakBox $display={optionalityModalOpen ? "none" : "block"}>
                 <CurricUnitDetails
                   unit={unitData}
+                  unitOption={unitOptionData}
                   handleUnitOverviewExploredAnalytics={
                     handleUnitOverviewExploredAnalytics
                   }


### PR DESCRIPTION
## Description
Display unit-option details when showing modal for options, currently displays unit details in web UI (docx is correct)

## Issue(s)
Hotfix

## How to test

1. Go to https://deploy-preview-3471--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Check unit modals show correct details for unit-options

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
