### PR TITLE
fix: update seo title on canonical media page [LESQ-1401]

### DIFF
--- a/src/pages/teachers/lessons/[lessonSlug]/media.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/media.tsx
@@ -32,7 +32,7 @@ export const CanonicalLessonMediaClipsPage: NextPage<
     <AppLayout
       seoProps={{
         ...getSeoProps({
-          title: `Lesson Share: ${lessonTitle}`,
+          title: `Lesson Media: ${lessonTitle}`,
           description:
             "Share online lesson activities with your students, such as videos, worksheets and quizzes.",
         }),


### PR DESCRIPTION
## Description

Music year: 2006

- update seo title on canonical media page

## Issue(s)

Fixes #
Incorrect title on page

## How to test

1. Go to https://deploy-preview-3528--oak-web-application.netlify.thenational.academy/teachers/lessons/passing-and-receiving-in-games/media
2. You should see `Lesson Media` in the tab title not `Lesson Share`

## Screenshots

How it used to look (delete if n/a):
<img width="800" alt="Screenshot 2025-07-07 at 11 58 19" src="https://github.com/user-attachments/assets/2ede1b80-1a54-4bd0-ac43-1b57db27f33f" />

How it should now look:
<img width="751" alt="Screenshot 2025-07-07 at 11 59 09" src="https://github.com/user-attachments/assets/f9845d46-aa5c-4c96-9d02-debfbaa3dc7d" />