### PR TITLE
chore: update label of NC download tile to match curriculum plan tile…

### DIFF
--- a/src/components/CurriculumComponents/CurriculumDownloadView/helper.ts
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/helper.ts
@@ -72,7 +72,7 @@ export const DOWNLOAD_TYPE_LABELS: {
   {
     id: "national-curriculum",
     label: "National curriculum",
-    subTitle: "XLSX",
+    subTitle: "Excel (accessible)",
     icon: "spreadsheet",
   },
 ];


### PR DESCRIPTION
… format

## Description

Music year: [2019](https://open.spotify.com/track/39exKIvycQDgs4T6uXdyu0)

- List of changes

Update subtitle of `National curriculum` download tile to match `Curriculum plan` subtitle format.

## Issue(s)

Fixes #ADOPT-1603

## How to test

1. Go to https://oak-web-application-website-48yxo36ph.vercel.thenational.academy/teachers/curriculum/physical-education-secondary-ocr/downloads
2. Observe subtitle of `National curriculum` resource tile
3. It should have a label of `Excel (accessible)`

## Screenshots

How it used to look (delete if n/a):
<img width="1170" height="723" alt="Screenshot 2025-09-16 at 11 40 32" src="https://github.com/user-attachments/assets/f7f5e306-7ad0-4fb6-96ae-f56f4aa942a9" />

How it should now look:
<img width="1093" height="863" alt="Screenshot 2025-09-16 at 12 17 48" src="https://github.com/user-attachments/assets/cba9af54-a676-4aae-b63a-a17c38261a89" />

## Checklist

- [X] Added or updated tests where appropriate
- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
