### PR TITLE
fix: Put all unit downloads back behind a login

### DIFF
--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
@@ -120,7 +120,7 @@ describe("UnitDownloadButton", () => {
         unitFileId="mockSlug"
         showNewTag
         georestricted={false}
-        loginRequired={false}
+        loginRequired={true}
       />,
     );
     const button = screen.getByText("Download unit");

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -41,7 +41,7 @@ export type UnitDownloadButtonProps = {
 };
 
 export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
-  const { unitFileId, showNewTag, georestricted, loginRequired } = props;
+  const { unitFileId, showNewTag, georestricted } = props;
   const authFlagEnabled = useFeatureFlagEnabled(
     "teachers-copyright-restrictions",
   );
@@ -88,7 +88,7 @@ export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
 
   return showDownloadButton ? (
     <LoginRequiredButton
-      loginRequired={loginRequired}
+      loginRequired={true}
       geoRestricted={georestricted}
       sizeVariant={isMobile ? "small" : "large"}
       actionProps={{


### PR DESCRIPTION
## Description

Fixes an issue with Unit downloads not requiring a login.

## Issue(s)

Fixes #

## How to test

1. Go to [https://oak-web-application-website-i48nmkqws.vercel-preview.thenational.academy](https://oak-web-application-website-git-fix-restrict-unit-downloads.vercel-preview.thenational.academy/)
2. When logged out, try to download a unit
3. You should be redirected to sign up

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
