### PR TITLE
Add in unit optionality to NC downloads

### DIFF
--- a/src/pages-helpers/curriculum/xlsx/index.ts
+++ b/src/pages-helpers/curriculum/xlsx/index.ts
@@ -267,6 +267,128 @@ function buildNatCurric<T extends Record<string, string>>(
   cellStyleIndexMap: T,
   data: BuildNationalCurriculumData,
 ) {
+  const unitXml: string[] = [];
+  const linkXml: string[] = [];
+  const goToUnitResourcesXml: string[] = [];
+  for (const [unitIndex, unit] of data.unitData.entries()) {
+    linkXml.push(safeXml`
+      <hyperlink
+        ref="${cartesianToExcelCoords([linkXml.length + 2, 3])}"
+        r:id="rId${1000 + linkXml.length}"
+      />
+    `);
+    goToUnitResourcesXml.push(safeXml`
+      <c
+        r="${cartesianToExcelCoords([goToUnitResourcesXml.length + 2, 3])}"
+        t="inlineStr"
+        s="${cellStyleIndexMap.temp3!}"
+      >
+        <is>
+          <r>
+            <rPr>
+              <sz val="12" />
+              <color rgb="FF000000" />
+              <rFont val="Arial" />
+              <family val="2" />
+              <u val="single" />
+            </rPr>
+            <t>Go to unit resources</t>
+          </r>
+        </is>
+      </c>
+    `);
+    unitXml.push(safeXml`
+      <c
+        r="${cartesianToExcelCoords([unitXml.length + 2, 2])}"
+        t="inlineStr"
+        s="${cellStyleIndexMap.temp3!}"
+      >
+        <is>
+          <r>
+            <rPr>
+              <sz val="14" />
+              <color rgb="FF000000" />
+              <rFont val="Arial" />
+              <family val="2" />
+            </rPr>
+            <t xml:space="preserve">${cdata(`\nUnit ${unitIndex + 1}\n`)}</t>
+          </r>
+          <r>
+            <rPr>
+              <sz val="14" />
+              <color rgb="FF000000" />
+              <rFont val="Arial Bold" />
+              <family val="2" />
+            </rPr>
+            <t xml:space="preserve">${cdata(`${unit.unit.title}\n`)}</t>
+          </r>
+        </is>
+      </c>
+    `);
+
+    for (const [
+      unitOptionIndex,
+      unitOption,
+    ] of unit.unit.unit_options.entries()) {
+      linkXml.push(safeXml`
+        <hyperlink
+          ref="${cartesianToExcelCoords([linkXml.length + 2, 3])}"
+          r:id="rId${1000 + linkXml.length}"
+        />
+      `);
+      goToUnitResourcesXml.push(safeXml`
+        <c
+          r="${cartesianToExcelCoords([goToUnitResourcesXml.length + 2, 3])}"
+          t="inlineStr"
+          s="${cellStyleIndexMap.temp3!}"
+        >
+          <is>
+            <r>
+              <rPr>
+                <sz val="12" />
+                <color rgb="FF000000" />
+                <rFont val="Arial" />
+                <family val="2" />
+                <u val="single" />
+              </rPr>
+              <t>Go to unit resources</t>
+            </r>
+          </is>
+        </c>
+      `);
+      unitXml.push(safeXml`
+        <c
+          r="${cartesianToExcelCoords([unitXml.length + 2, 2])}"
+          t="inlineStr"
+          s="${cellStyleIndexMap.temp3!}"
+        >
+          <is>
+            <r>
+              <rPr>
+                <sz val="14" />
+                <color rgb="FF000000" />
+                <rFont val="Arial" />
+                <family val="2" />
+              </rPr>
+              <t xml:space="preserve">${cdata(
+                  `\nOption ${unitOptionIndex + 1}\n`,
+                )}</t>
+            </r>
+            <r>
+              <rPr>
+                <sz val="14" />
+                <color rgb="FF000000" />
+                <rFont val="Arial Bold" />
+                <family val="2" />
+              </rPr>
+              <t xml:space="preserve">${cdata(`${unitOption.title}\n`)}</t>
+            </r>
+          </is>
+        </c>
+      `);
+    }
+  }
+
   return safeXml`
     <worksheet
       xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -306,7 +428,7 @@ function buildNatCurric<T extends Record<string, string>>(
         />
         <col
           min="2"
-          max="${data.unitData.length + 1}"
+          max="${unitXml.length + 1}"
           width="${pxToColumnWidth(185, 7)}"
           customWidth="1"
         />
@@ -331,29 +453,7 @@ function buildNatCurric<T extends Record<string, string>>(
                 )}</t>
             </is>
           </c>
-          ${data.unitData.map((unit, unitIndex) => {
-            return safeXml`
-              <c
-                r="${cartesianToExcelCoords([unitIndex + 2, 2])}"
-                t="inlineStr"
-                s="${cellStyleIndexMap.temp3!}"
-              >
-                <is>
-                  <r>
-                    <rPr>
-                      <sz val="14" />
-                      <color rgb="FF000000" />
-                      <rFont val="Arial Bold" />
-                      <family val="2" />
-                    </rPr>
-                    <t xml:space="preserve">${cdata(
-                        `\nUnit ${unitIndex + 1}\n${unit.unit.title}\n`,
-                      )}</t>
-                  </r>
-                </is>
-              </c>
-            `;
-          })}
+          ${unitXml}
         </row>
         <row r="3" spans="1:26">
           <c r="A3" t="inlineStr" s="${cellStyleIndexMap.temp2!}">
@@ -361,28 +461,7 @@ function buildNatCurric<T extends Record<string, string>>(
               <t />
             </is>
           </c>
-          ${data.unitData.map((_unit, unitIndex) => {
-            return safeXml`
-              <c
-                r="${cartesianToExcelCoords([unitIndex + 2, 3])}"
-                t="inlineStr"
-                s="${cellStyleIndexMap.temp3!}"
-              >
-                <is>
-                  <r>
-                    <rPr>
-                      <sz val="12" />
-                      <color rgb="FF000000" />
-                      <rFont val="Arial" />
-                      <family val="2" />
-                      <u val="single" />
-                    </rPr>
-                    <t>Go to unit resources</t>
-                  </r>
-                </is>
-              </c>
-            `;
-          })}
+          ${goToUnitResourcesXml}
         </row>
         ${[...data.nationalCurric.entries()].map(
           ([id, nationalCurricText], nationalCurricTextIndex) => {
@@ -424,16 +503,7 @@ function buildNatCurric<T extends Record<string, string>>(
           },
         )}
       </sheetData>
-      <hyperlinks>
-        ${data.unitData.map((unit, unitIndex) => {
-          return safeXml`
-            <hyperlink
-              ref="${cartesianToExcelCoords([unitIndex + 2, 3])}"
-              r:id="rId${1000 + unitIndex}"
-            />
-          `;
-        })}
-      </hyperlinks>
+      <hyperlinks>${linkXml}</hyperlinks>
       <pageMargins
         left="0.7"
         right="0.7"
@@ -462,6 +532,32 @@ async function buildNationalCurriculum(
   zip.writeString("xl/styles.xml", styleXml);
 
   data.forEach((item, index) => {
+    const linksXml = [];
+    for (const unit of item.unitData) {
+      linksXml.push(safeXml`
+        <Relationship
+          Id="rId${1000 + linksXml.length}"
+          Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+          Target="https://www.thenational.academy/teachers/curriculum/${unit
+            .unit.subject_slug}-${unit.unit.phase_slug}/units/${unit.unit.slug}"
+          TargetMode="External"
+        />
+      `);
+
+      for (const unitOption of unit.unit.unit_options) {
+        linksXml.push(safeXml`
+          <Relationship
+            Id="rId${1000 + linksXml.length}"
+            Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+            Target="https://www.thenational.academy/teachers/curriculum/${unit
+              .unit.subject_slug}-${unit.unit
+              .phase_slug}/units/${unitOption.slug!}"
+            TargetMode="External"
+          />
+        `);
+      }
+    }
+
     zip.writeString(
       `xl/worksheets/_rels/sheet${10 + index}.xml.rels`,
       safeXml`
@@ -469,18 +565,7 @@ async function buildNationalCurriculum(
         <Relationships
           xmlns="http://schemas.openxmlformats.org/package/2006/relationships"
         >
-          ${item.unitData.map((unit, unitIndex) => {
-            return safeXml`
-              <Relationship
-                Id="rId${1000 + unitIndex}"
-                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
-                Target="https://www.thenational.academy/teachers/curriculum/${unit
-                  .unit.subject_slug}-${unit.unit.phase_slug}/units/${unit.unit
-                  .slug}"
-                TargetMode="External"
-              />
-            `;
-          })}
+          ${linksXml}
         </Relationships>
       `.trim(),
     );

--- a/src/pages-helpers/curriculum/xlsx/index.ts
+++ b/src/pages-helpers/curriculum/xlsx/index.ts
@@ -466,8 +466,43 @@ function buildNatCurric<T extends Record<string, string>>(
         ${[...data.nationalCurric.entries()].map(
           ([id, nationalCurricText], nationalCurricTextIndex) => {
             const yPos = 4 + nationalCurricTextIndex;
+            const tickXml: string[] = [];
+
+            for (const unit of data.unitData) {
+              const hasNcCriteria = unit.nationalCurricIds.includes(id);
+              tickXml.push(safeXml`
+                <c
+                  r="${cartesianToExcelCoords([tickXml.length + 2, yPos])}"
+                  t="inlineStr"
+                  s="${hasNcCriteria
+                    ? cellStyleIndexMap.temp5!
+                    : cellStyleIndexMap.temp0!}"
+                >
+                  <is>
+                    <t>${cdata(hasNcCriteria ? "✓" : "")}</t>
+                  </is>
+                </c>
+              `);
+
+              unit.unit.unit_options.forEach(() => {
+                tickXml.push(safeXml`
+                  <c
+                    r="${cartesianToExcelCoords([tickXml.length + 2, yPos])}"
+                    t="inlineStr"
+                    s="${hasNcCriteria
+                      ? cellStyleIndexMap.temp5!
+                      : cellStyleIndexMap.temp0!}"
+                  >
+                    <is>
+                      <t>${cdata(hasNcCriteria ? "✓" : "")}</t>
+                    </is>
+                  </c>
+                `);
+              });
+            }
+
             return safeXml`
-              <row r="${yPos}" spans="1:${data.unitData.length + 1}">
+              <row r="${yPos}" spans="1:${unitXml.length + 2}">
                 <c
                   r="${cartesianToExcelCoords([1, yPos])}"
                   t="inlineStr"
@@ -479,25 +514,7 @@ function buildNatCurric<T extends Record<string, string>>(
                       )}</t>
                   </is>
                 </c>
-                ${data.unitData.map((unit, unitIndex) => {
-                  return safeXml`
-                    <c
-                      r="${cartesianToExcelCoords([unitIndex + 2, yPos])}"
-                      t="inlineStr"
-                      s="${unit.nationalCurricIds.includes(id)
-                        ? cellStyleIndexMap.temp5!
-                        : cellStyleIndexMap.temp0!}"
-                    >
-                      <is>
-                        <t>
-                          ${cdata(
-                            unit.nationalCurricIds.includes(id) ? "✓" : "",
-                          )}
-                        </t>
-                      </is>
-                    </c>
-                  `;
-                })}
+                ${tickXml}
               </row>
             `;
           },


### PR DESCRIPTION
## Description
Add in unit optionality to NC downloads

## Issue(s)
Fixes `CUR-1505`

## How to test

1. Go to https://oak-web-application-website-3ob63i4uh.vercel-preview.thenational.academy/teachers/curriculum
2. Navigate to NC downloads
3. Verify unit optionality is correct as-per ticket
4. Verify no regressions in NC spreadsheet

## Screenshots
<img width="1400" height="736" alt="Screenshot 2025-08-04 at 14 06 59" src="https://github.com/user-attachments/assets/c25ff8e4-0b12-4f11-b043-74a6054b4369" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
