### PR TITLE
Fix/share with pupils button feature flag [LESQ-1600]

### DIFF
--- a/src/components/TeacherComponents/LessonMediaAttributions/LessonMediaAttributions.test.tsx
+++ b/src/components/TeacherComponents/LessonMediaAttributions/LessonMediaAttributions.test.tsx
@@ -4,29 +4,9 @@ import { LessonMediaAttributions } from "./LessonMediaAttributions";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
-const mockFeatureFlagEnabled = jest.fn().mockReturnValue(false);
-jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => mockFeatureFlagEnabled(),
-}));
 const render = renderWithProviders();
 describe("lesson media attributions", () => {
-  it("does not render when the feature flag is disabled", () => {
-    render(
-      <LessonMediaAttributions
-        mediaClipsWithAttributions={[
-          { name: "clip 1", attribution: "provided by jest" },
-        ]}
-      />,
-    );
-
-    const attributions = screen.queryByTestId("media-attributions");
-    expect(attributions).not.toBeInTheDocument();
-
-    const clipAttribution = screen.queryByText("clip 1");
-    expect(clipAttribution).not.toBeInTheDocument();
-  });
   it("does not render when there are no media clips", () => {
-    mockFeatureFlagEnabled.mockReturnValue(true);
     render(<LessonMediaAttributions mediaClipsWithAttributions={[]} />);
     const attributions = screen.queryByTestId("media-attributions");
     expect(attributions).not.toBeInTheDocument();

--- a/src/components/TeacherComponents/LessonMediaAttributions/LessonMediaAttributions.tsx
+++ b/src/components/TeacherComponents/LessonMediaAttributions/LessonMediaAttributions.tsx
@@ -1,15 +1,11 @@
 import { OakBox, OakSpan } from "@oaknational/oak-components";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 
 export const LessonMediaAttributions = ({
   mediaClipsWithAttributions,
 }: {
   mediaClipsWithAttributions: Array<{ name: string; attribution: string }>;
 }) => {
-  const featureFlagActive = useFeatureFlagEnabled(
-    "teachers-copyright-restrictions",
-  );
-  return mediaClipsWithAttributions.length && featureFlagActive ? (
+  return mediaClipsWithAttributions.length ? (
     <OakBox $pv="inner-padding-xl2" data-testid="media-attributions">
       {mediaClipsWithAttributions.map((clip) => (
         <OakSpan

--- a/src/components/TeacherComponents/LessonOverviewHeaderShareAllButton/LessonOverViewHeaderShareAllButton.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderShareAllButton/LessonOverViewHeaderShareAllButton.test.tsx
@@ -10,11 +10,6 @@ import lessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/lesso
 import { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import { AnalyticsUseCaseValueType } from "@/browser-lib/avo/Avo";
 
-const mockFeatureFlagEnabled = jest.fn();
-jest.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: () => mockFeatureFlagEnabled(),
-}));
-
 jest.mock("next/router", () => require("next-router-mock"));
 const mockOnClickShareAll = jest.fn();
 
@@ -48,14 +43,6 @@ const baseProps = {
 const render = renderWithProviders();
 
 describe("LessonOverviewHeaderShareAllButton", () => {
-  beforeEach(() => {
-    mockFeatureFlagEnabled.mockReturnValue(false);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("renders the share button with correct text", () => {
     const { getByTestId } = render(
       <LessonOverviewHeaderShareAllButton {...baseProps} />,
@@ -80,22 +67,7 @@ describe("LessonOverviewHeaderShareAllButton", () => {
     expect(shareButton.tagName).toBe("BUTTON");
   });
 
-  it("renders a button when feature flag disabled and content is restricted", () => {
-    mockFeatureFlagEnabled.mockReturnValue(false);
-    const { queryByTestId } = render(
-      <LessonOverviewHeaderShareAllButton
-        {...baseProps}
-        loginRequired={true}
-        geoRestricted={true}
-      />,
-    );
-    const shareButton = queryByTestId("share-all-button");
-    expect(shareButton).toBeInTheDocument();
-  });
-
-  it("does not render a button when loginRequired and feature flag enabled", () => {
-    mockFeatureFlagEnabled.mockReturnValue(true);
-
+  it("does not render a button when loginRequired", () => {
     const { queryByTestId } = render(
       <LessonOverviewHeaderShareAllButton
         {...baseProps}
@@ -106,8 +78,7 @@ describe("LessonOverviewHeaderShareAllButton", () => {
     expect(shareButton).not.toBeInTheDocument();
   });
 
-  it("does not render a button when geoRestricted and feature flag enabled", () => {
-    mockFeatureFlagEnabled.mockReturnValue(true);
+  it("does not render a button when geoRestricted", () => {
     const { queryByTestId } = render(
       <LessonOverviewHeaderShareAllButton
         {...baseProps}

--- a/src/components/TeacherComponents/LessonOverviewHeaderShareAllButton/LessonOverviewHeaderShareAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderShareAllButton/LessonOverviewHeaderShareAllButton.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
 import { OakSmallSecondaryButton } from "@oaknational/oak-components";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 
 import { LessonOverviewHeaderProps } from "@/components/TeacherComponents/LessonOverviewHeader";
 import { resolveOakHref } from "@/common-lib/urls";
@@ -20,10 +19,8 @@ export const LessonOverviewHeaderShareAllButton: FC<
     geoRestricted,
     loginRequired,
   } = props;
-  const featureFlagEnabled = useFeatureFlagEnabled(
-    "teachers-copyright-restrictions",
-  );
-  if (featureFlagEnabled && (geoRestricted || loginRequired)) return null;
+
+  if (geoRestricted || loginRequired) return null;
 
   const preselected = "all";
 


### PR DESCRIPTION
## Description

Music year: 2022

- remove remaining `teachers-copyright` feature flag in codebase

## Issue(s)

Fixes #
Share with pupils button visible when cookies not accepted on lessons with copyrighted content

## How to test

1. Go to https://oak-web-application-website-b9ebvkuw4.vercel.thenational.academy/teachers/programmes/english-primary-ks2/units/the-jabberwocky-narrative-writing/lessons/understanding-the-plot-of-jabberwocky 
2. Sign out if signed in, and refuse cookies
3. You should not see the share with pupils button
4. This also removes feature flagging from copyright attributions on the media page, I don't think we have any of these to test against

## Screenshots

<img width="600" height="503" alt="Screenshot 2025-09-04 at 09 50 42" src="https://github.com/user-attachments/assets/abfe0a03-4e4e-471a-bb56-4d31c4a8c14e" />

