### PR TITLE
fix: clerk sign in via sign up

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -264,7 +264,11 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
     // https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#allowedorigins
     experimental: {
       serverActions: {
-        allowedOrigins: ["*.netlify.app", "*.netlify.thenational.academy"],
+        allowedOrigins: [
+          "*.netlify.app",
+          "*.netlify.thenational.academy",
+          "owa.thenational.academy",
+        ],
       },
     },
     // Need this so static URLs and dynamic URLs match.


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- attempt to fix failing sso-callback request when signing in via the sign up page in clerk by adding owa.thenational.academy as allowed origin for server actions
- seeing the following errors in server logs when a sign in fails:

<img width="600" height="167" alt="Screenshot 2025-07-21 at 07 55 45" src="https://github.com/user-attachments/assets/69021f29-36d4-413d-ba46-4a3bbc514744" />

We saw a similar error on deploy preview domains when updating to next 15 and adding to allowed origins was the solution. It's not clear to me why the forwarded host header would now have value `owa.thenational.academy` to begin with in this case though, it's possible this isn't related to the issue with the clerk request failing


## How to test

We won't be able to test properly until it's deployed, but we shuld ensure sign up is still working as expected

1. Go to https://deploy-preview-3548--oak-web-application.netlify.thenational.academy
2. Click on sign up button on the header
3. You should be able to sign in and up

