### PR TITLE
feat: add Aila signposting to lesson list

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -66,11 +66,14 @@ jest.mock("posthog-js", () => ({
   },
 }));
 
-jest.mock("@mux/mux-player-react/lazy", () => ({
-  __esModule: true,
-  // noop component
-  default: () => null,
-}));
+jest.mock("@mux/mux-player-react/lazy", () => {
+  const { forwardRef } = jest.requireActual("react");
+  return {
+    __esModule: true,
+    // noop component with forwardRef to handle ref passing
+    default: forwardRef(() => null),
+  };
+});
 
 jest.mock("./src/image-data/generated/inline-sprite.svg", () => "svg");
 

--- a/src/components/TeacherComponents/LessonList/LessonList.test.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.test.tsx
@@ -40,7 +40,7 @@ describe("components/ Lesson List", () => {
 
     expect(listHeading).toBeInTheDocument();
   });
-  test("it renders pagination if lesson count is greater than 10 ", () => {
+  test("it renders pagination if lesson count is greater than 20 ", () => {
     const { getByTestId } = render(
       <LessonList
         paginationProps={mockPaginationProps}
@@ -49,7 +49,7 @@ describe("components/ Lesson List", () => {
         headingTag={"h2"}
         currentPageItems={lessonsWithUnitData}
         unitTitle={"Unit title"}
-        lessonCount={11}
+        lessonCount={21}
         onClick={onClick}
         lessonCountHeader={`Lessons (${lessons.length})`}
       />,
@@ -59,7 +59,7 @@ describe("components/ Lesson List", () => {
 
     expect(pagination).toBeInTheDocument();
   });
-  test("it does not renders pagination if lesson count is less than or equal to 10 ", () => {
+  test("it does not renders pagination if lesson count is less than or equal to 20 ", () => {
     const { queryByTestId } = render(
       <LessonList
         paginationProps={mockPaginationProps}
@@ -68,7 +68,7 @@ describe("components/ Lesson List", () => {
         headingTag={"h2"}
         currentPageItems={lessonsWithUnitData}
         unitTitle={"Unit title"}
-        lessonCount={10}
+        lessonCount={20}
         onClick={onClick}
         lessonCountHeader={`Lessons (${lessons.length})`}
       />,

--- a/src/components/TeacherComponents/LessonList/LessonList.test.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.test.tsx
@@ -36,11 +36,11 @@ describe("components/ Lesson List", () => {
       />,
     );
 
-    const listHeading = getByRole("heading", { level: 2 });
+    const listHeading = getByRole("heading", { name: "Lessons (5)" });
 
     expect(listHeading).toBeInTheDocument();
   });
-  test("it renders pagination if lesson count is greater than 5 ", () => {
+  test("it renders pagination if lesson count is greater than 10 ", () => {
     const { getByTestId } = render(
       <LessonList
         paginationProps={mockPaginationProps}
@@ -49,7 +49,7 @@ describe("components/ Lesson List", () => {
         headingTag={"h2"}
         currentPageItems={lessonsWithUnitData}
         unitTitle={"Unit title"}
-        lessonCount={10}
+        lessonCount={11}
         onClick={onClick}
         lessonCountHeader={`Lessons (${lessons.length})`}
       />,
@@ -59,7 +59,7 @@ describe("components/ Lesson List", () => {
 
     expect(pagination).toBeInTheDocument();
   });
-  test("it does not renders pagination if lesson count is less than 5 ", () => {
+  test("it does not renders pagination if lesson count is less than or equal to 10 ", () => {
     const { queryByTestId } = render(
       <LessonList
         paginationProps={mockPaginationProps}
@@ -68,7 +68,7 @@ describe("components/ Lesson List", () => {
         headingTag={"h2"}
         currentPageItems={lessonsWithUnitData}
         unitTitle={"Unit title"}
-        lessonCount={4}
+        lessonCount={10}
         onClick={onClick}
         lessonCountHeader={`Lessons (${lessons.length})`}
       />,

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -8,6 +8,8 @@ import {
   OakBox,
 } from "@oaknational/oak-components";
 
+import SignPostToAila from "../NoSearchResults/SignPostToAila";
+
 import { LessonListSeoHelper } from "./LessonListSeoHelper";
 
 import LessonListItem, {
@@ -111,11 +113,11 @@ const LessonList: FC<LessonListProps> = (props) => {
           </OakUL>
         </>
       ) : null}
+
       {lessonCount > LESSONS_PER_PAGE ? (
         <OakBox
           $width="100%"
           $mt={["space-between-none", "auto"]}
-          $pb={["inner-padding-xl2", "inner-padding-xl4"]}
           $pt={["inner-padding-xl4", "inner-padding-xl3"]}
           data-testid="pagination-box"
         >
@@ -125,9 +127,17 @@ const LessonList: FC<LessonListProps> = (props) => {
             paginationHref={paginationRoute}
           />
         </OakBox>
-      ) : (
-        <OakBox $pb="inner-padding-xl2" />
-      )}
+      ) : null}
+
+      <OakBox $pb={["inner-padding-xl2", "inner-padding-xl4"]}>
+        <SignPostToAila
+          title="Can't find what you need?"
+          text="Create a tailor-made lesson plan and resources on any topic with Aila, our free AI-powered lesson assistant. Entirely adaptable to your class and context."
+          keyStage={keyStageSlug}
+          subject={subjectSlug}
+        />
+      </OakBox>
+
       {showSEOAccordion && (
         <LessonListSeoHelper
           examBoardSlug={examBoardSlug}

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -137,6 +137,7 @@ const LessonList: FC<LessonListProps> = (props) => {
           text="Create a tailor-made lesson plan and resources on any topic with Aila, our free AI-powered lesson assistant. Entirely adaptable to your class and context."
           keyStage={keyStageSlug}
           subject={subjectSlug}
+          unitTitle={unitTitle}
         />
       </OakBox>
       {showSEOAccordion && (

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -46,7 +46,7 @@ export type LessonListProps = {
   examBoardSlug?: string | null;
 };
 
-const LESSONS_PER_PAGE = 5;
+const LESSONS_PER_PAGE = 10;
 
 /**
  * Contains a list of lessons
@@ -94,7 +94,6 @@ const LessonList: FC<LessonListProps> = (props) => {
         </OakHeading>
         {expiringBanner}
       </OakFlex>
-
       {currentPageItems?.length ? (
         <>
           <OakUL aria-label="A list of lessons" $reset>
@@ -118,7 +117,7 @@ const LessonList: FC<LessonListProps> = (props) => {
         <OakBox
           $width="100%"
           $mt={["space-between-none", "auto"]}
-          $pt={["inner-padding-xl4", "inner-padding-xl3"]}
+          $pt={["inner-padding-xs", "inner-padding-xl"]}
           data-testid="pagination-box"
         >
           <OakPagination
@@ -129,7 +128,10 @@ const LessonList: FC<LessonListProps> = (props) => {
         </OakBox>
       ) : null}
 
-      <OakBox $pb={["inner-padding-xl2", "inner-padding-xl4"]}>
+      <OakBox
+        $pb={["inner-padding-xl", "inner-padding-xl2"]}
+        $pt={[null, "inner-padding-m"]}
+      >
         <SignPostToAila
           title="Can't find what you need?"
           text="Create a tailor-made lesson plan and resources on any topic with Aila, our free AI-powered lesson assistant. Entirely adaptable to your class and context."
@@ -137,7 +139,6 @@ const LessonList: FC<LessonListProps> = (props) => {
           subject={subjectSlug}
         />
       </OakBox>
-
       {showSEOAccordion && (
         <LessonListSeoHelper
           examBoardSlug={examBoardSlug}

--- a/src/components/TeacherComponents/LessonList/LessonList.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.tsx
@@ -46,7 +46,7 @@ export type LessonListProps = {
   examBoardSlug?: string | null;
 };
 
-const LESSONS_PER_PAGE = 10;
+const LESSONS_PER_PAGE = 20;
 
 /**
  * Contains a list of lessons


### PR DESCRIPTION
Added SignPostToAila component positioned between pagination and SEO helper to guide users to AI lesson creation when they can't find what they need.

## Description

- Added SignPostToAila component to LessonList component
- Component displays at bottom of lesson listings with video preview and call-to-action
- Passes contextual parameters (subject, key stage) to Aila for better user experience
- Fixed pagination threshold from 5 to 20 lessons to match actual pagination behavior
- Implemented responsive spacing that works with and without pagination present
- Resolved React ref warnings in VideoPlayer component with updated Mux mock
- Updated LessonList test to handle multiple h2 headings

## Issue(s)

Fixes #AI-81290

## How to test

1. Go to lesson listing page (e.g., any unit's lessons page)
2. Scroll to bottom of lesson list
3. You should see "Can't find what you need?" section with Aila promotion
4. "Create a lesson with AI" button should link to Aila with correct parameters
5. Test spacing with both paginated (>10 lessons) and non-paginated lesson lists

## Screenshots

Before


![CleanShot 2025-06-16 at 17 10 57@2x](https://github.com/user-attachments/assets/42989464-58a8-458e-b92a-f9090082982c)

![CleanShot 2025-06-16 at 17 10 06@2x](https://github.com/user-attachments/assets/6333ac42-fd3e-43d9-a7f0-2c3f5afc5a53)

After
![CleanShot 2025-06-16 at 17 11 08@2x](https://github.com/user-attachments/assets/29465dd6-454d-48a5-84a4-7c09ce1150a3)
![CleanShot 2025-06-16 at 17 10 24@2x](https://github.com/user-attachments/assets/c5d94011-f098-403c-a0ff-ea5c83483750)
<img src="https://github.com/user-attachments/assets/a3040a15-6570-44c2-8aae-c8e1cc1e054b" width="350" alt="After 
  screenshot">
  <img src="https://github.com/user-attachments/assets/353b5deb-21d7-4b96-9bdf-217d9ba2645d" width="350" alt="After 
  screenshot">

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change