### PR TITLE
Refactor/update search owa link

### DIFF
--- a/src/components/TeacherComponents/SearchDropdown/SearchDropdown.tsx
+++ b/src/components/TeacherComponents/SearchDropdown/SearchDropdown.tsx
@@ -5,11 +5,22 @@ import {
   OakP,
   OakIcon,
   OakBox,
+  OakLink,
+  OakSpan,
 } from "@oaknational/oak-components";
+import styled from "styled-components";
 
 import { SearchResultsItemProps } from "@/components/TeacherComponents/SearchResultsItem";
-import OwaLink from "@/components/SharedComponents/OwaLink";
 import { PathwaySchemaCamel } from "@/context/Search/search.types";
+import { LessonOverviewLinkProps, resolveOakHref } from "@/common-lib/urls";
+
+const StyledOakLink = styled(OakLink)`
+  text-decoration: none;
+
+  :hover {
+    text-decoration: underline;
+  }
+`;
 
 const SearchDropdown: FC<
   SearchResultsItemProps & {
@@ -77,22 +88,24 @@ const SearchDropdown: FC<
                   $mb="space-between-none"
                   $textAlign="left"
                 >
-                  <OwaLink
-                    $color={"navy"}
-                    data-testid="search-dropdown-link"
-                    $font={"heading-7"}
-                    $width={"fit-content"}
-                    $focusStyles={["new-underline"]}
+                  <StyledOakLink
                     {...props.buttonLinkProps}
-                    programmeSlug={item.programmeSlug}
-                    unitSlug={item.unitSlug}
-                    onClick={(e) => {
+                    onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                       onClick?.({ ...props, isToggleOpen });
                       e.stopPropagation();
                     }}
+                    data-testid="search-dropdown-link"
+                    href={resolveOakHref({
+                      programmeSlug: item.programmeSlug,
+                      unitSlug: item.unitSlug,
+                      lessonSlug: (
+                        props.buttonLinkProps as LessonOverviewLinkProps
+                      )?.lessonSlug,
+                      page: props.buttonLinkProps.page,
+                    })}
                   >
-                    {buttonTitle}
-                  </OwaLink>
+                    <OakSpan $font="heading-7">{buttonTitle}</OakSpan>
+                  </StyledOakLink>
                 </OakLI>
               );
             })}

--- a/src/components/TeacherViews/Search/Search.view.test.tsx
+++ b/src/components/TeacherViews/Search/Search.view.test.tsx
@@ -10,6 +10,10 @@ import { SearchProps } from "./search.view.types";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { SearchHit, SearchQuery } from "@/context/Search/search.types";
 import { LEGACY_COHORT } from "@/config/cohort";
+import {
+  setupMockLinkClick,
+  teardownMockLinkClick,
+} from "@/utils/mockLinkClick";
 
 jest.mock("@mux/mux-player-react/lazy", () => {
   return forwardRef((props, ref) => {
@@ -228,6 +232,11 @@ describe("Search.page.tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouter.setCurrentUrl("/teachers/search");
+    setupMockLinkClick();
+  });
+
+  afterEach(() => {
+    teardownMockLinkClick();
   });
 
   test("status: error message displayed status is fail", () => {


### PR DESCRIPTION
## Description

Music year: 1970

- change `owaLink` in search dropdown to use `oakLink` instead


## How to test

1. Go to https://oak-web-application-website-itlpk8x88.vercel-preview.thenational.academy/teachers/search?term=macbeth
3. Search results in drop downs should be correct and match the [latest designs in figma](https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14795-19491&p=f&m=dev)
4. Keyboard nav should work the same

## Screenshots

How it used to look (delete if n/a):
<img width="700" height="387" alt="Screenshot 2025-08-18 at 08 47 35" src="https://github.com/user-attachments/assets/64822027-7de6-459f-bdb6-bf7eed204d7f" />

How it should now look:
<img width="700" height="374" alt="Screenshot 2025-08-18 at 08 47 59" src="https://github.com/user-attachments/assets/9b8137ba-c753-4175-b959-1a222914e609" />

