### PR TITLE
Fix/pupil 1476/remove music year 11

### DIFF
--- a/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
+++ b/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
@@ -23,7 +23,6 @@ type PupilViewsSubjectListingProps = {
 export const PupilViewsSubjectListing = ({
   subjects,
 }: PupilViewsSubjectListingProps) => {
-  console.log("subjects", subjects);
   const { track } = useAnalytics();
   const groupedBySubject = groupBy(
     subjects,

--- a/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
+++ b/src/components/PupilViews/PupilSubjectListing/PupilSubjectListing.view.tsx
@@ -23,6 +23,7 @@ type PupilViewsSubjectListingProps = {
 export const PupilViewsSubjectListing = ({
   subjects,
 }: PupilViewsSubjectListingProps) => {
+  console.log("subjects", subjects);
   const { track } = useAnalytics();
   const groupedBySubject = groupBy(
     subjects,

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -32949,6 +32949,266 @@ export type Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Stream_Cursor_Value
   year_slug?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0 = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_1_0';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_1_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0>;
+};
+
+/** aggregate fields of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_1_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_synthetic_programmes_by_year_18_1_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  year_slug?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Max_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_1_0_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Min_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_1_0_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_synthetic_programmes_by_year_18_1_0". */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  base_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  is_legacy?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  year_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_synthetic_programmes_by_year_18_1_0" */
+export enum Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  YearSlug = 'year_slug'
+}
+
+/** Streaming cursor of the table "published_mv_synthetic_programmes_by_year_18_1_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_slug?: InputMaybe<Scalars['String']['input']>;
+  year_slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0 = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0';
+  actions?: Maybe<Scalars['jsonb']['output']>;
+  base_slug?: Maybe<Scalars['String']['output']>;
+  features?: Maybe<Scalars['jsonb']['output']>;
+  is_legacy?: Maybe<Scalars['Boolean']['output']>;
+  programme_fields?: Maybe<Scalars['jsonb']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0ActionsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0FeaturesArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0Programme_FieldsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0_aggregate';
+  aggregate?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate_Fields>;
+  nodes: Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0>;
+};
+
+/** aggregate fields of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Max_Fields>;
+  min?: Maybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Min_Fields>;
+};
+
+
+/** aggregate fields of "published.mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "published.mv_synthetic_programmes_by_year_18_2_0". All fields are combined with a logical 'AND'. */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp = {
+  _and?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>>;
+  _not?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
+  _or?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>>;
+  actions?: InputMaybe<Jsonb_Comparison_Exp>;
+  base_slug?: InputMaybe<String_Comparison_Exp>;
+  features?: InputMaybe<Jsonb_Comparison_Exp>;
+  is_legacy?: InputMaybe<Boolean_Comparison_Exp>;
+  programme_fields?: InputMaybe<Jsonb_Comparison_Exp>;
+  programme_slug?: InputMaybe<String_Comparison_Exp>;
+  year_slug?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Max_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0_max_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Min_Fields = {
+  __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0_min_fields';
+  base_slug?: Maybe<Scalars['String']['output']>;
+  programme_slug?: Maybe<Scalars['String']['output']>;
+  year_slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Ordering options when selecting data from "published.mv_synthetic_programmes_by_year_18_2_0". */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Order_By = {
+  actions?: InputMaybe<Order_By>;
+  base_slug?: InputMaybe<Order_By>;
+  features?: InputMaybe<Order_By>;
+  is_legacy?: InputMaybe<Order_By>;
+  programme_fields?: InputMaybe<Order_By>;
+  programme_slug?: InputMaybe<Order_By>;
+  year_slug?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "published.mv_synthetic_programmes_by_year_18_2_0" */
+export enum Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column {
+  /** column name */
+  Actions = 'actions',
+  /** column name */
+  BaseSlug = 'base_slug',
+  /** column name */
+  Features = 'features',
+  /** column name */
+  IsLegacy = 'is_legacy',
+  /** column name */
+  ProgrammeFields = 'programme_fields',
+  /** column name */
+  ProgrammeSlug = 'programme_slug',
+  /** column name */
+  YearSlug = 'year_slug'
+}
+
+/** Streaming cursor of the table "published_mv_synthetic_programmes_by_year_18_2_0" */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Stream_Cursor_Value_Input = {
+  actions?: InputMaybe<Scalars['jsonb']['input']>;
+  base_slug?: InputMaybe<Scalars['String']['input']>;
+  features?: InputMaybe<Scalars['jsonb']['input']>;
+  is_legacy?: InputMaybe<Scalars['Boolean']['input']>;
+  programme_fields?: InputMaybe<Scalars['jsonb']['input']>;
+  programme_slug?: InputMaybe<Scalars['String']['input']>;
+  year_slug?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** columns and relationships of "published.mv_synthetic_unitvariant_lessons_by_keystage_13_1_0" */
 export type Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_13_1_0 = {
   __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_13_1_0';
@@ -51595,6 +51855,14 @@ export type Query_Root = {
   published_mv_synthetic_programmes_by_year_18_0_0: Array<Published_Mv_Synthetic_Programmes_By_Year_18_0_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_18_0_0" */
   published_mv_synthetic_programmes_by_year_18_0_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Aggregate;
+  /** fetch data from the table: "published.mv_synthetic_programmes_by_year_18_1_0" */
+  published_mv_synthetic_programmes_by_year_18_1_0: Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_18_1_0" */
+  published_mv_synthetic_programmes_by_year_18_1_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate;
+  /** fetch data from the table: "published.mv_synthetic_programmes_by_year_18_2_0" */
+  published_mv_synthetic_programmes_by_year_18_2_0: Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_18_2_0" */
+  published_mv_synthetic_programmes_by_year_18_2_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_13_1_0" */
   published_mv_synthetic_unitvariant_lessons_by_keystage_13_1_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_13_1_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_13_1_0" */
@@ -53619,6 +53887,42 @@ export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_18_0_0_Aggregate
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Order_By>>;
   where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_18_1_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_18_1_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_18_2_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
+};
+
+
+export type Query_RootPublished_Mv_Synthetic_Programmes_By_Year_18_2_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
 };
 
 
@@ -57599,6 +57903,18 @@ export type Subscription_Root = {
   published_mv_synthetic_programmes_by_year_18_0_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Aggregate;
   /** fetch data from the table in a streaming manner: "published.mv_synthetic_programmes_by_year_18_0_0" */
   published_mv_synthetic_programmes_by_year_18_0_0_stream: Array<Published_Mv_Synthetic_Programmes_By_Year_18_0_0>;
+  /** fetch data from the table: "published.mv_synthetic_programmes_by_year_18_1_0" */
+  published_mv_synthetic_programmes_by_year_18_1_0: Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_18_1_0" */
+  published_mv_synthetic_programmes_by_year_18_1_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_synthetic_programmes_by_year_18_1_0" */
+  published_mv_synthetic_programmes_by_year_18_1_0_stream: Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0>;
+  /** fetch data from the table: "published.mv_synthetic_programmes_by_year_18_2_0" */
+  published_mv_synthetic_programmes_by_year_18_2_0: Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0>;
+  /** fetch aggregated fields from the table: "published.mv_synthetic_programmes_by_year_18_2_0" */
+  published_mv_synthetic_programmes_by_year_18_2_0_aggregate: Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Aggregate;
+  /** fetch data from the table in a streaming manner: "published.mv_synthetic_programmes_by_year_18_2_0" */
+  published_mv_synthetic_programmes_by_year_18_2_0_stream: Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0>;
   /** fetch data from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_13_1_0" */
   published_mv_synthetic_unitvariant_lessons_by_keystage_13_1_0: Array<Published_Mv_Synthetic_Unitvariant_Lessons_By_Keystage_13_1_0>;
   /** fetch aggregated fields from the table: "published.mv_synthetic_unitvariant_lessons_by_keystage_13_1_0" */
@@ -60369,6 +60685,56 @@ export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_0_0_St
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Stream_Cursor_Input>>;
   where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_0_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_1_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_1_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_1_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_1_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_2_0Args = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_2_0_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Order_By>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
+};
+
+
+export type Subscription_RootPublished_Mv_Synthetic_Programmes_By_Year_18_2_0_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Stream_Cursor_Input>>;
+  where?: InputMaybe<Published_Mv_Synthetic_Programmes_By_Year_18_2_0_Bool_Exp>;
 };
 
 
@@ -70653,7 +71019,7 @@ export type PupilSubjectListingQueryVariables = Exact<{
 }>;
 
 
-export type PupilSubjectListingQuery = { __typename?: 'query_root', data: Array<{ __typename?: 'published_mv_synthetic_programmes_by_year_18_0_0', programme_slug?: string | null, base_slug?: string | null, year_slug?: string | null, programme_fields?: any | null, is_legacy?: boolean | null, features?: any | null }> };
+export type PupilSubjectListingQuery = { __typename?: 'query_root', data: Array<{ __typename?: 'published_mv_synthetic_programmes_by_year_18_2_0', programme_slug?: string | null, base_slug?: string | null, year_slug?: string | null, programme_fields?: any | null, is_legacy?: boolean | null, features?: any | null, actions?: any | null }> };
 
 export type PupilUnitListingQueryVariables = Exact<{
   baseSlug: Scalars['String']['input'];
@@ -71310,7 +71676,7 @@ export const PupilProgrammeListingDocument = gql`
     `;
 export const PupilSubjectListingDocument = gql`
     query pupilSubjectListing($yearSlug: String!) {
-  data: published_mv_synthetic_programmes_by_year_18_0_0(
+  data: published_mv_synthetic_programmes_by_year_18_2_0(
     where: {year_slug: {_eq: $yearSlug}}
   ) {
     programme_slug
@@ -71319,6 +71685,7 @@ export const PupilSubjectListingDocument = gql`
     programme_fields
     is_legacy
     features
+    actions
   }
 }
     `;

--- a/src/node-lib/curriculum-api-2023/queries/pupilSubjectListing/pupilSubjectListing.gql
+++ b/src/node-lib/curriculum-api-2023/queries/pupilSubjectListing/pupilSubjectListing.gql
@@ -1,5 +1,5 @@
 query pupilSubjectListing($yearSlug: String!) {
-  data: published_mv_synthetic_programmes_by_year_18_0_0(
+  data: published_mv_synthetic_programmes_by_year_18_2_0(
     where: { year_slug: { _eq: $yearSlug } }
   ) {
     programme_slug
@@ -8,5 +8,6 @@ query pupilSubjectListing($yearSlug: String!) {
     programme_fields
     is_legacy
     features
+    actions
   }
 }


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes
subject if all lessons on a programme have a feature than the subject on the subject page will have the same feature

in the case of 11 music all lessons have complex copyright so subject button wont display

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}/pupils/years/year-11/subjects
2. Click on subject page
3. You should see no music option for year 11

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
