### PR TITLE
[ADOPT-1611] Add visualiser link to timetable behind feature flag

### DIFF
--- a/src/components/CurriculumComponents/CurricVisualiser/CurricVisualiser.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiser/CurricVisualiser.tsx
@@ -25,6 +25,7 @@ import {
   getModes,
 } from "@/utils/curriculum/by-pathway";
 import { Ks4Option } from "@/node-lib/curriculum-api-2023/queries/curriculumPhaseOptions/curriculumPhaseOptions.schema";
+import { generateQueryParams } from "@/components/CurriculumComponents/helpers/curricTimetabling";
 import { findUnitOrOptionBySlug } from "@/utils/curriculum/units";
 
 type CurricVisualiserProps = {
@@ -134,6 +135,12 @@ export default function CurricVisualiser({
           itemEls.current[index] = element;
         };
 
+        const subjectSlug = units[0]?.subject_slug;
+        const timetablingQueryParams = generateQueryParams({
+          year,
+          subject: subjectSlug ?? "",
+        });
+
         const actions = units[0]?.actions;
 
         const yearTitle = getYearGroupTitle(yearData, year, undefined);
@@ -159,6 +166,7 @@ export default function CurricVisualiser({
               id={`year-${type}-${year}`}
             />
             <CurricYearCard
+              timetablingQueryParams={timetablingQueryParams}
               isExamboard={type === "non_core"}
               yearTitle={yearTitle}
               yearSubheading={yearSubheadingText}

--- a/src/components/CurriculumComponents/CurricYearCard/index.test.tsx
+++ b/src/components/CurriculumComponents/CurricYearCard/index.test.tsx
@@ -8,11 +8,17 @@ import { CurricYearCard } from "./index";
 import { createUnit } from "@/fixtures/curriculum/unit";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
+const mockFeatureFlagEnabled = jest.fn().mockReturnValue(false);
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFeatureFlagEnabled(),
+}));
+
 describe("CurricYearCard component", () => {
   const defaultProps = {
     yearTitle: "Year 7",
     isExamboard: false,
     children: <div>Test content</div>,
+    timetablingQueryParams: "subject=maths&year=7",
   };
 
   it("should render with year heading", () => {
@@ -139,5 +145,37 @@ describe("CurricYearCard component", () => {
     expect(unitCards[0]).toHaveTextContent("Mechanics");
     expect(unitCards[1]).toHaveTextContent("Waves and Electricity");
     expect(unitCards[2]).toHaveTextContent("Quantum Physics");
+  });
+
+  it("should render the map to timetable link if feature flag is enabled ", () => {
+    mockFeatureFlagEnabled.mockReturnValue(true);
+    const { container } = renderWithTheme(
+      <CurricYearCard {...defaultProps} isExamboard={false} />,
+    );
+
+    expect(container).toHaveTextContent("Map to school timetable");
+  });
+
+  it("should not render the map to timetable link if feature flag is not enabled ", () => {
+    mockFeatureFlagEnabled.mockReturnValue(false);
+    const { container } = renderWithTheme(
+      <CurricYearCard {...defaultProps} isExamboard={false} />,
+    );
+
+    expect(container).not.toHaveTextContent("Map to school timetable");
+  });
+
+  it("should have the correct href for the map to timetable link", () => {
+    mockFeatureFlagEnabled.mockReturnValue(true);
+    const { getByRole } = renderWithTheme(
+      <CurricYearCard {...defaultProps} isExamboard={false} />,
+    );
+
+    const link = getByRole("link");
+
+    expect(link).toHaveAttribute(
+      "href",
+      "/timetabling/new?subject=maths&year=7",
+    );
   });
 });

--- a/src/components/CurriculumComponents/CurricYearCard/index.tsx
+++ b/src/components/CurriculumComponents/CurricYearCard/index.tsx
@@ -1,20 +1,30 @@
-import { OakBox, OakHeading } from "@oaknational/oak-components";
+import {
+  OakBox,
+  OakFlex,
+  OakHeading,
+  OakSecondaryLink,
+} from "@oaknational/oak-components";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import React from "react";
 
 type CurricYearCardProps = {
+  timetablingQueryParams?: string;
   yearTitle: string;
   yearSubheading?: string | null;
   additional?: React.ReactNode;
   children: React.ReactNode;
   isExamboard: boolean;
 };
+
 export function CurricYearCard({
+  timetablingQueryParams,
   yearTitle,
   yearSubheading,
   additional,
   children,
   isExamboard,
 }: CurricYearCardProps) {
+  const timetablingEnabled = useFeatureFlagEnabled("adopt-timetabling-proto");
   return (
     <OakBox
       $background={isExamboard ? "pink50" : "pink30"}
@@ -24,15 +34,25 @@ export function CurricYearCard({
       $borderRadius={"border-radius-s"}
       className="mobileYearDisplay"
     >
-      <OakHeading
-        tag="h3"
-        $font={["heading-5", "heading-4"]}
-        $mb={yearSubheading ? "space-between-xs" : "space-between-s"}
-        data-testid="year-heading"
-      >
-        {yearTitle}
-      </OakHeading>
-
+      <OakFlex $flexDirection={"row"} $justifyContent={"space-between"}>
+        <OakHeading
+          tag="h3"
+          $font={["heading-5", "heading-4"]}
+          $mb={yearSubheading ? "space-between-xs" : "space-between-s"}
+          data-testid="year-heading"
+        >
+          {yearTitle}
+        </OakHeading>
+        {timetablingEnabled === true && (
+          <OakSecondaryLink
+            href={`/timetabling/new?${timetablingQueryParams}`}
+            iconName="external"
+            isTrailingIcon
+          >
+            Map to school timetable
+          </OakSecondaryLink>
+        )}
+      </OakFlex>
       {yearSubheading && (
         <OakHeading
           tag="h4"

--- a/src/components/CurriculumComponents/helpers/curricTimetabling.test.ts
+++ b/src/components/CurriculumComponents/helpers/curricTimetabling.test.ts
@@ -1,0 +1,11 @@
+import { generateQueryParams } from "./curricTimetabling";
+
+describe("curricTimetabling", () => {
+  it("should generate a string correctly given some timetabling parameters", () => {
+    const result = generateQueryParams({
+      subject: "maths",
+      year: 1,
+    });
+    expect(result).toBe("subject=maths&year=1");
+  });
+});

--- a/src/components/CurriculumComponents/helpers/curricTimetabling.ts
+++ b/src/components/CurriculumComponents/helpers/curricTimetabling.ts
@@ -1,0 +1,12 @@
+type TimetableParams = {
+  subject: string;
+  year: number;
+};
+
+export function generateQueryParams(
+  params: TimetableParams | Record<string, string | number | boolean>,
+) {
+  return Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes
- Create function to generate URL params
- Add link to visualiser groups
- Update params to include subject and year group 
- Tests


## How to test

1. Go to {owa_deployment_url}/teachers/curriculum/maths-secondary/units
2. If the feature flag is enabled, you should be able to see the link to visualiser
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
<img width="1420" height="799" alt="Screenshot 2025-09-18 at 14 13 28" src="https://github.com/user-attachments/assets/a118ad7f-b119-4296-a7f3-ec0944deddd5" />

How it should now look:
<img width="1433" height="791" alt="Screenshot 2025-09-18 at 14 12 54" src="https://github.com/user-attachments/assets/6cab5db2-6fbd-4361-a43b-34b8bbc18361" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
