### PR TITLE
[ENG-1301] Add missing NEXT_PUBLIC_CLIENT_APP_BASE_URL to prod

### DIFF
--- a/infrastructure/project/locals.tf
+++ b/infrastructure/project/locals.tf
@@ -6,9 +6,9 @@ locals {
       preview = ["OAK_CONFIG_LOCATION"]
     }
     storybook = {
-      shared  = []
+      shared  = ["NEXT_PUBLIC_CLIENT_APP_BASE_URL"]
       prod    = ["OAK_CONFIG_LOCATION"]
-      preview = ["OAK_CONFIG_LOCATION", "NEXT_PUBLIC_CLIENT_APP_BASE_URL"]
+      preview = ["OAK_CONFIG_LOCATION"]
     }
   }
 

--- a/infrastructure/project/variables.tf
+++ b/infrastructure/project/variables.tf
@@ -29,16 +29,16 @@ variable "sensitive_custom_env_vars" {
 variable "env_vars" {
   type = object({
     shared = optional(object({
-      NEXT_PUBLIC_CLERK_SIGN_IN_URL = optional(string)
-      NEXT_PUBLIC_CLERK_SIGN_UP_URL = optional(string)
+      NEXT_PUBLIC_CLERK_SIGN_IN_URL   = optional(string)
+      NEXT_PUBLIC_CLERK_SIGN_UP_URL   = optional(string)
+      NEXT_PUBLIC_CLIENT_APP_BASE_URL = optional(string)
     }))
     prod = optional(object({
       OAK_CONFIG_LOCATION = optional(string)
       OVERRIDE_URL        = optional(string)
     }))
     preview = optional(object({
-      OAK_CONFIG_LOCATION             = optional(string)
-      NEXT_PUBLIC_CLIENT_APP_BASE_URL = optional(string)
+      OAK_CONFIG_LOCATION = optional(string)
     }))
   })
   validation {


### PR DESCRIPTION


## Description

 - In `Owa-storybook`, `NEXT_PUBLIC_CLIENT_APP_BASE_URL` environment variable was only available in preview, causing sitemap generation to fail in production builds. Added the env_var to production env

## Issue(s)

[ENG-1244 ](https://www.notion.so/oaknationalacademy/Better-sensitive-variable-handling-in-Vercel-projects-21826cc4e1b1804897f6ea2237d0fab0)

## How to test

1. Check that owa-storybook production branches are building successfully on vercel

## Checklist

- [ ] terraform apply