### PR TITLE
Feat/lesq 1440/my library categories [LESQ-1440]

### DIFF
--- a/src/__tests__/pages/api/educator/getSavedContentLists/index.test.tsx
+++ b/src/__tests__/pages/api/educator/getSavedContentLists/index.test.tsx
@@ -78,12 +78,14 @@ describe("api/educator-api/getSavedContentLists", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({
       "mock-programme": {
+        programmeSlug: "mock-programme",
         keystage: "KS2",
         keystageSlug: "ks2",
         subject: "Maths",
         subjectSlug: "maths",
         tier: null,
         examboard: null,
+        subjectCategory: null,
         units: [
           {
             unitSlug: "mock-unit",

--- a/src/components/TeacherViews/MyLibrary/MyLibrary.tsx
+++ b/src/components/TeacherViews/MyLibrary/MyLibrary.tsx
@@ -27,6 +27,7 @@ export type CollectionData = Array<{
   programmeSlug: string;
   programmeTitle: string;
   searchQuery: string | null;
+  uniqueProgrammeKey: string;
 }>;
 
 type MyLibraryProps = {
@@ -73,7 +74,7 @@ export default function MyLibrary(props: MyLibraryProps) {
               menuItems={collectionData.map((item) => ({
                 heading: item.subject,
                 subheading: item.subheading,
-                href: `#${item.programmeSlug}`,
+                href: `#${item.uniqueProgrammeKey}`,
               }))}
               heading="Collections"
               anchorTargetId="collections-menu"
@@ -88,9 +89,9 @@ export default function MyLibrary(props: MyLibraryProps) {
           >
             {collectionData.map((collection) => (
               <MyLibraryProgrammeCard
-                key={collection.programmeSlug}
+                key={collection.uniqueProgrammeKey}
                 programmeTitle={collection.programmeTitle}
-                anchorId={collection.programmeSlug}
+                anchorId={collection.uniqueProgrammeKey}
                 programmeHref={resolveOakHref({
                   page: "unit-index",
                   programmeSlug: collection.programmeSlug,

--- a/src/fixtures/teachers/myLibrary/collectionData.ts
+++ b/src/fixtures/teachers/myLibrary/collectionData.ts
@@ -10,6 +10,7 @@ export const generateMockCollectionData = (count: number): CollectionData => {
     programmeTitle:
       index === 3 ? "Programme: subcategory KS4" : `Programme ${index + 1} KS4`,
     searchQuery: null,
+    uniqueProgrammeKey: `programme-${index + 1}`,
     units: [
       {
         unitSlug: `unit-${index + 1}`,

--- a/src/node-lib/educator-api/generated/sdk.ts
+++ b/src/node-lib/educator-api/generated/sdk.ts
@@ -4092,7 +4092,7 @@ export type Content_Bool_Exp = {
 export enum Content_Constraint {
   /** unique or primary key constraint on columns "id" */
   ContentPkey = "content_pkey",
-  /** unique or primary key constraint on columns "unit_slug", "programme_slug" */
+  /** unique or primary key constraint on columns "programme_slug", "unit_slug" */
   ContentProgrammeSlugUnitSlugKey = "content_programme_slug_unit_slug_key",
 }
 
@@ -48246,9 +48246,9 @@ export type Query_Root = {
   lessons_aggregate: Lessons_Aggregate;
   /** fetch data from the table: "lessons" using primary key columns */
   lessons_by_pk?: Maybe<Lessons>;
-  /** fetch data from the table: "lists" */
+  /** An array relationship */
   lists: Array<Lists>;
-  /** fetch aggregated fields from the table: "lists" */
+  /** An aggregate relationship */
   lists_aggregate: Lists_Aggregate;
   /** fetch data from the table: "lists" using primary key columns */
   lists_by_pk?: Maybe<Lists>;
@@ -48782,10 +48782,6 @@ export type Query_Root = {
   unitvariants_aggregate: Unitvariants_Aggregate;
   /** fetch data from the table: "unitvariants" using primary key columns */
   unitvariants_by_pk?: Maybe<Unitvariants>;
-  /** fetch data from the table: "user_list_content_view" */
-  user_list_content_view: Array<User_List_Content_View>;
-  /** fetch aggregated fields from the table: "user_list_content_view" */
-  user_list_content_view_aggregate: User_List_Content_View_Aggregate;
   /** fetch data from the table: "users" */
   users: Array<Users>;
   /** fetch aggregated fields from the table: "users" */
@@ -51885,22 +51881,6 @@ export type Query_RootUnitvariants_By_PkArgs = {
   unitvariant_id: Scalars["Int"]["input"];
 };
 
-export type Query_RootUser_List_Content_ViewArgs = {
-  distinct_on?: InputMaybe<Array<User_List_Content_View_Select_Column>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<User_List_Content_View_Order_By>>;
-  where?: InputMaybe<User_List_Content_View_Bool_Exp>;
-};
-
-export type Query_RootUser_List_Content_View_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<User_List_Content_View_Select_Column>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<User_List_Content_View_Order_By>>;
-  where?: InputMaybe<User_List_Content_View_Bool_Exp>;
-};
-
 export type Query_RootUsersArgs = {
   distinct_on?: InputMaybe<Array<Users_Select_Column>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
@@ -53966,9 +53946,9 @@ export type Subscription_Root = {
   lessons_by_pk?: Maybe<Lessons>;
   /** fetch data from the table in a streaming manner: "lessons" */
   lessons_stream: Array<Lessons>;
-  /** fetch data from the table: "lists" */
+  /** An array relationship */
   lists: Array<Lists>;
-  /** fetch aggregated fields from the table: "lists" */
+  /** An aggregate relationship */
   lists_aggregate: Lists_Aggregate;
   /** fetch data from the table: "lists" using primary key columns */
   lists_by_pk?: Maybe<Lists>;
@@ -54744,12 +54724,6 @@ export type Subscription_Root = {
   unitvariants_by_pk?: Maybe<Unitvariants>;
   /** fetch data from the table in a streaming manner: "unitvariants" */
   unitvariants_stream: Array<Unitvariants>;
-  /** fetch data from the table: "user_list_content_view" */
-  user_list_content_view: Array<User_List_Content_View>;
-  /** fetch aggregated fields from the table: "user_list_content_view" */
-  user_list_content_view_aggregate: User_List_Content_View_Aggregate;
-  /** fetch data from the table in a streaming manner: "user_list_content_view" */
-  user_list_content_view_stream: Array<User_List_Content_View>;
   /** fetch data from the table: "users" */
   users: Array<Users>;
   /** fetch aggregated fields from the table: "users" */
@@ -58973,28 +58947,6 @@ export type Subscription_RootUnitvariants_StreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<Unitvariants_Stream_Cursor_Input>>;
   where?: InputMaybe<Unitvariants_Bool_Exp>;
-};
-
-export type Subscription_RootUser_List_Content_ViewArgs = {
-  distinct_on?: InputMaybe<Array<User_List_Content_View_Select_Column>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<User_List_Content_View_Order_By>>;
-  where?: InputMaybe<User_List_Content_View_Bool_Exp>;
-};
-
-export type Subscription_RootUser_List_Content_View_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<User_List_Content_View_Select_Column>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<User_List_Content_View_Order_By>>;
-  where?: InputMaybe<User_List_Content_View_Bool_Exp>;
-};
-
-export type Subscription_RootUser_List_Content_View_StreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<User_List_Content_View_Stream_Cursor_Input>>;
-  where?: InputMaybe<User_List_Content_View_Bool_Exp>;
 };
 
 export type Subscription_RootUsersArgs = {
@@ -65705,186 +65657,15 @@ export type Unitvariants_Variance_Order_By = {
   unitvariant_id?: InputMaybe<Order_By>;
 };
 
-/** columns and relationships of "user_list_content_view" */
-export type User_List_Content_View = {
-  __typename?: "user_list_content_view";
-  content_id?: Maybe<Scalars["Int"]["output"]>;
-  list_id?: Maybe<Scalars["Int"]["output"]>;
-  programme_slug?: Maybe<Scalars["String"]["output"]>;
-  unit_slug?: Maybe<Scalars["String"]["output"]>;
-  user_id?: Maybe<Scalars["String"]["output"]>;
-  /** An object relationship */
-  user_list_content_mv?: Maybe<Content>;
-};
-
-/** aggregated selection of "user_list_content_view" */
-export type User_List_Content_View_Aggregate = {
-  __typename?: "user_list_content_view_aggregate";
-  aggregate?: Maybe<User_List_Content_View_Aggregate_Fields>;
-  nodes: Array<User_List_Content_View>;
-};
-
-/** aggregate fields of "user_list_content_view" */
-export type User_List_Content_View_Aggregate_Fields = {
-  __typename?: "user_list_content_view_aggregate_fields";
-  avg?: Maybe<User_List_Content_View_Avg_Fields>;
-  count: Scalars["Int"]["output"];
-  max?: Maybe<User_List_Content_View_Max_Fields>;
-  min?: Maybe<User_List_Content_View_Min_Fields>;
-  stddev?: Maybe<User_List_Content_View_Stddev_Fields>;
-  stddev_pop?: Maybe<User_List_Content_View_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<User_List_Content_View_Stddev_Samp_Fields>;
-  sum?: Maybe<User_List_Content_View_Sum_Fields>;
-  var_pop?: Maybe<User_List_Content_View_Var_Pop_Fields>;
-  var_samp?: Maybe<User_List_Content_View_Var_Samp_Fields>;
-  variance?: Maybe<User_List_Content_View_Variance_Fields>;
-};
-
-/** aggregate fields of "user_list_content_view" */
-export type User_List_Content_View_Aggregate_FieldsCountArgs = {
-  columns?: InputMaybe<Array<User_List_Content_View_Select_Column>>;
-  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
-};
-
-/** aggregate avg on columns */
-export type User_List_Content_View_Avg_Fields = {
-  __typename?: "user_list_content_view_avg_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** Boolean expression to filter rows from the table "user_list_content_view". All fields are combined with a logical 'AND'. */
-export type User_List_Content_View_Bool_Exp = {
-  _and?: InputMaybe<Array<User_List_Content_View_Bool_Exp>>;
-  _not?: InputMaybe<User_List_Content_View_Bool_Exp>;
-  _or?: InputMaybe<Array<User_List_Content_View_Bool_Exp>>;
-  content_id?: InputMaybe<Int_Comparison_Exp>;
-  list_id?: InputMaybe<Int_Comparison_Exp>;
-  programme_slug?: InputMaybe<String_Comparison_Exp>;
-  unit_slug?: InputMaybe<String_Comparison_Exp>;
-  user_id?: InputMaybe<String_Comparison_Exp>;
-  user_list_content_mv?: InputMaybe<Content_Bool_Exp>;
-};
-
-/** aggregate max on columns */
-export type User_List_Content_View_Max_Fields = {
-  __typename?: "user_list_content_view_max_fields";
-  content_id?: Maybe<Scalars["Int"]["output"]>;
-  list_id?: Maybe<Scalars["Int"]["output"]>;
-  programme_slug?: Maybe<Scalars["String"]["output"]>;
-  unit_slug?: Maybe<Scalars["String"]["output"]>;
-  user_id?: Maybe<Scalars["String"]["output"]>;
-};
-
-/** aggregate min on columns */
-export type User_List_Content_View_Min_Fields = {
-  __typename?: "user_list_content_view_min_fields";
-  content_id?: Maybe<Scalars["Int"]["output"]>;
-  list_id?: Maybe<Scalars["Int"]["output"]>;
-  programme_slug?: Maybe<Scalars["String"]["output"]>;
-  unit_slug?: Maybe<Scalars["String"]["output"]>;
-  user_id?: Maybe<Scalars["String"]["output"]>;
-};
-
-/** Ordering options when selecting data from "user_list_content_view". */
-export type User_List_Content_View_Order_By = {
-  content_id?: InputMaybe<Order_By>;
-  list_id?: InputMaybe<Order_By>;
-  programme_slug?: InputMaybe<Order_By>;
-  unit_slug?: InputMaybe<Order_By>;
-  user_id?: InputMaybe<Order_By>;
-  user_list_content_mv?: InputMaybe<Content_Order_By>;
-};
-
-/** select columns of table "user_list_content_view" */
-export enum User_List_Content_View_Select_Column {
-  /** column name */
-  ContentId = "content_id",
-  /** column name */
-  ListId = "list_id",
-  /** column name */
-  ProgrammeSlug = "programme_slug",
-  /** column name */
-  UnitSlug = "unit_slug",
-  /** column name */
-  UserId = "user_id",
-}
-
-/** aggregate stddev on columns */
-export type User_List_Content_View_Stddev_Fields = {
-  __typename?: "user_list_content_view_stddev_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** aggregate stddev_pop on columns */
-export type User_List_Content_View_Stddev_Pop_Fields = {
-  __typename?: "user_list_content_view_stddev_pop_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** aggregate stddev_samp on columns */
-export type User_List_Content_View_Stddev_Samp_Fields = {
-  __typename?: "user_list_content_view_stddev_samp_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** Streaming cursor of the table "user_list_content_view" */
-export type User_List_Content_View_Stream_Cursor_Input = {
-  /** Stream column input with initial value */
-  initial_value: User_List_Content_View_Stream_Cursor_Value_Input;
-  /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type User_List_Content_View_Stream_Cursor_Value_Input = {
-  content_id?: InputMaybe<Scalars["Int"]["input"]>;
-  list_id?: InputMaybe<Scalars["Int"]["input"]>;
-  programme_slug?: InputMaybe<Scalars["String"]["input"]>;
-  unit_slug?: InputMaybe<Scalars["String"]["input"]>;
-  user_id?: InputMaybe<Scalars["String"]["input"]>;
-};
-
-/** aggregate sum on columns */
-export type User_List_Content_View_Sum_Fields = {
-  __typename?: "user_list_content_view_sum_fields";
-  content_id?: Maybe<Scalars["Int"]["output"]>;
-  list_id?: Maybe<Scalars["Int"]["output"]>;
-};
-
-/** aggregate var_pop on columns */
-export type User_List_Content_View_Var_Pop_Fields = {
-  __typename?: "user_list_content_view_var_pop_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** aggregate var_samp on columns */
-export type User_List_Content_View_Var_Samp_Fields = {
-  __typename?: "user_list_content_view_var_samp_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
-/** aggregate variance on columns */
-export type User_List_Content_View_Variance_Fields = {
-  __typename?: "user_list_content_view_variance_fields";
-  content_id?: Maybe<Scalars["Float"]["output"]>;
-  list_id?: Maybe<Scalars["Float"]["output"]>;
-};
-
 /** columns and relationships of "users" */
 export type Users = {
   __typename?: "users";
   created_at?: Maybe<Scalars["timestamptz"]["output"]>;
   id: Scalars["String"]["output"];
   last_signed_in?: Maybe<Scalars["timestamptz"]["output"]>;
-  /** fetch data from the table: "lists" */
+  /** An array relationship */
   lists: Array<Lists>;
-  /** fetch aggregated fields from the table: "lists" */
+  /** An aggregate relationship */
   lists_aggregate: Lists_Aggregate;
   source_app?: Maybe<Scalars["String"]["output"]>;
   updated_at?: Maybe<Scalars["timestamptz"]["output"]>;
@@ -67851,6 +67632,7 @@ export type GetUserListContentQuery = {
         unit_title?: any | null;
         optionality_title?: any | null;
         tier?: any | null;
+        pathway?: any | null;
         examboard?: any | null;
         unit_order?: any | null;
         year_order?: any | null;
@@ -67971,7 +67753,10 @@ export const GetUserContentDocument = gql`
 `;
 export const GetUserListContentDocument = gql`
   query getUserListContent($userId: String!) {
-    content_lists(where: { list: { user_id: { _eq: $userId } } }) {
+    content_lists(
+      distinct_on: content_id
+      where: { list: { user_id: { _eq: $userId } } }
+    ) {
       content {
         unit_slug
         programme_slug
@@ -67985,6 +67770,7 @@ export const GetUserListContentDocument = gql`
           unit_title: unit_data(path: "title")
           optionality_title: programme_fields(path: "optionality")
           tier: programme_fields(path: "tier")
+          pathway: programme_fields(path: "pathway")
           examboard: programme_fields(path: "examboard")
           unit_order: supplementary_data(path: "unit_order")
           year_order: programme_fields(path: "year_display_order")

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
@@ -312,10 +312,10 @@ describe("useMyLibrary", () => {
         keystage: "KS4",
         keystageSlug: "ks4",
         programmeSlug: "programme1",
-        programmeTitle: "Maths KS4 Core",
+        programmeTitle: "Maths Core KS4",
         subject: "Maths",
         subjectSlug: "maths",
-        subheading: "KS4 Core",
+        subheading: "Core KS4",
         uniqueProgrammeKey: "programme1",
         units: [
           {

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
@@ -83,7 +83,7 @@ const mockProgrammeData: UserlistContentApiResponse = {
 };
 
 const mockProgrammeDataWithSubjectCategories: UserlistContentApiResponse = {
-  programme1: {
+  "programme1-Literacy": {
     programmeSlug: "programme1",
     units: [
       {
@@ -206,6 +206,7 @@ describe("useMyLibrary", () => {
         subject: "Maths",
         subjectSlug: "maths",
         subheading: "KS1",
+        uniqueProgrammeKey: "programme1",
         units: [
           {
             unitSlug: "unit1",
@@ -245,6 +246,7 @@ describe("useMyLibrary", () => {
         subject: "Biology",
         subjectSlug: "biology",
         subheading: "KS1",
+        uniqueProgrammeKey: "programme2",
         units: [
           {
             unitSlug: "bio-unit1",
@@ -274,6 +276,7 @@ describe("useMyLibrary", () => {
         subject: "English",
         subjectSlug: "english",
         subheading: "Literacy KS1",
+        uniqueProgrammeKey: "programme1-Literacy",
         units: [
           {
             unitSlug: "unit1",
@@ -313,6 +316,7 @@ describe("useMyLibrary", () => {
         subject: "Maths",
         subjectSlug: "maths",
         subheading: "KS4 Core",
+        uniqueProgrammeKey: "programme1",
         units: [
           {
             unitSlug: "unit1",

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
@@ -52,6 +52,7 @@ const renderHook = renderHookWithProviders();
 
 const mockProgrammeData: UserlistContentApiResponse = {
   programme1: {
+    programmeSlug: "programme1",
     units: [
       {
         unitSlug: "unit1",
@@ -77,12 +78,13 @@ const mockProgrammeData: UserlistContentApiResponse = {
     tier: null,
     subjectSlug: "maths",
     keystageSlug: "ks1",
-    subjectCategories: null,
+    subjectCategory: null,
   },
 };
 
 const mockProgrammeDataWithSubjectCategories: UserlistContentApiResponse = {
   programme1: {
+    programmeSlug: "programme1",
     units: [
       {
         unitSlug: "unit1",
@@ -108,9 +110,10 @@ const mockProgrammeDataWithSubjectCategories: UserlistContentApiResponse = {
     tier: null,
     subjectSlug: "english",
     keystageSlug: "ks1",
-    subjectCategories: ["Literacy"],
+    subjectCategory: "Literacy",
   },
   programme2: {
+    programmeSlug: "programme2",
     units: [
       {
         unitSlug: "bio-unit1",
@@ -136,12 +139,13 @@ const mockProgrammeDataWithSubjectCategories: UserlistContentApiResponse = {
     tier: null,
     subjectSlug: "biology",
     keystageSlug: "ks1",
-    subjectCategories: ["Biology"],
+    subjectCategory: null,
   },
 };
 
 const mockProgrammeDataWithPathways: UserlistContentApiResponse = {
   programme1: {
+    programmeSlug: "programme1",
     units: [
       {
         unitSlug: "unit1",
@@ -168,7 +172,7 @@ const mockProgrammeDataWithPathways: UserlistContentApiResponse = {
     pathway: "Core",
     subjectSlug: "maths",
     keystageSlug: "ks4",
-    subjectCategories: null,
+    subjectCategory: null,
   },
 };
 
@@ -269,7 +273,7 @@ describe("useMyLibrary", () => {
         programmeTitle: "English: Literacy KS1",
         subject: "English",
         subjectSlug: "english",
-        subheading: "KS1",
+        subheading: "Literacy KS1",
         units: [
           {
             unitSlug: "unit1",

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.test.tsx
@@ -140,6 +140,38 @@ const mockProgrammeDataWithSubjectCategories: UserlistContentApiResponse = {
   },
 };
 
+const mockProgrammeDataWithPathways: UserlistContentApiResponse = {
+  programme1: {
+    units: [
+      {
+        unitSlug: "unit1",
+        unitTitle: "Unit 1",
+        optionalityTitle: null,
+        savedAt: "2023-10-01T00:00:00Z",
+        unitOrder: 1,
+        yearOrder: 1,
+        year: "1",
+        lessons: [
+          {
+            slug: "lesson1",
+            title: "Lesson 1",
+            state: "published",
+            order: 1,
+          },
+        ],
+      },
+    ],
+    keystage: "KS4",
+    subject: "Maths",
+    examboard: null,
+    tier: null,
+    pathway: "Core",
+    subjectSlug: "maths",
+    keystageSlug: "ks4",
+    subjectCategories: null,
+  },
+};
+
 const mockTrackingData = {
   savedFrom: "my-library-save-button" as const,
   keyStageTitle: "Key stage 1" as KeyStageTitleValueType,
@@ -258,6 +290,45 @@ describe("useMyLibrary", () => {
           },
         ],
         searchQuery: "literacy",
+      },
+    ]);
+  });
+  it("should handle programmes with pathways", async () => {
+    mockUseGetEducatorData.mockImplementation(() => ({
+      data: mockProgrammeDataWithPathways,
+      error: null,
+      isLoading: false,
+    }));
+    const { result } = renderHook(() => useMyLibrary());
+    expect(result.current.collectionData).toEqual([
+      {
+        keystage: "KS4",
+        keystageSlug: "ks4",
+        programmeSlug: "programme1",
+        programmeTitle: "Maths KS4 Core",
+        subject: "Maths",
+        subjectSlug: "maths",
+        subheading: "KS4 Core",
+        units: [
+          {
+            unitSlug: "unit1",
+            unitTitle: "Unit 1",
+            optionalityTitle: null,
+            savedAt: "2023-10-01T00:00:00Z",
+            unitOrder: 1,
+            yearOrder: 1,
+            year: "1",
+            lessons: [
+              {
+                slug: "lesson1",
+                title: "Lesson 1",
+                state: "published",
+                order: 1,
+              },
+            ],
+          },
+        ],
+        searchQuery: null,
       },
     ]);
   });

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -49,6 +49,7 @@ export const useMyLibrary = () => {
           .map(([programmeSlug, programmeData]) => {
             const {
               keystage,
+              pathway,
               subject,
               examboard,
               tier,
@@ -57,7 +58,7 @@ export const useMyLibrary = () => {
               keystageSlug,
               subjectCategories,
             } = programmeData;
-            const subheading = `${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${keystage}`;
+            const subheading = `${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${keystage}${pathway ? " " + pathway : ""}`;
             const validSubjectCategory =
               subjectCategories &&
               subjectCategories[0] &&

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -45,9 +45,10 @@ export const useMyLibrary = () => {
         userListContentApiResponse.safeParse(savedProgrammeUnits);
 
       if (parsedData.success) {
-        const collectionData = Object.entries(parsedData.data)
-          .map(([programmeSlug, programmeData]) => {
+        const collectionData = Object.values(parsedData.data)
+          .map((programmeData) => {
             const {
+              programmeSlug,
               keystage,
               pathway,
               subject,
@@ -56,18 +57,16 @@ export const useMyLibrary = () => {
               units,
               subjectSlug,
               keystageSlug,
-              subjectCategories,
+              subjectCategory,
             } = programmeData;
-            const subheading = `${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${keystage}${pathway ? " " + pathway : ""}`;
-            const validSubjectCategory =
-              subjectCategories &&
-              subjectCategories[0] &&
-              subjectCategories[0] !== subject
-                ? subjectCategories[0]
-                : null;
-            const programmeTitle = `${subject}${validSubjectCategory ? `: ${validSubjectCategory}` : ""} ${subheading}`;
-            const searchQuery = validSubjectCategory
-              ? `${kebabCase(validSubjectCategory)}`
+
+            const subjectCategoryHeading = `${subjectCategory ? `${subjectCategory} ` : ""}`;
+
+            const subheading = `${subjectCategoryHeading}${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${keystage}${pathway ? " " + pathway : ""}`;
+
+            const programmeTitle = `${subject}${subjectCategoryHeading && ":"} ${subheading}`;
+            const searchQuery = subjectCategory
+              ? `${kebabCase(subjectCategory)}`
               : null;
 
             units.sort(

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -62,7 +62,7 @@ export const useMyLibrary = () => {
 
             const subjectCategoryHeading = `${subjectCategory ? `${subjectCategory} ` : ""}`;
 
-            const subheading = `${subjectCategoryHeading}${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${keystage}${pathway ? " " + pathway : ""}`;
+            const subheading = `${subjectCategoryHeading}${examboard ? examboard + " " : ""}${tier ? tier + " " : ""}${pathway ? pathway + " " : ""}${keystage}`;
 
             const programmeTitle = `${subject}${subjectCategoryHeading && ":"} ${subheading}`;
             const searchQuery = subjectCategory

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -45,8 +45,8 @@ export const useMyLibrary = () => {
         userListContentApiResponse.safeParse(savedProgrammeUnits);
 
       if (parsedData.success) {
-        const collectionData = Object.values(parsedData.data)
-          .map((programmeData) => {
+        const collectionData = Object.entries(parsedData.data)
+          .map(([uniqueProgrammeKey, programmeData]) => {
             const {
               programmeSlug,
               keystage,
@@ -83,6 +83,7 @@ export const useMyLibrary = () => {
               programmeSlug,
               programmeTitle,
               searchQuery,
+              uniqueProgrammeKey,
             };
           })
           .sort((a, b) => {

--- a/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.gql
+++ b/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.gql
@@ -16,6 +16,7 @@ query getUserListContent($userId: String!) {
         unit_title: unit_data(path: "title")
         optionality_title: programme_fields(path: "optionality")
         tier: programme_fields(path: "tier")
+        pathway: programme_fields(path: "pathway")
         examboard: programme_fields(path: "examboard")
         unit_order: supplementary_data(path: "unit_order")
         year_order: programme_fields(path: "year_display_order")

--- a/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.types.ts
+++ b/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.types.ts
@@ -18,6 +18,7 @@ const content = z.object({
       year: z.string(),
       keystage: z.string(),
       keystage_slug: z.string(),
+      pathway: z.string().nullish(),
       subject: z.string(),
       subject_slug: z.string(),
       tier: z.string().nullable(),
@@ -63,6 +64,7 @@ export const userListContentApiResponse = z.record(
   z.object({
     keystage: z.string(),
     keystageSlug: z.string(),
+    pathway: z.string().nullish(),
     subject: z.string(),
     subjectSlug: z.string(),
     subjectCategories: z.array(z.string()).nullish(),

--- a/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.types.ts
+++ b/src/node-lib/educator-api/queries/getUserListContent/getUserListContent.types.ts
@@ -62,12 +62,13 @@ export type MyLibraryUnit = z.infer<typeof unit>;
 export const userListContentApiResponse = z.record(
   z.string(),
   z.object({
+    programmeSlug: z.string(),
     keystage: z.string(),
     keystageSlug: z.string(),
     pathway: z.string().nullish(),
     subject: z.string(),
     subjectSlug: z.string(),
-    subjectCategories: z.array(z.string()).nullish(),
+    subjectCategory: z.string().nullish(),
     tier: z.string().nullable(),
     examboard: z.string().nullable(),
     units: z.array(unit),

--- a/src/pages/api/educator/getSavedContentLists/index.ts
+++ b/src/pages/api/educator/getSavedContentLists/index.ts
@@ -42,11 +42,19 @@ async function handleRequest(req: NextApiRequest, res: NextApiResponse) {
           order: lesson.order,
         }));
 
-        if (!acc[programmeSlug]) {
-          acc[programmeSlug] = {
+        // Subject categories are not included in the programme slug but we want to keep them distinct
+        const subjectCategory = browseData.subject_categories?.[0];
+        const useSubjectCategory =
+          subjectCategory && subjectCategory !== browseData.subject;
+
+        const uniqueProgrammeIdentifier = `${programmeSlug}${useSubjectCategory ? subjectCategory : ""}`;
+
+        if (!acc[uniqueProgrammeIdentifier]) {
+          acc[uniqueProgrammeIdentifier] = {
+            programmeSlug,
             subject: browseData.subject,
             subjectSlug: browseData.subject_slug,
-            subjectCategories: browseData.subject_categories,
+            subjectCategory: useSubjectCategory ? subjectCategory : null,
             keystage: browseData.keystage,
             keystageSlug: browseData.keystage_slug,
             pathway: browseData.pathway,
@@ -55,7 +63,7 @@ async function handleRequest(req: NextApiRequest, res: NextApiResponse) {
             units: [],
           };
         }
-        acc[programmeSlug].units.push({
+        acc[uniqueProgrammeIdentifier].units.push({
           unitSlug: contentList.unit_slug,
           unitTitle: browseData.unit_title,
           optionalityTitle: browseData.optionality_title || null,

--- a/src/pages/api/educator/getSavedContentLists/index.ts
+++ b/src/pages/api/educator/getSavedContentLists/index.ts
@@ -49,6 +49,7 @@ async function handleRequest(req: NextApiRequest, res: NextApiResponse) {
             subjectCategories: browseData.subject_categories,
             keystage: browseData.keystage,
             keystageSlug: browseData.keystage_slug,
+            pathway: browseData.pathway,
             tier: browseData.tier,
             examboard: browseData.examboard,
             units: [],

--- a/src/pages/api/educator/getSavedContentLists/index.ts
+++ b/src/pages/api/educator/getSavedContentLists/index.ts
@@ -47,7 +47,7 @@ async function handleRequest(req: NextApiRequest, res: NextApiResponse) {
         const useSubjectCategory =
           subjectCategory && subjectCategory !== browseData.subject;
 
-        const uniqueProgrammeIdentifier = `${programmeSlug}${useSubjectCategory ? subjectCategory : ""}`;
+        const uniqueProgrammeIdentifier = `${programmeSlug}${useSubjectCategory ? "-" + subjectCategory : ""}`;
 
         if (!acc[uniqueProgrammeIdentifier]) {
           acc[uniqueProgrammeIdentifier] = {


### PR DESCRIPTION
## Description

Music year: 2004

This PR covers [LESQ-1432](https://www.notion.so/oaknationalacademy/Citizenship-Core-and-GCSE-do-not-have-distinct-label-in-My-library-20326cc4e1b1802abc66c353209128ed?source=copy_link) as well.

- Add `pathway` to my library query and use in programme headers and sidenav subheadings
- Refactor how programme cards are generated to create separate cards for subject categories within a programme (when they don't match the subject)
- Update anchor links to work with multiples of the same programme

## How to test

1. Go to https://deploy-preview-3492--oak-web-application.netlify.thenational.academy
2. Save a KS4 citizenship unit in each pathway, core and gcse
3. Go to my library
4. You should see separate programme cards for each pathway, with the pathway in the title of the card, linking to the correct programme
5. Save units from KS2 English or KS4 Combined Science from different subject categories
6. Go to my library
7. You should see separate cards for each subject category (eg. Physics in combined science, Handwriting in English)
8. Each programme heading should link to the correct page with the subject category preselected as a filter
9. All other saved units without the above programme features should work as before

## Screenshots

How it should now look:
<img width="800" alt="Screenshot 2025-06-17 at 14 00 38" src="https://github.com/user-attachments/assets/22ef1243-8aa7-421b-a398-04d020a5fe34" />

<img width="800" alt="Screenshot 2025-06-17 at 14 04 56" src="https://github.com/user-attachments/assets/abe29253-043b-470d-b78c-e0f23936a683" />

