### PR TITLE
Refactor/classroom gradebook refactor

### DIFF
--- a/src/app/api/classroom/attachment/create/route.test.ts
+++ b/src/app/api/classroom/attachment/create/route.test.ts
@@ -8,11 +8,13 @@ import { POST } from "./route";
 
 import { getOakGoogleClassroomAddon } from "@/node-lib/google-classroom";
 
-jest.mock("next/server", () => ({
-  NextResponse: {
-    json: jest.fn(),
-  },
-}));
+jest.mock("next/server", () => {
+  class MockNextResponse {}
+  (MockNextResponse as unknown as { json: jest.Mock }).json = jest.fn(
+    () => new MockNextResponse(),
+  );
+  return { NextResponse: MockNextResponse };
+});
 
 jest.mock("@/node-lib/google-classroom", () => {
   const reporterMock = jest.fn();

--- a/src/app/api/classroom/attachment/create/route.ts
+++ b/src/app/api/classroom/attachment/create/route.ts
@@ -4,21 +4,19 @@ import { createAnnouncementAttachmentArgsSchema } from "@oaknational/google-clas
 import {
   createClassroomErrorReporter,
   getOakGoogleClassroomAddon,
-  isOakGoogleClassroomException,
 } from "@/node-lib/google-classroom";
+import {
+  handleClassroomError,
+  requireClassroomAuthHeaders,
+} from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("create-attachment");
 
 export async function POST(request: NextRequest) {
   try {
-    const accessToken = request.headers.get("Authorization");
-    const session = request.headers.get("x-oakgc-session");
-
-    if (!session || !accessToken)
-      return NextResponse.json(
-        { message: "Authentication required" },
-        { status: 401 },
-      );
+    const auth = requireClassroomAuthHeaders(request);
+    if (auth instanceof NextResponse) return auth;
+    const { accessToken, session } = auth;
 
     const oakClassroomClient = getOakGoogleClassroomAddon(request);
     const body = await request.json();
@@ -31,12 +29,6 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
-    // this isn't reachable because of initial session check
-    if (!session)
-      return NextResponse.json(
-        { message: "Missing auth header" },
-        { status: 400 },
-      );
 
     await oakClassroomClient.createAttachment(
       parsed.data,
@@ -46,11 +38,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({}, { status: 201 });
   } catch (e) {
-    const errorObject = isOakGoogleClassroomException(e) ? e.toObject() : e;
-    reportError(errorObject);
-    return NextResponse.json(
-      { error: e instanceof Error ? e?.message : String(e) },
-      { status: 500 },
-    );
+    return handleClassroomError(reportError, e);
   }
 }

--- a/src/app/api/classroom/auth/callback/route.ts
+++ b/src/app/api/classroom/auth/callback/route.ts
@@ -8,43 +8,15 @@ import {
   createClassroomErrorReporter,
 } from "@/node-lib/google-classroom";
 import { handleNewsletterSignup } from "@/node-lib/google-classroom/handleNewsletterSignup";
+import {
+  getOAuthError,
+  getNewsletterPreference,
+  isTeacherLogin,
+  parseStateParam,
+  type OAuthError,
+} from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("callback");
-
-type OAuthError = {
-  error: string;
-  errorDescription?: string | null;
-};
-
-function getOAuthError(searchParams: URLSearchParams): OAuthError | null {
-  const error = searchParams.get("error");
-  if (!error) return null;
-  return { error, errorDescription: searchParams.get("error_description") };
-}
-
-function getNewsletterPreference(searchParams: URLSearchParams): boolean {
-  const stateParam = searchParams.get("state");
-  if (!stateParam) return false;
-
-  try {
-    const parsed = JSON.parse(stateParam);
-    return parsed.subscribeToNewsletter === true;
-  } catch {
-    return false;
-  }
-}
-
-function isTeacherLogin(searchParams: URLSearchParams): boolean {
-  const stateParam = searchParams.get("state");
-  if (!stateParam) return true;
-
-  try {
-    const parsed = JSON.parse(stateParam);
-    return parsed.isPupil !== true;
-  } catch {
-    return true;
-  }
-}
 
 function oauthErrorResponse(oauthError: OAuthError) {
   return NextResponse.json(
@@ -78,7 +50,8 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const code = searchParams.get("code");
     const oauthError = getOAuthError(searchParams);
-    const subscribeToNewsletter = getNewsletterPreference(searchParams);
+    const state = parseStateParam(searchParams);
+    const subscribeToNewsletter = getNewsletterPreference(state);
     const parsedCode = codeSchema.safeParse(code);
 
     // Check for OAuth errors from Google -
@@ -96,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
 
     const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
-    const onNewsletterSignup = isTeacherLogin(searchParams)
+    const onNewsletterSignup = isTeacherLogin(state)
       ? (email: string) =>
           handleNewsletterSignup(
             email,

--- a/src/app/api/classroom/classroomUtils.ts
+++ b/src/app/api/classroom/classroomUtils.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isOakGoogleClassroomException } from "@/node-lib/google-classroom";
+
+export type OAuthError = {
+  error: string;
+  errorDescription?: string | null;
+};
+
+export type OAuthState = {
+  subscribeToNewsletter?: boolean;
+  isPupil?: boolean;
+};
+
+export function getOAuthError(
+  searchParams: URLSearchParams,
+): OAuthError | null {
+  const error = searchParams.get("error");
+  if (!error) return null;
+  return { error, errorDescription: searchParams.get("error_description") };
+}
+
+export function parseStateParam(searchParams: URLSearchParams): OAuthState {
+  const stateParam = searchParams.get("state");
+  if (!stateParam) return {};
+  try {
+    return JSON.parse(stateParam) as OAuthState;
+  } catch {
+    return {};
+  }
+}
+
+export function getNewsletterPreference(state: OAuthState): boolean {
+  return state.subscribeToNewsletter === true;
+}
+
+export function isTeacherLogin(state: OAuthState): boolean {
+  return state.isPupil !== true;
+}
+
+export function handleClassroomError(
+  reportError: (e: unknown) => void,
+  e: unknown,
+): NextResponse {
+  const errorObject = isOakGoogleClassroomException(e) ? e.toObject() : e;
+  reportError(errorObject);
+  return NextResponse.json(
+    { error: e instanceof Error ? e.message : String(e) },
+    { status: 500 },
+  );
+}
+
+export function requireClassroomAuthHeaders(
+  request: NextRequest,
+): { accessToken: string; session: string } | NextResponse {
+  const accessToken = request.headers.get("Authorization");
+  const session = request.headers.get("x-oakgc-session");
+
+  if (!session || !accessToken) {
+    return NextResponse.json(
+      { message: "Authentication required" },
+      { status: 401 },
+    );
+  }
+
+  return { accessToken, session };
+}

--- a/src/app/api/classroom/context/route.test.ts
+++ b/src/app/api/classroom/context/route.test.ts
@@ -8,11 +8,13 @@ import { POST } from "./route";
 
 import { getOakGoogleClassroomAddon } from "@/node-lib/google-classroom";
 
-jest.mock("next/server", () => ({
-  NextResponse: {
-    json: jest.fn(),
-  },
-}));
+jest.mock("next/server", () => {
+  class MockNextResponse {}
+  (MockNextResponse as unknown as { json: jest.Mock }).json = jest.fn(
+    () => new MockNextResponse(),
+  );
+  return { NextResponse: MockNextResponse };
+});
 
 jest.mock("@/node-lib/google-classroom", () => {
   const reporterMock = jest.fn();

--- a/src/app/api/classroom/context/route.ts
+++ b/src/app/api/classroom/context/route.ts
@@ -4,8 +4,11 @@ import z from "zod";
 import {
   createClassroomErrorReporter,
   getOakGoogleClassroomAddon,
-  isOakGoogleClassroomException,
 } from "@/node-lib/google-classroom";
+import {
+  handleClassroomError,
+  requireClassroomAuthHeaders,
+} from "@/app/api/classroom/classroomUtils";
 
 const getAddOnContextSchema = z.object({
   courseId: z.string(),
@@ -17,14 +20,9 @@ const reportError = createClassroomErrorReporter("addon-context");
 
 export async function POST(request: NextRequest) {
   try {
-    const accessToken = request.headers.get("Authorization");
-    const session = request.headers.get("x-oakgc-session");
-
-    if (!session || !accessToken)
-      return NextResponse.json(
-        { message: "Authentication required" },
-        { status: 401 },
-      );
+    const auth = requireClassroomAuthHeaders(request);
+    if (auth instanceof NextResponse) return auth;
+    const { accessToken, session } = auth;
 
     const oakClassroomClient = getOakGoogleClassroomAddon(request);
     const body = await request.json();
@@ -48,11 +46,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(context, { status: 200 });
   } catch (e) {
-    const errorObject = isOakGoogleClassroomException(e) ? e.toObject() : e;
-    reportError(errorObject);
-    return NextResponse.json(
-      { error: e instanceof Error ? e?.message : String(e) },
-      { status: 500 },
-    );
+    return handleClassroomError(reportError, e);
   }
 }

--- a/src/app/api/classroom/pupil/progress/route.test.ts
+++ b/src/app/api/classroom/pupil/progress/route.test.ts
@@ -8,11 +8,13 @@ import { GET } from "./route";
 
 import { getOakGoogleClassroomAddon } from "@/node-lib/google-classroom";
 
-jest.mock("next/server", () => ({
-  NextResponse: {
-    json: jest.fn(),
-  },
-}));
+jest.mock("next/server", () => {
+  class MockNextResponse {}
+  (MockNextResponse as unknown as { json: jest.Mock }).json = jest.fn(
+    () => new MockNextResponse(),
+  );
+  return { NextResponse: MockNextResponse };
+});
 
 jest.mock("@/node-lib/google-classroom", () => {
   const reporterMock = jest.fn();

--- a/src/app/api/classroom/pupil/progress/route.test.ts
+++ b/src/app/api/classroom/pupil/progress/route.test.ts
@@ -114,9 +114,7 @@ describe("GET /api/classroom/pupil/progress", () => {
     expect(mockGetPupilLessonProgress).not.toHaveBeenCalled();
     expect(mockUpsertPupilLessonProgress).not.toHaveBeenCalled();
     expect(NextResponse.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: expect.any(String),
-      }),
+      { message: "Authentication required" },
       { status: 401 },
     );
   });

--- a/src/app/api/classroom/pupil/progress/route.test.ts
+++ b/src/app/api/classroom/pupil/progress/route.test.ts
@@ -98,4 +98,26 @@ describe("GET /api/classroom/pupil/progress", () => {
       { status: 400 },
     );
   });
+
+  it("should reject with 401 if auth headers are missing", async () => {
+    const mockMissingAuthHeaders = {
+      get: jest.fn(() => null),
+    };
+
+    const mockRequest = {
+      headers: mockMissingAuthHeaders,
+      url: "http://localhost/api/classroom/pupil/progress?submissionId=sub-1&courseId=course-1&itemId=item-1&attachmentId=attachment-1",
+    } as unknown as NextRequest;
+
+    await GET(mockRequest);
+
+    expect(mockGetPupilLessonProgress).not.toHaveBeenCalled();
+    expect(mockUpsertPupilLessonProgress).not.toHaveBeenCalled();
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(String),
+      }),
+      { status: 401 },
+    );
+  });
 });

--- a/src/app/api/classroom/pupil/progress/route.ts
+++ b/src/app/api/classroom/pupil/progress/route.ts
@@ -2,15 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 
 import {
   getOakGoogleClassroomAddon,
-  isOakGoogleClassroomException,
   createClassroomErrorReporter,
 } from "@/node-lib/google-classroom";
+import {
+  handleClassroomError,
+  requireClassroomAuthHeaders,
+} from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("pupil-progress");
 
 export async function GET(request: NextRequest) {
   try {
-    // add requireClassroomAuthHeaders check here
+    const auth = requireClassroomAuthHeaders(request);
+    if (auth instanceof NextResponse) return auth;
+
     const requestUrl = new URL(request.url);
     const submissionId = requestUrl.searchParams.get("submissionId");
     const attachmentId = requestUrl.searchParams.get("attachmentId");
@@ -31,11 +36,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(result ?? { lessonProgress: null });
   } catch (e) {
-    const errorObject = isOakGoogleClassroomException(e) ? e.toObject() : e;
-    reportError(errorObject);
-    return NextResponse.json(
-      { error: e instanceof Error ? e?.message : String(e) },
-      { status: 500 },
-    );
+    return handleClassroomError(reportError, e);
   }
 }

--- a/src/app/api/classroom/pupil/progress/route.ts
+++ b/src/app/api/classroom/pupil/progress/route.ts
@@ -4,12 +4,18 @@ import {
   getOakGoogleClassroomAddon,
   createClassroomErrorReporter,
 } from "@/node-lib/google-classroom";
-import { handleClassroomError } from "@/app/api/classroom/classroomUtils";
+import {
+  handleClassroomError,
+  requireClassroomAuthHeaders,
+} from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("pupil-progress");
 
 export async function GET(request: NextRequest) {
   try {
+    const auth = requireClassroomAuthHeaders(request);
+    if (auth instanceof NextResponse) return auth;
+
     const requestUrl = new URL(request.url);
     const submissionId = requestUrl.searchParams.get("submissionId");
     const attachmentId = requestUrl.searchParams.get("attachmentId");

--- a/src/app/api/classroom/pupil/progress/route.ts
+++ b/src/app/api/classroom/pupil/progress/route.ts
@@ -4,18 +4,12 @@ import {
   getOakGoogleClassroomAddon,
   createClassroomErrorReporter,
 } from "@/node-lib/google-classroom";
-import {
-  handleClassroomError,
-  requireClassroomAuthHeaders,
-} from "@/app/api/classroom/classroomUtils";
+import { handleClassroomError } from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("pupil-progress");
 
 export async function GET(request: NextRequest) {
   try {
-    const auth = requireClassroomAuthHeaders(request);
-    if (auth instanceof NextResponse) return auth;
-
     const requestUrl = new URL(request.url);
     const submissionId = requestUrl.searchParams.get("submissionId");
     const attachmentId = requestUrl.searchParams.get("attachmentId");

--- a/src/app/api/classroom/pupil/progress/submit/route.test.ts
+++ b/src/app/api/classroom/pupil/progress/submit/route.test.ts
@@ -13,11 +13,13 @@ import { POST } from "./route";
 
 import { getOakGoogleClassroomAddon } from "@/node-lib/google-classroom";
 
-jest.mock("next/server", () => ({
-  NextResponse: {
-    json: jest.fn(),
-  },
-}));
+jest.mock("next/server", () => {
+  class MockNextResponse {}
+  (MockNextResponse as unknown as { json: jest.Mock }).json = jest.fn(
+    () => new MockNextResponse(),
+  );
+  return { NextResponse: MockNextResponse };
+});
 
 jest.mock("@/node-lib/google-classroom", () => {
   const reporterMock = jest.fn();

--- a/src/app/api/classroom/pupil/progress/submit/route.ts
+++ b/src/app/api/classroom/pupil/progress/submit/route.ts
@@ -6,24 +6,18 @@ import {
   getOakGoogleClassroomAddon,
   isOakGoogleClassroomException,
 } from "@/node-lib/google-classroom";
+import {
+  handleClassroomError,
+  requireClassroomAuthHeaders,
+} from "@/app/api/classroom/classroomUtils";
 
 const reportError = createClassroomErrorReporter("submit-pupil-progress");
 
-const hasAuthHeaders = (request: NextRequest) => {
-  const accessToken = request.headers.get("Authorization");
-  const session = request.headers.get("x-oakgc-session");
-  return { accessToken, session };
-};
-
 export async function POST(request: NextRequest) {
   try {
-    const { accessToken, session } = hasAuthHeaders(request);
-
-    if (!session || !accessToken)
-      return NextResponse.json(
-        { message: "Authentication required" },
-        { status: 401 },
-      );
+    const auth = requireClassroomAuthHeaders(request);
+    if (auth instanceof NextResponse) return auth;
+    const { accessToken, session } = auth;
 
     const oakClassroomClient = getOakGoogleClassroomAddon(request);
     const body = await request.json();
@@ -44,16 +38,11 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result, { status: 200 });
   } catch (e) {
-    // Check if it's an OakGoogleClassroomException with submission state error
     if (isOakGoogleClassroomException(e)) {
       const errorObject = e.toObject();
       reportError(errorObject);
       return NextResponse.json(errorObject, { status: 403 });
     }
-    reportError(e);
-    return NextResponse.json(
-      { error: e instanceof Error ? e?.message : String(e) },
-      { status: 500 },
-    );
+    return handleClassroomError(reportError, e);
   }
 }

--- a/src/app/classroom/pupil/programmes/[programmeSlug]/[unitSlug]/[lessonSlug]/results/printable/page.tsx
+++ b/src/app/classroom/pupil/programmes/[programmeSlug]/[unitSlug]/[lessonSlug]/results/printable/page.tsx
@@ -43,11 +43,9 @@ function GoogleClassroomPupilResultsPage() {
 
   const getPupilResults = async (): Promise<PupilLessonProgress | null> => {
     const submissionId = searchParams?.get("submissionId");
-    // courseId is not required to fetch pupil progress, cna it be removed?
-    const courseId = searchParams?.get("courseId");
     const itemId = searchParams?.get("itemId");
     const attachmentId = searchParams?.get("attachmentId");
-    if (!submissionId || !courseId || !itemId || !attachmentId) {
+    if (!submissionId || !itemId || !attachmentId) {
       throw new Error("Missing required query parameters");
     }
     const pupilProgress = await googleClassroomApi.getPupilLessonProgress({

--- a/src/browser-lib/google-classroom/googleClassroomApi.ts
+++ b/src/browser-lib/google-classroom/googleClassroomApi.ts
@@ -226,7 +226,7 @@ const getPupilLessonProgress = async (
       `/api/classroom/pupil/progress?${params.toString()}`,
       "GET",
       undefined,
-      await getOakGCAuthHeaders(),
+      await getOakGCAuthHeaders(true),
     );
   } catch (error) {
     console.error("Failed to fetch pupil lesson progress:", error);

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.test.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.test.tsx
@@ -59,7 +59,11 @@ describe("createAndClickHiddenDownloadLink()", () => {
 
     createAndClickHiddenDownloadLink("testUrl");
 
-    expect(windowOpenSpy).toHaveBeenCalledWith("testUrl", "_blank");
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "testUrl",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 
   it("creates a hidden download link when not in an iframe", () => {

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink.tsx
@@ -21,7 +21,7 @@ export const isInIframe = () => {
 
 const createAndClickHiddenDownloadLink = (url: string) => {
   if (isInIframe()) {
-    globalThis.open(encodeURI(url), "_blank");
+    globalThis.open(encodeURI(url), "_blank", "noopener,noreferrer");
     return;
   }
   const link = createLink();

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.test.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.test.tsx
@@ -90,6 +90,7 @@ describe("downloadLessonResources", () => {
       expect(windowOpenSpy).toHaveBeenCalledWith(
         "/classroom/download/lesson-slug?selection=exit-quiz-answers%2Cworksheet-pdf",
         "_blank",
+        "noopener,noreferrer",
       );
       expect(createLessonDownloadLink).not.toHaveBeenCalled();
     });
@@ -105,6 +106,7 @@ describe("downloadLessonResources", () => {
       expect(windowOpenSpy).toHaveBeenCalledWith(
         "/classroom/download/lesson-slug?selection=exit-quiz-answers%2Cworksheet-pdf&additionalFiles=1%2C2%2C3",
         "_blank",
+        "noopener,noreferrer",
       );
     });
 

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources.tsx
@@ -49,7 +49,7 @@ const downloadLessonResources = async ({
       selection,
       additionalFilesIdsSelection,
     });
-    globalThis.open(downloadPageUrl, "_blank");
+    globalThis.open(downloadPageUrl, "_blank", "noopener,noreferrer");
     return;
   }
 


### PR DESCRIPTION
## Description

Music year: 2003

## refactor: Google Classroom API cleanup and Avo tracking events

### Summary

- **Centralised classroom API utilities** into a new `classroomUtils.ts` file, extracting shared logic (`requireClassroomAuthHeaders`, `handleClassroomError`, `getOAuthError`, `parseStateParam`, `getNewsletterPreference`, `isTeacherLogin`) that was previously duplicated or inline across multiple route handlers.
- **Refactored classroom API routes** (`attachment/create`, `context`, `pupil/progress`, `pupil/progress/submit`, `auth/callback`) to use the shared utilities, removing dead code and unreachable branches.
- **Added `loginHint`** to the auth verify route response to surface the pupil's Google login hint downstream.
- **Updated `NextResponse` mocking strategy** in all classroom route tests to use a class-based mock, enabling `instanceof NextResponse` checks (required by `requireClassroomAuthHeaders`) to work correctly in tests.

### Test plan

- [ ] All classroom API route tests pass (auth/verify, attachment/create, context, pupil/progress, pupil/progress/submit)
- [ ] Avo analytics components render without errors on browse pages
- [ ] Tracking events fire correctly during the Google Classroom browse journey (subjects → units → options → lesson listing)
- [ ] Auth flows (teacher and pupil sign-in, OAuth callback) behave correctly end-to-end
