### PR TITLE
[ENG-1274] Attach www.tn.a domain directly to project 

### DIFF
--- a/infrastructure/project/builds.tf
+++ b/infrastructure/project/builds.tf
@@ -2,7 +2,7 @@ locals {
   builds = {
     website = {
       description     = "Oak Web Application Website"
-      domains         = ["owa.thenational.academy"]
+      domains         = ["owa.thenational.academy", "www.thenational.academy"]
       build_type      = "website"
       deployment_type = "standard_protection"
       framework       = "nextjs"


### PR DESCRIPTION


## Description

-  Since the Load Balancer has been removed for www.thenational.academy, we need to add `www.thenational.academy` as a custom domain on the Vercel project

## Issue(s)

[ENG-1274](https://www.notion.so/oaknationalacademy/Remove-the-load-balancer-from-www-23926cc4e1b180d7b773f2feab506dea)

## How to test

1. check that `www.tn.a` has been created and attached to the vercel project

## Checklist

- [X] Terraform Apply