### PR TITLE
feat: lesson listing page SEO body text [LESQ-1453]

### DIFF
--- a/src/components/TeacherComponents/LessonList/LessonList.test.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.test.tsx
@@ -98,4 +98,46 @@ describe("components/ Lesson List", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+  test("it renders the SEO accordion for non-legacy units", async () => {
+    const { getByTestId } = render(
+      <LessonList
+        paginationProps={mockPaginationProps}
+        subjectSlug={"computing"}
+        keyStageSlug={"ks2"}
+        headingTag={"h2"}
+        currentPageItems={lessonsWithUnitData}
+        unitTitle={"Unit title"}
+        lessonCount={4}
+        onClick={onClick}
+        lessonCountHeader={`Lessons (${lessons.length})`}
+        programmeSlug="computing-primary-ks2"
+        yearTitle="Year 6"
+        subjectTitle="Computing"
+      />,
+    );
+    const seoAccordion = getByTestId("lesson-list-seo-accordion");
+
+    expect(seoAccordion).toBeInTheDocument();
+  });
+  test("it does not render the SEO accordion for legacy units", async () => {
+    const { queryByTestId } = render(
+      <LessonList
+        paginationProps={mockPaginationProps}
+        subjectSlug={"computing"}
+        keyStageSlug={"ks2"}
+        headingTag={"h2"}
+        currentPageItems={lessonsWithUnitData}
+        unitTitle={"Unit title"}
+        lessonCount={4}
+        onClick={onClick}
+        lessonCountHeader={`Lessons (${lessons.length})`}
+        programmeSlug="computing-primary-ks2-l"
+        yearTitle="Year 6"
+        subjectTitle="Computing"
+      />,
+    );
+    const seoAccordion = queryByTestId("lesson-list-seo-accordion");
+
+    expect(seoAccordion).not.toBeInTheDocument();
+  });
 });

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -8,6 +8,8 @@ import {
   OakBox,
 } from "@oaknational/oak-components";
 
+import { LessonListSeoHelper } from "./LessonListSeoHelper";
+
 import LessonListItem, {
   LessonListItemProps,
 } from "@/components/TeacherComponents/LessonListItem";
@@ -18,6 +20,7 @@ import {
 import { SpecialistLessonListItemProps } from "@/components/TeacherComponents/LessonListItem/LessonListItem";
 import { SpecialistLesson } from "@/node-lib/curriculum-api-2023/queries/specialistLessonListing/specialistLessonListing.schema";
 import { UnpublishedLessonListItem } from "@/node-lib/curriculum-api-2023/shared.schema";
+import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 
 export type LessonListProps = {
   lessonCount: number;
@@ -35,6 +38,9 @@ export type LessonListProps = {
   unitTitle: string;
   onClick: (props: LessonListItemProps | SpecialistLessonListItemProps) => void;
   expiringBanner?: React.ReactNode;
+  yearTitle?: string;
+  subjectTitle?: string;
+  programmeSlug?: string;
 };
 
 const LESSONS_PER_PAGE = 5;
@@ -55,9 +61,21 @@ const LessonList: FC<LessonListProps> = (props) => {
     unitTitle,
     onClick,
     expiringBanner,
+    yearTitle,
+    subjectTitle,
+    keyStageSlug,
+    programmeSlug,
   } = props;
   const { currentPage, pageSize, firstItemRef, paginationRoute } =
     paginationProps;
+
+  const showSEOAccordion =
+    programmeSlug &&
+    !isSlugLegacy(programmeSlug) &&
+    yearTitle &&
+    keyStageSlug &&
+    unitTitle &&
+    subjectTitle;
 
   return (
     <OakFlex $flexDirection="column">
@@ -106,6 +124,14 @@ const LessonList: FC<LessonListProps> = (props) => {
         </OakBox>
       ) : (
         <OakBox $pb="inner-padding-xl2" />
+      )}
+      {showSEOAccordion && (
+        <LessonListSeoHelper
+          year={yearTitle}
+          subject={subjectTitle}
+          keystage={keyStageSlug}
+          unitTitle={unitTitle}
+        />
       )}
     </OakFlex>
   );

--- a/src/components/TeacherComponents/LessonList/LessonListSeoHelper.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonListSeoHelper.tsx
@@ -1,0 +1,58 @@
+import { OakBasicAccordion, OakBox, OakP } from "@/styles/oakThemeApp";
+
+const getPhase = (year: string) => {
+  return Number(year) < 7 ? "primary" : "secondary";
+};
+
+const formatSubjectName = (subject: string) => {
+  const excludedSubjects = [
+    "English",
+    "French",
+    "Spanish",
+    "German",
+    "RSHE (PSHE)",
+  ];
+
+  return excludedSubjects.includes(subject) ? subject : subject.toLowerCase();
+};
+
+export const LessonListSeoHelper = ({
+  keystage,
+  subject,
+  unitTitle,
+  year,
+}: {
+  keystage: string;
+  subject: string;
+  unitTitle: string;
+  year: string;
+}) => {
+  return (
+    <OakBox $mb="space-between-xxl">
+      <OakBasicAccordion
+        header={
+          <OakP $font="body-1" $textAlign="left">
+            Explore this {year.toLowerCase()} {formatSubjectName(subject)} unit
+            to find free lesson teaching resources, including...
+          </OakP>
+        }
+        initialOpen={false}
+        id="lesson-list-seo"
+        data-testid="lesson-list-seo-accordion"
+        $bt="border-solid-s"
+        $bb="border-solid-s"
+        $borderColor="border-neutral-lighter"
+        $alignItems="flex-start"
+      >
+        <OakP $font="body-1" $textAlign="left">
+          slide decks, worksheet PDFs, quizzes and lesson overviews. You can
+          select individual lessons from the {unitTitle} unit and download the
+          resources you need, or download the entire unit now. See every unit
+          listed in our {getPhase(year)} {formatSubjectName(subject)} curriculum
+          and discover more of our teaching resources for{" "}
+          {keystage.toUpperCase()}.
+        </OakP>
+      </OakBasicAccordion>
+    </OakBox>
+  );
+};


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds LessonListSEOHelper to lesson list page for non-legacy units

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
3. You should see body text accordion at the bottom of the page

## Screenshots

How it should now look:
<img width="881" alt="image" src="https://github.com/user-attachments/assets/768b5d90-aaff-4c32-88e1-a036789307a3" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
