### PR TITLE
Fix toasts rendering behind the header

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CurriculumTab renders 1`] = `
     >
       <div
         aria-live="polite"
-        class="sc-fqkvVR sc-gsFSXq sc-442d8add-0 hkKUlc cQyxGE ehPczd"
+        class="sc-fqkvVR sc-gsFSXq sc-d65e4df9-0 hkKUlc cQyxGE jTGGef"
       />
       <div
         class="sc-fqkvVR gZEYWU"

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CurriculumTab renders 1`] = `
     >
       <div
         aria-live="polite"
-        class="sc-fqkvVR sc-gsFSXq sc-f4cbd139-0 hkKUlc cQyxGE kKBKcm"
+        class="sc-fqkvVR sc-gsFSXq sc-442d8add-0 hkKUlc cQyxGE ehPczd"
       />
       <div
         class="sc-fqkvVR gZEYWU"

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CurriculumTab renders 1`] = `
     >
       <div
         aria-live="polite"
-        class="sc-fqkvVR sc-gsFSXq sc-da07f570-0 hkKUlc cQyxGE kbCuxI"
+        class="sc-fqkvVR sc-gsFSXq sc-f4cbd139-0 hkKUlc cQyxGE kKBKcm"
       />
       <div
         class="sc-fqkvVR gZEYWU"

--- a/src/context/OakToast/OakToastProvider.test.tsx
+++ b/src/context/OakToast/OakToastProvider.test.tsx
@@ -1,0 +1,98 @@
+import { act, waitFor } from "@testing-library/react";
+
+import { useOakToastContext } from "./useOakToastContext";
+
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+
+const mockIntersectionObserver = jest.fn();
+const mockDisconnect = jest.fn();
+
+const render = renderWithProviders();
+
+beforeEach(() => {
+  mockIntersectionObserver.mockClear();
+  mockDisconnect.mockClear();
+
+  global.IntersectionObserver = jest.fn().mockImplementation((callback) => {
+    mockIntersectionObserver.mockImplementation(callback);
+    return {
+      disconnect: mockDisconnect,
+      unobserve: jest.fn(),
+    };
+  });
+
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+const TestComponent = () => {
+  const { currentToastProps, setCurrentToastProps } = useOakToastContext();
+  return (
+    <div>
+      <button
+        onClick={() =>
+          setCurrentToastProps({
+            message: "test",
+            variant: "success",
+            autoDismiss: true,
+            showIcon: false,
+          })
+        }
+        data-testid="show-toast"
+      >
+        Show Toast
+      </button>
+      {currentToastProps && (
+        <div data-testid="toast-message">{currentToastProps.message}</div>
+      )}
+    </div>
+  );
+};
+
+describe("OakToastProvider", () => {
+  test("sets offset to 32 when header is not visible", async () => {
+    const { container } = render(<TestComponent />);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      mockIntersectionObserver([{ isIntersecting: false }]);
+    });
+
+    await waitFor(() => {
+      const toastContainer = container.querySelector('[aria-live="polite"]');
+      expect(toastContainer).toHaveStyle("top: 32px");
+    });
+  });
+
+  test("sets offset to 82 when header is visible", async () => {
+    const { container } = render(<TestComponent />);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      mockIntersectionObserver([{ isIntersecting: true }]);
+    });
+
+    await waitFor(() => {
+      const toastContainer = container.querySelector('[aria-live="polite"]');
+      expect(toastContainer).toHaveStyle("top: 82px");
+    });
+  });
+
+  test("cleans up observer on unmount", () => {
+    const { unmount } = render(<TestComponent />);
+
+    unmount();
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/src/context/OakToast/OakToastProvider.tsx
+++ b/src/context/OakToast/OakToastProvider.tsx
@@ -29,8 +29,10 @@ export const OakToastProvider: FC<{
       (entries) => {
         const headerIsVisible = entries[0]?.isIntersecting;
         if (headerIsVisible) {
+          console.log("Header is visible");
           setOffsetTop(82);
         } else {
+          console.log("Header is not visible");
           setOffsetTop(32);
         }
       },
@@ -44,7 +46,7 @@ export const OakToastProvider: FC<{
       if (headerElement) {
         observer.observe(headerElement);
       }
-    }, 100);
+    }, 500);
 
     return () => {
       clearTimeout(timeOut);

--- a/src/context/OakToast/OakToastProvider.tsx
+++ b/src/context/OakToast/OakToastProvider.tsx
@@ -25,17 +25,30 @@ export const OakToastProvider: FC<{
 
   useEffect(() => {
     // Adjust the distance from the top of the screen when the header is visible
-    const observer = new IntersectionObserver((entries) => {
-      if (entries && entries[0] && entries[0].isIntersecting) {
-        setOffsetTop(82);
-      } else {
-        setOffsetTop(32);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const headerIsVisible = entries[0]?.isIntersecting;
+        if (headerIsVisible) {
+          setOffsetTop(82);
+        } else {
+          setOffsetTop(32);
+        }
+      },
+      // Only when the header is 50% visible, is it considered to be intersecting
+      { threshold: 0.5 },
+    );
+
+    // Wait for the header to be rendered before observing it
+    const timeOut = setTimeout(() => {
+      const headerElement = document.querySelector("header");
+      if (headerElement) {
+        observer.observe(headerElement);
       }
-    });
-    const headerElement = document.querySelector("header");
-    if (headerElement) {
-      observer.observe(headerElement);
-    }
+    }, 100);
+
+    return () => {
+      clearTimeout(timeOut);
+    };
   }, [asPath]);
 
   const setToastPropsAndId = (props: OakToastProps | null) => {


### PR DESCRIPTION
## Description

This PR fixes an issue where toasts intermittently appeared behind the header. I think this was due to a race condition where the IntersectionObserver evaluated header visibility before DOM was fully rendered. It wasn't just happening in the unit listing page, but on other pages also.

### Solution

- Added 100ms timeout before observing header element (this feels a bit brittle. from reading around I think [a mutation observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) might be better. I tried to use one but I couldn't get it to work)
- Drive-by fix : Set intersection threshold to 0.5 (header must be 50% visible)
- Drive-by refactor: added a named variable for header visibility to make the code read a bit more clearly

#### threshold behaviour

Old behaviour: header is barely visible, toasts are offset
![Kapture 2025-06-12 at 11 43 08](https://github.com/user-attachments/assets/583efa21-2d16-4121-b9e1-e95145baf547)

New behaviour: toasts are not offset until more than 50% is visible
![Kapture 2025-06-12 at 11 46 38](https://github.com/user-attachments/assets/0438976a-89f7-469e-a72e-0d59cfb5375b)

## Issue(s)

Fixes https://www.notion.so/oaknationalacademy/Toast-still-appears-in-wrong-position-sometimes-20326cc4e1b1801ebfc8ff3dd26ee5e3

## How to test

This bug didn't appear every time the steps below were followed, but often enough that a few repetitions will ensure it's no longer a problem

1. Go to a key stage (subjet listing page?)
2. Click on a subject
3. Without scrolling, click save on a unit
4. The toast should render below the header

## Screenshots

How it used to look (delete if n/a):

![screenshot](https://private-user-images.githubusercontent.com/98838967/448863584-f8b4649f-8a68-4b9b-b2c4-b5695c1941d4.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk3MjU3NjcsIm5iZiI6MTc0OTcyNTQ2NywicGF0aCI6Ii85ODgzODk2Ny80NDg4NjM1ODQtZjhiNDY0OWYtOGE2OC00YjliLWIyYzQtYjU2OTVjMTk0MWQ0LmdpZj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MTIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjEyVDEwNTEwN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTQ3NThiMmQ5ZGVmN2NkY2Q2NjRjNjgxOTFmZTQ5NGE1ZjQ2ZDc1NDIwOWM5NDM0ZGIxMWJlMDkwMGMxOGViMTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.sQFvdTBGGSyNo9Vo-AUcZ_8DnQes8c_3KydGu3FSKpw)

How it should now look:
As above

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
