### PR TITLE
Hide cyber essentials logo from percy

### DIFF
--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
@@ -269,6 +269,7 @@ const LayoutSiteFooter: FC = () => {
           </OakGrid>
           <StyledLogo
             alt="Cyber Essentials Logo"
+            data-percy-hide="contents"
             src={getCloudinaryImageUrl(
               "v1751992190/OWA/illustrations/Cyber-Essentials-Logo_ryiskg.png",
             )}


### PR DESCRIPTION
## Description
Hide cyber essentials logo from percy as it's flakey and causes lots of false percy errors.

## Issue(s)
hotfix

## How to test
Check that the logo no longer appears in percy


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
