### PR TITLE
`useFeatureFlag()` now just returns value and does type assertion on returned value

### DIFF
--- a/src/app/(beta)/timetabling/name/page.test.tsx
+++ b/src/app/(beta)/timetabling/name/page.test.tsx
@@ -8,13 +8,13 @@ jest.mock("src/utils/featureFlags");
 
 describe("/timetabling/units", () => {
   test("when enabled", async () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: true });
+    (useFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { baseElement } = render(await Page());
     expect(baseElement).toHaveTextContent("Input name");
   });
 
-  test("when disabled", () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: false });
+  test("when disabled", async () => {
+    (useFeatureFlag as jest.Mock).mockResolvedValue(false);
     expect(async () => {
       return await Page();
     }).rejects.toEqual(new Error("NEXT_HTTP_ERROR_FALLBACK;404"));

--- a/src/app/(beta)/timetabling/name/page.tsx
+++ b/src/app/(beta)/timetabling/name/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { useFeatureFlag } from "@/utils/featureFlags";
 
 const Page = async () => {
-  const { isEnabled } = await useFeatureFlag("adopt-timetabling-proto");
+  const isEnabled = await useFeatureFlag("adopt-timetabling-proto", "boolean");
   if (!isEnabled) {
     return notFound();
   }

--- a/src/app/(beta)/timetabling/new/page.test.tsx
+++ b/src/app/(beta)/timetabling/new/page.test.tsx
@@ -8,13 +8,13 @@ jest.mock("src/utils/featureFlags");
 
 describe("/timetabling/units", () => {
   test("when enabled", async () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: true });
+    (useFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { baseElement } = render(await Page());
     expect(baseElement).toHaveTextContent("New timetable");
   });
 
-  test("when disabled", () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: false });
+  test("when disabled", async () => {
+    (useFeatureFlag as jest.Mock).mockResolvedValue(false);
     expect(async () => {
       return await Page();
     }).rejects.toEqual(new Error("NEXT_HTTP_ERROR_FALLBACK;404"));

--- a/src/app/(beta)/timetabling/new/page.tsx
+++ b/src/app/(beta)/timetabling/new/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { useFeatureFlag } from "@/utils/featureFlags";
 
 const Page = async () => {
-  const { isEnabled } = await useFeatureFlag("adopt-timetabling-proto");
+  const isEnabled = await useFeatureFlag("adopt-timetabling-proto", "boolean");
   if (!isEnabled) {
     return notFound();
   }

--- a/src/app/(beta)/timetabling/units/page.test.tsx
+++ b/src/app/(beta)/timetabling/units/page.test.tsx
@@ -8,13 +8,13 @@ jest.mock("src/utils/featureFlags");
 
 describe("/timetabling/units", () => {
   test("when enabled", async () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: true });
+    (useFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { baseElement } = render(await Page());
     expect(baseElement).toHaveTextContent("View timetable");
   });
 
-  test("when disabled", () => {
-    (useFeatureFlag as jest.Mock).mockResolvedValue({ isEnabled: false });
+  test("when disabled", async () => {
+    (useFeatureFlag as jest.Mock).mockResolvedValue(false);
     expect(async () => {
       return await Page();
     }).rejects.toEqual(new Error("NEXT_HTTP_ERROR_FALLBACK;404"));

--- a/src/app/(beta)/timetabling/units/page.tsx
+++ b/src/app/(beta)/timetabling/units/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { useFeatureFlag } from "@/utils/featureFlags";
 
 const Page = async () => {
-  const { isEnabled } = await useFeatureFlag("adopt-timetabling-proto");
+  const isEnabled = await useFeatureFlag("adopt-timetabling-proto", "boolean");
   if (!isEnabled) {
     return notFound();
   }

--- a/src/utils/featureFlags.test.ts
+++ b/src/utils/featureFlags.test.ts
@@ -2,10 +2,9 @@ import { renderHook } from "@testing-library/react";
 
 import { useFeatureFlag } from "./featureFlags";
 
-jest.mock("@/node-lib/posthog/getFeatureFlag", () => ({
-  __esModule: true,
-  getFeatureFlag: () => true,
-}));
+import { getFeatureFlag } from "@/node-lib/posthog/getFeatureFlag";
+
+jest.mock("@/node-lib/posthog/getFeatureFlag");
 
 const getAllCookiesMock = jest.fn();
 jest.mock("next/headers", () => ({
@@ -22,13 +21,63 @@ describe("useFeatureFlag", () => {
         value: JSON.stringify({ distinct_id: "1111" }),
       },
     ]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useFeatureFlag("foo"));
-    expect(await result.current).toEqual({ isEnabled: true, flag: true });
+    expect(await result.current).toEqual(true);
   });
 
   test("does not exist", async () => {
     getAllCookiesMock.mockReturnValue([]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useFeatureFlag("foo"));
-    expect(await result.current).toEqual({ isEnabled: false, flag: undefined });
+    expect(await result.current).toEqual(undefined);
+  });
+
+  test("string assertion with valid type", async () => {
+    getAllCookiesMock.mockReturnValue([
+      {
+        name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
+        value: JSON.stringify({ distinct_id: "1111" }),
+      },
+    ]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue("testing");
+    const { result } = renderHook(() => useFeatureFlag("foo", "string"));
+    expect(await result.current).toEqual("testing");
+  });
+
+  test("string assertion with invalid type", async () => {
+    getAllCookiesMock.mockReturnValue([
+      {
+        name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
+        value: JSON.stringify({ distinct_id: "1111" }),
+      },
+    ]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useFeatureFlag("foo", "string"));
+    expect(await result.current).toEqual(undefined);
+  });
+
+  test("boolean assertion with valid type", async () => {
+    getAllCookiesMock.mockReturnValue([
+      {
+        name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
+        value: JSON.stringify({ distinct_id: "1111" }),
+      },
+    ]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useFeatureFlag("foo", "boolean"));
+    expect(await result.current).toEqual(true);
+  });
+
+  test("boolean assertion with invalid type", async () => {
+    getAllCookiesMock.mockReturnValue([
+      {
+        name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
+        value: JSON.stringify({ distinct_id: "1111" }),
+      },
+    ]);
+    (getFeatureFlag as jest.Mock).mockResolvedValue("test");
+    const { result } = renderHook(() => useFeatureFlag("foo", "boolean"));
+    expect(await result.current).toEqual(undefined);
   });
 });

--- a/src/utils/featureFlags.test.ts
+++ b/src/utils/featureFlags.test.ts
@@ -14,26 +14,8 @@ jest.mock("next/headers", () => ({
 }));
 
 describe("useFeatureFlag", () => {
-  test("exists", async () => {
-    getAllCookiesMock.mockReturnValue([
-      {
-        name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
-        value: JSON.stringify({ distinct_id: "1111" }),
-      },
-    ]);
-    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
-    const { result } = renderHook(() => useFeatureFlag("foo"));
-    expect(await result.current).toEqual(true);
-  });
-
-  test("does not exist", async () => {
-    getAllCookiesMock.mockReturnValue([]);
-    (getFeatureFlag as jest.Mock).mockResolvedValue(true);
-    const { result } = renderHook(() => useFeatureFlag("foo"));
-    expect(await result.current).toEqual(undefined);
-  });
-
   test("string assertion with valid type", async () => {
+    console.log = jest.fn();
     getAllCookiesMock.mockReturnValue([
       {
         name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
@@ -43,6 +25,13 @@ describe("useFeatureFlag", () => {
     (getFeatureFlag as jest.Mock).mockResolvedValue("testing");
     const { result } = renderHook(() => useFeatureFlag("foo", "string"));
     expect(await result.current).toEqual("testing");
+    expect(console.log).toHaveBeenCalledWith(
+      "[%cfeature-flag%c] %s=%o",
+      "color: green",
+      "color: initial",
+      "foo",
+      "testing",
+    );
   });
 
   test("string assertion with invalid type", async () => {
@@ -58,6 +47,7 @@ describe("useFeatureFlag", () => {
   });
 
   test("boolean assertion with valid type", async () => {
+    console.log = jest.fn();
     getAllCookiesMock.mockReturnValue([
       {
         name: "ph_NEXT_PUBLIC_POSTHOG_API_KEY_posthog",
@@ -67,6 +57,13 @@ describe("useFeatureFlag", () => {
     (getFeatureFlag as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useFeatureFlag("foo", "boolean"));
     expect(await result.current).toEqual(true);
+    expect(console.log).toHaveBeenCalledWith(
+      "[%cfeature-flag%c] %s=%o",
+      "color: green",
+      "color: initial",
+      "foo",
+      true,
+    );
   });
 
   test("boolean assertion with invalid type", async () => {

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -15,7 +15,10 @@ function cookieAsObj(c: ReadonlyRequestCookies) {
 
 const posthogApiKey = getBrowserConfig("posthogApiKey");
 
-export async function useFeatureFlag(flagName: string) {
+export async function useFeatureFlag(
+  flagName: string,
+  assertType?: "boolean" | "string",
+) {
   const cookieStore = cookieAsObj(await cookies());
 
   const posthogUserId = getPosthogIdFromCookie(cookieStore, posthogApiKey);
@@ -29,5 +32,8 @@ export async function useFeatureFlag(flagName: string) {
     });
   }
 
-  return { isEnabled: Boolean(flag), flag };
+  if (assertType && typeof flag !== assertType) {
+    return;
+  }
+  return flag;
 }


### PR DESCRIPTION
## Description
`useFeatureFlag()` now just returns value and does type assertion on returned value

Safe usage is now

```ts
const flagBooleanValue = await useFeatureFlag("some-flag", "boolean");
const flagStringValue = await useFeatureFlag("some-flag", "string");
```

## Issue(s)
n/a

## How to test
Test https://oak-web-application-website-fr0s92pqx.vercel.thenational.academy/timetabling/new is only shown when feature flag is enabled.


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
