### PR TITLE
feat: enable unpublished media clips page

### DIFF
--- a/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
+++ b/src/components/TeacherViews/LessonMedia/LessonMedia.view.tsx
@@ -51,7 +51,7 @@ type BaseLessonMedia = {
   keyStageTitle: string;
   mediaClips: MediaClipListCamelCase;
   lessonOutline: { lessonOutline: string }[];
-  lessonReleaseDate: string;
+  lessonReleaseDate: string | null;
   actions?: Actions;
 };
 
@@ -240,7 +240,7 @@ export const LessonMedia = (props: LessonMediaProps) => {
       mediaClipsCount, // int
       mediaClipIndex,
       lessonReleaseCohort: "2023-2026",
-      lessonReleaseDate,
+      lessonReleaseDate: lessonReleaseDate ?? "unreleased",
     });
   };
 

--- a/src/node-lib/curriculum-api-2023/queries/lessonBetaMediaClips/lessonBetaMediaClips.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonBetaMediaClips/lessonBetaMediaClips.query.ts
@@ -48,16 +48,21 @@ export const betaLessonMediaClipsQuery =
     const lessonData = {
       ...browseDataSnake?.lesson_data,
       key_learning_points: [],
+      lesson_release_date:
+        browseDataSnake?.lesson_data?.lesson_release_date ?? null,
     };
 
-    const manipulatedData = { ...browseDataSnake, lesson_data: lessonData };
+    const manipulatedData = {
+      ...browseDataSnake,
+      lesson_data: lessonData,
+    };
     lessonBrowseDataByKsSchema.parse({
       ...manipulatedData,
       supplementary_data: { order_in_unit: 0, unit_order: 0 },
     });
 
     const browseData = keysToCamelCase(
-      browseDataSnake,
+      manipulatedData,
     ) as LessonBrowseDataByKs & {
       mediaClips: MediaClipListCamelCase;
     };

--- a/src/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema.ts
@@ -78,7 +78,7 @@ const baseLessonMediaClipsPageSchema = z.object({
   mediaClips: mediaClipsRecordCamelSchema,
   lessonOutline: z.array(z.object({ lessonOutline: z.string() })),
   actions: zodToCamelCase(actionsSchema).nullish(),
-  lessonReleaseDate: z.string(),
+  lessonReleaseDate: z.string().nullable(),
 });
 
 export const lessonMediaClipsSchema = baseLessonMediaClipsPageSchema.extend({


### PR DESCRIPTION
## Description

Music year: 1991

- update query for beta media clips page to convert `undefined` lesson release date values to `null`
- update schema to make lesson release date nullable
- update tracking query lesson release date value when null
- This enables testing copyright restriction work against lessons with media clips with login_required and georestrction applied

## Issue(s)

Fixes #
500 errors on unpublished lesson media clip pages

## How to test

1. For a lesson with georestriction go to https://deploy-preview-3491--oak-web-application.netlify.thenational.academy/teachers/beta/lessons/learning-about-the-poet-joseph-coelho/media
3. You should see a media clips page
4. For a lesson with only login required go to https://deploy-preview-3491--oak-web-application.netlify.thenational.academy/teachers/beta/lessons/exploring-connections-to-i-opened-the-door/media
5. You should see a media clips page
6. Media clips pages for published lessons should work as before eg. https://deploy-preview-3491--oak-web-application.netlify.thenational.academy/teachers/programmes/physical-education-primary-ks2/units/invasion-games-maintaining-possession-and-stopping-an-attack-through-basketball/lessons/combine-passing-and-dribbling-to-create-space/media
7. Analytics event `mediaClipsPlaylistPlayed` for published lessons should include the lesson release date

## Screenshots

How it should now look:
{screenshots}

