### PR TITLE
feat: update download all button text and accordion behaviour [LESQ-1607]

### DIFF
--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -119,7 +119,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
     render(<LessonOverviewPage curriculumData={lessonOverviewFixture()} />);
 
     expect(screen.getAllByTestId("download-all-button")[0]).toHaveTextContent(
-      "Download all resources",
+      "Download all",
     );
   });
 

--- a/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
+++ b/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug].test.tsx
@@ -59,7 +59,7 @@ describe("pages/teachers/specialist/programmes/units/[unitSlug]/lessons/[lessonS
     );
 
     expect(screen.getAllByTestId("download-all-button")[0]).toHaveTextContent(
-      "Download all resources",
+      "Download all",
     );
   });
 

--- a/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
+++ b/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
@@ -181,6 +181,7 @@ const DownloadPageWithAccordionContent = (
         handleToggleSelectAll={handleToggleSelectAll}
         selectAllChecked={selectAllChecked}
         id="downloads-accordion"
+        initialOpen={!selectAllChecked}
       >
         <OakBox
           $pa={"inner-padding-none"}

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.test.tsx
@@ -78,7 +78,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
 
     expect(downloadButton).toBeInTheDocument();
     expect(downloadButton.tagName).toBe("A");
-    expect(getByText("Download all resources")).toBeInTheDocument();
+    expect(getByText("Download all")).toBeInTheDocument();
     expect(downloadButton).toHaveAttribute("href");
     downloadButton.click();
     expect(mockDownloadAllButton).toHaveBeenCalled();

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -57,10 +57,10 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
       rel="nofollow"
       loginRequired={loginRequired ?? false}
       geoRestricted={geoRestricted ?? false}
-      onboardingProps={{ name: "Download all resources" }}
-      signUpProps={{ name: "Download all resources" }}
+      onboardingProps={{ name: "Download all" }}
+      signUpProps={{ name: "Download all" }}
       actionProps={{
-        name: "Download all resources",
+        name: "Download all",
         onClick: onClickDownloadAll,
         isActionGeorestricted: true,
         shouldHidewhenGeoRestricted: true,
@@ -69,9 +69,9 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
       sizeVariant="small"
       element="a"
       data-testid="download-all-button"
-      iconName="arrow-right"
+      iconName="download"
       isTrailingIcon
-      aria-label="Download all resources"
+      aria-label="Download all"
     />
   );
 };


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- Updates text and icon on `Download all` button on lesson overview page
- Individual preselect download links on lesson overview page link to downloads page with expanded accordion when feature flag and `with-accordion` variant is active

## Issue(s)

Fixes LESQ-1607

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
