### PR TITLE
fix  setting authentication headers in lesson download requests

### DIFF
--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.test.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.test.tsx
@@ -168,6 +168,18 @@ describe("createLessonDownloadLink()", () => {
     );
   });
 
+  it("should not throw an error if authRequired & no auth token provided", async () => {
+    expect(async () => {
+      await createLessonDownloadLink({
+        lessonSlug: "lesson-slug",
+        selection: "exit-quiz-answers,worksheet-pdf",
+        isLegacyDownload: true,
+        authToken: null,
+        authRequired: true,
+      });
+    }).not.toThrow();
+  });
+
   it("should fetch with X-Should-Authenticate-Download set to false when authFlagEnabled is false", async () => {
     await createLessonDownloadLink({
       lessonSlug: "lesson-slug",
@@ -236,13 +248,13 @@ describe("createUnitDownloadLink()", () => {
       });
     }).rejects.toThrow();
   });
-  it("should throw an error if authFlagEnabled is true and getToken returns null", async () => {
-    await expect(async () => {
+  it("should not throw an error if authFlagEnabled is true and getToken returns null", async () => {
+    expect(async () => {
       await createUnitDownloadLink({
         unitFileId: "unitvariant-123",
         authRequired: true,
         getToken: jest.fn().mockResolvedValue(null),
       });
-    }).rejects.toThrow();
+    }).not.toThrow();
   });
 });

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink.tsx
@@ -40,12 +40,6 @@ const getDownloadLink = async ({
   authRequired?: boolean;
   authToken?: string | null;
 }) => {
-  if (authRequired && !authToken) {
-    throw new OakError({
-      code: "downloads/missing-auth-token",
-      meta,
-    });
-  }
   const authHeader = authToken
     ? { Authorization: `Bearer ${authToken}` }
     : undefined;

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.test.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.test.ts
@@ -57,7 +57,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -74,7 +73,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -99,7 +97,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -124,7 +121,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -141,7 +137,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -155,7 +150,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -179,7 +173,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: true,
       }),
     );
     result.current.onSubmit(data, "lesson");
@@ -214,7 +207,6 @@ describe("useResourceFormSubmit", () => {
       useResourceFormSubmit({
         isLegacyDownload: true,
         type: "download",
-        authRequired: false,
       }),
     );
     result.current.onSubmit(dataWithAdditionalFiles, "lesson");

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormSubmit.ts
@@ -11,10 +11,7 @@ import downloadLessonResources from "@/components/SharedComponents/helpers/downl
 
 type UseResourceFormProps = {
   onSubmit?: () => void;
-} & (
-  | { type: "share" }
-  | { type: "download"; isLegacyDownload: boolean; authRequired: boolean }
-);
+} & ({ type: "share" } | { type: "download"; isLegacyDownload: boolean });
 
 const useResourceFormSubmit = (props: UseResourceFormProps) => {
   const {
@@ -76,13 +73,13 @@ const useResourceFormSubmit = (props: UseResourceFormProps) => {
             .filter((d) => additionalFilesRegex.test(d))
             .map((d) => parseInt(d.split("additional-files-")?.[1] ?? ""))
         : [];
-      const authRequired = authFlagEnabled && props.authRequired;
+
       await downloadLessonResources({
         lessonSlug: slug,
         selectedResourceTypes: selectedResourceTypes as DownloadResourceType[],
         selectedAdditionalFilesIds,
         isLegacyDownload: props.isLegacyDownload,
-        authRequired,
+        authRequired: authFlagEnabled,
         authToken: accessToken,
       });
     }

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -226,7 +226,6 @@ export function LessonDownloads(props: LessonDownloadsProps) {
   const { onSubmit } = useResourceFormSubmit({
     type: "download",
     isLegacyDownload,
-    authRequired: downloadsRestricted,
   });
 
   const { onHubspotSubmit } = useHubspotSubmit();


### PR DESCRIPTION
## Description

Previously authentication headers for lesson downloads were tied to the copyrights hook, which does feature flag checks and authentication itself. Since the authentication is supposed to happen server-side this doesn't make sense.

This fix simply uses the feature flag to set the should authenticate header.

## Issue(s)

Fixes [LESQ-1549](https://www.notion.so/oaknationalacademy/Lesson-downloads-don-t-require-auth-for-restricted-content-24526cc4e1b1801d9ed2c25bf12b788f)

## How to test

1. Go to [https://oak-web-application-website-18clupdh7.vercel-preview.thenational.academy](https://oak-web-application-website-git-fix-lesq-1549lesson-down-180e3e.vercel-preview.thenational.academy/)
2. While signed in, onboarded, region authorised and with the feature flag on...
3. Go to the downloads page of a restricted lesson, i.e: [Yoshi the stonecutter](https://oak-web-application-website-git-fix-lesq-1549lesson-down-180e3e.vercel-preview.thenational.academy/teachers/programmes/english-primary-ks1/units/yoshi-the-stonecutter-reading/lessons/building-comprehension-of-yoshi-the-stonecutter/downloads?preselected=all)
4. Click download
5. You should see the should-authenticate header of the request set to true in the network tab

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
