### PR TITLE
`curric` -> `adopt` in github action auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,7 @@
 # Configuration for the GitHub Actions labeler
 # This file defines rules for automatically labeling PRs based on branch names
 
-# Label PRs from branches matching CUR-* patterns with "curric squad group"
-"curric squad group":
-  - head-branch: ['^[^/]+[/]CUR-.+', '^CUR-.+']  # Matches any prefix/CUR- or direct CUR- patterns 
+# Label PRs from branches matching patterns with "adopt squad group"
+# Matches any `prefix/ADOPT-`, `ADOPT-`, `prefix/CUR-` or `CUR-` patterns
+"adopt squad group":
+  - head-branch: ['^[^/]+[/]CUR-.+', '^CUR-.+', '^[^/]+[/]ADOPT-.+', '^ADOPT-.+']


### PR DESCRIPTION
## Description
Changed the github labels from `curric` to `adopt` in github action auto-labeler

## Issue(s)
none

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
