### PR TITLE
Fix/pupil 1683/fix back button

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.query.ts
@@ -18,7 +18,9 @@ export const pupilUnitListingQuery =
     const res = await sdk.pupilUnitListing({
       baseSlug,
     });
-
+    res.browseData.forEach((item) => {
+      item.actions = { ...item.actions, programme_field_overrides: {} };
+    });
     const modifiedBrowseData = applyGenericOverridesAndExceptions<
       PupilUnitListingQuery["browseData"][number]
     >({

--- a/src/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/pupilUnitListing/pupilUnitListing.query.ts
@@ -19,7 +19,12 @@ export const pupilUnitListingQuery =
       baseSlug,
     });
     res.browseData.forEach((item) => {
-      item.actions = { ...item.actions, programme_field_overrides: {} };
+      if (item.programme_fields.subject_slug == "rule-of-law") {
+        item.actions = {
+          ...item.actions,
+          programme_field_overrides: {},
+        };
+      }
     });
     const modifiedBrowseData = applyGenericOverridesAndExceptions<
       PupilUnitListingQuery["browseData"][number]


### PR DESCRIPTION
## Description

Heres one way to fix overrides on OWA when we dont want to change it on the database, could we potentially add a "opt_out" clause to the action instead

- List of changes

## Issue(s)
the override changing the year slug, breaks the back button as its tries to take you back to the subject page for "all-years"
Fixes #

remove the override, but do it in owa at the query level - no change to data

## How to test

Note: issue and page only exists in staging

1. Go to /pupils/programmes/rule-of-law-primary-year-1/units)
2. Click on "change subject" back biutton
3. You should see takes you back to same year subject page

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
