### PR TITLE
Fix: small mobile header layout [LESQ-1429]

### DIFF
--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -83,7 +83,7 @@ const AppHeader: FC<HeaderProps> = () => {
           >
             <OakBox $display={["block", "none"]}>
               <StyledOakLink href={resolveOakHref({ page: "home" })}>
-                <Logo height={48} width={24} variant="without text" />
+                <Logo height={24} width={24} variant="without text" />
               </StyledOakLink>
             </OakBox>
             {selectedArea == siteAreas.teachers && <SaveCount />}

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -1,7 +1,8 @@
 import { FC, useRef } from "react";
-import { OakBox, OakFlex } from "@oaknational/oak-components";
+import { OakBox, OakFlex, OakLink } from "@oaknational/oak-components";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/router";
+import styled from "styled-components";
 
 import TeacherAccountButton from "@/components/TeacherComponents/TeacherAccountButton/TeacherAccountButton";
 import { resolveOakHref } from "@/common-lib/urls";
@@ -26,6 +27,10 @@ export const siteAreas = {
 } as const;
 
 export type SelectedArea = (typeof siteAreas)[keyof typeof siteAreas];
+
+const StyledOakLink = styled(OakLink)`
+  display: block;
+`;
 
 /**
  * Header for logging in and using search -
@@ -56,25 +61,31 @@ const AppHeader: FC<HeaderProps> = () => {
         data-testid="app-header"
       >
         <OakFlex
-          $justifyContent={"space-between"}
           $flexGrow={1}
           $alignItems={"center"}
+          $gap={["all-spacing-0", "space-between-s"]}
         >
-          <OakFlex $justifyContent={"center"} $alignItems={"center"}>
-            <OwaLink page={"home"}>
-              <OakBox $display={["block", "none"]}>
-                <Logo height={48} width={31} variant="without text" />
-              </OakBox>
-              <OakBox $display={["none", "block"]}>
-                <Logo variant="with text" height={48} width={104} />
-              </OakBox>
-            </OwaLink>
+          <OakFlex
+            $justifyContent={"center"}
+            $alignItems={"center"}
+            $display={["none", "block"]}
+          >
+            <StyledOakLink href={resolveOakHref({ page: "home" })}>
+              <Logo variant="with text" height={48} width={104} />
+            </StyledOakLink>
           </OakFlex>
           <OakFlex
             $alignItems={"center"}
-            $gap={["all-spacing-4", "all-spacing-6"]}
+            $gap={["all-spacing-0", "all-spacing-6"]}
             $font="heading-7"
+            $width="100%"
+            $justifyContent={["space-between", "end"]}
           >
+            <OakBox $display={["block", "none"]}>
+              <StyledOakLink href={resolveOakHref({ page: "home" })}>
+                <Logo height={48} width={24} variant="without text" />
+              </StyledOakLink>
+            </OakBox>
             {selectedArea == siteAreas.teachers && <SaveCount />}
             <TeacherAccountButton
               selectedArea={selectedArea}

--- a/src/components/AppComponents/AppHeaderUnderline/AppHeaderUnderline.tsx
+++ b/src/components/AppComponents/AppHeaderUnderline/AppHeaderUnderline.tsx
@@ -8,7 +8,7 @@ export const AppHeaderUnderline: FC = () => {
       $zIndex={"behind"}
       $height={"all-spacing-1"}
       $width={"100%"}
-      $top={"all-spacing-12"}
+      $top={["all-spacing-10", "all-spacing-12"]}
       $right={"all-spacing-0"}
       $left={"all-spacing-0"}
     >

--- a/src/components/SharedComponents/OwaLink/OwaLink.tsx
+++ b/src/components/SharedComponents/OwaLink/OwaLink.tsx
@@ -84,6 +84,9 @@ export const ActiveLinkUnderline = styled(OakSvg)`
   position: absolute;
   height: 8px;
   bottom: -29px;
+  @media (max-width: 768px) {
+    bottom: -20px;
+  }
   left: 0px;
   ${StyledNextLink}:focus & {
     display: none;


### PR DESCRIPTION
## Description

Music year: 1997

- adjust width of logo in app header on mobile to 24px
- move to a flex layout with even spacing for all items in the app header on mobile 
- update `OwaLink` on logo to `OakLink`
- update positions of app header underline and active link underline to fit new header height

## Issue(s)

Fixes #
Buttons too close together on small mobiles

## How to test

1. Go to https://deploy-preview-3526--oak-web-application.netlify.thenational.academy
2. Look at the app header in mobile view, it should match the design on the ticket
3. the tablet & desktop width header should be unchanged

## Screenshots

How it used to look (delete if n/a):

<img width="383" alt="Screenshot 2025-07-07 at 10 27 40" src="https://github.com/user-attachments/assets/7f5246de-0176-4c7a-a8b7-3424fe9609d8" />

How it should now look:
<img width="379" alt="Screenshot 2025-07-07 at 10 02 49" src="https://github.com/user-attachments/assets/c7dc1c25-ab53-4724-ad0a-448ab9406fd6" />
<img width="384" alt="Screenshot 2025-07-07 at 10 05 20" src="https://github.com/user-attachments/assets/874aafa2-8beb-4528-8075-c55fa8130cf5" />

