### PR TITLE
fix: update logo colour in app header 

### DIFF
--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -71,7 +71,7 @@ const AppHeader: FC<HeaderProps> = () => {
             $display={["none", "block"]}
           >
             <StyledOakLink href={resolveOakHref({ page: "home" })}>
-              <Logo variant="with text" height={48} width={104} />
+              <Logo variant="with text" height={48} width={104} color="black" />
             </StyledOakLink>
           </OakFlex>
           <OakFlex
@@ -83,7 +83,12 @@ const AppHeader: FC<HeaderProps> = () => {
           >
             <OakBox $display={["block", "none"]}>
               <StyledOakLink href={resolveOakHref({ page: "home" })}>
-                <Logo height={24} width={24} variant="without text" />
+                <Logo
+                  height={24}
+                  width={24}
+                  variant="without text"
+                  color="black"
+                />
               </StyledOakLink>
             </OakBox>
             {selectedArea == siteAreas.teachers && <SaveCount />}

--- a/src/components/AppComponents/Logo/Logo.tsx
+++ b/src/components/AppComponents/Logo/Logo.tsx
@@ -8,6 +8,7 @@ type LogoProps = {
   width: number;
   height: number;
   variant: "with text" | "without text";
+  color?: string;
 };
 
 const LogoWrapper = styled.div<LogoProps>`
@@ -20,6 +21,7 @@ const Logo: FC<LogoProps> = (props) => {
     <LogoWrapper {...props}>
       <ScreenReaderOnly>Oak National Academy</ScreenReaderOnly>
       <InlineSpriteSvg
+        color={props.color}
         name={props.variant === "with text" ? "logo-with-text" : "logo"}
       />
     </LogoWrapper>

--- a/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSvg.tsx
+++ b/src/components/GenericPagesComponents/InlineSpriteSheet/InlineSpriteSvg.tsx
@@ -4,15 +4,17 @@ import { InlineSpriteSvgName } from "@/image-data";
 
 export type SvgProps = {
   name: InlineSpriteSvgName;
+  color?: string;
 };
 const Svg: FC<SvgProps> = (props) => {
-  const { name } = props;
+  const { name, color } = props;
   return (
     <svg
       aria-hidden={true}
       xmlns="http://www.w3.org/2000/svg"
       width="100%"
       height="100%"
+      color={color ?? undefined}
     >
       <use xlinkHref={`#${name}`} />
     </svg>


### PR DESCRIPTION
## Description

Music year: 1950

- Add an optional colour overide to the logo 

## Issue(s)

Fixes #
The logo being blue

## How to test

1. Go to https://deploy-preview-3532--oak-web-application.netlify.thenational.academy
2. Check the logo in the app header on mobile and desktop views, it should be black
3. Check the logo in the footer and hamburger, it should be unchanged

## Screenshots

How it used to look (delete if n/a):
<img width="491" alt="Screenshot 2025-07-08 at 13 37 38" src="https://github.com/user-attachments/assets/21fb534f-9d0b-47e2-a098-bc238b8a4e03" />


How it should now look:
<img width="490" alt="Screenshot 2025-07-08 at 13 37 21" src="https://github.com/user-attachments/assets/d23ce680-4d7c-4d66-ab7c-60fa8f0a036f" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
