### PR TITLE
fix: improve Aila signposting link accessibility for screen readers

### DIFF
--- a/src/components/TeacherComponents/NoSearchResults/SignPostToAila.tsx
+++ b/src/components/TeacherComponents/NoSearchResults/SignPostToAila.tsx
@@ -44,7 +44,7 @@ const SignPostToAila = ({
     <PromoBannerWithVideo
       title={title}
       text={text}
-      buttonText="Get started"
+      buttonText="Create a lesson with AI"
       buttonIconName="external"
       href={composeAilaLink({ keyStage, subject, unitTitle, searchExpression })}
       videoPlaybackID={videoPlaybackID}

--- a/src/components/TeacherComponents/PromoBannerWithVideo/index.tsx
+++ b/src/components/TeacherComponents/PromoBannerWithVideo/index.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import { StyledVideoFlex } from "../NewContentBanner/NewContentBanner";
 
 import VideoPlayer from "@/components/SharedComponents/VideoPlayer";
+import { isExternalHref } from "@/common-lib/urls";
 
 type PromoBannerWithVideoProps = {
   title: string;
@@ -36,6 +37,7 @@ const PromoBannerWithVideo = ({
   buttonIconName,
   textUnderVideo,
 }: PromoBannerWithVideoProps) => {
+  const isExternal = href ? isExternalHref(href) : false;
   return (
     <StyledOakFlex
       $flexDirection={["column-reverse", "row"]}
@@ -59,6 +61,11 @@ const PromoBannerWithVideo = ({
           element={href ? "a" : "button"}
           onClick={onClick}
           href={href}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+          aria-label={
+            isExternal ? `${buttonText} (opens in a new tab)` : buttonText
+          }
         >
           {buttonText}
         </OakTertiaryButton>


### PR DESCRIPTION
  ## Description

  Music year: 1991

  - Changed button text from 'Get started' to 'Create a lesson with AI' for better context
  - Added automatic external link detection using existing isExternalHref utility
  - Applied target='_blank' and proper aria-label for external Aila links only
  - Maintained existing behavior for internal links in PromoBannerWithVideo component

  ## Issue(s)

  Fixes AI-840

  ## How to test

  1. Go to https://deploy-preview-3484--oak-web-application.netlify.thenational.academy
  2. Search for a lesson that returns no results
  3. Look for the Aila signposting banner with video
  4. Verify the button text reads 'Create a lesson with AI'
  5. Verify the link opens in a new tab
  6. Test with screen reader to confirm proper aria-label

  ## Screenshots

  How it used to look:
  - Button text: 'Get started'
  - No explicit new tab indication for screen readers

  How it should now look:
  - Button text: 'Create a lesson with AI'  
  - Proper aria-label: 'Create a lesson with AI (opens in a new tab)'
  - Opens in new tab with target='_blank'

  ## Checklist

  - [x] Added or updated tests where appropriate
  - [x] Manually tested across browsers / devices
  - [x] Considered impact on accessibility
  - [x] Design sign-off
  - [ ] Approved by product owner
  - [ ] Does this PR update a package with a breaking change