### PR TITLE
Move `pingdom-uptime-check` up into the first 10kb of response body

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,6 +42,10 @@ class MyDocument extends Document {
     return (
       <Html lang="en-GB">
         <Head>
+          <meta
+            name="pingdom-uptime-check"
+            content={getBrowserConfig("pingdomUptimeId")}
+          />
           {parse(FAVICON_LINKS_HEAD_INNER_HTML)}
           <meta
             name="release-stage"
@@ -49,11 +53,6 @@ class MyDocument extends Document {
           />
           <meta name="revised" content={new Date().toUTCString()} />
           <meta name="version" content={getBrowserConfig("appVersion")} />
-
-          <meta
-            name="pingdom-uptime-check"
-            content={getBrowserConfig("pingdomUptimeId")}
-          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Description
Move `pingdom-uptime-check` up into the first 10kb of response body for green-blue deployment of vercel via cloudflare

Requested by @KofoworolaOgunleye 

## Issue(s)
None

## How to test

1. Go to https://deploy-preview-3513--oak-web-application.netlify.thenational.academy/
2. Check that `pingdom-uptime-check` in the the first 10kb of the response

**Note**: I've tested this with locally with

```
curl -s http://localhost:3000 | head -c 10240 |grep "pingdom-uptime-check"
```

## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
