### PR TITLE
FEC-122 get worksheet info more logging

### DIFF
--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.test.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.test.tsx
@@ -97,6 +97,7 @@ describe("checkIfDownloadResourcesExist()", () => {
         isLegacyDownload: true,
         lessonSlug: "lesson-slug",
         resourceTypesString: "exit-quiz-answers,worksheet-pdf",
+        errorSource: "getDownloadExistence",
       });
     }
   });
@@ -126,6 +127,7 @@ describe("checkIfDownloadResourcesExist()", () => {
         isLegacyDownload: true,
         lessonSlug: "lesson-slug",
         resourceTypesString: "exit-quiz-answers,worksheet-pdf",
+        errorSource: "getDownloadExistence",
       });
     }
   });

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.tsx
@@ -78,7 +78,10 @@ const getDownloadExistence = async (
   if (!res.ok) {
     throw new OakError({
       code: "downloads/check-files-failed",
-      meta,
+      meta: {
+        ...meta,
+        errorSource: "getDownloadExistence",
+      },
     });
   }
 

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/getParsedData.ts
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/getParsedData.ts
@@ -33,6 +33,7 @@ export const getParsedData = (
         ...MediaMetadata,
         type: "zod error",
         error: parsedJson.error.message,
+        errorSource: "getParsedData - parsedJson failed",
       },
     });
   }
@@ -45,6 +46,7 @@ export const getParsedData = (
       meta: {
         ...meta,
         error,
+        errorSource: "getParsedData - no data or error",
       },
     });
   }


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

Added errorSource strings to some OakErrors thrown within the getWorksheetInfo. Bugsnag is showing no meta on the original error. 

These logs will indicate either:
1. The errors thrown from one of these places, but the meta is undefined
2. The error is not being thrown from any of these places

## Issue(s)
Related to [this ticket](https://www.notion.so/oaknationalacademy/getWorksheetInfo-bug-21126cc4e1b18075a294fd0c36124959?source=copy_link), where I have been tracking the investigation

## How to test
Code changes only

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
