### PR TITLE
Unique filenames for zipped downloads on NC documents

### DIFF
--- a/src/pages/api/curriculum-downloads/index.ts
+++ b/src/pages/api/curriculum-downloads/index.ts
@@ -17,6 +17,7 @@ import curriculumApi2023, {
 import { logErrorMessage } from "@/utils/curriculum/testing";
 import { Ks4Option } from "@/node-lib/curriculum-api-2023/queries/curriculumPhaseOptions/curriculumPhaseOptions.schema";
 import { CombinedCurriculumData } from "@/utils/curriculum/types";
+import { generateHash } from "@/pages-helpers/curriculum/docx/docx";
 
 const stale_while_revalidate_seconds = 60 * 3;
 const s_maxage_seconds = 60 * 60 * 24;
@@ -359,7 +360,11 @@ export default async function handler(
         examboardTitle: data.combinedCurriculumData?.examboardTitle,
         childSubjectSlug,
         tierSlug,
-        prefix: "Documents",
+        prefix: "Curriculum downloads",
+        suffix: generateHash([...types, actualMvRefreshTime].join("|")).slice(
+          0,
+          8,
+        ),
       });
     } else if (files.length === 1 && files[0]) {
       outputBuffer = files[0].buffer;

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -1201,4 +1201,31 @@ describe("getFilename", () => {
       );
     });
   });
+
+  describe("Combined zip files", () => {
+    it("without suffix", () => {
+      const result = getFilename("zip", {
+        subjectTitle: "Mathematics",
+        phaseTitle: "Secondary",
+        tierSlug: "higher",
+        prefix: "Curriculum documents",
+      });
+      expect(result).toBe(
+        "Curriculum documents - Mathematics - Secondary - Higher - 10-06-2025.zip",
+      );
+    });
+
+    it("with suffix", () => {
+      const result = getFilename("zip", {
+        subjectTitle: "Mathematics",
+        phaseTitle: "Secondary",
+        tierSlug: "higher",
+        prefix: "Curriculum documents",
+        suffix: "00000000",
+      });
+      expect(result).toBe(
+        "Curriculum documents - Mathematics - Secondary - Higher - 10-06-2025 - 00000000.zip",
+      );
+    });
+  });
 });

--- a/src/utils/curriculum/formatting.ts
+++ b/src/utils/curriculum/formatting.ts
@@ -403,6 +403,7 @@ export function getFilename(
     childSubjectSlug,
     tierSlug,
     prefix,
+    suffix,
   }: {
     subjectTitle: string;
     phaseTitle: string;
@@ -410,6 +411,7 @@ export function getFilename(
     childSubjectSlug?: string;
     tierSlug?: string;
     prefix: string;
+    suffix?: string;
   },
 ) {
   // Handle child subject formatting based on file type
@@ -446,6 +448,7 @@ export function getFilename(
       // Note: dashes "-" rather than ":" because colon is invalid on windows
       "dd-MM-yyyy",
     ),
+    suffix,
   ]
     .filter(Boolean)
     .join(" - ");


### PR DESCRIPTION
## Description
Unique filenames for zipped downloads on NC documents

## Issue(s)
Fixes `ADOPT-1564`

## How to test

1. Go to https://oak-web-application-website-git-feat-adopt-1564-unique-f-5c2d36.vercel-preview.thenational.academy/teachers/curriculum
2. Navigate to NC alignment document downloads
3. Verify that the filename is suffixed with hash of contents

Note I'll add some e2e tests for xlsx soon, so the filename generation tests are all that's currently required. 

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
