### PR TITLE
[ENG-1273] Set override_url for prod

### DIFF
--- a/infrastructure/project/locals.tf
+++ b/infrastructure/project/locals.tf
@@ -2,7 +2,7 @@ locals {
   required_env_keys = {
     website = {
       shared  = ["NEXT_PUBLIC_CLERK_SIGN_IN_URL", "NEXT_PUBLIC_CLERK_SIGN_UP_URL"]
-      prod    = ["OAK_CONFIG_LOCATION"]
+      prod    = ["OAK_CONFIG_LOCATION", "OVERRIDE_URL"]
       preview = ["OAK_CONFIG_LOCATION"]
     }
     storybook = {

--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -17,7 +17,7 @@ resource "terraform_data" "workspace_validation" {
 }
 
 module "vercel" {
-  source                 = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.2.4"
+  source                 = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.2.5"
   build_command          = try(local.build_config.build_command, null)
   build_type             = local.build_config.build_type
   cloudflare_zone_domain = var.cloudflare_zone_domain

--- a/infrastructure/project/variables.tf
+++ b/infrastructure/project/variables.tf
@@ -21,6 +21,7 @@ variable "env_vars" {
     }))
     prod = optional(object({
       OAK_CONFIG_LOCATION = optional(string)
+      OVERRIDE_URL        = optional(string)
     }))
     preview = optional(object({
       OAK_CONFIG_LOCATION             = optional(string)


### PR DESCRIPTION
## Description

- OWA now detects its domain via `VERCEL_BRANCH_URL` in preview deployments. In production builds, `OVERRIDE_URL` is used to enforce the `www.thenational.academy` domain. 
See [here](https://github.com/oaknational/Oak-Web-Application/pull/3545)

## Issue(s)

[ENG-1273](https://www.notion.so/oaknationalacademy/Set-OVERRIDE_URL-for-Production-OWA-Vercel-23426cc4e1b180e4a190ebd44bbc9c54)

## How to test

1. Once merged, go to https://owa-vercel.thenational.academy/sitemap.xml and see that each of the links has a domain name of www.thenational.academy

## Checklist

- [X] Terrafform Apply

