### PR TITLE
feat: update getFilename to support NC alignment xlsx file

### DIFF
--- a/src/pages/api/curriculum-plans/index.ts
+++ b/src/pages/api/curriculum-plans/index.ts
@@ -276,7 +276,7 @@ export default async function handler(
   });
 
   // FIXME: Poor use of types here
-  if (!data.notFound) {
+  if (data.notFound === false) {
     const buffer = await docx(
       data.combinedCurriculumData,
       {
@@ -296,7 +296,7 @@ export default async function handler(
       examboardTitle: data.combinedCurriculumData?.examboardTitle,
       childSubjectSlug,
       tierSlug,
-      suffix: "curriculum plan",
+      prefix: "Curriculum plan",
     });
 
     res

--- a/src/pages/api/national-curriculum/index.ts
+++ b/src/pages/api/national-curriculum/index.ts
@@ -234,7 +234,7 @@ export default async function handler(
       examboardTitle: data.combinedCurriculumData.examboardTitle,
       childSubjectSlug,
       tierSlug,
-      suffix: "NC alignment",
+      prefix: "NC alignment",
     });
 
     res

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -13,6 +13,7 @@ import {
   getPhaseFromCategory,
   getPathwaySuffix,
   truncatePortableTextBlock,
+  getFilename,
 } from "./formatting";
 
 import { createYearData } from "@/fixtures/curriculum/yearData";
@@ -733,5 +734,471 @@ describe("truncatePortableTextBlock", () => {
 
     const result = truncatePortableTextBlock(mixedBlocks, 100);
     expect(result).toBe("Valid text and more text");
+  });
+});
+
+describe("getFilename", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(new Date("2025-06-10").getTime());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("NC alignment xlsx files", () => {
+    describe("Individual filename parameters and edge cases", () => {
+      it("should generate filename with only phase", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Mathematics - Secondary - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should generate filename with phase and examboard", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "English",
+          phaseTitle: "Secondary",
+          examboardTitle: "AQA",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - English - Secondary - AQA - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should generate filename with phase and tier", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          tierSlug: "higher",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Mathematics - Secondary - Higher - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should generate filename with phase, examboard and tier", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Computing",
+          phaseTitle: "Secondary",
+          examboardTitle: "Edexcel",
+          tierSlug: "foundation",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Computing - Secondary - Edexcel - Foundation - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should handle undefined tier slug", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "History",
+          phaseTitle: "Secondary",
+          examboardTitle: "AQA",
+          tierSlug: undefined,
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - History - Secondary - AQA - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should capitalise tier slug correctly", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Design and Technology",
+          phaseTitle: "Secondary",
+          tierSlug: "higher",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Design and Technology - Secondary - Higher - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should use child subject instead of main subject when available for NC alignment", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Science",
+          phaseTitle: "Secondary",
+          childSubjectSlug: "physics",
+          examboardTitle: "Edexcel",
+          tierSlug: "foundation",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Physics - Secondary - Edexcel - Foundation - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should use child subject with examboard and tier", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Science",
+          phaseTitle: "Secondary",
+          childSubjectSlug: "biology",
+          examboardTitle: "AQA",
+          tierSlug: "higher",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Biology - Secondary - AQA - Higher - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should handle empty strings by filtering them out", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Art",
+          phaseTitle: "Primary",
+          examboardTitle: "",
+          tierSlug: "",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Art - Primary - 10-06-2025.docx",
+        );
+      });
+
+      it("should handle undefined child subject slug", () => {
+        const result = getFilename("xlsx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          childSubjectSlug: undefined,
+          examboardTitle: "AQA",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Mathematics - Secondary - AQA - 10-06-2025.xlsx",
+        );
+      });
+
+      it("should format date consistently", () => {
+        // Test with a different date to ensure formatting is correct
+        jest
+          .spyOn(Date, "now")
+          .mockReturnValue(new Date("2025-12-25").getTime());
+
+        const result = getFilename("xlsx", {
+          subjectTitle: "Computing",
+          phaseTitle: "Secondary",
+          prefix: "NC alignment",
+        });
+        expect(result).toBe(
+          "NC alignment - Computing - Secondary - 25-12-2025.xlsx",
+        );
+      });
+    });
+
+    it("should generate NC alignment filename for Primary English", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "English",
+        phaseTitle: "Primary",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe("NC alignment - English - Primary - 10-06-2025.xlsx");
+    });
+
+    it("should generate NC alignment filename for Primary Science", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Science",
+        phaseTitle: "Primary",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe("NC alignment - Science - Primary - 10-06-2025.xlsx");
+    });
+
+    it("should generate NC alignment filename for Secondary Science - Biology", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "biology",
+        examboardTitle: "AQA",
+        tierSlug: "higher",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe(
+        "NC alignment - Biology - Secondary - AQA - Higher - 10-06-2025.xlsx",
+      );
+    });
+
+    it("should generate NC alignment filename for Secondary Science - Chemistry", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "chemistry",
+        examboardTitle: "Edexcel",
+        tierSlug: "foundation",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe(
+        "NC alignment - Chemistry - Secondary - Edexcel - Foundation - 10-06-2025.xlsx",
+      );
+    });
+
+    it("should generate NC alignment filename for Secondary Science - Physics", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "physics",
+        examboardTitle: "Edexcel",
+        tierSlug: "foundation",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe(
+        "NC alignment - Physics - Secondary - Edexcel - Foundation - 10-06-2025.xlsx",
+      );
+    });
+
+    it("should generate NC alignment filename for Secondary Science - Combined Science", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "combined-science",
+        examboardTitle: "OCR",
+        tierSlug: "foundation",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe(
+        "NC alignment - Combined Science - Secondary - OCR - Foundation - 10-06-2025.xlsx",
+      );
+    });
+
+    it("should generate correct filename for Secondary Maths (no exam board)", () => {
+      const result = getFilename("xlsx", {
+        subjectTitle: "Mathematics",
+        phaseTitle: "Secondary",
+        tierSlug: "higher",
+        prefix: "NC alignment",
+      });
+      expect(result).toBe(
+        "NC alignment - Mathematics - Secondary - Higher - 10-06-2025.xlsx",
+      );
+    });
+  });
+
+  describe("Curriculum plan docx files", () => {
+    describe("Individual filename parameters and edge cases", () => {
+      it("should generate filename with only phase", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Mathematics - Secondary - 10-06-2025.docx",
+        );
+      });
+
+      it("should generate filename with phase and examboard", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "English",
+          phaseTitle: "Secondary",
+          examboardTitle: "AQA",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - English - Secondary - AQA - 10-06-2025.docx",
+        );
+      });
+
+      it("should generate filename with phase and tier", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          tierSlug: "higher",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Mathematics - Secondary - Higher - 10-06-2025.docx",
+        );
+      });
+
+      it("should generate filename with phase, examboard and tier", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Computing",
+          phaseTitle: "Secondary",
+          examboardTitle: "Edexcel",
+          tierSlug: "foundation",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Computing - Secondary - Edexcel - Foundation - 10-06-2025.docx",
+        );
+      });
+
+      it("should handle undefined tier slug", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "History",
+          phaseTitle: "Secondary",
+          examboardTitle: "AQA",
+          tierSlug: undefined,
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - History - Secondary - AQA - 10-06-2025.docx",
+        );
+      });
+
+      it("should capitalise tier slug correctly", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Design and Technology",
+          phaseTitle: "Secondary",
+          tierSlug: "higher",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Design and Technology - Secondary - Higher - 10-06-2025.docx",
+        );
+      });
+
+      it("should use main subject and child subject when available for Curriculum plan", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Science",
+          phaseTitle: "Secondary",
+          childSubjectSlug: "physics",
+          examboardTitle: "Edexcel",
+          tierSlug: "foundation",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Science - Physics - Secondary - Edexcel - Foundation - 10-06-2025.docx",
+        );
+      });
+
+      it("should handle empty strings by filtering them out", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Art",
+          phaseTitle: "Primary",
+          examboardTitle: "",
+          tierSlug: "",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Art - Primary - 10-06-2025.docx",
+        );
+      });
+
+      it("should handle undefined child subject slug", () => {
+        const result = getFilename("docx", {
+          subjectTitle: "Mathematics",
+          phaseTitle: "Secondary",
+          childSubjectSlug: undefined,
+          examboardTitle: "AQA",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - Mathematics - Secondary - AQA - 10-06-2025.docx",
+        );
+      });
+
+      it("should format date consistently", () => {
+        // Test with a different date to ensure formatting is correct
+        jest
+          .spyOn(Date, "now")
+          .mockReturnValue(new Date("2025-12-25").getTime());
+
+        const result = getFilename("docx", {
+          subjectTitle: "English",
+          phaseTitle: "Secondary",
+          prefix: "Curriculum plan",
+        });
+        expect(result).toBe(
+          "Curriculum plan - English - Secondary - 25-12-2025.docx",
+        );
+      });
+    });
+
+    it("should generate Curriculum plan filename for Primary English", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "English",
+        phaseTitle: "Primary",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - English - Primary - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate Curriculum plan filename for Primary Science", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Science",
+        phaseTitle: "Primary",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Science - Primary - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate Curriculum plan filename for Secondary Science – Biology", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "biology",
+        examboardTitle: "AQA",
+        tierSlug: "higher",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Science - Biology - Secondary - AQA - Higher - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate Curriculum plan filename for Secondary Science – Chemistry", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "chemistry",
+        examboardTitle: "Edexcel",
+        tierSlug: "foundation",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Science - Chemistry - Secondary - Edexcel - Foundation - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate Curriculum plan filename for Secondary Science – Physics", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "physics",
+        examboardTitle: "Edexcel",
+        tierSlug: "foundation",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Science - Physics - Secondary - Edexcel - Foundation - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate Curriculum plan filename for Secondary Science – Combined Science", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Science",
+        phaseTitle: "Secondary",
+        childSubjectSlug: "combined-science",
+        examboardTitle: "OCR",
+        tierSlug: "foundation",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Science - Combined Science - Secondary - OCR - Foundation - 10-06-2025.docx",
+      );
+    });
+
+    it("should generate correct filename for Secondary Maths (no exam board)", () => {
+      const result = getFilename("docx", {
+        subjectTitle: "Mathematics",
+        phaseTitle: "Secondary",
+        tierSlug: "higher",
+        prefix: "Curriculum plan",
+      });
+      expect(result).toBe(
+        "Curriculum plan - Mathematics - Secondary - Higher - 10-06-2025.docx",
+      );
+    });
   });
 });

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -402,23 +402,45 @@ export function getFilename(
     examboardTitle,
     childSubjectSlug,
     tierSlug,
-    suffix,
+    prefix,
   }: {
     subjectTitle: string;
     phaseTitle: string;
     examboardTitle?: string | null;
     childSubjectSlug?: string;
     tierSlug?: string;
-    suffix?: string;
+    prefix: string;
   },
 ) {
+  // Handle child subject formatting based on file type
+  const childSubjectTitle = childSubjectSlug
+    ? childSubjectSlug
+        .split("-")
+        .map((word) => capitalize(word))
+        .join(" ")
+    : null;
+
+  let subjectParts: string[];
+
+  if (fileExt === "xlsx") {
+    // For xlsx files: Use child subject as replacement (e.g., "Physics" instead of "Science")
+    subjectParts = childSubjectTitle ? [childSubjectTitle] : [subjectTitle];
+  } else if (fileExt === "docx") {
+    // For docx files: Include both main subject and child subject (e.g., "Science - Biology")
+    subjectParts = childSubjectTitle
+      ? [subjectTitle, childSubjectTitle]
+      : [subjectTitle];
+  } else {
+    // Fallback to xlsx behaviour
+    subjectParts = childSubjectTitle ? [childSubjectTitle] : [subjectTitle];
+  }
+
   const pageTitle: string = [
-    subjectTitle,
+    prefix,
+    ...subjectParts,
     phaseTitle,
     examboardTitle,
-    capitalize(childSubjectSlug?.split("-").join(" ")),
     capitalize(tierSlug),
-    suffix,
     format(
       Date.now(),
       // Note: dashes "-" rather than ":" because colon is invalid on windows


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

Added logic for both National Curriculum alignment xlsx and Curriculum plan docx files which implement the new filename patterns:

- National curriculum alignment xlsx files: Added logic for subjects with child subjects, which ensures that the child subject replaces the main subject in the file name (e.g., "Physics" instead"Science")
- Curriculum plan docx files: Added logic which for subjects with child subjects, which ensures that both main and child subject are included in the filename (e.g., "Science - Biology")
- Added test s to match this new behaviour

## Issue(s)

Fixes #[1503](https://www.notion.so/oaknationalacademy/Generate-correct-filename-for-docx-and-xlsx-downloads-20e26cc4e1b18066bdecf1af9626fb74?v=d9869bab5f8a4e28a7a960d37f6ab31e&source=copy_link)

## How to test

1. Generate a series of docx / xlsx files for both primary and secondary phases. Ensure that Secondary Science is comprehensively tested.
2. Ensure they adhere to the established conventions:
    1. `NC alignment - {subject} - {phase} [- {examboard} - {tier}] - {date}.xlsx`
    2. `Curriculum plan - {subject} - {child subject} - {phase} [- {examboard} - {tier}] - {date}.docx`

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
