### PR TITLE
Added edit-details/copy-link timetabling units header

### DIFF
--- a/src/components/CurriculumComponents/CurricTimetableHeader/CurricTimetableHeader.tsx
+++ b/src/components/CurriculumComponents/CurricTimetableHeader/CurricTimetableHeader.tsx
@@ -40,7 +40,7 @@ export function CurricTimetableHeader({
           </OakFlex>
           <OakFlex>
             <OakFlex
-              $gap={"all-spacing-9"}
+              $gap={"all-spacing-6"}
               $flexDirection={"column"}
               $flexGrow={1}
             >

--- a/src/components/CurriculumComponents/CurricTimetablingNewView/index.tsx
+++ b/src/components/CurriculumComponents/CurricTimetablingNewView/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 import {
-  OakBox,
   OakFlex,
   OakHeading,
   OakP,
@@ -13,7 +12,6 @@ import { useMemo } from "react";
 import Link from "next/link";
 
 import { CurricTimetableHeader } from "../CurricTimetableHeader";
-import { CurricShowSteps } from "../CurricShowSteps";
 
 import {
   simpleObjectAsSearchParams,
@@ -38,11 +36,6 @@ export const CurricTimetablingNewView = ({
         <CurricTimetableHeader
           titleSlot={`Year ${data.year} ${subjectSlug}`}
           illustrationSlug={"magic-carpet"}
-          additionalSlot={
-            <OakBox $maxWidth={"all-spacing-20"}>
-              <CurricShowSteps numberOfSteps={2} currentStepIndex={0} />
-            </OakBox>
-          }
         />
       </OakFlex>
 

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/CurricTimetablingUnits.test.tsx
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/CurricTimetablingUnits.test.tsx
@@ -1,0 +1,50 @@
+import { waitFor } from "@testing-library/dom";
+import { act } from "@testing-library/react";
+
+import { CurricTimetablingUnits } from ".";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+describe("CurricTimetablingUnits", () => {
+  test("snapshot", () => {
+    const { container } = renderWithTheme(
+      <CurricTimetablingUnits subjectPhaseSlug={"maths-primary"} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  test("edit details", () => {
+    const { getAllByRole, getByTestId } = renderWithTheme(
+      <CurricTimetablingUnits subjectPhaseSlug={"maths-primary"} />,
+    );
+    const els = getAllByRole("button");
+    expect(els[0]).toHaveTextContent("Edit details");
+
+    act(() => {
+      els[0]!.click();
+    });
+
+    waitFor(() => {
+      expect(getByTestId("edit-details-modal")).toBeTruthy();
+    });
+  });
+
+  test("copy link", () => {
+    const { getAllByRole } = renderWithTheme(
+      <CurricTimetablingUnits subjectPhaseSlug={"maths-primary"} />,
+    );
+    const els = getAllByRole("button");
+    expect(els[1]).toHaveTextContent("Copy link");
+
+    act(() => {
+      els[1]!.click();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  });
+});

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CurricTimetableHeader basic usage 1`] = `
-<body>
-  <div>
+exports[`CurricTimetablingUnits snapshot 1`] = `
+<div>
+  <div
+    class="sc-fqkvVR sc-kAyceB fDrQuw eeevb"
+  >
     <div
       class="sc-fqkvVR iYZQrv"
     >
@@ -40,13 +42,88 @@ exports[`CurricTimetableHeader basic usage 1`] = `
                 class="sc-kpDqfm jGrEMo"
                 data-testid="timetable-header-title"
               >
-                TITLE
+                Year 1 maths
               </h1>
               <div
                 class="sc-fqkvVR fgBWrW"
                 data-testid="timetable-header-additional"
               >
-                ADDITIONAL
+                <div
+                  class="sc-fqkvVR sc-kAyceB emCiKl ddfwpL"
+                >
+                  <div
+                    class="sc-fqkvVR sc-fXSgeo eJBGXR efioha"
+                  >
+                    <div
+                      class="sc-fqkvVR iPpXCP grey-shadow"
+                    />
+                    <div
+                      class="sc-fqkvVR iPpXCP yellow-shadow"
+                    />
+                    <button
+                      class="sc-iHGNWf sc-esYiGF iKUgIm hnQzKH internal-button"
+                    >
+                      <div
+                        class="sc-fqkvVR sc-kAyceB fgBWrW cHFgFN"
+                      >
+                        <span
+                          class="sc-dAlyuH hcOVuy"
+                        >
+                          Edit details
+                        </span>
+                        <div
+                          class="sc-fqkvVR kbnxKi"
+                        >
+                          <img
+                            alt=""
+                            class="sc-dcJsrY beWtwI"
+                            data-nimg="fill"
+                            decoding="async"
+                            loading="lazy"
+                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1727861316/icons/Icon_Copy_qxgynv.svg"
+                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                          />
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                  <div
+                    class="sc-fqkvVR sc-fXSgeo eJBGXR efioha"
+                  >
+                    <div
+                      class="sc-fqkvVR iPpXCP grey-shadow"
+                    />
+                    <div
+                      class="sc-fqkvVR iPpXCP yellow-shadow"
+                    />
+                    <button
+                      class="sc-iHGNWf sc-esYiGF iKUgIm hnQzKH internal-button"
+                    >
+                      <div
+                        class="sc-fqkvVR sc-kAyceB fgBWrW cHFgFN"
+                      >
+                        <span
+                          class="sc-dAlyuH hcOVuy"
+                        >
+                          Copy link
+                        </span>
+                        <div
+                          class="sc-fqkvVR kbnxKi"
+                        >
+                          <img
+                            alt=""
+                            class="sc-dcJsrY beWtwI"
+                            data-nimg="fill"
+                            decoding="async"
+                            loading="lazy"
+                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699894149/icons/qxlunbg5tfrdherzsvlt.svg"
+                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                          />
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -69,5 +146,18 @@ exports[`CurricTimetableHeader basic usage 1`] = `
       </div>
     </div>
   </div>
-</body>
+  <div
+    class="sc-fqkvVR sc-kAyceB sc-jEACwC drEYrk jOTTNg"
+  >
+    <pre>
+      {
+  "autumn": 30,
+  "spring": 30,
+  "summer": 30,
+  "year": "1",
+  "name": ""
+}
+    </pre>
+  </div>
+</div>
 `;

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/index.tsx
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {
+  OakBox,
   OakFlex,
   OakInformativeModal,
   OakMaxWidth,
@@ -61,7 +62,7 @@ export const CurricTimetablingUnits = ({
         onClose={() => setModalOpen(false)}
         closeOnBackgroundClick={true}
       >
-        Edit details modal
+        <OakBox data-testid="edit-details-modal">Edit details modal</OakBox>
       </OakInformativeModal>
 
       <OakMaxWidth $ph={"inner-padding-xl5"}>

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/index.tsx
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/index.tsx
@@ -1,8 +1,13 @@
 "use client";
-import { OakBox, OakFlex, OakMaxWidth } from "@oaknational/oak-components";
+import {
+  OakFlex,
+  OakInformativeModal,
+  OakMaxWidth,
+  OakSecondaryButton,
+} from "@oaknational/oak-components";
+import { useState } from "react";
 
 import { CurricTimetableHeader } from "../CurricTimetableHeader";
-import { CurricShowSteps } from "../CurricShowSteps";
 
 import { useTimetableParams } from "@/utils/curriculum/timetabling";
 import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
@@ -11,8 +16,18 @@ type CurricTimetablingUnitsProps = { subjectPhaseSlug: string };
 export const CurricTimetablingUnits = ({
   subjectPhaseSlug,
 }: CurricTimetablingUnitsProps) => {
+  const [modalOpen, setModalOpen] = useState(false);
   const [data] = useTimetableParams();
   const { subjectSlug } = parseSubjectPhaseSlug(subjectPhaseSlug)!;
+
+  const onEditDetails = () => {
+    setModalOpen(true);
+  };
+
+  const onCopyLink = () => {
+    const urlToCopy = window.location.href;
+    navigator.clipboard.writeText(urlToCopy);
+  };
 
   return (
     <>
@@ -21,12 +36,33 @@ export const CurricTimetablingUnits = ({
           titleSlot={`Year ${data.year} ${subjectSlug}`}
           illustrationSlug={"magic-carpet"}
           additionalSlot={
-            <OakBox $maxWidth={"all-spacing-20"}>
-              <CurricShowSteps numberOfSteps={2} currentStepIndex={1} />
-            </OakBox>
+            <OakFlex $maxWidth={"all-spacing-20"} $gap={"all-spacing-4"}>
+              <OakSecondaryButton
+                iconName="copy"
+                isTrailingIcon={true}
+                onClick={onEditDetails}
+              >
+                Edit details
+              </OakSecondaryButton>
+              <OakSecondaryButton
+                iconName="edit"
+                isTrailingIcon={true}
+                onClick={onCopyLink}
+              >
+                Copy link
+              </OakSecondaryButton>
+            </OakFlex>
           }
         />
       </OakFlex>
+
+      <OakInformativeModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        closeOnBackgroundClick={true}
+      >
+        Edit details modal
+      </OakInformativeModal>
 
       <OakMaxWidth $ph={"inner-padding-xl5"}>
         <pre>{JSON.stringify(data, null, 2)}</pre>


### PR DESCRIPTION
## Description
Added edit-details/copy-link timetabling units header

 - "copy link" — copies the current URL
 - "edit details" — opens a blank modal

The above is so I can add stub unit tests to the buttons 

## Issue(s)
Fixes `ADOPT-1629`

## How to test
1. Go to [OWA Preview URL from Vercel bot comment]/timetabling/english-primary/new
2. Verify links work as expected

## Screenshots
<img width="914" height="357" alt="Screenshot 2025-10-06 at 16 46 14" src="https://github.com/user-attachments/assets/42cf08ff-bbfa-400f-86d3-de645833ac75" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
