### PR TITLE
Add animation to CurriculumDownloadBanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.121.3",
+        "@oaknational/oak-components": "^1.123.0",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.62.0",
         "@oaknational/oak-pupil-client": "^2.15.0",
@@ -6635,9 +6635,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.121.3",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.121.3.tgz",
-      "integrity": "sha512-IeZkYY1AXFn3a4vQDvK+y0H0Ait2+HDB5qFD7CWp0AvCv3gZ8BPxsrY5QRqZe8dQvTEtHRxtYOYoKjYfvVZ6ow==",
+      "version": "1.123.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.123.0.tgz",
+      "integrity": "sha512-efMQg2idbBeBVka4Hgoz5c1EyDzZx9WbcTiELQLeMe0whYMTANHXDOq3fHJcOTGwLsa5SBXp/xny64ezLerakQ==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.121.3",
+    "@oaknational/oak-components": "^1.123.0",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.62.0",
     "@oaknational/oak-pupil-client": "^2.15.0",

--- a/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.tsx
+++ b/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.tsx
@@ -43,6 +43,7 @@ const CurriculumDownloadBanner = (props: CurriculumDownloadBannerProps) => {
 
   return (
     <OakLinkCard
+      hasAnimation
       mainSection={
         <OakFlex $flexDirection="column" $gap="space-between-s">
           <OakHeading tag="h2">


### PR DESCRIPTION
## Description

This PR adds a bg animation to the CurriculumDownloadBanner component. The animation itself already has a sign off from the designer.

## Issue(s)

Fixes https://www.notion.so/oaknationalacademy/I-want-animations-on-the-curriculum-download-banner-20d26cc4e1b18061a302f7820ecdfe6e

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
