### PR TITLE
Chore/ss 2231/set no index pupil

### DIFF
--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.test.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.test.tsx
@@ -422,7 +422,7 @@ describe("PupilExperienceView", () => {
 
     expect(
       document.querySelector("meta[name=robots]")?.getAttribute("content"),
-    ).toEqual("index,follow");
+    ).toEqual("noindex,follow");
   });
 
   it("should have robots meta tag with noindex & nofollow", async () => {

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -255,7 +255,7 @@ const PupilExperienceLayout = ({
           title: browseData.lessonData.title,
           description: browseData.lessonData.pupilLessonOutcome,
         }),
-        noIndex: isSensitive,
+        noIndex: true,
         noFollow: isSensitive,
       }}
     >

--- a/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
+++ b/src/components/PupilViews/PupilLessonListing/PupilLessonListing.view.tsx
@@ -122,6 +122,8 @@ export const PupilViewsLessonListing = (props: PupilLessonListingViewProps) => {
             title: `${subject}, ${phaseSlug}, ${yearDescription} - Lesson listing`,
             description: `Lesson listing for ${subject}, ${phaseSlug}, ${yearDescription}`,
           }),
+          noIndex: true,
+          noFollow: false,
         }}
       >
         {" "}

--- a/src/components/PupilViews/PupilProgrammeListing/PupilProgrammeListing.view.tsx
+++ b/src/components/PupilViews/PupilProgrammeListing/PupilProgrammeListing.view.tsx
@@ -255,6 +255,8 @@ export const PupilViewsProgrammeListing = ({
             title: `${subjectDescription}, ${phaseSlug}, ${yearDescriptions} - Programme listing`,
             description: `Programme listing for ${subjectDescription}, ${phaseSlug}, ${yearDescriptions}`,
           }),
+          noIndex: true,
+          noFollow: false,
         }}
       >
         {" "}

--- a/src/pages/pupils/programmes/[programmeSlug]/units.tsx
+++ b/src/pages/pupils/programmes/[programmeSlug]/units.tsx
@@ -68,6 +68,8 @@ const PupilUnitListingPage = ({
             title: `${subject}, ${phase}, ${yearDescription} - Unit listing`,
             description: `Unit listing for ${subject}, ${phase}, ${yearDescription}`,
           }),
+          noIndex: true,
+          noFollow: false,
         }}
       >
         <PupilViewsUnitListing

--- a/src/pages/pupils/years/[yearSlug]/subjects.tsx
+++ b/src/pages/pupils/years/[yearSlug]/subjects.tsx
@@ -30,6 +30,8 @@ const PupilSubjectListing = (props: SubjectListingPageProps) => {
             title: `${yearDescription} - Subject listing`,
             description: `Subject listing for ${yearDescription}`,
           }),
+          noIndex: true,
+          noFollow: false,
         }}
       >
         <PupilViewsSubjectListing subjects={curriculumData} />


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes
- **Option B - Update meta-robots file on relevant pages to:**

<aside>
🛠

**<meta name="robots" content="noindex,follow" data-next-head="">**

</aside>

## Issue(s)

Fixes #


## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
