### PR TITLE
feat: update curriculum banner copy [LESQ-1626]

### DIFF
--- a/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.test.tsx
+++ b/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.test.tsx
@@ -60,7 +60,7 @@ describe("CurriculumDownloadBanner", () => {
     render(<CurriculumDownloadBanner {...defaultProps} />);
 
     const heading = screen.getByRole("heading", {
-      name: "New fully-sequenced curriculum plan and lesson resources for Maths.",
+      name: "New fully-sequenced curriculum plan and lesson resources for maths.",
     });
     expect(heading).toBeInTheDocument();
     const downloadButton = screen.getByRole("button", {
@@ -236,5 +236,19 @@ describe("CurriculumDownloadBanner", () => {
         screen.getByText("Something went wrong with your download"),
       ).toBeInTheDocument();
     });
+  });
+  it("capitalises language subjects correctly", () => {
+    render(
+      <CurriculumDownloadBanner
+        {...defaultProps}
+        subjectSlug="french"
+        subjectTitle="French"
+      />,
+    );
+
+    const heading = screen.getByRole("heading", {
+      name: "New fully-sequenced curriculum plan and lesson resources for French.",
+    });
+    expect(heading).toBeInTheDocument();
   });
 });

--- a/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.tsx
+++ b/src/components/TeacherComponents/CurriculumDownloadBanner/CurriculumDownloadBanner.tsx
@@ -41,6 +41,15 @@ const CurriculumDownloadBanner = (props: CurriculumDownloadBannerProps) => {
     childSubjectSlug,
   });
 
+  const subjectDisplayTitle = [
+    "english",
+    "french",
+    "spanish",
+    "german",
+  ].includes(subjectSlug)
+    ? subjectTitle
+    : subjectTitle.toLowerCase();
+
   return (
     <OakLinkCard
       hasAnimation
@@ -48,7 +57,7 @@ const CurriculumDownloadBanner = (props: CurriculumDownloadBannerProps) => {
         <OakFlex $flexDirection="column" $gap="space-between-s">
           <OakHeading tag="h2">
             New fully-sequenced curriculum plan and lesson resources for{" "}
-            {subjectTitle}.
+            {subjectDisplayTitle}.
           </OakHeading>
           <OakP $font="heading-light-7">
             Download the curriculum plan now to explore the thinking behind our


### PR DESCRIPTION
## Description

Music year: 1997

- Update banner copy
- remove `.toLowerCase()` on subject name

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1626curriculum-b8a632.vercel.thenational.academy/teachers/programmes/french-primary-ks2/units
2. Other cycle 2 subjects should have the new copy on the banner

## Screenshots

How it used to look:
<img width="500" height="625" alt="Screenshot 2025-09-30 at 15 03 21" src="https://github.com/user-attachments/assets/0338c191-74e2-4ffc-b40c-7e04033c9abd" />

How it should now look:
<img width="500" height="631" alt="Screenshot 2025-09-30 at 15 02 57" src="https://github.com/user-attachments/assets/6f91377b-b0fe-4299-b102-3c01123f850d" />

