### PR TITLE
NC document fix swimming all-years unit ordering

### DIFF
--- a/src/pages-helpers/curriculum/xlsx/helper.test.ts
+++ b/src/pages-helpers/curriculum/xlsx/helper.test.ts
@@ -29,10 +29,30 @@ describe("getFlatUnits", () => {
     const subcat1 = createSubjectCategory({ id: 1, slug: "subcat1" });
     const subcat2 = createSubjectCategory({ id: 2, slug: "subcat1" });
     const units = [
-      createUnit({ slug: "one", subjectcategories: [subcat1], actions }),
-      createUnit({ slug: "two", subjectcategories: [subcat2], actions }),
-      createUnit({ slug: "three", subjectcategories: [subcat1], actions }),
-      createUnit({ slug: "four", subjectcategories: [subcat2], actions }),
+      createUnit({
+        slug: "one",
+        order: 1,
+        subjectcategories: [subcat1],
+        actions,
+      }),
+      createUnit({
+        slug: "two",
+        order: 5,
+        subjectcategories: [subcat2],
+        actions,
+      }),
+      createUnit({
+        slug: "three",
+        order: 7,
+        subjectcategories: [subcat1],
+        actions,
+      }),
+      createUnit({
+        slug: "four",
+        order: 9,
+        subjectcategories: [subcat2],
+        actions,
+      }),
     ];
     const flatUnits = getFlatUnits(units);
     expect(flatUnits).toEqual([
@@ -56,19 +76,19 @@ describe("getFlatUnits", () => {
       }),
       createUnit({
         slug: "two",
-        order: 2,
+        order: 5,
         subjectcategories: [subcat2],
         actions,
       }),
       createUnit({
         slug: "three",
-        order: 3,
+        order: 7,
         subjectcategories: [subcat1],
         actions,
       }),
       createUnit({
         slug: "four",
-        order: 4,
+        order: 9,
         subjectcategories: [subcat2],
         actions,
       }),

--- a/src/pages-helpers/curriculum/xlsx/helper.ts
+++ b/src/pages-helpers/curriculum/xlsx/helper.ts
@@ -56,9 +56,10 @@ export function getFlatUnits(units: Unit[]): GetFlatUnitsOutput {
     );
     return flatUnits;
   } else {
-    return units.map((unit) => {
+    return units.map((unit, unitIndex) => {
       return {
         ...unit,
+        order: unitIndex + 1,
       };
     });
   }


### PR DESCRIPTION
## Description
NC alignment document fixes for swimming all-years unit ordering

## Issue(s)
Fixes `ADOPT-1550`

## How to test

1. Go to https://oak-web-application-website-git-fix-adopt-1550-swimming-f0405d.vercel-preview.thenational.academy/teachers/curriculum
2. Go to the physical-education primacy sequence and verify unit numbering is now correct
3. Verify the unit numbering in other sequences is still correct

## Screenshots
Functioning correctly in physical-education primary all-years
<img width="1322" height="738" alt="Screenshot 2025-08-07 at 15 39 14" src="https://github.com/user-attachments/assets/4251d8a0-7eda-45a7-8672-4bd1c71c29d6" />

Functioning correctly for subject category grouped units
<img width="1322" height="738" alt="Screenshot 2025-08-07 at 15 39 10" src="https://github.com/user-attachments/assets/e56f0275-1e79-4f31-9a3c-5fd9e5bfc72a" />

Functioning correctly for regular non-grouped units
<img width="1322" height="738" alt="Screenshot 2025-08-07 at 15 42 48" src="https://github.com/user-attachments/assets/d2540509-bbbb-46cf-9188-5cd78d3a4b7b" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
