### PR TITLE
feat: add empty endpoint scaffold for search intent [AI-1597]

### DIFF
--- a/src/__tests__/pages/api/search/intent.test.ts
+++ b/src/__tests__/pages/api/search/intent.test.ts
@@ -1,0 +1,93 @@
+import { createNextApiMocks } from "@/__tests__/__helpers__/createNextApiMocks";
+import handler from "@/pages/api/search/intent";
+
+const mockErrorReporter = jest.fn();
+jest.mock("@/common-lib/error-reporter", () => ({
+  __esModule: true,
+  default:
+    () =>
+    (...args: []) =>
+      mockErrorReporter(...args),
+}));
+
+describe("/api/search/intent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return direct match response for 'maths' search term", async () => {
+    const { req, res } = createNextApiMocks({
+      method: "GET",
+      query: { searchTerm: "maths" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      directMatch: {
+        subject: "maths",
+        keyStage: null,
+        year: null,
+        examBoard: null,
+      },
+      suggestedFilters: [
+        { type: "subject", value: "maths" },
+        { type: "key-stage", value: "ks1" },
+        { type: "key-stage", value: "ks2" },
+        { type: "key-stage", value: "ks3" },
+        { type: "key-stage", value: "ks4" },
+        { type: "exam-board", value: "aqa" },
+        { type: "exam-board", value: "edexcel" },
+      ],
+    });
+  });
+
+  it("should return AI response for other search terms", async () => {
+    const { req, res } = createNextApiMocks({
+      method: "GET",
+      query: { searchTerm: "science" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      directMatch: null,
+      suggestedFilters: [
+        { type: "subject", value: "maths" },
+        { type: "key-stage", value: "ks4" },
+        { type: "exam-board", value: "aqa" },
+        { type: "subject", value: "science" },
+      ],
+    });
+  });
+
+  it("should return 400 for missing searchTerm", async () => {
+    const { req, res } = createNextApiMocks({
+      method: "GET",
+      query: {},
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: "Invalid search term",
+    });
+  });
+
+  it("should return 400 for searchTerm that is too short", async () => {
+    const { req, res } = createNextApiMocks({
+      method: "GET",
+      query: { searchTerm: "a" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: "Invalid search term",
+    });
+  });
+});

--- a/src/errors/OakError.ts
+++ b/src/errors/OakError.ts
@@ -8,6 +8,7 @@ const ERROR_CODES = [
   "misc/network-error",
   "misc/unexpected-type",
   "misc/import-count",
+  "search/failed-to-get-intent",
   "search/unknown",
   "hubspot/invalid-email",
   "hubspot/unknown",
@@ -63,6 +64,11 @@ const errorConfigs: Record<ErrorCode, ErrorConfig> = {
   "misc/unexpected-type": {
     message:
       "An unexpected type was encountered, so action may not have completed successfully",
+    shouldNotify: true,
+  },
+  "search/failed-to-get-intent": {
+    message: "Failed to get search intent",
+    responseStatusCode: 500,
     shouldNotify: true,
   },
   "search/unknown": {

--- a/src/pages/api/search/intent.ts
+++ b/src/pages/api/search/intent.ts
@@ -1,0 +1,71 @@
+import type { NextApiHandler } from "next";
+import { z } from "zod";
+
+import { intentRequestSchema, searchIntentSchema } from "./schemas";
+
+import errorReporter from "@/common-lib/error-reporter/errorReporter";
+import OakError from "@/errors/OakError";
+
+const reportError = errorReporter("search-intent");
+
+const DUMMY_DIRECT_MATCH_RESPONSE = {
+  directMatch: {
+    subject: "maths",
+    keyStage: null,
+    year: null,
+    examBoard: null,
+  },
+  suggestedFilters: [
+    { type: "subject", value: "maths" },
+    { type: "key-stage", value: "ks1" },
+    { type: "key-stage", value: "ks2" },
+    { type: "key-stage", value: "ks3" },
+    { type: "key-stage", value: "ks4" },
+    { type: "exam-board", value: "aqa" },
+    { type: "exam-board", value: "edexcel" },
+  ],
+} satisfies z.infer<typeof searchIntentSchema>;
+
+const DUMMY_AI_RESPONSE = {
+  directMatch: null,
+  suggestedFilters: [
+    { type: "subject", value: "maths" },
+    { type: "key-stage", value: "ks4" },
+    { type: "exam-board", value: "aqa" },
+    { type: "subject", value: "science" },
+  ],
+} satisfies z.infer<typeof searchIntentSchema>;
+
+const handler: NextApiHandler = async (req, res) => {
+  let searchTerm: string;
+
+  try {
+    const parsed = intentRequestSchema.parse(req.query);
+    searchTerm = parsed.searchTerm;
+  } catch (err) {
+    return res.status(400).json({ error: "Invalid search term" });
+  }
+
+  try {
+    // TEMP: return direct match response if searchTerm is "maths"
+    if (searchTerm === "maths") {
+      const payload = searchIntentSchema.parse(DUMMY_DIRECT_MATCH_RESPONSE);
+      return res.status(200).json(payload);
+    }
+
+    const payload = searchIntentSchema.parse(DUMMY_AI_RESPONSE);
+    return res.status(200).json(payload);
+  } catch (err) {
+    const error = new OakError({
+      code: "search/failed-to-get-intent",
+      meta: {
+        error: err,
+      },
+    });
+    reportError(error);
+
+    return res.status(500).json({ error: JSON.stringify(error) });
+  }
+};
+
+export default handler;

--- a/src/pages/api/search/schemas.ts
+++ b/src/pages/api/search/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import {
+  examboardSlugs,
+  keystageSlugs,
+  subjectSlugs,
+  yearSlugs,
+} from "@oaknational/oak-curriculum-schema";
+
+export const intentRequestSchema = z.object({
+  searchTerm: z.string().min(2).max(250),
+});
+
+export const directMatchSchema = z.object({
+  subject: subjectSlugs.nullable(),
+  keyStage: keystageSlugs.nullable(),
+  year: yearSlugs.nullable(),
+  examBoard: examboardSlugs.nullable(),
+});
+
+export const suggestedFilterSchema = z.union([
+  z.object({
+    type: z.literal("subject"),
+    value: subjectSlugs,
+  }),
+  z.object({
+    type: z.literal("key-stage"),
+    value: keystageSlugs,
+  }),
+  z.object({
+    type: z.literal("year"),
+    value: yearSlugs,
+  }),
+  z.object({
+    type: z.literal("exam-board"),
+    value: examboardSlugs,
+  }),
+]);
+
+export const searchIntentSchema = z.object({
+  directMatch: directMatchSchema.nullable(),
+  suggestedFilters: z.array(suggestedFilterSchema),
+});


### PR DESCRIPTION
## Description

Music year: 1967

- This is the base for our other tasks around search intent
- Returns dummy content
  - Type "maths" for an exact match
  - Type anything else for an AI-style match

## Issue(s)

Fixes #AI-1597

## How to test

```bash
# Test with "maths" (returns direct match response)
  curl "https://oak-web-application-website-git-feat-search-intent-scaffold.vercel.thenational.academy/api/search/intent?searchTerm=maths"

  # Test with other search term (returns AI response)
  curl "https://oak-web-application-website-git-feat-search-intent-scaffold.vercel.thenational.academy/api/search/intent?searchTerm=some+valid+search+term"
```

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
