### PR TITLE
chore: remove owa_deployment_url from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Fixes #
 
 ## How to test
 
-1. Go to {owa_deployment_url}
+1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
 2. Click on \_\_\_\_\_\_
 3. You should see \_\_\_\_\_\_
 


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Removes `owa_deployment_url` placeholder from PR template, as it was linking to the environment for the initially-pushed commit and creating the risk of testing against stale environments.
- Leaves the [update_pr_description](https://github.com/oaknational/Oak-Web-Application/blob/b1117319d07cdd89cde0738e52a9af76fd7618d4/.github/workflows/post_deployment_actions.yml#L13-L43) job in place, so it can still be fixed/replace in future.

## Issue(s)

Fixes #FEC-125

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
