### PR TITLE
[ENG 1244] Refactor sensitive env vars

### DIFF
--- a/infrastructure/project/builds.tf
+++ b/infrastructure/project/builds.tf
@@ -22,8 +22,6 @@ locals {
       build_type       = "storybook"
       deployment_type  = "all_deployments"
       framework        = "storybook"
-      git_branch       = "feat/eng-1145-vercel-migration"
-      ignore_command   = "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"feat/eng-1145-vercel-migration\" ]; then exit 1; else exit 0; fi"
       output_directory = "storybook-static"
       skew_protection  = "1 day"
     }

--- a/infrastructure/project/locals.tf
+++ b/infrastructure/project/locals.tf
@@ -45,14 +45,28 @@ locals {
     ]
   ])
 
+  sensitive_env_vars = {
+    shared = {}
+    prod = {
+      CLERK_SECRET_KEY                      = var.clerk_secret_key_prod
+      GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT = var.google_secret_manager_service_account_prod
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY     = var.next_public_clerk_publishable_key_prod
+    }
+    preview = {
+      CLERK_SECRET_KEY                      = var.clerk_secret_key_preview
+      GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT = var.google_secret_manager_service_account_preview
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY     = var.next_public_clerk_publishable_key_preview
+    }
+  }
+
   sensitive_vars = flatten([
     for group, target in local.env_groups : [
-      for key, value in var.sensitive_env_vars[group] : {
+      for key, value in local.sensitive_env_vars[group] : {
         key       = key
         value     = value
         target    = target
         sensitive = true
-      }
+      } if value != null
     ]
   ])
 

--- a/infrastructure/project/variables.tf
+++ b/infrastructure/project/variables.tf
@@ -51,28 +51,80 @@ variable "env_vars" {
   }
 }
 
-variable "sensitive_env_vars" {
-  type = object({
-    shared = optional(object({}))
-    prod = optional(object({
-      CLERK_SECRET_KEY                      = optional(string)
-      GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT = optional(string)
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY     = optional(string)
-    }))
-    preview = optional(object({
-      CLERK_SECRET_KEY                      = optional(string)
-      GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT = optional(string)
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY     = optional(string)
-    }))
-  })
-  sensitive = true
+variable "clerk_secret_key_preview" {
+  description = "Clerk secret key for preview environment"
+  type        = string
+  sensitive   = true
+  default     = null
 
   validation {
-    condition = alltrue([
-      for gk, gv in local.required_current_sensitive_env : alltrue([
-        toset(keys({ for k, v in var.sensitive_env_vars[gk] : k => v if v != null })) == toset(gv)
-      ])
-    ])
-    error_message = "Sensitive environment variables don't match requirements for '${local.build_type}' build. Required: ${jsonencode(local.required_current_sensitive_env)}"
+    condition = contains(local.required_current_sensitive_env.preview, "CLERK_SECRET_KEY") ? var.clerk_secret_key_preview != null : var.clerk_secret_key_preview == null
+
+    error_message = contains(local.required_current_sensitive_env.preview, "CLERK_SECRET_KEY") ? "Missing clerk_secret_key_preview for '${local.build_type}' build." : "clerk_secret_key_preview is set but not required for '${local.build_type}' build."
+  }
+}
+
+variable "clerk_secret_key_prod" {
+  description = "Clerk secret key for production environment"
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition = contains(local.required_current_sensitive_env.prod, "CLERK_SECRET_KEY") ? var.clerk_secret_key_prod != null : var.clerk_secret_key_prod == null
+
+    error_message = contains(local.required_current_sensitive_env.prod, "CLERK_SECRET_KEY") ? "Missing clerk_secret_key_prod for '${local.build_type}' build." : "clerk_secret_key_prod is set but not required for '${local.build_type}' build."
+  }
+}
+
+variable "google_secret_manager_service_account_preview" {
+  description = "Google Secret Manager service account for preview environment"
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition = contains(local.required_current_sensitive_env.preview, "GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT") ? var.google_secret_manager_service_account_preview != null : var.google_secret_manager_service_account_preview == null
+
+    error_message = contains(local.required_current_sensitive_env.preview, "GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT") ? "Missing google_secret_manager_service_account_preview for '${local.build_type}' build." : "google_secret_manager_service_account_preview is set but not required for '${local.build_type}' build."
+  }
+}
+
+variable "google_secret_manager_service_account_prod" {
+  description = "Google Secret Manager service account for production environment"
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition = contains(local.required_current_sensitive_env.prod, "GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT") ? var.google_secret_manager_service_account_prod != null : var.google_secret_manager_service_account_prod == null
+
+    error_message = contains(local.required_current_sensitive_env.prod, "GOOGLE_SECRET_MANAGER_SERVICE_ACCOUNT") ? "Missing google_secret_manager_service_account_prod for '${local.build_type}' build." : "google_secret_manager_service_account_prod is set but not required for '${local.build_type}' build."
+  }
+}
+
+variable "next_public_clerk_publishable_key_preview" {
+  description = "Clerk publishable key for production environment"
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition = contains(local.required_current_sensitive_env.preview, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY") ? var.next_public_clerk_publishable_key_preview != null : var.next_public_clerk_publishable_key_preview == null
+
+    error_message = contains(local.required_current_sensitive_env.preview, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY") ? "Missing next_public_clerk_publishable_key_preview for '${local.build_type}' build." : "next_public_clerk_publishable_key_preview is set but not required for '${local.build_type}' build."
+  }
+}
+
+variable "next_public_clerk_publishable_key_prod" {
+  description = "Clerk publishable key for production environment"
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition = contains(local.required_current_sensitive_env.prod, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY") ? var.next_public_clerk_publishable_key_prod != null : var.next_public_clerk_publishable_key_prod == null
+
+    error_message = contains(local.required_current_sensitive_env.prod, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY") ? "Missing next_public_clerk_publishable_key_prod for '${local.build_type}' build." : "next_public_clerk_publishable_key_prod is set but not required for '${local.build_type}' build."
   }
 }


### PR DESCRIPTION

## Description

-  Remove ignore build and git branch since migration to vercel is complete, `feat/eng-1145-vercel-migration` has been merged into main
- Refactor sensitive env vars to individual variables for easier management. Currently, we need to know all the values of sensitive env var object when we add/update a var because TFC hides sensitive values. This ticket breaks down the monolithic senstive env vars object into individual variables, making it easier to update single sensitive values without knowing all others

## Issue(s)

[ENG-1244](https://www.notion.so/oaknationalacademy/7a067876b8d94be0b4100d6c831d5a1a?v=450b96370cb34a7dacd6994b6a8540c4&p=21826cc4e1b1804897f6ea2237d0fab0&pm=c)

## How to test

1.Terraform plan should show no changes

