### PR TITLE
Added back in `unitOverviewAccessed` analytics tracking

### DIFF
--- a/src/components/CurriculumComponents/CurricUnitCard/CurricUnitCard.tsx
+++ b/src/components/CurriculumComponents/CurricUnitCard/CurricUnitCard.tsx
@@ -40,9 +40,10 @@ type CurricUnitCardProps = {
   index: number;
   isHighlighted: boolean;
   href: string;
+  onClick?: () => void;
 };
 export default function CurricUnitCard(props: CurricUnitCardProps) {
-  const { href, isHighlighted, unit, index } = props;
+  const { href, isHighlighted, unit, index, onClick } = props;
   const isUnitOption = "unit_options" in unit;
   return (
     <FocusIndicator
@@ -59,6 +60,7 @@ export default function CurricUnitCard(props: CurricUnitCardProps) {
         shallow={true}
         scroll={false}
         replace={true}
+        onClick={onClick}
       >
         <OakFlex
           $pv={"inner-padding-s"}

--- a/src/components/CurriculumComponents/CurricUnitCard/__snapshots__/CurricUnitCard.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricUnitCard/__snapshots__/CurricUnitCard.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CurricUnitCard changes color when highlighed 1`] = `
       class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
     >
       <a
-        class="sc-79c3f222-0 bginFa"
+        class="sc-7353c220-0 eacPWx"
         data-testid="unit-info-link"
         href="/"
       >
@@ -84,7 +84,7 @@ exports[`CurricUnitCard highlighted state 1`] = `
       class="sc-fqkvVR sc-1c55d370-0 jdSkEU dNUCNM"
     >
       <a
-        class="sc-79c3f222-0 krmtss"
+        class="sc-7353c220-0 cSHgvT"
         data-testid="unit-info-link"
         href="/"
       >
@@ -166,7 +166,7 @@ exports[`CurricUnitCard index is correct 1`] = `
       class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
     >
       <a
-        class="sc-79c3f222-0 bginFa"
+        class="sc-7353c220-0 eacPWx"
         data-testid="unit-info-link"
         href="/"
       >
@@ -243,7 +243,7 @@ exports[`CurricUnitCard render 1`] = `
       class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
     >
       <a
-        class="sc-79c3f222-0 bginFa"
+        class="sc-7353c220-0 eacPWx"
         data-testid="unit-info-link"
         href="/"
       >

--- a/src/components/CurriculumComponents/CurricVisualiser/CurricVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiser/CurricVisualiser.tsx
@@ -159,6 +159,7 @@ export default function CurricVisualiser({
                 year={year}
                 yearData={yearData}
                 basePath={basePath}
+                selectedThread={selectedThread}
               />
             </CurricYearCard>
           </OakBox>

--- a/src/components/CurriculumComponents/CurricVisualiserUnitList/CurricVisualiserUnitList.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserUnitList/CurricVisualiserUnitList.test.tsx
@@ -1,8 +1,20 @@
+import { act } from "@testing-library/react";
+
 import { basicFixtures } from "./CurricVisualiserUnitList.fixtures";
 
 import { CurricVisualiserUnitList } from ".";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+const unitOverviewAccessedMock = jest.fn();
+jest.mock("@/context/Analytics/useAnalytics", () => ({
+  __esModule: true,
+  default: () => ({
+    track: {
+      unitOverviewAccessed: (...args: []) => unitOverviewAccessedMock(...args),
+    },
+  }),
+}));
 
 describe("CurricVisualiserUnitList", () => {
   it("should display a list of units", async () => {
@@ -17,5 +29,35 @@ describe("CurricVisualiserUnitList", () => {
     expect(allLinks[2]?.textContent).toEqual(expect.stringContaining("Three"));
     expect(allLinks[3]?.textContent).toEqual(expect.stringContaining("Four"));
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it("clicking should trigger analytics", async () => {
+    const { findAllByRole } = renderWithTheme(
+      <CurricVisualiserUnitList {...basicFixtures} />,
+    );
+
+    const allLinks = await findAllByRole("link");
+    expect(allLinks[0]);
+    act(() => {
+      allLinks[0]?.click();
+    });
+    expect(unitOverviewAccessedMock).toHaveBeenCalledWith({
+      analyticsUseCase: null,
+      componentType: "unit_info_button",
+      engagementIntent: "use",
+      eventVersion: "2.0.0",
+      isUnitPublished: false,
+      platform: "owa",
+      product: "curriculum visualiser",
+      subjectSlug: "transfiguration",
+      subjectTitle: "Transfiguration",
+      threadSlug: null,
+      threadTitle: null,
+      unitHighlighted: false,
+      unitName: "One",
+      unitSlug: "one",
+      yearGroupName: "Year 5",
+      yearGroupSlug: "5",
+    });
   });
 });

--- a/src/components/CurriculumComponents/CurricVisualiserUnitList/__snapshots__/CurricVisualiserUnitList.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricVisualiserUnitList/__snapshots__/CurricVisualiserUnitList.test.tsx.snap
@@ -9,17 +9,17 @@ exports[`CurricVisualiserUnitList should display a list of units 1`] = `
       style="margin-bottom: -1rem;"
     >
       <ol
-        class="sc-a964d3a7-0 csZIsZ"
+        class="sc-de453114-0 gEnlCh"
         role="list"
       >
         <li
-          class="sc-a964d3a7-1 hFJsag"
+          class="sc-de453114-1 epQOIs"
         >
           <div
             class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
           >
             <a
-              class="sc-79c3f222-0 bginFa"
+              class="sc-7353c220-0 eacPWx"
               data-testid="unit-info-link"
               href="/one"
             >
@@ -76,13 +76,13 @@ exports[`CurricVisualiserUnitList should display a list of units 1`] = `
           </div>
         </li>
         <li
-          class="sc-a964d3a7-1 hFJsag"
+          class="sc-de453114-1 epQOIs"
         >
           <div
             class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
           >
             <a
-              class="sc-79c3f222-0 bginFa"
+              class="sc-7353c220-0 eacPWx"
               data-testid="unit-info-link"
               href="/two"
             >
@@ -139,13 +139,13 @@ exports[`CurricVisualiserUnitList should display a list of units 1`] = `
           </div>
         </li>
         <li
-          class="sc-a964d3a7-1 hFJsag"
+          class="sc-de453114-1 epQOIs"
         >
           <div
             class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
           >
             <a
-              class="sc-79c3f222-0 bginFa"
+              class="sc-7353c220-0 eacPWx"
               data-testid="unit-info-link"
               href="/three"
             >
@@ -202,13 +202,13 @@ exports[`CurricVisualiserUnitList should display a list of units 1`] = `
           </div>
         </li>
         <li
-          class="sc-a964d3a7-1 hFJsag"
+          class="sc-de453114-1 epQOIs"
         >
           <div
             class="sc-fqkvVR sc-1c55d370-0 jdSkEU iHxKuU"
           >
             <a
-              class="sc-79c3f222-0 bginFa"
+              class="sc-7353c220-0 eacPWx"
               data-testid="unit-info-link"
               href="/four"
             >

--- a/src/components/CurriculumComponents/CurricVisualiserUnitList/index.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserUnitList/index.tsx
@@ -4,11 +4,19 @@ import { OakFlex, OakP } from "@oaknational/oak-components";
 import styled from "styled-components";
 import { useSearchParams } from "next/navigation";
 
-import CurriculumUnitCard from "../CurricUnitCard";
+import CurricUnitCard from "../CurricUnitCard";
 
 import { isHighlightedUnit } from "@/utils/curriculum/filtering";
-import { CurriculumFilters, Unit, YearData } from "@/utils/curriculum/types";
+import {
+  CurriculumFilters,
+  Thread,
+  Unit,
+  YearData,
+} from "@/utils/curriculum/types";
 import { getSubjectCategoryMessage } from "@/utils/curriculum/formatting";
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import useAnalyticsPageProps from "@/hooks/useAnalyticsPageProps";
+import { buildUnitOverviewAccessedAnalytics } from "@/utils/curriculum/analytics";
 
 const UnitList = styled("ol")`
   margin: 0;
@@ -35,6 +43,7 @@ type CurricVisualiserUnitListProps = {
   year: string;
   yearData: YearData;
   basePath: string;
+  selectedThread?: Thread;
 };
 export function CurricVisualiserUnitList({
   units,
@@ -42,8 +51,23 @@ export function CurricVisualiserUnitList({
   year,
   filters,
   basePath,
+  selectedThread,
 }: CurricVisualiserUnitListProps) {
+  const { track } = useAnalytics();
+  const { analyticsUseCase } = useAnalyticsPageProps();
   const searchParams = useSearchParams();
+
+  const onClick = (unit: Unit, isHighlighted: boolean) => {
+    track.unitOverviewAccessed(
+      buildUnitOverviewAccessedAnalytics({
+        unit,
+        isHighlighted,
+        componentType: "unit_info_button",
+        selectedThread,
+        analyticsUseCase,
+      }),
+    );
+  };
 
   function getItems(unit: Unit, index: number) {
     const isHighlighted = isHighlightedUnit(unit, filters.threads);
@@ -54,12 +78,13 @@ export function CurricVisualiserUnitList({
 
     return (
       <UnitListItem key={`${unit.slug}-${index}`}>
-        <CurriculumUnitCard
+        <CurricUnitCard
           unit={unit}
           key={unit.slug + index}
           index={index}
           isHighlighted={isHighlighted}
           href={unitUrl}
+          onClick={() => onClick(unit, isHighlighted)}
         />
       </UnitListItem>
     );

--- a/src/utils/curriculum/analytics.ts
+++ b/src/utils/curriculum/analytics.ts
@@ -1,4 +1,5 @@
-import { CurriculumFilters } from "./types";
+import { CurriculumFilters, Thread, Unit } from "./types";
+import { areLessonsAvailable } from "./lessons";
 
 import {
   Platform,
@@ -11,6 +12,7 @@ import {
   UnitSequenceRefinedProperties,
   AnalyticsUseCaseValueType,
   PathwayValueType,
+  UnitOverviewAccessedProperties,
 } from "@/browser-lib/avo/Avo";
 import { CurriculumUnitsTrackingData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
@@ -72,5 +74,38 @@ export function buildUnitSequenceRefinedAnalytics(
         ? filters.subjectCategories[0]
         : null,
     pathway: assertValidPathway(filters.pathways[0]),
+  };
+}
+
+export function buildUnitOverviewAccessedAnalytics({
+  unit,
+  isHighlighted,
+  analyticsUseCase,
+  selectedThread,
+  componentType,
+}: {
+  unit: Unit;
+  isHighlighted: boolean;
+  analyticsUseCase: AnalyticsUseCaseValueType;
+  selectedThread?: Thread;
+  componentType: UnitOverviewAccessedProperties["componentType"];
+}): UnitOverviewAccessedProperties {
+  return {
+    unitName: unit.title,
+    unitSlug: unit.slug,
+    subjectTitle: unit.subject,
+    subjectSlug: unit.subject_slug,
+    yearGroupName: `Year ${unit.year}`,
+    yearGroupSlug: unit.year,
+    threadTitle: selectedThread?.title ?? null,
+    threadSlug: selectedThread?.slug ?? null,
+    platform: "owa",
+    product: "curriculum visualiser",
+    engagementIntent: "use",
+    componentType,
+    eventVersion: "2.0.0",
+    analyticsUseCase,
+    unitHighlighted: isHighlighted,
+    isUnitPublished: areLessonsAvailable(unit.lessons),
   };
 }


### PR DESCRIPTION
## Description
Clicking unit cards in the visualiser now calls `unitOverviewAccessed` again (regression)

## Issue(s)
Fixes `CUR-1541`

## How to test

1. Go to https://deploy-preview-3523--oak-web-application.netlify.thenational.academy/teachers/curriculum
2. Select a subject/phase from the picker
3. When clicking on the unit cards the `unitOverviewAccessed` analytics call should trigger with the correct details


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
