### PR TITLE
Takedown of legacy curriculum downloads from the curriculum UI

### DIFF
--- a/src/pages/teachers/curriculum/previous-downloads.tsx
+++ b/src/pages/teachers/curriculum/previous-downloads.tsx
@@ -29,12 +29,43 @@ import CurriculumDownloads, {
 import DropdownSelect from "@/components/GenericPagesComponents/DropdownSelect";
 import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 
+type Document = ReturnType<
+  typeof curriculumPreviousDownloadsFixture
+>["documents"][0];
+
+function excludeBySlug(
+  data: { documents: Document[] },
+  excludeSlugs: string[],
+) {
+  return {
+    documents: data.documents.filter((document) => {
+      return !excludeSlugs.includes(document.slug);
+    }),
+  };
+}
+
 const CurriculumPreviousDownloadsPage: NextPage = () => {
   const router = useRouter();
-  const data = curriculumPreviousDownloadsFixture();
+  const data = excludeBySlug(curriculumPreviousDownloadsFixture(), [
+    "early-years-foundation-stage-maths",
+    "key-stage-1-english",
+    "key-stage-1-history",
+    "key-stage-1-maths",
+    "key-stage-1-science",
+    "key-stage-2-english",
+    "key-stage-2-history",
+    "key-stage-2-maths",
+    "key-stage-2-science",
+    "key-stage-3-english",
+    "key-stage-3-history",
+    "key-stage-3-maths",
+    "key-stage-3-science",
+    "key-stage-4-english",
+    "key-stage-4-history",
+    "key-stage-4-maths",
+  ]);
   const [activeTab, setActiveTab] = useState<DownloadCategory>("EYFS");
   const downloadsRef = useRef<CurriculumDownloadsRef>(null);
-  type Document = (typeof data)["documents"][0];
 
   const categoryDocuments = useMemo(() => {
     const documents: { [key in DownloadCategory]?: Document[] } = {};

--- a/src/pages/teachers/curriculum/previous-downloads.tsx
+++ b/src/pages/teachers/curriculum/previous-downloads.tsx
@@ -28,6 +28,7 @@ import CurriculumDownloads, {
 } from "@/components/CurriculumComponents/CurriculumDownloads/CurriculumDownloads";
 import DropdownSelect from "@/components/GenericPagesComponents/DropdownSelect";
 import getBrowserConfig from "@/browser-lib/getBrowserConfig";
+import { PREVIOUS_DOWNLOAD_EXCLUSIONS } from "@/utils/curriculum/constants";
 
 type Document = ReturnType<
   typeof curriculumPreviousDownloadsFixture
@@ -46,24 +47,10 @@ function excludeBySlug(
 
 const CurriculumPreviousDownloadsPage: NextPage = () => {
   const router = useRouter();
-  const data = excludeBySlug(curriculumPreviousDownloadsFixture(), [
-    "early-years-foundation-stage-maths",
-    "key-stage-1-english",
-    "key-stage-1-history",
-    "key-stage-1-maths",
-    "key-stage-1-science",
-    "key-stage-2-english",
-    "key-stage-2-history",
-    "key-stage-2-maths",
-    "key-stage-2-science",
-    "key-stage-3-english",
-    "key-stage-3-history",
-    "key-stage-3-maths",
-    "key-stage-3-science",
-    "key-stage-4-english",
-    "key-stage-4-history",
-    "key-stage-4-maths",
-  ]);
+  const data = excludeBySlug(
+    curriculumPreviousDownloadsFixture(),
+    PREVIOUS_DOWNLOAD_EXCLUSIONS,
+  );
   const [activeTab, setActiveTab] = useState<DownloadCategory>("EYFS");
   const downloadsRef = useRef<CurriculumDownloadsRef>(null);
 

--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -3,3 +3,21 @@ export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;
 export const DISABLE_DOWNLOADS = false;
 export const ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE = true;
 export const ENABLE_PRIOR_KNOWLEDGE_REQUIREMENTS = true;
+export const PREVIOUS_DOWNLOAD_EXCLUSIONS = [
+  "early-years-foundation-stage-maths",
+  "key-stage-1-english",
+  "key-stage-1-history",
+  "key-stage-1-maths",
+  "key-stage-1-science",
+  "key-stage-2-english",
+  "key-stage-2-history",
+  "key-stage-2-maths",
+  "key-stage-2-science",
+  "key-stage-3-english",
+  "key-stage-3-history",
+  "key-stage-3-maths",
+  "key-stage-3-science",
+  "key-stage-4-english",
+  "key-stage-4-history",
+  "key-stage-4-maths",
+];


### PR DESCRIPTION
## Description
Takedown of legacy curriculum downloads from the curriculum UI. Looking at the code these were previously hard coded, so I just added an exclusion list to the frontend. 

## Issue(s)
Closes `ADOPT-1562`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/previous-downloads
2. Check that the following are no longer shown
  - English
  - Maths
  - Science
  - History

## Screenshots
#### EYFS

<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 22" src="https://github.com/user-attachments/assets/77ed40c8-9f08-4e5c-91ed-2ef5b1f4e753" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 25" src="https://github.com/user-attachments/assets/73c7fd08-f1de-4eef-a027-5c0ccb95e050" />

#### KS1
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 30" src="https://github.com/user-attachments/assets/56439396-845f-4fbb-bbab-de7291bee1f8" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 35" src="https://github.com/user-attachments/assets/d55a2f7c-5f8b-43d7-ad54-9c511ac1f39b" />

#### KS2
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 40" src="https://github.com/user-attachments/assets/27e83ff9-f9a2-4c10-9c64-e357ed8eb837" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 44" src="https://github.com/user-attachments/assets/4329d33e-a3f3-4cd5-bdc8-571a5b72bb54" />

#### KS3
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 50" src="https://github.com/user-attachments/assets/c5148181-034c-47cb-a971-f24782d181c9" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 28 56" src="https://github.com/user-attachments/assets/d30e981e-4bbd-417e-a664-9dc991df4e01" />

#### KS4
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 02" src="https://github.com/user-attachments/assets/5a617577-40b5-4ba1-abef-f2a5a423e4a7" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 06" src="https://github.com/user-attachments/assets/3673d906-1967-4a8b-81c4-56c6cfe385c1" />

#### Specialist
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 11" src="https://github.com/user-attachments/assets/6226fec2-c4bb-4a17-84f5-dd5b717a9b68" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 20" src="https://github.com/user-attachments/assets/e7a13952-49c4-43c5-a665-2689fc6d0f24" />

#### Therapies
<img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 27" src="https://github.com/user-attachments/assets/dd3118ea-20ea-4479-b873-296398857247" /> <img width="335" height="1155" alt="Screenshot 2025-08-14 at 14 29 30" src="https://github.com/user-attachments/assets/008ad898-1da0-4802-b0d8-ab40d21abc9e" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
