### PR TITLE
Add more URLs for Percy VRT

### DIFF
--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -31,11 +31,13 @@ function getDeploymentTestUrls() {
     // "/lp/oak-calendar",
     // Legacy content pages
     "/teachers/key-stages/ks1/subjects",
+    "/teachers/key-stages/ks4/subjects", // subjects with pathways
     "/teachers/key-stages/ks4/subjects/maths/programmes",
     "/teachers/programmes/maths-secondary-ks4-foundation/units",
     "/teachers/programmes/computing-secondary-ks4-gcse-l/units",
     "/teachers/programmes/maths-secondary-ks4-foundation/units/algebraic-manipulation/lessons", // unit with tiers
     "/teachers/programmes/english-primary-ks2-l/units/oliver-twist-narrative-writing-280c/lessons?page=2", // unit with pagination
+    "/teachers/programmes/combined-science-secondary-ks4-foundation-aqa/units?page=2", // unit with pagination
     "/teachers/programmes/design-technology-secondary-ks3-l/units/packaging-pop-outs-bc35/lessons/designing-for-others-6mtk2t", // all yellow boxes
     "/teachers/programmes/maths-secondary-ks4-foundation/units/algebraic-manipulation/lessons/further-algebraic-terminology/downloads?preselected=slide+deck",
     // "/teachers/search?term=computing&keyStages=ks4&subjects=computing&contentTypes=unit",
@@ -51,7 +53,13 @@ function getDeploymentTestUrls() {
     "/teachers/programmes/spanish-secondary-ks4-edexcel/units/travel-and-tourism-nuevas-experiencias/lessons",
     "/teachers/programmes/biology-secondary-ks4-higher-aqa/units/health-and-disease/lessons",
     "/teachers/programmes/history-primary-ks1/units/traditional-stories-what-do-they-tell-us-about-the-distant-past-1757/lessons", // optionality variant using null lessons
-    "/teachers/programmes/physical-education-primary-ks2/units/invasion-games-principles-of-attack-and-defence-through-ball-games/lessons/passing-and-receiving-skills",
+    "/teachers/programmes/physical-education-primary-ks2/units/invasion-games-principles-of-attack-and-defence-through-ball-games/lessons/passing-and-receiving-skills", // practical PE lesson
+    "/teachers/specialist/subjects", // specialist
+    "/teachers/key-stages/early-years-foundation-stage/subjects", // EYFS
+    "/teachers/programmes/computing-primary-ks1/units/building-sequences-in-programs/lessons/building-blocks-to-create-a-sequence", // lesson with media clips and additional materials
+    "/teachers/programmes/music-primary-ks2/units/compose-and-create-improvising-within-hindustani-classical-music/lessons/playing-taals-and-speaking-bols/media", // media clips page
+    "/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil", // lesson with lesson files,
+    "/teachers/programmes/geography-secondary-ks4-edexcelb/units/global-inequalities/lessons", // incomplete unit
     // Canonical lesson pages
     "/teachers/lessons/duncan-as-a-father-figure",
     "/teachers/lessons/duncan-as-a-father-figure/downloads",
@@ -65,6 +73,7 @@ function getDeploymentTestUrls() {
     "/pupils/programmes/maths-primary-year-5/units/multiplication-by-partitioning-leading-to-short-multiplication-3-by-1-digit/lessons",
     "/pupils/programmes/geography-primary-year-5/units/north-and-south-america-how-diverse-are-their-places-and-landscapes/lessons/physical-geography-of-north-and-south-america/overview",
     "/pupils/programmes/computing-primary-year-5-l/units/vector-drawing-ea06/lessons/create-a-vector-drawing-cgvpac/intro",
+    "/pupils/programmes/english-secondary-year-10-aqa/units/modern-text-first-study-198/lessons/the-windrush-generation-k2397/overview", // lesson with content guidance
     // Below urls have tickets raised for pa11y errors
     // "/pupils/lessons/sexual-consent-and-the-law-6gt3et/overview",
     // "/pupils/programmes/art-primary-year-1-l/units/drawing-c92d/lessons/exploring-shadows-and-tone-6hjk0t/intro",
@@ -82,6 +91,13 @@ function getDeploymentTestUrls() {
     "/teachers/curriculum/english-primary/units/speaking-and-listening",
     "/teachers/curriculum/english-primary/units/king-tut-or-healthy-lifestyle-non-chronological-report",
     "/teachers/curriculum/english-primary/units/king-tut-or-healthy-lifestyle-non-chronological-report-629",
+    // User pages
+    "/sign-up",
+    "/sign-in",
+    "/onboarding",
+    // Search
+    "/teachers/search?term=waves",
+    "/teachers/search?term=waves&contentTypes=unit"
   ];
 }
 

--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -37,15 +37,17 @@ function getDeploymentTestUrls() {
     "/teachers/programmes/computing-secondary-ks4-gcse-l/units",
     "/teachers/programmes/maths-secondary-ks4-foundation/units/algebraic-manipulation/lessons", // unit with tiers
     "/teachers/programmes/english-primary-ks2-l/units/oliver-twist-narrative-writing-280c/lessons?page=2", // unit with pagination
-    "/teachers/programmes/combined-science-secondary-ks4-foundation-aqa/units?page=2", // unit with pagination
     "/teachers/programmes/design-technology-secondary-ks3-l/units/packaging-pop-outs-bc35/lessons/designing-for-others-6mtk2t", // all yellow boxes
     "/teachers/programmes/maths-secondary-ks4-foundation/units/algebraic-manipulation/lessons/further-algebraic-terminology/downloads?preselected=slide+deck",
+    "/teachers/specialist/subjects", // specialist
+    "/teachers/key-stages/early-years-foundation-stage/subjects", // EYFS
     // "/teachers/search?term=computing&keyStages=ks4&subjects=computing&contentTypes=unit",
     // New content pages
     "/teachers/programmes/english-secondary-ks3/units", // No programme factors
     "/teachers/programmes/english-secondary-ks3/units/victorian-childhood-non-fiction-reading-and-writing/lessons",
     "/teachers/programmes/english-secondary-ks3/units/victorian-childhood-non-fiction-reading-and-writing/lessons/victorian-childhood-preparing-an-argument",
     "/teachers/key-stages/ks4/subjects/combined-science/programmes",
+    "/teachers/programmes/combined-science-secondary-ks4-foundation-aqa/units?page=2", // unit with pagination
     "/teachers/programmes/combined-science-secondary-ks4-higher-aqa/units",
     "/teachers/programmes/combined-science-secondary-ks4-higher-aqa/units/measuring-waves/lessons",
     "/teachers/programmes/combined-science-secondary-ks4-higher-aqa/units/measuring-waves/lessons/oscilloscope",
@@ -54,8 +56,6 @@ function getDeploymentTestUrls() {
     "/teachers/programmes/biology-secondary-ks4-higher-aqa/units/health-and-disease/lessons",
     "/teachers/programmes/history-primary-ks1/units/traditional-stories-what-do-they-tell-us-about-the-distant-past-1757/lessons", // optionality variant using null lessons
     "/teachers/programmes/physical-education-primary-ks2/units/invasion-games-principles-of-attack-and-defence-through-ball-games/lessons/passing-and-receiving-skills", // practical PE lesson
-    "/teachers/specialist/subjects", // specialist
-    "/teachers/key-stages/early-years-foundation-stage/subjects", // EYFS
     "/teachers/programmes/computing-primary-ks1/units/building-sequences-in-programs/lessons/building-blocks-to-create-a-sequence", // lesson with media clips and additional materials
     "/teachers/programmes/music-primary-ks2/units/compose-and-create-improvising-within-hindustani-classical-music/lessons/playing-taals-and-speaking-bols/media", // media clips page
     "/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil", // lesson with lesson files,

--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -97,7 +97,7 @@ function getDeploymentTestUrls() {
     "/onboarding",
     // Search
     "/teachers/search?term=waves",
-    "/teachers/search?term=waves&contentTypes=unit"
+    "/teachers/search?term=waves&contentTypes=unit",
   ];
 }
 


### PR DESCRIPTION
## Description
Expand list of URLs for Percy VRT to include recent features

Music year: 1989

- List of changes
Add URLs for sign in and onboarding, incomplete units, search, lesson files, media clips, content guidance, specialist, EYFS, subjects with pathways

## Issue(s)
None

## How to test
Wait for Percy to pick up the changes via the CI and see the results.
Remove any that are problematic or not helpful or slows the deployments too much.

## Checklist
- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
