### PR TITLE
fix: radio button formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.1.0",
-        "@oaknational/oak-components": "^1.137.0",
+        "@oaknational/oak-components": "^1.142.1",
         "@oaknational/oak-consent-client": "^2.1.1",
         "@oaknational/oak-curriculum-schema": "^1.67.0",
         "@oaknational/oak-pupil-client": "^2.15.0",
@@ -7194,9 +7194,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "1.137.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.137.0.tgz",
-      "integrity": "sha512-gp/SLApk/WUbqr4t/dfKzbXSIZ4Z1jI/vJ0InPKIKBm+ARhw3j6bGjiatw04a5gr/F1ixa/0MUEoEeIVMIlDHA==",
+      "version": "1.142.1",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-1.142.1.tgz",
+      "integrity": "sha512-fB0jsyenGy1+WWB6PWH5LRjGn8LvvVQgEPbrSxlBMsEtKEpJuICGJFw2jWshDhXHEOcdBfy18HiNzgSbkqvhXg==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.1.0",
-    "@oaknational/oak-components": "^1.137.0",
+    "@oaknational/oak-components": "^1.142.1",
     "@oaknational/oak-consent-client": "^2.1.1",
     "@oaknational/oak-curriculum-schema": "^1.67.0",
     "@oaknational/oak-pupil-client": "^2.15.0",


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- update oak components

## Issue(s)

Fixes #
Formatting on radio buttons

## How to test

1. Go to {owa_deployment_url}/onboarding
2. Click no and go to role selection
3. the form should be formatted correctly with no dots and proper spacing

## Screenshots

How it used to look (delete if n/a):

<img width="492" height="775" alt="Screenshot 2025-09-04 at 15 11 35" src="https://github.com/user-attachments/assets/60a000ed-0f77-4042-87ad-5a4a134cd7de" />

<img width="310" height="235" alt="Screenshot 2025-09-04 at 11 59 54" src="https://github.com/user-attachments/assets/99bbf6fa-830a-4a61-a5f6-9bb880cddeef" />

How it should now look:

<img width="416" height="762" alt="Screenshot 2025-09-04 at 12 00 04" src="https://github.com/user-attachments/assets/b63dbbf2-e0f2-4bc2-b2a1-bbe6fd4b3f14" />

<img width="291" height="218" alt="Screenshot 2025-09-04 at 11 59 59" src="https://github.com/user-attachments/assets/65141088-b813-456d-a7c6-3634759363d2" />

