### PR TITLE
fix: unit list accessibility issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.135.1",
+        "@oaknational/oak-components": "^1.136.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.66.0",
         "@oaknational/oak-pupil-client": "^2.15.0",
@@ -7182,9 +7182,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.135.1",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.135.1.tgz",
-      "integrity": "sha512-WBhzdGbOiLm3RtQSqqhLdnMQwgvHGM7IqSRJrCdu2hPzgzdLp7/KZMlmAb5bfd4JwNzjsGpaanKm/miEOvVPVw==",
+      "version": "1.136.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.136.1.tgz",
+      "integrity": "sha512-JKJkdLs/98Pz/xHIsdCgAD0cARgLAebeuwOBWZ1xvL4GvZxSJR61EaQQdDml2yXHi0tHONnAgTo0zN8aRKAr4w==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.129.0",
+        "@oaknational/oak-components": "^1.135.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.65.1",
         "@oaknational/oak-pupil-client": "^2.15.0",
@@ -7178,9 +7178,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.130.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.130.0.tgz",
-      "integrity": "sha512-otyLYFgiBTB/dlY57E/fsCfPtQrl/uXJ+n9bYSXVn6vawJNHYrQzRvHi0xndBc15bdo+9lV+UvVOy7EC0NYbsQ==",
+      "version": "1.135.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.135.1.tgz",
+      "integrity": "sha512-WBhzdGbOiLm3RtQSqqhLdnMQwgvHGM7IqSRJrCdu2hPzgzdLp7/KZMlmAb5bfd4JwNzjsGpaanKm/miEOvVPVw==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.129.0",
+    "@oaknational/oak-components": "^1.135.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.65.1",
     "@oaknational/oak-pupil-client": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.135.1",
+    "@oaknational/oak-components": "^1.136.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.66.0",
     "@oaknational/oak-pupil-client": "^2.15.0",


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Update oak-components to latest version to include fixes for `OakUnitHeadings`, `OakUnitListItem`, and `OakUnitOptionalityListItem`

## Issue(s)

Fixes LESQ-1465

## How to test

1. Go to [https://oak-web-application-website-git-fix-lesq-1465unit-listin-e3668a.vercel-preview.thenational.academy](https://oak-web-application-website-git-fix-lesq-1465unit-listin-e3668a.vercel-preview.thenational.academy)
2. Go to a unit listing page with optionality units [https://oak-web-application-website-git-fix-lesq-1465unit-listin-e3668a.vercel-preview.thenational.academy/teachers/programmes/english-secondary-ks4-aqa/units](https://oak-web-application-website-git-fix-lesq-1465unit-listin-e3668a.vercel-preview.thenational.academy/teachers/programmes/english-secondary-ks4-aqa/units)
3. You should see the `<Subject> units` heading as `h3`
4. You should see all unit numbers (optionality and non-optionality) as `span`
5. You should see unit optionality list headings as `h4`

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
