### PR TITLE
Fix button missing from saving signed out modal

### DIFF
--- a/src/components/TeacherComponents/LoginRequiredButton/LoginRequiredButton.tsx
+++ b/src/components/TeacherComponents/LoginRequiredButton/LoginRequiredButton.tsx
@@ -62,6 +62,7 @@ type BaseProps = {
   buttonVariant?: ButtonVariant;
   sizeVariant?: SizeVariant;
   element?: "a" | "button";
+  isBehindFeatureFlag?: boolean;
 };
 
 type LoginRequiredButtonProps = BaseProps & OakPrimaryButtonProps;
@@ -94,6 +95,7 @@ const LoginRequiredButton = (props: LoginRequiredButtonProps) => {
     element = "button",
     loginRequired,
     geoRestricted,
+    isBehindFeatureFlag,
     ...overrideProps
   } = props;
   const router = useRouter();
@@ -103,7 +105,11 @@ const LoginRequiredButton = (props: LoginRequiredButtonProps) => {
     showSignedOutLoginRequired,
     showGeoBlocked,
     isLoaded,
-  } = useCopyrightRequirements({ loginRequired, geoRestricted });
+  } = useCopyrightRequirements({
+    loginRequired,
+    geoRestricted,
+    isBehindFeatureFlag,
+  });
 
   const contentRestricted = loginRequired || geoRestricted;
   const buttonState = useMemo((): ButtonState => {

--- a/src/components/TeacherComponents/SavingSignedOutModal/SavingSignedOutModal.tsx
+++ b/src/components/TeacherComponents/SavingSignedOutModal/SavingSignedOutModal.tsx
@@ -39,6 +39,7 @@ const SavingSignedOutModalContent = () => {
       <LoginRequiredButton
         loginRequired={true}
         geoRestricted={false}
+        isBehindFeatureFlag={false}
         onboardingProps={{ name: "Finish sign up" }}
         width="100%"
       />

--- a/src/hooks/useCopyrightRequirements.ts
+++ b/src/hooks/useCopyrightRequirements.ts
@@ -4,6 +4,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 interface UseCopyrightRequirementsProps {
   loginRequired: boolean;
   geoRestricted: boolean;
+  isBehindFeatureFlag?: boolean;
 }
 
 export interface UseCopyrightRequirementsReturn {
@@ -17,6 +18,7 @@ export interface UseCopyrightRequirementsReturn {
 export function useCopyrightRequirements({
   loginRequired,
   geoRestricted,
+  isBehindFeatureFlag = true,
 }: UseCopyrightRequirementsProps): UseCopyrightRequirementsReturn {
   const { user, isSignedIn, isLoaded } = useUser();
   const featureFlagEnabled = useFeatureFlagEnabled(
@@ -26,7 +28,7 @@ export function useCopyrightRequirements({
   const isUserOnboarded =
     (isSignedIn && user?.publicMetadata?.owa?.isOnboarded) ?? false;
 
-  if (!featureFlagEnabled) {
+  if (isBehindFeatureFlag && !featureFlagEnabled) {
     return {
       showGeoBlocked: false,
       showSignedOutLoginRequired: false,


### PR DESCRIPTION
## Description

Bug introduced in: https://github.com/oaknational/Oak-Web-Application/pull/3563

With the feature flag turned off and no `actionProps` defined, the `LoginRequiredButton` component would return `null`. I've added an optional prop, defaulting to `true` that can be used to bypass the feature flag check. Open to ideas for a better solution as this doesn't feel ideal.

## Issue(s)

Fixes #

## How to test

1. With the `teachers-copyright-restrictions` feature flag turned off
2. Go to https://oak-web-application-website-ahdv7bhvq.vercel-preview.thenational.academy
3. Sign out of an account
4. Go to save a unit
5. You should see the sign in to continue button on the modal

## Screenshots

How it used to look (delete if n/a):
<img width="1682" height="1084" alt="image" src="https://github.com/user-attachments/assets/7222cbe8-491d-4885-b6a4-480b36334e03" />

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
