### PR TITLE
Append ellipsis to lotpicker error text overflow

### DIFF
--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -141,11 +141,11 @@ exports[`CurriculumTab renders 1`] = `
                           style="width: 50%;"
                         >
                           <div
-                            class="sc-fqkvVR sc-1c55d370-0 sc-ef6f71a4-2 jEHEPk knawKC iZanzX"
+                            class="sc-fqkvVR sc-1c55d370-0 sc-35935596-3 jEHEPk knawKC iXICN"
                           >
                             <button
                               aria-expanded="false"
-                              class="sc-ef6f71a4-1 gMkvmi"
+                              class="sc-35935596-2 jPfOaO"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
@@ -209,11 +209,11 @@ exports[`CurriculumTab renders 1`] = `
                             class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                           >
                             <div
-                              class="sc-fqkvVR sc-1c55d370-0 sc-ef6f71a4-2 eMDDOo knawKC iZanzX"
+                              class="sc-fqkvVR sc-1c55d370-0 sc-35935596-3 eMDDOo knawKC iXICN"
                             >
                               <button
                                 aria-expanded="false"
-                                class="sc-ef6f71a4-1 gMkvmi"
+                                class="sc-35935596-2 jPfOaO"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
@@ -331,11 +331,11 @@ exports[`CurriculumTab renders 1`] = `
                       style="width: 50%;"
                     >
                       <div
-                        class="sc-fqkvVR sc-1c55d370-0 sc-ef6f71a4-2 jEHEPk knawKC iZanzX"
+                        class="sc-fqkvVR sc-1c55d370-0 sc-35935596-3 jEHEPk knawKC iXICN"
                       >
                         <button
                           aria-expanded="false"
-                          class="sc-ef6f71a4-1 gMkvmi"
+                          class="sc-35935596-2 jPfOaO"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
@@ -399,11 +399,11 @@ exports[`CurriculumTab renders 1`] = `
                         class="sc-fqkvVR sc-gsFSXq fxkSvJ ehZBcc"
                       >
                         <div
-                          class="sc-fqkvVR sc-1c55d370-0 sc-ef6f71a4-2 eMDDOo knawKC iZanzX"
+                          class="sc-fqkvVR sc-1c55d370-0 sc-35935596-3 eMDDOo knawKC iXICN"
                         >
                           <button
                             aria-expanded="false"
-                            class="sc-ef6f71a4-1 gMkvmi"
+                            class="sc-35935596-2 jPfOaO"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -43,6 +43,14 @@ import useMediaQuery from "@/hooks/useMediaQuery";
 import type { CurriculumTab } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { PhaseValueType } from "@/browser-lib/avo/Avo";
 
+const TruncatedFlex = styled(OakFlex)`
+  max-width: calc(100% - 1rem);
+
+  @media (min-width: 750px) {
+    max-width: calc(100% - 8rem);
+  }
+`;
+
 // FIXME: This is from <@/pages-helpers/pupil/options-pages/options-pages-helpers> being duplicated here to fix bundle issues.
 const isExamboardSlug = (
   examboardSlug: ProgrammeFields["examboard_slug"] | string | null,
@@ -953,14 +961,20 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
                           </OakFlex>
                         )}
                         {showKS4OptionError && (
-                          <OakFlex>
+                          <TruncatedFlex>
                             <OakIcon
                               iconName="content-guidance"
                               $colorFilter={"red"}
                               $height={"all-spacing-6"}
                             />
-                            Select an option for KS4
-                          </OakFlex>
+                            <OakSpan
+                              $textOverflow="ellipsis"
+                              $overflow="hidden"
+                              $whiteSpace="nowrap"
+                            >
+                              Select an option for KS4
+                            </OakSpan>
+                          </TruncatedFlex>
                         )}
                         {selectedPhase && !showKS4OptionError && (
                           <>


### PR DESCRIPTION
## Description

Music year: 1954

- Added ellipsis to lotpicker error message

## Issue(s)

Fixes #[1334](https://www.notion.so/oaknationalacademy/Homepage-lot-picker-error-message-is-cut-off-1b526cc4e1b180c7ace6e0d6e6bd8a39?source=copy_link)

## How to test

1. Go to https://deploy-preview-3509--oak-web-application.netlify.app/curriculum
2. Select a subject with KS4 variance (e.g. English, Science, Computing)
3. Select the secondary phase
4. Close the lot picker without choosing a KS4 option
5. Click the View button.
3. You should see that the error message has now been truncated with ellipsis

## Screenshots

How it used to look (delete if n/a):
![image](https://github.com/user-attachments/assets/fa11396c-a5d8-4f47-a18f-3b6df0bce228)

How it should now look:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/b322d621-1493-41cf-b51d-ebdee496b858" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [X] Design sign-off
- [X] Approved by product owner
- [ ] Does this PR update a package with a breaking change
