### PR TITLE
feat: set lesson child pages seo to nofollow [LESQ-1489]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -588,7 +588,7 @@ describe("pages/teachers/lessons/[lessonSlug]/downloads", () => {
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
         canonical:
           "NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/combined-science-secondary-ks4-foundation-edexcel/units/measuring-waves/lessons/transverse-waves",
-        robots: "noindex,follow",
+        robots: "noindex,nofollow",
       });
     });
   });

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
@@ -366,7 +366,7 @@ describe("pages/teachers/lessons/[lessonSlug]/share", () => {
         ogUrl: "NEXT_PUBLIC_SEO_APP_URL/",
         canonical:
           "NEXT_PUBLIC_SEO_APP_URL/teachers/programmes/maths-higher-ks4-l/units/geometry/lessons/macbeth-lesson-1",
-        robots: "noindex,follow",
+        robots: "noindex,nofollow",
       });
     });
   });

--- a/src/pages/teachers/beta/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/teachers/beta/lessons/[lessonSlug]/downloads.tsx
@@ -42,6 +42,7 @@ const LessonDownloadsCanonicalPage = (
           description: "Lesson downloads",
         }),
         noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonDownloads isCanonical lesson={curriculumData} />

--- a/src/pages/teachers/beta/lessons/[lessonSlug]/media.tsx
+++ b/src/pages/teachers/beta/lessons/[lessonSlug]/media.tsx
@@ -34,6 +34,8 @@ const BetaLessonMediaPage: NextPage<CanonicalLessonMediaClipsPageProps> = ({
           description: "View beta extra video and audio for the lesson",
           canonicalURL: `${getBrowserConfig("seoAppUrl")}/teachers/beta/lessons/${lessonSlug}`,
         }),
+        noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonMedia isCanonical={true} lesson={curriculumData} />

--- a/src/pages/teachers/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/downloads.tsx
@@ -42,6 +42,7 @@ const LessonDownloadsCanonicalPage = (
           description: "Lesson downloads",
         }),
         noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonDownloads isCanonical lesson={curriculumData} />

--- a/src/pages/teachers/lessons/[lessonSlug]/media.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/media.tsx
@@ -36,6 +36,8 @@ export const CanonicalLessonMediaClipsPage: NextPage<
           description:
             "Share online lesson activities with your students, such as videos, worksheets and quizzes.",
         }),
+        noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonMedia isCanonical={true} lesson={curriculumData} />

--- a/src/pages/teachers/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/lessons/[lessonSlug]/share.tsx
@@ -34,6 +34,7 @@ const LessonShareCanonicalPage: NextPage<LessonShareCanonicalPageProps> = ({
             "Share online lesson activities with your students, such as videos, worksheets and quizzes.",
         }),
         noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonShare isCanonical={true} lesson={curriculumData} />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.tsx
@@ -37,6 +37,7 @@ const LessonDownloadsPage = ({ curriculumData }: LessonDownloadsPageProps) => {
           }`,
         }),
         noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonDownloads isCanonical={false} lesson={curriculumData} />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/media.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/media.tsx
@@ -46,6 +46,8 @@ export const LessonMediaClipsPage: NextPage<LessonMediaClipsPageProps> = ({
             programmeSlug
           }/units/${unitSlug}/lessons/${lessonSlug}`,
         }),
+        noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonMedia isCanonical={false} lesson={curriculumData} />

--- a/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
+++ b/src/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.tsx
@@ -40,6 +40,7 @@ const LessonSharePage: NextPage<LessonSharePageProps> = ({
           }`,
         }),
         noIndex: true,
+        noFollow: true,
       }}
     >
       <LessonShare isCanonical={false} lesson={curriculumData} />


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Adds `noFollow: true` to lesson child pages (downloads, share, media)

## Issue(s)

Fixes LESQ-1489

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
