### PR TITLE
Allow download of multiple files from curric downloads

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/CurriculumDownloadTab.test.tsx
@@ -1,5 +1,7 @@
 import { act, screen } from "@testing-library/react";
 
+import { DownloadType } from "../CurriculumDownloadView/helper";
+
 import CurriculumDownloadTab, { trackCurriculumDownload } from ".";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
@@ -263,7 +265,7 @@ describe("trackCurriculumDownload", () => {
           status: "Open",
         },
       ],
-      downloadType: "curriculum-plans" as const,
+      downloadTypes: ["curriculum-plans"] as DownloadType[],
     };
 
     const subjectTitle = "Mathematics";

--- a/src/components/CurriculumComponents/CurriculumDownloadTab/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadTab/index.tsx
@@ -161,7 +161,7 @@ const CurriculumDownloadTab: FC<CurriculumDownloadTabProps> = ({
     schoolId: undefined,
     schoolName: undefined,
     email: undefined,
-    downloadType: "curriculum-plans",
+    downloadTypes: ["curriculum-plans"],
     termsAndConditions: false,
     schoolNotListed: false,
     schools: [],
@@ -187,7 +187,7 @@ const CurriculumDownloadTab: FC<CurriculumDownloadTabProps> = ({
         schoolId: localStorageData.schoolId,
         schoolName: localStorageData.schoolName,
         email: localStorageData.email,
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         termsAndConditions: localStorageData.termsAndConditions,
         schoolNotListed: localStorageData.schoolNotListed,
         schools: [],
@@ -241,16 +241,18 @@ const CurriculumDownloadTab: FC<CurriculumDownloadTabProps> = ({
   const onSubmit = async (data: CurriculumDownloadViewData) => {
     setIsSubmitting(true);
 
-    const downloadPath = createCurriculumDownloadsUrl(
-      data.downloadType,
-      "published",
-      mvRefreshTime,
-      slugs.subjectSlug,
-      slugs.phaseSlug,
-      slugs.ks4OptionSlug,
-      tierSelected,
-      childSubjectSelected,
-    );
+    const downloadPaths = data.downloadTypes.map((downloadType) => {
+      return createCurriculumDownloadsUrl(
+        downloadType,
+        "published",
+        mvRefreshTime,
+        slugs.subjectSlug,
+        slugs.phaseSlug,
+        slugs.ks4OptionSlug,
+        tierSelected,
+        childSubjectSelected,
+      );
+    });
 
     const schoolData = {
       schoolId: data.schoolId!,
@@ -262,7 +264,9 @@ const CurriculumDownloadTab: FC<CurriculumDownloadTabProps> = ({
     saveDownloadsDataToLocalStorage(schoolData);
 
     try {
-      await downloadFileFromUrl(downloadPath);
+      for (const downloadPath of downloadPaths) {
+        await downloadFileFromUrl(downloadPath);
+      }
     } finally {
       await trackCurriculumDownload(
         data,

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.stories.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.stories.tsx
@@ -107,7 +107,7 @@ export const CurriculumDownloadView: Story = {
       ],
       schoolId: undefined,
       email: "test@example.com",
-      downloadType: "curriculum-plans",
+      downloadTypes: ["curriculum-plans"],
       termsAndConditions: true,
       schoolNotListed: false,
     },

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadView.test.tsx
@@ -44,7 +44,7 @@ describe("CurriculumDownloadView", () => {
           },
         ],
         email: "test@example.com",
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         schoolNotListed: true,
         termsAndConditions: true,
       } as const;
@@ -75,7 +75,7 @@ describe("CurriculumDownloadView", () => {
           },
         ],
         email: "test@example.com",
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         schoolNotListed: true,
         termsAndConditions: true,
       } as const;
@@ -105,7 +105,7 @@ describe("CurriculumDownloadView", () => {
           },
         ],
         email: undefined,
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         schoolNotListed: false,
         termsAndConditions: true,
       } as const;
@@ -142,7 +142,7 @@ describe("CurriculumDownloadView", () => {
           },
         ],
         email: undefined,
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         schoolNotListed: false,
         termsAndConditions: true,
       } as const;
@@ -160,7 +160,7 @@ describe("CurriculumDownloadView", () => {
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith({
-          downloadType: "curriculum-plans",
+          downloadTypes: ["curriculum-plans", "national-curriculum"],
           email: "EMAIL",
           schoolId: "SCHOOL_ID-SCHOOL_NAME",
           schoolName: "SCHOOL_NAME",

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumResourcesSelector.tsx
@@ -1,8 +1,5 @@
-import {
-  OakFlex,
-  OakHeading,
-  OakRadioGroup,
-} from "@oaknational/oak-components";
+import { OakFlex, OakHeading } from "@oaknational/oak-components";
+import { uniq } from "lodash";
 
 import {
   DOWNLOAD_TYPES,
@@ -31,45 +28,46 @@ export type CurriculumDownloadViewErrors = Partial<{
 }>;
 
 type CurriculumResourcesSectionProps = {
-  downloadType: DownloadType;
-  onChangeDownloadType: (newDownloadType: DownloadType) => void;
+  downloadTypes: DownloadType[];
+  onChangeDownloadTypes: (newDownloadType: DownloadType[]) => void;
 };
 export function CurriculumResourcesSelector({
-  downloadType,
-  onChangeDownloadType,
+  downloadTypes,
+  onChangeDownloadTypes,
 }: CurriculumResourcesSectionProps) {
   return (
     <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
       <OakHeading tag="h3" $font={["heading-5"]} data-testid="download-heading">
         Curriculum resources
       </OakHeading>
-      <OakRadioGroup
-        name="subject-download-options"
-        aria-label="Subject Download Options"
-        value={downloadType}
-        onChange={(e) => {
-          const newDownloadType = assertValidDownloadType(e.target.value);
-          onChangeDownloadType(newDownloadType);
-        }}
-      >
-        <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
-          {DOWNLOAD_TYPES.map((download) => {
-            return (
-              <ResourceCard
-                id={download.id}
-                key={download.label}
-                name={download.label}
-                label={download.label}
-                subtitle={download.subTitle ?? ""}
-                resourceType="curriculum-pdf"
-                onChange={() => {}}
-                subjectIcon={download.icon}
-                asRadio={true}
-              />
-            );
-          })}
-        </OakFlex>
-      </OakRadioGroup>
+      <OakFlex $flexDirection={"column"} $gap={"space-between-s"}>
+        {DOWNLOAD_TYPES.map((download) => {
+          return (
+            <ResourceCard
+              id={download.id}
+              key={download.label}
+              name={download.label}
+              label={download.label}
+              subtitle={download.subTitle ?? ""}
+              resourceType="curriculum-pdf"
+              subjectIcon={download.icon}
+              checked={downloadTypes.includes(download.id)}
+              onChange={(e) => {
+                const downloadType = assertValidDownloadType(e.target.value);
+                let newDownloadTypes: DownloadType[];
+                if (e.target.checked) {
+                  newDownloadTypes = uniq([...downloadTypes, downloadType]);
+                } else {
+                  newDownloadTypes = downloadTypes.filter(
+                    (id) => id !== downloadType,
+                  );
+                }
+                onChangeDownloadTypes(newDownloadTypes);
+              }}
+            />
+          );
+        })}
+      </OakFlex>
     </OakFlex>
   );
 }

--- a/src/components/CurriculumComponents/CurriculumDownloadView/SignedInFlow.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/SignedInFlow.tsx
@@ -34,7 +34,9 @@ type SignedInFlowProps = CurriculumDownloadViewProps & {
 };
 export default function SignedInFlow({ onSubmit, schools }: SignedInFlowProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [downloadType, setDownloadType] = useState(DOWNLOAD_TYPES[0]!.id);
+  const [downloadTypes, setDownloadTypes] = useState(() =>
+    DOWNLOAD_TYPES.map(({ id }) => id),
+  );
 
   const onDownload = async () => {
     try {
@@ -49,7 +51,7 @@ export default function SignedInFlow({ onSubmit, schools }: SignedInFlowProps) {
             undefined,
           schoolName: hubspotContact.schoolName ?? undefined,
           email: hubspotContact?.email,
-          downloadType: downloadType,
+          downloadTypes: downloadTypes,
           termsAndConditions: true,
           schoolNotListed: !hubspotContact.schoolId,
         });
@@ -69,8 +71,8 @@ export default function SignedInFlow({ onSubmit, schools }: SignedInFlowProps) {
     >
       <Box $width={["100%", 510]} $textAlign={"left"}>
         <CurriculumResourcesSelector
-          downloadType={downloadType}
-          onChangeDownloadType={setDownloadType}
+          downloadTypes={downloadTypes}
+          onChangeDownloadTypes={setDownloadTypes}
         />
         <OakBox $mt="space-between-m">
           <Terms />
@@ -79,6 +81,7 @@ export default function SignedInFlow({ onSubmit, schools }: SignedInFlowProps) {
       <OakPrimaryButton
         data-testid="download"
         isLoading={isSubmitting}
+        disabled={downloadTypes.length < 1}
         onClick={onDownload}
         iconName="download"
         isTrailingIcon={true}

--- a/src/components/CurriculumComponents/CurriculumDownloadView/SignedOutFlow.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/SignedOutFlow.tsx
@@ -34,7 +34,7 @@ export type CurriculumDownloadViewData = {
   schoolId?: string;
   schoolName?: string;
   email?: string;
-  downloadType: DownloadType;
+  downloadTypes: DownloadType[];
   termsAndConditions?: boolean;
   schoolNotListed?: boolean;
 };
@@ -52,8 +52,8 @@ type SignedOutFlowProps = {
   schools: School[];
   onChange?: (value: CurriculumDownloadViewData) => void;
   onSubmit?: (value: CurriculumDownloadViewData) => void;
-  downloadType: DownloadType;
-  onChangeDownloadType: (newDownloadType: DownloadType) => void;
+  downloadTypes: DownloadType[];
+  onChangeDownloadTypes: (newDownloadType: DownloadType[]) => void;
 };
 export default function SignedOutFlow({
   schools,
@@ -61,8 +61,8 @@ export default function SignedOutFlow({
   onChange,
   onSubmit,
   isSubmitting,
-  downloadType,
-  onChangeDownloadType,
+  downloadTypes,
+  onChangeDownloadTypes,
 }: SignedOutFlowProps) {
   const errorMessageListId = useId();
   const [errors, setErrors] = useState<CurriculumDownloadViewErrors>({});
@@ -84,7 +84,7 @@ export default function SignedOutFlow({
       if (newSubmitValidatioResults.success) {
         onSubmit({
           ...data,
-          downloadType,
+          downloadTypes,
         });
       }
     }
@@ -104,8 +104,8 @@ export default function SignedOutFlow({
     >
       <Box $width={["100%", 510]} $textAlign={"left"}>
         <CurriculumResourcesSelector
-          downloadType={downloadType}
-          onChangeDownloadType={onChangeDownloadType}
+          downloadTypes={downloadTypes}
+          onChangeDownloadTypes={onChangeDownloadTypes}
         />
       </Box>
 
@@ -179,7 +179,7 @@ export default function SignedOutFlow({
                   aria-errormessage={errorMessageListId}
                   isLoading={isSubmitting}
                   type="submit"
-                  disabled={false}
+                  disabled={downloadTypes.length < 1}
                   iconName="download"
                   isTrailingIcon={true}
                 >

--- a/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/index.tsx
@@ -14,7 +14,7 @@ export type CurriculumDownloadViewData = {
   schoolId?: string;
   schoolName?: string;
   email?: string;
-  downloadType: DownloadType;
+  downloadTypes: DownloadType[];
   termsAndConditions?: boolean;
   schoolNotListed?: boolean;
 };
@@ -28,7 +28,9 @@ export type CurriculumDownloadViewProps = {
   onBackToKs4Options?: () => void;
 };
 const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = (props) => {
-  const [downloadType, setDownloadType] = useState(DOWNLOAD_TYPES[0]!.id);
+  const [downloadTypes, setDownloadTypes] = useState(() =>
+    DOWNLOAD_TYPES.map(({ id }) => id),
+  );
   const user = useUser();
 
   return (
@@ -59,8 +61,8 @@ const CurriculumDownloadView: FC<CurriculumDownloadViewProps> = (props) => {
               {!user.isSignedIn && (
                 <SignedOutFlow
                   {...props}
-                  onChangeDownloadType={setDownloadType}
-                  downloadType={downloadType}
+                  onChangeDownloadTypes={setDownloadTypes}
+                  downloadTypes={downloadTypes}
                 />
               )}
               {user.isSignedIn && <SignedInFlow {...props} user={user} />}

--- a/src/components/TeacherComponents/CurriculumDownloadBanner/useCurriculumDownloads.tsx
+++ b/src/components/TeacherComponents/CurriculumDownloadBanner/useCurriculumDownloads.tsx
@@ -41,7 +41,7 @@ const useCurriculumDownloads = (props: useCurriculumDownloadsProps) => {
     schoolId: undefined,
     schoolName: undefined,
     email: undefined,
-    downloadType: "curriculum-plans",
+    downloadTypes: ["curriculum-plans"],
     termsAndConditions: false,
     schoolNotListed: false,
     schools: [],
@@ -59,7 +59,7 @@ const useCurriculumDownloads = (props: useCurriculumDownloadsProps) => {
         schoolId: localStorageData.schoolId,
         schoolName: localStorageData.schoolName,
         email: localStorageData.email,
-        downloadType: "curriculum-plans",
+        downloadTypes: ["curriculum-plans"],
         termsAndConditions: localStorageData.termsAndConditions,
         schoolNotListed: localStorageData.schoolNotListed,
         schools: [],
@@ -70,7 +70,7 @@ const useCurriculumDownloads = (props: useCurriculumDownloadsProps) => {
   const onSubmit = async () => {
     setIsSubmitting(true);
     const downloadPath = createCurriculumDownloadsUrl(
-      data.downloadType,
+      data.downloadTypes[0]!,
       "published",
       mvRefreshTime,
       subjectSlug,


### PR DESCRIPTION
## Description
Allow download of multiple files from curric downloads

## Issue(s)
Fixes `CUR-618`

## How to test

1. Go to https://oak-web-application-website-c1tt0rap4.vercel-preview.thenational.academy/teachers/curriculum/english-primary/downloads
2. Select files
3. Click download

This PR downloads multiple files rather than a `.zip`. I think this is supported by all browsers, but we'd need to double check during QA. Also check with @HelenHarlow on her return this is desired behaviour

## Screenshots
<img width="843" height="766" alt="Screenshot 2025-08-04 at 11 34 01" src="https://github.com/user-attachments/assets/88ae3c1c-c39f-4365-915d-9371eddd2e34" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
