### PR TITLE
Remove pupil link from lesson seo accordion when restricted

### DIFF
--- a/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDetails/LessonOverviewDetails.tsx
@@ -149,7 +149,9 @@ const LessonOverviewDetails: FC<LessonOverviewDetailsProps> = ({
                 examBoardSlug={examBoardSlug}
                 subjectSlug={subjectSlug}
                 parentSubject={subjectParent}
-                disablePupilLink={disablePupilLink}
+                disablePupilLink={
+                  disablePupilLink || geoRestricted || loginRequired
+                }
                 lesson={lesson}
               />
             )}


### PR DESCRIPTION
## Description

- removes the pupil link from the lesson seo accordion when a lesson is georestricted or loginrequired

## Issue(s)

[Fixes LESQ-1581](https://www.notion.so/oaknationalacademy/Pupil-link-in-SEO-accordion-404s-for-copyright-lessons-25726cc4e1b180f6b342c58bc2e809f3)

## How to test

1. Go to a restricted lesson
2. Open the SEO accordion
3. The pupil link should not be there
4. Go to a normal lesson
5. The pupil link should be there

## Screenshots

How it used to look (delete if n/a):

<img width="643" height="166" alt="Screenshot 2025-08-22 at 10 30 37" src="https://github.com/user-attachments/assets/76e43fc5-4086-458d-8e63-0c3f961c5ca9" />


How it should now look:

<img width="606" height="110" alt="Screenshot 2025-08-22 at 10 31 04" src="https://github.com/user-attachments/assets/ac64abfb-78fc-464d-a507-ed6f1973fa53" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
