### PR TITLE
fix: switch over to <OakFieldError/>

### DIFF
--- a/src/components/SharedComponents/Input/Input.tsx
+++ b/src/components/SharedComponents/Input/Input.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 import styled from "styled-components";
-import { OakSpan } from "@oaknational/oak-components";
+import { OakBox, OakFieldError, OakSpan } from "@oaknational/oak-components";
 
 import InputIcon from "./InputIcon";
 
@@ -18,7 +18,6 @@ import { OakColorName } from "@/styles/theme/types";
 import getColorByName from "@/styles/themeHelpers/getColorByName";
 import { zIndexMap } from "@/styles/utils/zIndex";
 import Svg from "@/components/SharedComponents/Svg";
-import FieldError from "@/components/SharedComponents/FieldError";
 import Label from "@/components/SharedComponents/Typography/Label";
 
 export type StyledInputProps = MarginProps & {
@@ -147,9 +146,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <>
       {error && (
-        <FieldError id={errorId} withoutMarginBottom={withoutMarginBottom}>
-          {error}
-        </FieldError>
+        <OakBox
+          id={errorId}
+          $mb={withoutMarginBottom ? "space-between-none" : "space-between-m"}
+        >
+          <OakFieldError>{error}</OakFieldError>
+        </OakBox>
       )}
       <InputFieldWrap
         $mb={$mb ?? 32}


### PR DESCRIPTION
Which in turn fixes the incorrect alt text on icon in the previous implementation

## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
