### PR TITLE
fix: indicate current section in header

### DIFF
--- a/src/components/AppComponents/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.test.tsx
@@ -9,6 +9,10 @@ import { mockLoggedIn, mockLoggedOut } from "@/__tests__/__helpers__/mockUser";
 
 const render = renderWithProviders();
 
+jest.mock("@/hooks/useSelectedArea", () => {
+  return jest.fn(() => "PUPILS");
+});
+
 jest.mock("posthog-js/react", () => ({
   useFeatureFlagVariantKey: jest.fn(() => "with-login"),
   useFeatureFlagEnabled: () => false,
@@ -112,5 +116,21 @@ describe("components/AppHeader", () => {
 
     const signUpButton = screen.queryByRole("button", { name: /Sign up/i });
     expect(signUpButton).not.toBeInTheDocument();
+  });
+  it("pupil link should have aria-current=true when selected area is PUPIL", () => {
+    const { getByRole } = render(<AppHeader />);
+
+    expect(getByRole("link", { name: /Pupils/i })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+  it.only("teacher link should have aria-current=true when selected area is TEACHER", () => {
+    const { getByRole } = render(<AppHeader />);
+
+    expect(getByRole("link", { name: /Pupils/i })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
   });
 });

--- a/src/components/AppComponents/AppHeader/AppHeader.tsx
+++ b/src/components/AppComponents/AppHeader/AppHeader.tsx
@@ -99,6 +99,7 @@ const AppHeader: FC<HeaderProps> = () => {
               page={"teachers-home-page"}
               $focusStyles={["underline"]}
               $isSelected={true}
+              aria-current={selectedArea !== siteAreas.pupils}
             >
               Teachers
               {selectedArea == siteAreas.teachers && (
@@ -118,6 +119,7 @@ const AppHeader: FC<HeaderProps> = () => {
                     track.classroomSelected({ navigatedFrom: "header" }),
                   "aria-label": "Pupils browse years",
                 }}
+                aria-current={selectedArea == siteAreas.pupils}
               >
                 Pupils
                 {selectedArea == siteAreas.pupils && (


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {owa_deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
