### PR TITLE
Update shouldAuthenticate header behaviour

### DIFF
--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
@@ -1,5 +1,5 @@
 import { useAuth } from "@clerk/nextjs";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 
 import useLocalStorageForDownloads from "./useLocalStorageForDownloads";
 
@@ -21,8 +21,9 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
   } = useLocalStorageForDownloads();
 
   const auth = useAuth();
-  const authFlagEnabled =
-    useFeatureFlagVariantKey("teacher-download-auth") === "with-login";
+  const authFlagEnabled = useFeatureFlagEnabled(
+    "teachers-copyright-restrictions",
+  );
 
   const onSubmit = async (data: ResourceFormProps, slug: string) => {
     if (props.onSubmit) {


### PR DESCRIPTION
## Description

When downloading a lesson the `shouldAuthenticate` is now set based on the `teachers-copyright-restrictions` feature flag. Tests have been updated accordingly.

## Issue(s)

A two-parter with [This PR](https://github.com/oaknational/curriculum-downloads-api/pull/243)
[Fixes #1399](LESQ-1399)

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
