### PR TITLE
fix: only use auth token when required by lesson restrictions [LESQ-1530]

### DIFF
--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.test.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.test.tsx
@@ -154,7 +154,7 @@ describe("createLessonDownloadLink()", () => {
       selection: "exit-quiz-answers,worksheet-pdf",
       isLegacyDownload: true,
       authToken,
-      authFlagEnabled: true,
+      authRequired: true,
     });
 
     expect(global.fetch).toBeCalledWith(
@@ -173,7 +173,7 @@ describe("createLessonDownloadLink()", () => {
       lessonSlug: "lesson-slug",
       selection: "exit-quiz-answers,worksheet-pdf",
       isLegacyDownload: true,
-      authFlagEnabled: false,
+      authRequired: false,
     });
 
     expect(global.fetch).toBeCalledWith(
@@ -191,7 +191,7 @@ describe("createUnitDownloadLink()", () => {
   it("should set authentication header to false when flag disabled", async () => {
     await createUnitDownloadLink({
       unitFileId: "unitvariant-123",
-      authFlagEnabled: false,
+      authRequired: false,
       getToken: jest.fn().mockResolvedValue(null),
     });
     expect(global.fetch).toHaveBeenCalledWith(
@@ -207,7 +207,7 @@ describe("createUnitDownloadLink()", () => {
     const getToken = jest.fn().mockResolvedValue("testToken");
     await createUnitDownloadLink({
       unitFileId: "unitvariant-123",
-      authFlagEnabled: true,
+      authRequired: true,
       getToken,
     });
     expect(global.fetch).toHaveBeenCalledWith(
@@ -231,7 +231,7 @@ describe("createUnitDownloadLink()", () => {
     await expect(async () => {
       await createUnitDownloadLink({
         unitFileId: "unitvariant-123",
-        authFlagEnabled: false,
+        authRequired: false,
         getToken: jest.fn().mockResolvedValue(null),
       });
     }).rejects.toThrow();
@@ -240,7 +240,7 @@ describe("createUnitDownloadLink()", () => {
     await expect(async () => {
       await createUnitDownloadLink({
         unitFileId: "unitvariant-123",
-        authFlagEnabled: true,
+        authRequired: true,
         getToken: jest.fn().mockResolvedValue(null),
       });
     }).rejects.toThrow();

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.tsx
@@ -28,7 +28,7 @@ export type DownloadsApiDownloadResponseSchema = z.infer<typeof schema>;
 const getDownloadLink = async ({
   downloadEndpoint,
   meta,
-  authFlagEnabled,
+  authRequired,
   authToken,
 }: {
   downloadEndpoint: string;
@@ -37,10 +37,10 @@ const getDownloadLink = async ({
     selection?: string;
     isLegacyDownload?: boolean;
   };
-  authFlagEnabled?: boolean;
+  authRequired?: boolean;
   authToken?: string | null;
 }) => {
-  if (authFlagEnabled && !authToken) {
+  if (authRequired && !authToken) {
     throw new OakError({
       code: "downloads/missing-auth-token",
       meta,
@@ -53,9 +53,7 @@ const getDownloadLink = async ({
   const res = await fetch(downloadEndpoint, {
     headers: {
       ...authHeader,
-      "X-Should-Authenticate-Download": JSON.stringify(
-        Boolean(authFlagEnabled),
-      ),
+      "X-Should-Authenticate-Download": JSON.stringify(Boolean(authRequired)),
     },
   });
 
@@ -77,14 +75,14 @@ export const createLessonDownloadLink = async ({
   isLegacyDownload,
   selection,
   additionalFilesIdsSelection,
-  authFlagEnabled,
+  authRequired,
   authToken,
 }: {
   lessonSlug: string;
   isLegacyDownload: boolean;
   selection?: string;
   additionalFilesIdsSelection?: string;
-  authFlagEnabled?: boolean;
+  authRequired?: boolean;
   authToken?: string | null;
 }) => {
   const selectionString = selection ? `?selection=${selection}` : "";
@@ -100,7 +98,7 @@ export const createLessonDownloadLink = async ({
   const url = await getDownloadLink({
     downloadEndpoint,
     meta,
-    authFlagEnabled,
+    authRequired,
     authToken,
   });
   return url;
@@ -108,11 +106,11 @@ export const createLessonDownloadLink = async ({
 
 export const createUnitDownloadLink = async ({
   unitFileId,
-  authFlagEnabled,
+  authRequired,
   getToken,
 }: {
   unitFileId: string;
-  authFlagEnabled?: boolean;
+  authRequired?: boolean;
   getToken: GetToken;
 }) => {
   const downloadEndpoint = `${DOWNLOADS_API_URL}/api/unit/${unitFileId}/download`;
@@ -124,7 +122,7 @@ export const createUnitDownloadLink = async ({
   const url = await getDownloadLink({
     downloadEndpoint,
     meta,
-    authFlagEnabled,
+    authRequired,
     authToken,
   });
   return url;

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.tsx
@@ -8,14 +8,14 @@ const downloadLessonResources = async ({
   selectedResourceTypes,
   selectedAdditionalFilesIds,
   isLegacyDownload,
-  authFlagEnabled,
+  authRequired,
   authToken,
 }: {
   lessonSlug: string;
   selectedResourceTypes: (DownloadResourceType | "worksheet-pdf-questions")[]; // FIXME: a new solution is required for types which are shared across different journeys . Also should the downloads schemas be added to oak-curriculum schema?
   selectedAdditionalFilesIds?: number[];
   isLegacyDownload: boolean;
-  authFlagEnabled?: boolean;
+  authRequired?: boolean;
   authToken?: string | null;
 }) => {
   if (selectedResourceTypes?.length === 0) {
@@ -31,7 +31,7 @@ const downloadLessonResources = async ({
     selection,
     additionalFilesIdsSelection,
     isLegacyDownload,
-    authFlagEnabled,
+    authRequired,
     authToken,
   });
 

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -66,7 +66,7 @@ export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
       setDownloadError(false);
       const downloadLink = await createUnitDownloadLink({
         unitFileId,
-        authFlagEnabled,
+        authRequired: authFlagEnabled,
         getToken: auth.getToken,
       });
 

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.test.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.test.ts
@@ -54,7 +54,11 @@ describe("useResourceFormSubmit", () => {
   });
   it("should set email in local storage if passed in props", async () => {
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
 
@@ -67,7 +71,11 @@ describe("useResourceFormSubmit", () => {
 
   it("should set school in local storage if passed in props", async () => {
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
     await waitFor(() => {
@@ -88,7 +96,11 @@ describe("useResourceFormSubmit", () => {
     };
 
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
     await waitFor(() => {
@@ -109,7 +121,11 @@ describe("useResourceFormSubmit", () => {
     };
 
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
     await waitFor(() => {
@@ -122,7 +138,11 @@ describe("useResourceFormSubmit", () => {
 
   it("should set terms in local storage if passed in props", async () => {
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
     await waitFor(() => {
@@ -132,7 +152,11 @@ describe("useResourceFormSubmit", () => {
 
   it("should call downloadLessonResources with correct parameters", async () => {
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(data, "lesson");
 
@@ -141,7 +165,7 @@ describe("useResourceFormSubmit", () => {
         lessonSlug: "lesson",
         selectedResourceTypes: ["intro-quiz-questions"],
         isLegacyDownload: true,
-        authFlagEnabled: false,
+        authRequired: false,
         authToken: null,
         selectedAdditionalFilesIds: [],
       });
@@ -152,7 +176,11 @@ describe("useResourceFormSubmit", () => {
     mockFeatureFlagEnabled.mockReturnValueOnce(true);
     mockAuthGetToken.mockResolvedValueOnce("token");
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: true,
+      }),
     );
     result.current.onSubmit(data, "lesson");
 
@@ -161,7 +189,7 @@ describe("useResourceFormSubmit", () => {
         lessonSlug: "lesson",
         selectedResourceTypes: ["intro-quiz-questions"],
         isLegacyDownload: true,
-        authFlagEnabled: true,
+        authRequired: true,
         authToken: "token",
         selectedAdditionalFilesIds: [],
       });
@@ -183,7 +211,11 @@ describe("useResourceFormSubmit", () => {
     };
 
     const { result } = renderHook(() =>
-      useResourceFormSubmit({ isLegacyDownload: true, type: "download" }),
+      useResourceFormSubmit({
+        isLegacyDownload: true,
+        type: "download",
+        authRequired: false,
+      }),
     );
     result.current.onSubmit(dataWithAdditionalFiles, "lesson");
 
@@ -192,7 +224,7 @@ describe("useResourceFormSubmit", () => {
         lessonSlug: "lesson",
         selectedResourceTypes: ["intro-quiz-questions", "additional-files"],
         isLegacyDownload: true,
-        authFlagEnabled: false,
+        authRequired: false,
         authToken: null,
         selectedAdditionalFilesIds: [123, 345],
       });

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
@@ -11,7 +11,10 @@ import downloadLessonResources from "@/components/SharedComponents/helpers/downl
 
 type UseResourceFormProps = {
   onSubmit?: () => void;
-} & ({ type: "share" } | { type: "download"; isLegacyDownload: boolean });
+} & (
+  | { type: "share" }
+  | { type: "download"; isLegacyDownload: boolean; authRequired: boolean }
+);
 
 const useResourceFormSubmit = (props: UseResourceFormProps) => {
   const {
@@ -73,13 +76,13 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
             .filter((d) => additionalFilesRegex.test(d))
             .map((d) => parseInt(d.split("additional-files-")?.[1] ?? ""))
         : [];
-
+      const authRequired = authFlagEnabled && props.authRequired;
       await downloadLessonResources({
         lessonSlug: slug,
         selectedResourceTypes: selectedResourceTypes as DownloadResourceType[],
         selectedAdditionalFilesIds,
         isLegacyDownload: props.isLegacyDownload,
-        authFlagEnabled,
+        authRequired,
         authToken: accessToken,
       });
     }

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -228,6 +228,7 @@ export function LessonDownloads(props: LessonDownloadsProps) {
   const { onSubmit } = useResourceFormSubmit({
     type: "download",
     isLegacyDownload,
+    authRequired: downloadsRestricted,
   });
 
   const { onHubspotSubmit } = useHubspotSubmit();


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- change prop to download fn to authRequired and use lesson level restrictions as well as the feature flag to determine if auth is required
- the downloads api already uses lesson level restrictions to determine whether auth is required

## Issue(s)

Fixes #
Signed out users unable to download when the copyright flag is enabled

## How to test

1. Go to {owa_deployment_url}
2. While signed out you should be able to download lessons without restrictions
3. While signed in you should be able to download units and lessons with restrictions




