### PR TITLE
Preserve tab with changing selection in the lot picker

### DIFF
--- a/src/browser-lib/fixtures/curriculumPhaseOptions.ts
+++ b/src/browser-lib/fixtures/curriculumPhaseOptions.ts
@@ -139,6 +139,7 @@ const curriculumPhaseOptions = {
       ],
     },
   ],
+  tab: "units" as const,
 };
 
 export default curriculumPhaseOptions;

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.test.tsx
@@ -25,7 +25,10 @@ describe("Component - Curriculum Header", () => {
     const defaultProps: ComponentProps<typeof CurriculumHeader> = {
       curriculumSelectionSlugs: parseSubjectPhaseSlug("english-secondary-aqa")!,
       keyStages: ["ks3", "ks4"],
-      curriculumPhaseOptions: { subjects: curriculumPhaseOptionsFixture() },
+      curriculumPhaseOptions: {
+        subjects: curriculumPhaseOptionsFixture(),
+        tab: "overview",
+      },
       tab: "overview",
       ...overrides,
     };

--- a/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
+++ b/src/components/CurriculumComponents/CurriculumHeader/CurriculumHeader.tsx
@@ -141,6 +141,7 @@ const CurriculumHeader: FC<CurriculumHeaderPageProps> = ({
           <SubjectPhasePicker
             {...curriculumPhaseOptions}
             currentSelection={currentSelection}
+            tab={tab}
           />
         </OakBox>
       </OakFlex>

--- a/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
+++ b/src/components/CurriculumComponents/UnitsTab/UnitsTab.test.tsx
@@ -294,6 +294,7 @@ describe("unitsTab !subject error", () => {
           ks4_options: [],
         },
       ],
+      tab: "units" as const,
     };
 
     expect(() => {

--- a/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.test.tsx
+++ b/src/components/GenericPagesComponents/CurriculumTab/CurriculumTab.test.tsx
@@ -15,6 +15,7 @@ describe("CurriculumTab", () => {
       <CurriculumTab
         curriculumPhaseOptions={{
           subjects: curriculumPhaseOptions.options,
+          tab: "units",
         }}
       />,
     );
@@ -28,6 +29,7 @@ describe("CurriculumTab", () => {
       <CurriculumTab
         curriculumPhaseOptions={{
           subjects: curriculumPhaseOptions.options,
+          tab: "units",
         }}
       />,
     );

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -141,11 +141,11 @@ exports[`CurriculumTab renders 1`] = `
                           style="width: 50%;"
                         >
                           <div
-                            class="sc-fqkvVR sc-1c55d370-0 sc-9e2d8449-3 jEHEPk knawKC cDrIuV"
+                            class="sc-fqkvVR sc-1c55d370-0 sc-b913af8d-3 jEHEPk knawKC dniwDs"
                           >
                             <button
                               aria-expanded="false"
-                              class="sc-9e2d8449-2 jSAqjS"
+                              class="sc-b913af8d-2 ebZCtT"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
@@ -210,11 +210,11 @@ exports[`CurriculumTab renders 1`] = `
                             class="sc-fqkvVR sc-kAyceB fxkSvJ jDFpDX"
                           >
                             <div
-                              class="sc-fqkvVR sc-1c55d370-0 sc-9e2d8449-3 eMDDOo knawKC cDrIuV"
+                              class="sc-fqkvVR sc-1c55d370-0 sc-b913af8d-3 eMDDOo knawKC dniwDs"
                             >
                               <button
                                 aria-expanded="false"
-                                class="sc-9e2d8449-2 jSAqjS"
+                                class="sc-b913af8d-2 ebZCtT"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
@@ -332,11 +332,11 @@ exports[`CurriculumTab renders 1`] = `
                       style="width: 50%;"
                     >
                       <div
-                        class="sc-fqkvVR sc-1c55d370-0 sc-9e2d8449-3 jEHEPk knawKC cDrIuV"
+                        class="sc-fqkvVR sc-1c55d370-0 sc-b913af8d-3 jEHEPk knawKC dniwDs"
                       >
                         <button
                           aria-expanded="false"
-                          class="sc-9e2d8449-2 jSAqjS"
+                          class="sc-b913af8d-2 ebZCtT"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
@@ -401,11 +401,11 @@ exports[`CurriculumTab renders 1`] = `
                         class="sc-fqkvVR sc-kAyceB fxkSvJ jDFpDX"
                       >
                         <div
-                          class="sc-fqkvVR sc-1c55d370-0 sc-9e2d8449-3 eMDDOo knawKC cDrIuV"
+                          class="sc-fqkvVR sc-1c55d370-0 sc-b913af8d-3 eMDDOo knawKC dniwDs"
                         >
                           <button
                             aria-expanded="false"
-                            class="sc-9e2d8449-2 jSAqjS"
+                            class="sc-b913af8d-2 ebZCtT"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
@@ -7,7 +7,6 @@ import SubjectPhasePicker from "./SubjectPhasePicker";
 import curriculumPhaseOptions from "@/browser-lib/fixtures/curriculumPhaseOptions";
 import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
 
-
 jest.mock("@/hooks/useMediaQuery.tsx", () => ({
   __esModule: true,
   default: () => false,

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.test.tsx
@@ -1,13 +1,20 @@
 import userEvent from "@testing-library/user-event";
 import { getByTestId, waitFor } from "@testing-library/react";
+import { useRouter } from "next/router";
+
+import SubjectPhasePicker from "./SubjectPhasePicker";
 
 import curriculumPhaseOptions from "@/browser-lib/fixtures/curriculumPhaseOptions";
-import SubjectPhasePicker from "@/components/SharedComponents/SubjectPhasePicker";
 import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+
 
 jest.mock("@/hooks/useMediaQuery.tsx", () => ({
   __esModule: true,
   default: () => false,
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
 }));
 
 const render = renderWithProvidersByName(["oakTheme", "theme"]);
@@ -180,6 +187,11 @@ describe("Component - subject phase picker", () => {
   });
 
   test("calls tracking.curriculumVisualiserAccessed once, with correct props", async () => {
+    const pushMock = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: async (...args: []) => pushMock(...args),
+    });
+
     const { findAllByTitle, getByTitle, findByTitle, baseElement } = render(
       <SubjectPhasePicker {...curriculumPhaseOptions} />,
     );
@@ -198,6 +210,10 @@ describe("Component - subject phase picker", () => {
     );
     await userEvent.click(viewButton);
 
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: "/teachers/curriculum/english-primary/units",
+    });
+
     expect(curriculumVisualiserAccessed).toHaveBeenCalledTimes(1);
     expect(curriculumVisualiserAccessed).toHaveBeenCalledWith({
       subjectTitle: "English",
@@ -209,6 +225,42 @@ describe("Component - subject phase picker", () => {
       eventVersion: "2.0.0",
       analyticsUseCase: "Teacher",
       phase: "primary",
+    });
+  });
+
+  test("preserve tab when chaging the lot picker", async () => {
+    const pushMock = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: async (...args: []) => pushMock(...args),
+    });
+
+    const { rerender, findAllByTitle, getByTitle, findByTitle, baseElement } =
+      render(<SubjectPhasePicker {...curriculumPhaseOptions} />);
+    await userEvent.click(getByTitle("Subject"));
+    const button = (await findAllByTitle("English"))[0];
+    if (!button) {
+      throw new Error("Could not find button");
+    }
+    await userEvent.click(button);
+
+    await userEvent.click(await findByTitle("Primary"));
+
+    const viewButton = getByTestId(
+      baseElement,
+      "lot-picker-view-curriculum-button",
+    );
+
+    await userEvent.click(viewButton);
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: "/teachers/curriculum/english-primary/units",
+    });
+
+    rerender(<SubjectPhasePicker {...curriculumPhaseOptions} tab="overview" />);
+
+    pushMock.mockReset();
+    await userEvent.click(viewButton);
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: "/teachers/curriculum/english-primary/overview",
     });
   });
 

--- a/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
+++ b/src/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker.tsx
@@ -38,7 +38,6 @@ import FocusWrap from "@/components/CurriculumComponents/OakComponentsKitchen/Fo
 import Button from "@/components/SharedComponents/Button";
 import { CurriculumModalCloseButton } from "@/components/CurriculumComponents/CurriculumModalCloseButton/CurriculumModalCloseButton";
 import useMediaQuery from "@/hooks/useMediaQuery";
-import type { CurriculumTab } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { PhaseValueType } from "@/browser-lib/avo/Avo";
 
 const TruncatedFlex = styled(OakFlex)`
@@ -75,6 +74,7 @@ export type SubjectPhasePickerData = {
     phase: Phase;
     ks4Option: KS4Option | null;
   };
+  tab: "overview" | "units" | "downloads";
 };
 
 const ButtonContainer = styled.div`
@@ -336,13 +336,13 @@ function SubjectContainer({
 const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
   subjects,
   currentSelection,
+  tab,
 }) => {
   const phasePickerButton = useRef<HTMLButtonElement>(null);
   const subjectPickerButton = useRef<HTMLButtonElement>(null);
   const subjectPickerButtonDesktopContainer = useRef<HTMLDivElement>(null);
   const subjectPickerButtonMobileContainer = useRef<HTMLDivElement>(null);
   const router = useRouter();
-  const tab = (router.query.tab as CurriculumTab) ?? "units";
 
   const ks4OptionErrorId = useId();
   const phaseErrorId = useId();
@@ -545,6 +545,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
       if (selectedKS4Option) {
         subjectPhaseSlug += "-" + selectedKS4Option.slug;
       }
+      const newPathname = `/teachers/curriculum/${subjectPhaseSlug}/${tab}`;
       trackViewCurriculum();
 
       // For mobile, keep the modal open during navigation
@@ -558,7 +559,7 @@ const SubjectPhasePicker: FC<SubjectPhasePickerData> = ({
       startTransition(() => {
         router
           .push({
-            pathname: `/teachers/curriculum/${subjectPhaseSlug}/${tab}`,
+            pathname: newPathname,
           })
           .finally(() => {
             setIsNavigating(false);

--- a/src/pages-helpers/curriculum/docx/tab-helpers.ts
+++ b/src/pages-helpers/curriculum/docx/tab-helpers.ts
@@ -372,5 +372,6 @@ export async function fetchSubjectPhasePickerData() {
   const subjects = await curriculumApi2023.curriculumPhaseOptions();
   return {
     subjects: filterValidCurriculumPhaseOptions(subjects),
+    tab: "units" as const,
   };
 }

--- a/src/pages/curriculum/index.tsx
+++ b/src/pages/curriculum/index.tsx
@@ -19,6 +19,7 @@ const fetchSubjectPhasePickerData: () => Promise<SubjectPhasePickerData> =
     const subjects = await curriculumApi2023.curriculumPhaseOptions();
     return {
       subjects: filterValidCurriculumPhaseOptions(subjects),
+      tab: "units",
     };
   };
 

--- a/src/pages/teachers/curriculum/index.tsx
+++ b/src/pages/teachers/curriculum/index.tsx
@@ -276,6 +276,7 @@ const fetchSubjectPhasePickerData: () => Promise<SubjectPhasePickerData> =
     const subjects = await curriculumApi2023.curriculumPhaseOptions();
     return {
       subjects: filterValidCurriculumPhaseOptions(subjects),
+      tab: "units",
     };
   };
 


### PR DESCRIPTION
## Description
When changing the selection in the in the lot-picker the tab no longer changes. 

## Issue(s)
Fixes `ADOPT-1568`

## How to test

1. Go to https://oak-web-application-website-7u1duza8q.vercel.thenational.academy/teachers/curriculum/
2. Make a selection in the lot picker
3. Change tabs to something other than "units"
4. Change the lot picker and press "view"
5. The tab should stay consistent


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
