### PR TITLE
feat: enable NC alignment document downloads

### DIFF
--- a/src/utils/curriculum/constants.ts
+++ b/src/utils/curriculum/constants.ts
@@ -3,4 +3,4 @@ export const ENABLE_FILTERS_IN_SEARCH_PARAMS = true;
 export const DISABLE_DOWNLOADS = false;
 export const ENABLE_WTWN_BY_UNIT_DESCRIPTION_FEATURE = true;
 export const ENABLE_PRIOR_KNOWLEDGE_REQUIREMENTS = true;
-export const ENABLE_NC_XLSX_DOCUMENT = false;
+export const ENABLE_NC_XLSX_DOCUMENT = true;


### PR DESCRIPTION
## Description
Enables NC alignment document, which is currently disabled behind a constant

## Issue(s)
Closes `CUREPIC-54`

## How to test

1. Go to {owa_deployment_url}/teachers/curriculum
2. Navigate to a sequences download tab
3. Downloads the new NC alignment document and verify it works as expected.


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
