### PR TITLE
Feat/posthog cookieless tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "node-fetch": "^2.6.7",
         "path-browserify": "^1.0.1",
         "path-to-regexp": "^6.2.1n",
-        "posthog-js": "^1.214.0",
+        "posthog-js": "^1.269.0",
         "posthog-node": "^4.10.1",
         "querystring-es3": "^0.2.1",
         "react": "^18.3.1",
@@ -8502,6 +8502,12 @@
         "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-f16Ozx6LIigRG+HsJdt+7kgSxZTHeX5f1JlCGKI1lXcvlZgfsCR338FuMI2QRYXGl+jg/vYFzGOTQBxl90lnBg==",
+      "license": "MIT"
+    },
     "node_modules/@prettier/plugin-xml": {
       "version": "3.2.2",
       "dev": true,
@@ -10177,11 +10183,22 @@
         "rrweb": "^2.0.0-alpha.18"
       }
     },
-    "node_modules/@rrweb/types": {
+    "node_modules/@rrweb/record/node_modules/@rrweb/types": {
       "version": "2.0.0-alpha.18",
       "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
       "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
       "license": "MIT"
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.17.tgz",
+      "integrity": "sha512-AfDTVUuCyCaIG0lTSqYtrZqJX39ZEYzs4fYKnexhQ+id+kbZIpIJtaut5cto6dWZbB3SEe4fW0o90Po3LvTmfg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.0-alpha.17"
+      }
     },
     "node_modules/@rrweb/utils": {
       "version": "2.0.0-alpha.18",
@@ -35893,15 +35910,28 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.214.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.214.0.tgz",
-      "integrity": "sha512-zJpTAB/85wkr2YtpeH6K/JLeenVRoFnyA4pj8Yern3sGkLj1bRao4AzFJuTvY5IduDRUIkKup5pr5NxjZ0QPnw==",
-      "license": "MIT",
+      "version": "1.269.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.269.1.tgz",
+      "integrity": "sha512-4GrcKQ89uLwBGNtHrhq5QRCzHmPPCxE6i0cDsk4mFMls9iZcsdTpITBNepHbP0Bvn62HZUVAiqGeRlOpy8XeCA==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@posthog/core": "1.2.2",
         "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",
-        "web-vitals": "^4.2.0"
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@rrweb/types": "2.0.0-alpha.17",
+        "rrweb-snapshot": "2.0.0-alpha.17"
+      },
+      "peerDependenciesMeta": {
+        "@rrweb/types": {
+          "optional": true
+        },
+        "rrweb-snapshot": {
+          "optional": true
+        }
       }
     },
     "node_modules/posthog-node": {
@@ -37940,6 +37970,15 @@
         "rrweb-snapshot": "^2.0.0-alpha.18"
       }
     },
+    "node_modules/rrdom/node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
     "node_modules/rrweb": {
       "version": "2.0.0-alpha.18",
       "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
@@ -37957,6 +37996,23 @@
       }
     },
     "node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.17.tgz",
+      "integrity": "sha512-GBg5pV8LHOTbeVmH2VHLEFR0mc2QpQMzAvcoxEGfPNWgWHc8UvKCyq7pqN1vA+fDZ+yXXbixeO0kB2pzVvFCBw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/rrweb/node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
+      "license": "MIT"
+    },
+    "node_modules/rrweb/node_modules/rrweb-snapshot": {
       "version": "2.0.0-alpha.18",
       "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
       "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "node-fetch": "^2.6.7",
     "path-browserify": "^1.0.1",
     "path-to-regexp": "^6.2.1n",
-    "posthog-js": "^1.214.0",
+    "posthog-js": "^1.269.0",
     "posthog-node": "^4.10.1",
     "querystring-es3": "^0.2.1",
     "react": "^18.3.1",

--- a/src/__tests__/pages/teachers/beta/lessons/lessonSlug.tsx/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/beta/lessons/lessonSlug.tsx/downloads.test.tsx
@@ -16,7 +16,9 @@ import {
 import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
 
 const render = renderWithProviders();
-
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagVariantKey: jest.fn(),
+}));
 const lesson = lessonDownloadsFixture({
   lessonTitle: "The meaning of time",
 });

--- a/src/__tests__/pages/teachers/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/lessons/[lessonSlug]/downloads.test.tsx
@@ -16,7 +16,9 @@ import {
 import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
 
 const render = renderWithProviders();
-
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagVariantKey: jest.fn(),
+}));
 const lesson = lessonDownloadsFixture({
   lessonTitle: "The meaning of time",
 });

--- a/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
+++ b/src/__tests__/pages/teachers/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads.test.tsx
@@ -13,7 +13,9 @@ import {
 } from "@/__tests__/__helpers__/mockUser";
 
 const render = renderWithProviders();
-
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagVariantKey: jest.fn(),
+}));
 describe("pages/specialist/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads", () => {
   it("renders lessons", () => {
     render(

--- a/src/browser-lib/analytics/useAnalyticsService.ts
+++ b/src/browser-lib/analytics/useAnalyticsService.ts
@@ -42,11 +42,11 @@ const useAnalyticsService = <T>({
   }, [consentState, hasAttemptedInit, config, service, setPosthogDistinctId]);
 
   useEffect(() => {
-    // do not track
     if (loaded) {
       if (consentState === "granted") {
         service.optIn();
       }
+      // do not track
       if (consentState === "denied") {
         service.optOut();
         if (setPosthogDistinctId) {

--- a/src/browser-lib/analytics/useAnalyticsService.ts
+++ b/src/browser-lib/analytics/useAnalyticsService.ts
@@ -36,7 +36,7 @@ const useAnalyticsService = <T>({
         setLoaded(true);
       }
     };
-    if (consentState === "granted" && !hasAttemptedInit) {
+    if (!hasAttemptedInit) {
       attemptInit();
     }
   }, [consentState, hasAttemptedInit, config, service, setPosthogDistinctId]);

--- a/src/browser-lib/posthog/posthog.ts
+++ b/src/browser-lib/posthog/posthog.ts
@@ -26,6 +26,7 @@ export const posthogToAnalyticsServiceWithoutQueue = (
         client.init(apiKey, {
           api_host: apiHost,
           ui_host: uiHost,
+          opt_out_capturing_by_default: true,
           debug: getBrowserConfig("releaseStage") !== "production",
           loaded: () => {
             const legacyAnonymousId = getLegacyAnonymousId();

--- a/src/browser-lib/posthog/posthog.ts
+++ b/src/browser-lib/posthog/posthog.ts
@@ -26,7 +26,7 @@ export const posthogToAnalyticsServiceWithoutQueue = (
         client.init(apiKey, {
           api_host: apiHost,
           ui_host: uiHost,
-          opt_out_capturing_by_default: true,
+          cookieless_mode: "on_reject",
           debug: getBrowserConfig("releaseStage") !== "production",
           loaded: () => {
             const legacyAnonymousId = getLegacyAnonymousId();

--- a/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.test.tsx
+++ b/src/components/TeacherViews/SpecialistLessonDownloads/SpecialistLessonDownloads.test.tsx
@@ -4,7 +4,9 @@ import SpecialistLessonDownloads from "./SpecialistLessonDownloads.view";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 const render = renderWithProviders();
-
+jest.mock("posthog-js/react", () => ({
+  useFeatureFlagVariantKey: jest.fn(),
+}));
 describe("SpecialistLessonDownloads", () => {
   test("renders component", () => {
     const { getByText } = render(


### PR DESCRIPTION
## Description

The goal of the change is to allow feature flags to load before consent has been accepted, or when consent has been rejected

- initialise posthog regardless of cookie consent status
- add `cookieless_mode` flag to init, so posthog wont create a cookie until we explicitly opt in to tracking
- opt in when cookies have been accepted
- opt out when cookies rejected

## Issue(s)

Fixes #
Feature flags don't load for users who have opted out of / not accepted analytics cookies

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. As a fresh user / not signed in / no cookies
3. You should retrieve a feature flag value (example flag to be given)
4. Click reject cookies
5. You should see no posthog cookie added
6. You should still see feature flagged content
7. Analytics event should contain no distinct id

## Screenshots

Test flag value enabled while cookies not accepted:
<img width="600" height="300" alt="Screenshot 2025-10-02 at 15 53 27" src="https://github.com/user-attachments/assets/067ca6ed-086f-4374-bfed-26f1317dfa95" />

No distinct id:
<img width="200" height="135" alt="Screenshot 2025-10-02 at 15 54 12" src="https://github.com/user-attachments/assets/d0ff0d6c-6346-4ada-8db9-ac23b5c8e1f9" />

