### PR TITLE
PUPIL-1315 fix: ensure that radio groups in quizzes are associated with question…

### DIFF
--- a/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.tsx
+++ b/src/components/PupilComponents/QuizMCQSingleAnswer/QuizMCQSingleAnswer.tsx
@@ -74,6 +74,7 @@ export const QuizMCQSingleAnswer = (props: QuizMCQSingleAnswerProps) => {
         $gap={"space-between-s"}
         onChange={onChange}
         disabled={isFeedbackMode}
+        aria-labelledby={`${questionUid}-legend`}
       >
         {answers?.map((answer, i) => {
           const label = answer.answer.find(isText);

--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.test.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.test.tsx
@@ -19,7 +19,11 @@ describe("QuestionListItem", () => {
 
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizQuestionStem questionStem={mcqText.questionStem} index={0} />
+        <QuizQuestionStem
+          questionUid={mcqText.questionUid}
+          questionStem={mcqText.questionStem}
+          index={0}
+        />
       </OakThemeProvider>,
     );
     const primaryQuestionText = getByText("What is a main clause?");
@@ -32,7 +36,11 @@ describe("QuestionListItem", () => {
 
     const { getByAltText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizQuestionStem questionStem={mcqStemImage.questionStem} index={0} />
+        <QuizQuestionStem
+          questionUid={mcqStemImage.questionUid}
+          questionStem={mcqStemImage.questionStem}
+          index={0}
+        />
       </OakThemeProvider>,
     );
     const image = getByAltText("An image in a quiz");
@@ -50,7 +58,11 @@ describe("QuestionListItem", () => {
 
     const { getByText } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <QuizQuestionStem questionStem={questionStem} index={0} />
+        <QuizQuestionStem
+          questionUid={mcqStemImage.questionUid}
+          questionStem={questionStem}
+          index={0}
+        />
       </OakThemeProvider>,
     );
     const secondaryText = getByText("This is some text");

--- a/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
+++ b/src/components/PupilComponents/QuizQuestionStem/QuizQuestionStem.tsx
@@ -22,12 +22,14 @@ export interface QuizQuestionStemProps {
   questionStem: (ImageItem | TextItem)[];
   index: number;
   takeFullHeight?: boolean;
+  questionUid: string;
 }
 
 export const QuizQuestionStem = ({
   questionStem,
   index,
   takeFullHeight,
+  questionUid,
 }: QuizQuestionStemProps) => {
   const [scaled, setScaled] = useState(false);
   const displayNumber = `Q${index + 1}.`;
@@ -57,6 +59,7 @@ export const QuizQuestionStem = ({
               key={`q-${displayNumber}-stem-element-0`}
               $font={["heading-6", "heading-4", "heading-4"]}
               $width={"100%"}
+              id={`${questionUid}-legend`}
             >
               {shortAnswerTitleFormatter(removeMarkdown(questionStem[0].text))}
             </OakBox>

--- a/src/components/PupilComponents/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/PupilComponents/QuizRenderer/QuizRenderer.tsx
@@ -126,6 +126,7 @@ export const QuizRenderer = (props: QuizRenderProps) => {
           <MathJaxWrap>
             {questionStem && (
               <QuizQuestionStem
+                questionUid={currentQuestionData.questionUid}
                 questionStem={questionStem}
                 index={currentQuestionIndex}
                 takeFullHeight={


### PR DESCRIPTION
Ensured that radio groups in quizzes are associated with question stem labels

## Description

Music year: {owa_music_year}

- Added `id` to question stems (format is questionUid-legend)
- Added `aria-labelledby` to single answer questions radio groups (should match the id on the stem)

## Issue(s)

[Notion Ticket Here](https://www.notion.so/oaknationalacademy/Associate-question-stem-with-radio-group-1d726cc4e1b1808c862ed9b1b3f94ff9?source=copy_link)

## How to test

1. Go to {owa_deployment_url}pupils/programmes/geography-primary-year-2/units/life-in-a-capital-city-london-cardiff-775/lessons/locating-london/exit-quiz
2. You should see the radio group has the `aria-labelledby` property, where the value matches the question stem `id`

## Checklist

- [ ] No visual UI changes
- [ ] Single Answer question radio group has `aria-labelledby`
- [ ] Question stem text has `id`
- [ ] `aria-labelledby` and `id` of question stems always match
- [ ] Checked Starter Quiz and Exit Quiz
- [ ] Checked variations of questions with radio button answers
- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
