### PR TITLE
Add previous + next lesson to the lesson overview query LESQ-1905

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -133,8 +133,8 @@ sonar.cpd.exclusions=\
   src/app/(core)/programmes/[subjectPhaseSlug]/**, \
   src/utils/curriculum/filteringApp.ts, \
   src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.ts, \
-  src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.schema.ts
-
+  src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.schema.ts, \
+  src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
 
 # don't bother at all with confirmic
 sonar.exclusions=\

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -51374,6 +51374,15 @@ export type TeachersPreviewUnitListingQueryVariables = Exact<{
 
 export type TeachersPreviewUnitListingQuery = { __typename?: 'query_root', units: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_ks_new_15_0_0', is_legacy?: boolean | null, programme_slug?: string | null, unit_slug?: string | null, programme_fields?: any | null, unit_data?: any | null, lesson_count?: number | null, lesson_expired_count?: number | null, lesson_sensitive_count?: number | null, expired?: boolean | null, supplementary_data?: any | null, threads?: any | null, actions?: any | null, features?: any | null }> };
 
+export type TeachersLessonOverviewQueryVariables = Exact<{
+  lessonSlug: Scalars['String']['input'];
+  unitSlug: Scalars['String']['input'];
+  programmeSlug: Scalars['String']['input'];
+}>;
+
+
+export type TeachersLessonOverviewQuery = { __typename?: 'query_root', browseData: Array<{ __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0', lesson_slug?: string | null, unit_slug?: string | null, programme_slug?: string | null, programme_slug_by_year?: any | null, lesson_data?: any | null, unit_data?: any | null, programme_fields?: any | null, actions?: any | null, features?: any | null, order_in_unit?: number | null }>, content: Array<{ __typename?: 'published_mv_lesson_content_published_9_0_0', lesson_id?: number | null, lesson_title?: string | null, lesson_slug?: string | null, deprecated_fields?: any | null, misconceptions_and_common_mistakes?: any | null, equipment_and_resources?: any | null, teacher_tips?: any | null, key_learning_points?: any | null, pupil_lesson_outcome?: string | null, phonics_outcome?: string | null, lesson_keywords?: any | null, content_guidance?: any | null, video_mux_playback_id?: string | null, video_id?: number | null, video_with_sign_language_mux_playback_id?: string | null, transcript_sentences?: string | null, starter_quiz?: any | null, starter_quiz_id?: number | null, exit_quiz?: any | null, exit_quiz_id?: number | null, supervision_level?: string | null, video_title?: string | null, has_worksheet_google_drive_downloadable_version?: boolean | null, has_slide_deck_asset_object?: boolean | null, worksheet_asset_id?: number | null, has_worksheet_asset_object?: boolean | null, worksheet_answers_asset_id?: number | null, has_worksheet_answers_asset_object?: boolean | null, supplementary_asset_id?: number | null, has_supplementary_asset_object?: boolean | null, slide_deck_asset_id?: number | null, slide_deck_asset_object_url?: string | null, worksheet_asset_object_url?: string | null, supplementary_asset_object_url?: string | null, has_lesson_guide_google_drive_downloadable_version?: boolean | null, lesson_guide_asset_object_url?: string | null, has_lesson_guide_object?: boolean | null, lesson_guide_asset_id?: number | null, downloadable_files?: any | null, lesson_release_date?: any | null, geo_restricted?: boolean | null, login_required?: boolean | null }>, unitData: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', lesson_count?: number | null, supplementary_data?: any | null }>, tpcWorks: Array<{ __typename?: 'published_mv_get_tpc_works_by_lesson_slug_1_0_0', slug?: string | null, lesson_id?: number | null, works_list?: any | null }> };
+
 export type TeachersSitemapQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -52480,6 +52489,83 @@ export const TeachersPreviewUnitListingDocument = gql`
   }
 }
     `;
+export const TeachersLessonOverviewDocument = gql`
+    query teachersLessonOverview($lessonSlug: String!, $unitSlug: String!, $programmeSlug: String!) {
+  browseData: published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0(
+    where: {lesson_slug: {_eq: $lessonSlug}, unit_slug: {_eq: $unitSlug}, programme_slug: {_eq: $programmeSlug}, is_legacy: {_eq: false}}
+  ) {
+    lesson_slug
+    unit_slug
+    programme_slug
+    programme_slug_by_year
+    lesson_data
+    unit_data
+    programme_fields
+    actions
+    features
+    order_in_unit
+  }
+  content: published_mv_lesson_content_published_9_0_0(
+    where: {lesson_slug: {_eq: $lessonSlug}}
+  ) {
+    lesson_id
+    lesson_title
+    lesson_slug
+    deprecated_fields
+    misconceptions_and_common_mistakes
+    equipment_and_resources
+    teacher_tips
+    key_learning_points
+    pupil_lesson_outcome
+    phonics_outcome
+    lesson_keywords
+    content_guidance
+    video_mux_playback_id
+    video_id
+    video_with_sign_language_mux_playback_id
+    transcript_sentences
+    starter_quiz
+    starter_quiz_id
+    exit_quiz
+    exit_quiz_id
+    supervision_level
+    video_title
+    has_worksheet_google_drive_downloadable_version
+    has_slide_deck_asset_object
+    worksheet_asset_id
+    has_worksheet_asset_object
+    worksheet_answers_asset_id
+    has_worksheet_answers_asset_object
+    supplementary_asset_id
+    has_supplementary_asset_object
+    slide_deck_asset_id
+    slide_deck_asset_object_url
+    worksheet_asset_object_url
+    supplementary_asset_object_url
+    has_lesson_guide_google_drive_downloadable_version
+    lesson_guide_asset_object_url
+    has_lesson_guide_object
+    lesson_guide_asset_id
+    downloadable_files
+    lesson_release_date
+    geo_restricted
+    login_required
+  }
+  unitData: published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0(
+    where: {supplementary_data: {_contains: {static_lesson_list: [{slug: $lessonSlug}]}}, unit_slug: {_eq: $unitSlug}, programme_slug: {_eq: $programmeSlug}, is_legacy: {_eq: false}}
+  ) {
+    lesson_count
+    supplementary_data
+  }
+  tpcWorks: published_mv_get_tpc_works_by_lesson_slug_1_0_0(
+    where: {slug: {_eq: $lessonSlug}}
+  ) {
+    slug
+    lesson_id
+    works_list
+  }
+}
+    `;
 export const TeachersSitemapDocument = gql`
     query teachersSitemap {
   keyStages: published_mv_key_stages_2_0_0 {
@@ -52756,6 +52842,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     teachersPreviewUnitListing(variables: TeachersPreviewUnitListingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<TeachersPreviewUnitListingQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<TeachersPreviewUnitListingQuery>({ document: TeachersPreviewUnitListingDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'teachersPreviewUnitListing', 'query', variables);
+    },
+    teachersLessonOverview(variables: TeachersLessonOverviewQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<TeachersLessonOverviewQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<TeachersLessonOverviewQuery>({ document: TeachersLessonOverviewDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'teachersLessonOverview', 'query', variables);
     },
     teachersSitemap(variables?: TeachersSitemapQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<TeachersSitemapQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<TeachersSitemapQuery>({ document: TeachersSitemapDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'teachersSitemap', 'query', variables);

--- a/src/node-lib/curriculum-api-2023/index.ts
+++ b/src/node-lib/curriculum-api-2023/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import sdk from "./sdk";
 import lessonOverviewQuery from "./queries/lessonOverview/lessonOverview.query";
+import teachersLessonOverviewQuery from "./queries/teachersLessonOverview/teachersLessonOverview.query";
 import lessonListingQuery from "./queries/lessonListing/lessonListing.query";
 import subjectListingQuery from "./queries/subjectListing/subjectListing.query";
 import lessonDownloadsQuery from "./queries/lessonDownloads/lessonDownloads.query";
@@ -126,6 +127,7 @@ const curriculumApi2023 = {
   lessonMediaClips: lessonMediaClipsQuery(sdk),
   lessonShare: lessonShareQuery(sdk),
   lessonOverview: lessonOverviewQuery(sdk),
+  teachersLessonOverview: teachersLessonOverviewQuery(sdk),
   pupilLessonQuery: pupilLessonQuery(sdk),
   pupilCanonicalLessonRedirectQuery: pupilCanonicalLessonRedirectQuery(sdk),
   pupilBrowseLessonRedirectQuery: pupilBrowseLessonRedirectQuery(sdk),

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.gql
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.gql
@@ -1,0 +1,91 @@
+query teachersLessonOverview(
+  $lessonSlug: String!
+  $unitSlug: String!
+  $programmeSlug: String!
+) {
+  browseData: published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0(
+    where: {
+      lesson_slug: { _eq: $lessonSlug }
+      unit_slug: { _eq: $unitSlug }
+      programme_slug: { _eq: $programmeSlug }
+      is_legacy: { _eq: false }
+    }
+  ) {
+    lesson_slug
+    unit_slug
+    programme_slug
+    programme_slug_by_year
+    lesson_data
+    unit_data
+    programme_fields
+    actions
+    features
+    order_in_unit
+  }
+  content: published_mv_lesson_content_published_9_0_0(
+    where: { lesson_slug: { _eq: $lessonSlug } }
+  ) {
+    lesson_id
+    lesson_title
+    lesson_slug
+    deprecated_fields
+    misconceptions_and_common_mistakes
+    equipment_and_resources
+    teacher_tips
+    key_learning_points
+    pupil_lesson_outcome
+    phonics_outcome
+    lesson_keywords
+    content_guidance
+    video_mux_playback_id
+    video_id
+    video_with_sign_language_mux_playback_id
+    transcript_sentences
+    starter_quiz
+    starter_quiz_id
+    exit_quiz
+    exit_quiz_id
+    supervision_level
+    video_title
+    has_worksheet_google_drive_downloadable_version
+    has_slide_deck_asset_object
+    worksheet_asset_id
+    has_worksheet_asset_object
+    worksheet_answers_asset_id
+    has_worksheet_answers_asset_object
+    supplementary_asset_id
+    has_supplementary_asset_object
+    slide_deck_asset_id
+    slide_deck_asset_object_url
+    worksheet_asset_object_url
+    supplementary_asset_object_url
+    has_lesson_guide_google_drive_downloadable_version
+    lesson_guide_asset_object_url
+    has_lesson_guide_object
+    lesson_guide_asset_id
+    downloadable_files
+    lesson_release_date
+    geo_restricted
+    login_required
+  }
+  unitData: published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0(
+    where: {
+      supplementary_data: {
+        _contains: { static_lesson_list: [{ slug: $lessonSlug }] }
+      }
+      unit_slug: { _eq: $unitSlug }
+      programme_slug: { _eq: $programmeSlug }
+      is_legacy: { _eq: false }
+    }
+  ) {
+    lesson_count
+    supplementary_data
+  }
+  tpcWorks: published_mv_get_tpc_works_by_lesson_slug_1_0_0(
+    where: { slug: { _eq: $lessonSlug } }
+  ) {
+    slug
+    lesson_id
+    works_list
+  }
+}

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
@@ -1,0 +1,658 @@
+/**
+ * @jest-environment node
+ */
+import {
+  lessonContentFixture,
+  syntheticUnitvariantLessonsByKsFixture,
+  additionalFilesFixture,
+  mediaClipsFixture,
+} from "@oaknational/oak-curriculum-schema";
+import { keysToCamelCase } from "zod-to-camel-case";
+
+import lessonMediaClipsFixtures from "../../fixtures/lessonMediaClips.fixture";
+
+import teachersLessonOverview, {
+  getContentGuidance,
+  getCopyrightContent,
+  getDownloadsArray,
+  getAdditionalFiles,
+  getAdjacentLessonsByOrderInUnit,
+} from "./teachersLessonOverview.query";
+
+import sdk from "@/node-lib/curriculum-api-2023/sdk";
+
+export const _additionalFilesFixture = keysToCamelCase(
+  additionalFilesFixture().downloadable_files,
+);
+
+const unitSlugTest = "unit-slug-test";
+const programmeSlugTest = "programme-slug-test";
+
+describe("teachersLessonOverview()", () => {
+  test("throws a not found error if no unit data is found", async () => {
+    const _syntheticUnitvariantLessonsByKsFixture =
+      syntheticUnitvariantLessonsByKsFixture({
+        overrides: {
+          lesson_slug: "lesson-slug-test",
+          unit_slug: unitSlugTest,
+          programme_slug: programmeSlugTest,
+          is_legacy: false,
+          programme_slug_by_year: [programmeSlugTest],
+        },
+      });
+
+    const _lessonContentFixture = lessonContentFixture({
+      overrides: {
+        exit_quiz: [],
+        starter_quiz: [],
+      },
+    });
+
+    await expect(async () => {
+      await teachersLessonOverview({
+        ...sdk,
+        teachersLessonOverview: jest.fn(() =>
+          Promise.resolve({
+            browseData: [_syntheticUnitvariantLessonsByKsFixture],
+            content: [_lessonContentFixture],
+            unitData: [],
+            tpcWorks: [],
+          }),
+        ),
+      })({
+        lessonSlug: "lesson-slug",
+        unitSlug: "unit-slug",
+        programmeSlug: "programme-slug",
+      });
+    }).rejects.toThrow(`Resource not found`);
+  });
+  test("throws a not found error if no lesson is found", async () => {
+    await expect(async () => {
+      await teachersLessonOverview({
+        ...sdk,
+        teachersLessonOverview: jest.fn(() =>
+          Promise.resolve({
+            content: [],
+            browseData: [],
+            unitData: [],
+            tpcWorks: [],
+          }),
+        ),
+      })({
+        lessonSlug: "lesson-slug",
+        unitSlug: "unit-slug",
+        programmeSlug: "programme-slug",
+      });
+    }).rejects.toThrow(`Resource not found`);
+  });
+
+  describe("getAdjacentLessonsByOrderInUnit", () => {
+    it("returns previous and next when current lesson is in the middle", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "a", title: "A", order: 1 },
+            { slug: "b", title: "B", order: 2 },
+            { slug: "c", title: "C", order: 3 },
+          ],
+          "b",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "a",
+          lessonTitle: "A",
+          lessonIndex: 1,
+        },
+        nextLesson: {
+          lessonSlug: "c",
+          lessonTitle: "C",
+          lessonIndex: 3,
+        },
+      });
+    });
+
+    it("returns null previous on first lesson and null next on last", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "a", title: "A", order: 1 },
+            { slug: "b", title: "B", order: 2 },
+          ],
+          "a",
+        ),
+      ).toEqual({
+        previousLesson: null,
+        nextLesson: {
+          lessonSlug: "b",
+          lessonTitle: "B",
+          lessonIndex: 2,
+        },
+      });
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "a", title: "A", order: 1 },
+            { slug: "b", title: "B", order: 2 },
+          ],
+          "b",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "a",
+          lessonTitle: "A",
+          lessonIndex: 1,
+        },
+        nextLesson: null,
+      });
+    });
+
+    it("returns both null when current slug is not in the list", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [{ slug: "a", title: "A", order: 1 }],
+          "missing",
+        ),
+      ).toEqual({ previousLesson: null, nextLesson: null });
+    });
+
+    it("sorts by order when rows are not in sequence order", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "lesson-c", title: "C", order: 3 },
+            { slug: "lesson-a", title: "A", order: 1 },
+            { slug: "lesson-b", title: "B", order: 2 },
+          ],
+          "lesson-b",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "lesson-a",
+          lessonTitle: "A",
+          lessonIndex: 1,
+        },
+        nextLesson: {
+          lessonSlug: "lesson-c",
+          lessonTitle: "C",
+          lessonIndex: 3,
+        },
+      });
+    });
+
+    it("breaks ties on equal order by slug", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "zebra", title: "Z", order: 1 },
+            { slug: "alpha", title: "A", order: 1 },
+            { slug: "mike", title: "M", order: 2 },
+          ],
+          "zebra",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "alpha",
+          lessonTitle: "A",
+          lessonIndex: 1,
+        },
+        nextLesson: {
+          lessonSlug: "mike",
+          lessonTitle: "M",
+          lessonIndex: 3,
+        },
+      });
+    });
+  });
+
+  test("it returns the lesson if found", async () => {
+    const _syntheticUnitvariantLessonsByKsFixture =
+      syntheticUnitvariantLessonsByKsFixture({
+        overrides: {
+          lesson_slug: "lesson-slug-test",
+          unit_slug: unitSlugTest,
+          programme_slug: programmeSlugTest,
+          is_legacy: false,
+          programme_slug_by_year: [programmeSlugTest],
+        },
+      });
+
+    const _lessonContentFixture = lessonContentFixture({
+      overrides: {
+        exit_quiz: [],
+        starter_quiz: [],
+      },
+    });
+
+    const _unitDataFixture = {
+      lesson_count:
+        _syntheticUnitvariantLessonsByKsFixture.static_lesson_list?.length ?? 1,
+      supplementary_data: {
+        unit_order: 16,
+        static_lesson_list: [
+          {
+            slug: "lesson-slug-test",
+            order: 1,
+            title: "Lesson Tile",
+            _state: "published",
+            lesson_uid: "test-uid",
+          },
+        ],
+      },
+    };
+
+    const lesson = await teachersLessonOverview({
+      ...sdk,
+      teachersLessonOverview: jest.fn(() =>
+        Promise.resolve({
+          browseData: [_syntheticUnitvariantLessonsByKsFixture],
+          content: [_lessonContentFixture],
+          unitData: [_unitDataFixture],
+          tpcWorks: [],
+        }),
+      ),
+    })({
+      lessonSlug: "lesson-slug-test",
+      unitSlug: unitSlugTest,
+      programmeSlug: programmeSlugTest,
+    });
+
+    expect(lesson.lessonSlug).toEqual(
+      _syntheticUnitvariantLessonsByKsFixture.lesson_slug,
+    );
+    expect(lesson.unitSlug).toEqual(
+      _syntheticUnitvariantLessonsByKsFixture.unit_slug,
+    );
+    expect(lesson.programmeSlug).toEqual(
+      _syntheticUnitvariantLessonsByKsFixture.programme_slug,
+    );
+    expect(lesson.lessonTitle).toEqual(_lessonContentFixture.lesson_title);
+    expect(lesson.orderInUnit).toEqual(
+      _syntheticUnitvariantLessonsByKsFixture.order_in_unit,
+    );
+    expect(lesson.unitTotalLessonCount).toEqual(
+      _unitDataFixture.supplementary_data.static_lesson_list.length,
+    );
+    expect(lesson.previousLesson).toBeNull();
+    expect(lesson.nextLesson).toBeNull();
+  });
+
+  test("returns null adjacent lessons when static_lesson_list is empty", async () => {
+    const row = syntheticUnitvariantLessonsByKsFixture({
+      overrides: {
+        lesson_slug: "lesson-b",
+        unit_slug: unitSlugTest,
+        programme_slug: programmeSlugTest,
+        order_in_unit: 2,
+        programme_slug_by_year: [programmeSlugTest],
+      },
+    });
+    const content = lessonContentFixture({
+      overrides: { exit_quiz: [], starter_quiz: [] },
+    });
+    const unitData = {
+      lesson_count: 3,
+      supplementary_data: {
+        unit_order: 1,
+        static_lesson_list: [],
+      },
+    };
+
+    const lesson = await teachersLessonOverview({
+      ...sdk,
+      teachersLessonOverview: jest.fn(() =>
+        Promise.resolve({
+          browseData: [row],
+          content: [content],
+          unitData: [unitData],
+          tpcWorks: [],
+        }),
+      ),
+    })({
+      lessonSlug: "lesson-b",
+      unitSlug: unitSlugTest,
+      programmeSlug: programmeSlugTest,
+    });
+
+    expect(lesson.previousLesson).toBeNull();
+    expect(lesson.nextLesson).toBeNull();
+  });
+
+  test("returns previous and next from static_lesson_list when unit and programme are provided", async () => {
+    const browseRow = syntheticUnitvariantLessonsByKsFixture({
+      overrides: {
+        lesson_slug: "lesson-b",
+        unit_slug: unitSlugTest,
+        programme_slug: programmeSlugTest,
+        order_in_unit: 2,
+        programme_slug_by_year: [programmeSlugTest],
+      },
+    });
+    const content = lessonContentFixture({
+      overrides: { exit_quiz: [], starter_quiz: [] },
+    });
+    const unitData = {
+      lesson_count: 3,
+      supplementary_data: {
+        unit_order: 1,
+        static_lesson_list: [
+          {
+            slug: "lesson-a",
+            order: 1,
+            title: "Lesson A",
+            _state: "published",
+            lesson_uid: "uid-a",
+          },
+          {
+            slug: "lesson-b",
+            order: 2,
+            title: "Lesson B",
+            _state: "published",
+            lesson_uid: "uid-b",
+          },
+          {
+            slug: "lesson-c",
+            order: 3,
+            title: "Lesson C",
+            _state: "published",
+            lesson_uid: "uid-c",
+          },
+        ],
+      },
+    };
+
+    const lesson = await teachersLessonOverview({
+      ...sdk,
+      teachersLessonOverview: jest.fn(() =>
+        Promise.resolve({
+          browseData: [browseRow],
+          content: [content],
+          unitData: [unitData],
+          tpcWorks: [],
+        }),
+      ),
+    })({
+      lessonSlug: "lesson-b",
+      unitSlug: unitSlugTest,
+      programmeSlug: programmeSlugTest,
+    });
+
+    expect(lesson.previousLesson).toEqual({
+      lessonSlug: "lesson-a",
+      lessonTitle: "Lesson A",
+      lessonIndex: 1,
+    });
+    expect(lesson.nextLesson).toEqual({
+      lessonSlug: "lesson-c",
+      lessonTitle: "Lesson C",
+      lessonIndex: 3,
+    });
+  });
+
+  test("throws a 'Resource not found' error if  data", async () => {
+    await expect(async () => {
+      await teachersLessonOverview({
+        ...sdk,
+        teachersLessonOverview: jest.fn(() =>
+          Promise.resolve({
+            browseData: [],
+            content: [],
+            unitData: [],
+            tpcWorks: [],
+          }),
+        ),
+      })({
+        lessonSlug: "lesson-slug",
+        unitSlug: "unit-slug",
+        programmeSlug: "programme-slug",
+      });
+    }).rejects.toThrow("Resource not found");
+  });
+
+  describe("getCopyrightContent", () => {
+    it("should return null if content is null", () => {
+      expect(getCopyrightContent(null)).toBeNull();
+    });
+
+    it("should return an array with copyrightInfo if provided", () => {
+      const content = [
+        { copyrightInfo: "Copyright 2024 Example Corp." },
+        { copyrightInfo: "Copyright 2023 Another Corp." },
+      ];
+      expect(getCopyrightContent(content)).toEqual([
+        { copyrightInfo: "Copyright 2024 Example Corp." },
+        { copyrightInfo: "Copyright 2023 Another Corp." },
+      ]);
+    });
+
+    it("should handle empty string copyrightInfo fields", () => {
+      const content = [{ copyrightInfo: "" }];
+      expect(getCopyrightContent(content)).toEqual([{ copyrightInfo: "" }]);
+    });
+  });
+  describe("getContentGuidance", () => {
+    it("should return null if content.contentGuidance is null", () => {
+      expect(getContentGuidance(null)).toBeNull();
+    });
+
+    it("should return an array with content guidance details if provided", () => {
+      expect(
+        getContentGuidance([
+          {
+            contentguidanceLabel: "Label 1",
+            contentguidanceDescription: "Description 1",
+            contentguidanceArea: "Area 1",
+          },
+          {
+            contentguidanceLabel: "Label 2",
+            contentguidanceDescription: "Description 2",
+            contentguidanceArea: "Area 2",
+          },
+        ]),
+      ).toEqual([
+        {
+          contentGuidanceLabel: "Label 1",
+          contentGuidanceDescription: "Description 1",
+          contentGuidanceArea: "Area 1",
+        },
+        {
+          contentGuidanceLabel: "Label 2",
+          contentGuidanceDescription: "Description 2",
+          contentGuidanceArea: "Area 2",
+        },
+      ]);
+    });
+
+    it("should return an array with content guidance details defaulted to empty strings in not provided", () => {
+      expect(
+        getContentGuidance([
+          {
+            contentguidanceLabel: null,
+            contentguidanceDescription: null,
+            contentguidanceArea: null,
+          },
+          {
+            contentguidanceLabel: "Label 2",
+            contentguidanceDescription: "Description 2",
+            contentguidanceArea: null,
+          },
+        ]),
+      ).toEqual([
+        {
+          contentGuidanceLabel: "",
+          contentGuidanceDescription: "",
+          contentGuidanceArea: "",
+        },
+        {
+          contentGuidanceLabel: "Label 2",
+          contentGuidanceDescription: "Description 2",
+          contentGuidanceArea: "",
+        },
+      ]);
+    });
+  });
+  describe("getDownloadsArray", () => {
+    it("should return correct downloads array when all content flags are true", () => {
+      const content = {
+        hasSlideDeckAssetObject: true,
+        hasStarterQuiz: true,
+        hasExitQuiz: true,
+        hasWorksheetAssetObject: true,
+        hasWorksheetAnswersAssetObject: true,
+        hasSupplementaryAssetObject: true,
+        hasLessonGuideObject: true,
+      };
+
+      const expectedDownloads = [
+        { exists: true, type: "presentation" },
+        { exists: true, type: "intro-quiz-questions" },
+        { exists: true, type: "intro-quiz-answers" },
+        { exists: true, type: "exit-quiz-questions" },
+        { exists: true, type: "exit-quiz-questions" },
+        { exists: true, type: "worksheet-pdf" },
+        { exists: true, type: "worksheet-pptx" },
+        { exists: true, type: "supplementary-pdf" },
+        { exists: true, type: "supplementary-docx" },
+        { exists: true, type: "lesson-guide-pdf" },
+      ];
+
+      expect(getDownloadsArray(content)).toEqual(expectedDownloads);
+    });
+
+    it("should return correct downloads array when all content flags are false", () => {
+      const content = {
+        hasSlideDeckAssetObject: false,
+        hasStarterQuiz: false,
+        hasExitQuiz: false,
+        hasWorksheetAssetObject: false,
+        hasWorksheetAnswersAssetObject: false,
+        hasSupplementaryAssetObject: false,
+        hasLessonGuideObject: false,
+      };
+
+      const expectedDownloads = [
+        { exists: false, type: "presentation" },
+        { exists: false, type: "intro-quiz-questions" },
+        { exists: false, type: "intro-quiz-answers" },
+        { exists: false, type: "exit-quiz-questions" },
+        { exists: false, type: "exit-quiz-questions" },
+        { exists: false, type: "worksheet-pdf" },
+        { exists: false, type: "worksheet-pptx" },
+        { exists: false, type: "supplementary-pdf" },
+        { exists: false, type: "supplementary-docx" },
+        { exists: false, type: "lesson-guide-pdf" },
+      ];
+
+      expect(getDownloadsArray(content)).toEqual(expectedDownloads);
+    });
+
+    it("should return correct downloads array when hasWorksheetAssetObject is true", () => {
+      const content = {
+        hasSlideDeckAssetObject: false,
+        hasStarterQuiz: false,
+        hasExitQuiz: false,
+        hasWorksheetAssetObject: true,
+        hasWorksheetAnswersAssetObject: false,
+        hasSupplementaryAssetObject: false,
+        hasLessonGuideObject: false,
+      };
+
+      const expectedDownloads = [
+        { exists: false, type: "presentation" },
+        { exists: false, type: "intro-quiz-questions" },
+        { exists: false, type: "intro-quiz-answers" },
+        { exists: false, type: "exit-quiz-questions" },
+        { exists: false, type: "exit-quiz-questions" },
+        { exists: true, type: "worksheet-pdf" },
+        { exists: true, type: "worksheet-pptx" },
+        { exists: false, type: "supplementary-pdf" },
+        { exists: false, type: "supplementary-docx" },
+        { exists: false, type: "lesson-guide-pdf" },
+      ];
+
+      expect(getDownloadsArray(content)).toEqual(expectedDownloads);
+    });
+  });
+
+  describe("getAdditionalFiles", () => {
+    it("should return an empty array if additionalFiles is null", () => {
+      expect(getAdditionalFiles(null)).toEqual([]);
+    });
+
+    it("should return an array of additional files if provided", () => {
+      expect(getAdditionalFiles(_additionalFilesFixture)).toEqual([
+        "File 1 1000 B (PDF)",
+        "File 2 1.95 KB (PDF)",
+      ]);
+    });
+  });
+});
+describe("hasMediaClips logic", () => {
+  test("it returns hasMediaClips as true when media clips are present", async () => {
+    const _syntheticUnitvariantLessonsByKsFixture =
+      syntheticUnitvariantLessonsByKsFixture({
+        overrides: {
+          lesson_slug: "lesson-slug-test",
+          unit_slug: unitSlugTest,
+          programme_slug: programmeSlugTest,
+          is_legacy: false,
+          programme_slug_by_year: [programmeSlugTest],
+          lesson_data: {
+            ...syntheticUnitvariantLessonsByKsFixture({}).lesson_data,
+            ...mediaClipsFixture(),
+          },
+        },
+      });
+
+    const _lessonContentFixture = lessonContentFixture({
+      overrides: {
+        exit_quiz: [],
+        starter_quiz: [],
+      },
+    });
+
+    const _unitDataFixture = {
+      lesson_count:
+        _syntheticUnitvariantLessonsByKsFixture.static_lesson_list?.length ?? 1,
+      supplementary_data: {
+        unit_order: 16,
+        static_lesson_list: [
+          {
+            slug: "lesson-slug-test",
+            order: 1,
+            title: "Lesson Tile",
+            _state: "published",
+            lesson_uid: "test-uid",
+          },
+        ],
+      },
+    };
+
+    const lesson = await teachersLessonOverview({
+      ...sdk,
+      teachersLessonOverview: jest.fn(() =>
+        Promise.resolve({
+          browseData: [_syntheticUnitvariantLessonsByKsFixture],
+          content: [_lessonContentFixture],
+          unitData: [_unitDataFixture],
+          tpcWorks: [],
+        }),
+      ),
+    })({
+      lessonSlug: "lesson-slug-test",
+      unitSlug: unitSlugTest,
+      programmeSlug: programmeSlugTest,
+    });
+
+    expect(lesson.lessonSlug).toEqual(
+      _syntheticUnitvariantLessonsByKsFixture.lesson_slug,
+    );
+    expect(lesson.hasMediaClips).toEqual(true);
+    expect(lesson.lessonMediaClips).toEqual(
+      lessonMediaClipsFixtures({
+        lessonSlug: "lesson-slug-test",
+        unitSlug: unitSlugTest,
+        programmeSlug: programmeSlugTest,
+      }).mediaClips,
+    );
+  });
+});

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
@@ -13,7 +13,6 @@ import lessonMediaClipsFixtures from "../../fixtures/lessonMediaClips.fixture";
 
 import teachersLessonOverview, {
   getContentGuidance,
-  getCopyrightContent,
   getDownloadsArray,
   getAdditionalFiles,
   getAdjacentLessonsByOrderInUnit,
@@ -408,27 +407,6 @@ describe("teachersLessonOverview()", () => {
     }).rejects.toThrow("Resource not found");
   });
 
-  describe("getCopyrightContent", () => {
-    it("should return null if content is null", () => {
-      expect(getCopyrightContent(null)).toBeNull();
-    });
-
-    it("should return an array with copyrightInfo if provided", () => {
-      const content = [
-        { copyrightInfo: "Copyright 2024 Example Corp." },
-        { copyrightInfo: "Copyright 2023 Another Corp." },
-      ];
-      expect(getCopyrightContent(content)).toEqual([
-        { copyrightInfo: "Copyright 2024 Example Corp." },
-        { copyrightInfo: "Copyright 2023 Another Corp." },
-      ]);
-    });
-
-    it("should handle empty string copyrightInfo fields", () => {
-      const content = [{ copyrightInfo: "" }];
-      expect(getCopyrightContent(content)).toEqual([{ copyrightInfo: "" }]);
-    });
-  });
   describe("getContentGuidance", () => {
     it("should return null if content.contentGuidance is null", () => {
       expect(getContentGuidance(null)).toBeNull();

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
@@ -140,28 +140,6 @@ export function getContentGuidance(
   }));
 }
 
-export function getCopyrightContent(
-  content:
-    | TeachersLessonBrowseDataByKs["lessonData"]["copyrightContent"]
-    | { copyrightInfo: string }[]
-    | null,
-): TeachersLessonOverviewPageData["legacyCopyrightContent"] {
-  if (content === null) {
-    return null;
-  }
-
-  return content.map((item) => {
-    if ("copyrightInfo" in item) {
-      return {
-        copyrightInfo: item.copyrightInfo ?? "",
-      };
-    }
-    return {
-      copyrightInfo: "",
-    };
-  });
-}
-
 export const getAdditionalFiles = (
   additionalFiles: TeachersLessonOverviewContent["downloadableFiles"],
 ): string[] | null => {
@@ -248,10 +226,6 @@ export const transformedTeachersLessonOverviewData = (
     keyLearningPoints: content.keyLearningPoints ?? null,
     pupilLessonOutcome: content.pupilLessonOutcome,
     lessonKeywords: content.lessonKeywords,
-    // TD: is this needed?
-    legacyCopyrightContent: getCopyrightContent(
-      browseData.lessonData.copyrightContent,
-    ),
     supervisionLevel: content.supervisionLevel,
     worksheetUrl: content.worksheetAssetObjectUrl,
     presentationUrl: content.slideDeckAssetObjectUrl,

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
@@ -1,0 +1,397 @@
+import { keysToCamelCase } from "zod-to-camel-case";
+
+import { TeachersLessonOverviewQuery } from "../../generated/sdk";
+import {
+  lessonOverviewQuizData,
+  LessonUnitDataByKs,
+  lessonUnitDataByKsSchema,
+} from "../../shared.schema";
+import { toSentenceCase } from "../../helpers";
+import { applyGenericOverridesAndExceptions } from "../../helpers/overridesAndExceptions";
+import { getCorrectYear } from "../../helpers/getCorrectYear";
+import { isExcludedFromTeachingMaterials } from "../../helpers/teachingMaterialsAi/isExcluded";
+
+import {
+  teachersLessonContentSchema,
+  TeachersLessonOverviewAdjacentLesson,
+  TeachersLessonOverviewContent,
+  TeachersLessonOverviewDownloads,
+  TeachersLessonOverviewPageData,
+  TeachersLessonBrowseDataByKs,
+  teachersLessonBrowseDataByKsSchema,
+} from "./teachersLessonOverview.schema";
+
+import errorReporter from "@/common-lib/error-reporter";
+import OakError from "@/errors/OakError";
+import { Sdk } from "@/node-lib/curriculum-api-2023/sdk";
+import { mediaClipsRecordCamelSchema } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
+import { convertBytesToMegabytes } from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
+
+export type TeachersLessonUnitStaticLessonList = NonNullable<
+  NonNullable<LessonUnitDataByKs["supplementaryData"]>["staticLessonList"]
+>;
+
+export function getAdjacentLessonsByOrderInUnit(
+  rows: TeachersLessonUnitStaticLessonList,
+  currentLessonSlug: string,
+): {
+  previousLesson: TeachersLessonOverviewAdjacentLesson | null;
+  nextLesson: TeachersLessonOverviewAdjacentLesson | null;
+} {
+  const sortedRows = rows.toSorted(
+    (a, b) => a.order - b.order || a.slug.localeCompare(b.slug),
+  );
+  const idx = sortedRows.findIndex((r) => r.slug === currentLessonSlug);
+
+  if (idx === -1) {
+    return { previousLesson: null, nextLesson: null };
+  }
+
+  const previousLesson = sortedRows[idx - 1] ?? null;
+  const nextLesson = sortedRows[idx + 1] ?? null;
+
+  return {
+    previousLesson: previousLesson
+      ? {
+          lessonSlug: previousLesson.slug,
+          lessonTitle: previousLesson.title,
+          lessonIndex: idx,
+        }
+      : null,
+    nextLesson: nextLesson
+      ? {
+          lessonSlug: nextLesson.slug,
+          lessonTitle: nextLesson.title,
+          lessonIndex: idx + 2,
+        }
+      : null,
+  };
+}
+
+export const getDownloadsArray = (content: {
+  hasSlideDeckAssetObject: boolean;
+  hasStarterQuiz: boolean;
+  hasExitQuiz: boolean;
+  hasWorksheetAssetObject: boolean;
+  hasWorksheetAnswersAssetObject: boolean;
+  hasSupplementaryAssetObject: boolean;
+  hasLessonGuideObject: boolean;
+}): TeachersLessonOverviewPageData["downloads"] => {
+  const downloads: TeachersLessonOverviewDownloads = [
+    {
+      exists: content.hasSlideDeckAssetObject,
+      type: "presentation",
+    },
+    {
+      exists: content.hasStarterQuiz,
+      type: "intro-quiz-questions",
+    },
+    {
+      exists: content.hasStarterQuiz,
+      type: "intro-quiz-answers",
+    },
+    {
+      exists: content.hasExitQuiz,
+      type: "exit-quiz-questions",
+    },
+    {
+      exists: content.hasExitQuiz,
+      type: "exit-quiz-questions",
+    },
+    {
+      exists:
+        content.hasWorksheetAssetObject ||
+        content.hasWorksheetAnswersAssetObject,
+      type: "worksheet-pdf",
+    },
+    {
+      exists:
+        content.hasWorksheetAssetObject ||
+        content.hasWorksheetAnswersAssetObject,
+      type: "worksheet-pptx",
+    },
+    {
+      exists: content.hasSupplementaryAssetObject,
+      type: "supplementary-pdf",
+    },
+    {
+      exists: content.hasSupplementaryAssetObject,
+      type: "supplementary-docx",
+    },
+    {
+      exists: content.hasLessonGuideObject,
+      type: "lesson-guide-pdf",
+    },
+  ];
+
+  return downloads;
+};
+
+export function getContentGuidance(
+  content: TeachersLessonOverviewContent["contentGuidance"],
+): TeachersLessonOverviewPageData["contentGuidance"] {
+  if (content === null) {
+    return null;
+  }
+  return content.map((item) => ({
+    contentGuidanceLabel: item.contentguidanceLabel ?? "",
+    contentGuidanceDescription: item.contentguidanceDescription ?? "",
+    contentGuidanceArea: item.contentguidanceArea ?? "",
+  }));
+}
+
+export function getCopyrightContent(
+  content:
+    | TeachersLessonBrowseDataByKs["lessonData"]["copyrightContent"]
+    | { copyrightInfo: string }[]
+    | null,
+): TeachersLessonOverviewPageData["legacyCopyrightContent"] {
+  if (content === null) {
+    return null;
+  }
+
+  return content.map((item) => {
+    if ("copyrightInfo" in item) {
+      return {
+        copyrightInfo: item.copyrightInfo ?? "",
+      };
+    }
+    return {
+      copyrightInfo: "",
+    };
+  });
+}
+
+export const getAdditionalFiles = (
+  additionalFiles: TeachersLessonOverviewContent["downloadableFiles"],
+): string[] | null => {
+  if (!additionalFiles) {
+    return [];
+  }
+
+  return additionalFiles.map((af) => {
+    const name = af.mediaObject.displayName;
+    const type = af.mediaObject.url.split(".").pop() ?? "";
+    const size = af.mediaObject.bytes;
+    const sizeString = convertBytesToMegabytes(size);
+    return `${name} ${sizeString} (${type.toUpperCase()})`;
+  });
+};
+
+export const transformedTeachersLessonOverviewData = (
+  browseData: TeachersLessonBrowseDataByKs,
+  content: TeachersLessonOverviewContent,
+  unitData: LessonUnitDataByKs,
+  excludedFromTeachingMaterials: boolean,
+  adjacentLessons?: {
+    previousLesson: TeachersLessonOverviewAdjacentLesson | null;
+    nextLesson: TeachersLessonOverviewAdjacentLesson | null;
+  } | null,
+): TeachersLessonOverviewPageData => {
+  const reportError = errorReporter("transformedTeachersLessonOverviewData");
+  const starterQuiz = lessonOverviewQuizData.parse(content.starterQuiz);
+  const exitQuiz = lessonOverviewQuizData.parse(content.exitQuiz);
+  const unitTitle =
+    browseData.programmeFields.optionality ?? browseData.unitData.title;
+  const additionalFiles = content?.downloadableFiles;
+  const hasAdditionalFiles = additionalFiles
+    ? additionalFiles.length > 0
+    : false;
+
+  let mediaClips = null;
+  try {
+    mediaClips = browseData.lessonData.mediaClips
+      ? mediaClipsRecordCamelSchema.parse(browseData.lessonData.mediaClips)
+      : null;
+  } catch (error) {
+    browseData.lessonData.mediaClips = null;
+    reportError(error);
+  }
+
+  return {
+    programmeSlug: browseData.programmeSlug,
+    unitSlug: browseData.unitSlug,
+    unitTitle,
+    keyStageSlug: browseData.programmeFields.keystageSlug,
+    keyStageTitle: toSentenceCase(
+      browseData.programmeFields.keystageDescription,
+    ),
+    subjectSlug: browseData.programmeFields.subjectSlug,
+    subjectTitle: browseData.programmeFields.subject,
+    subjectParent: browseData.programmeFields.subjectParent ?? null,
+    yearTitle: browseData.programmeFields.yearDescription,
+    year: browseData.programmeFields.year,
+    examBoardTitle: browseData.programmeFields.examboard,
+    examBoardSlug: browseData.programmeFields.examboardSlug,
+    downloads: getDownloadsArray({
+      hasExitQuiz: content.exitQuiz && Boolean(content.exitQuiz.length > 1),
+      hasStarterQuiz:
+        content.starterQuiz && Boolean(content.starterQuiz.length > 1),
+      hasSupplementaryAssetObject: Boolean(content.hasSupplementaryAssetObject),
+      hasWorksheetAnswersAssetObject: Boolean(
+        content.hasWorksheetAnswersAssetObject,
+      ),
+      hasWorksheetAssetObject: Boolean(content.hasWorksheetAssetObject),
+      hasSlideDeckAssetObject: Boolean(content.hasSlideDeckAssetObject),
+      hasLessonGuideObject: Boolean(content.hasLessonGuideObject),
+    }),
+    updatedAt: browseData.lessonData.updatedAt,
+    lessonSlug: browseData.lessonSlug,
+    lessonTitle: browseData.lessonData.title,
+    tierTitle: browseData.programmeFields.tierDescription,
+    tierSlug: browseData.programmeFields.tierSlug,
+    contentGuidance: getContentGuidance(content.contentGuidance),
+    misconceptionsAndCommonMistakes: content.misconceptionsAndCommonMistakes,
+    teacherTips: content.teacherTips,
+    lessonEquipmentAndResources: browseData.lessonData.equipmentAndResources,
+    additionalMaterialUrl: content.supplementaryAssetObjectUrl,
+    keyLearningPoints: content.keyLearningPoints ?? null,
+    pupilLessonOutcome: content.pupilLessonOutcome,
+    lessonKeywords: content.lessonKeywords,
+    // TD: is this needed?
+    legacyCopyrightContent: getCopyrightContent(
+      browseData.lessonData.copyrightContent,
+    ),
+    supervisionLevel: content.supervisionLevel,
+    worksheetUrl: content.worksheetAssetObjectUrl,
+    presentationUrl: content.slideDeckAssetObjectUrl,
+    videoMuxPlaybackId: content.videoMuxPlaybackId,
+    videoWithSignLanguageMuxPlaybackId:
+      content.videoWithSignLanguageMuxPlaybackId,
+    transcriptSentences: content.transcriptSentences,
+    isWorksheetLandscape: Boolean(
+      browseData.lessonData.deprecatedFields?.worksheetIsLandscape,
+    ),
+    expired: Boolean(browseData.lessonData.deprecatedFields?.expired) || false,
+    starterQuiz: starterQuiz,
+    exitQuiz: exitQuiz,
+    videoTitle: content.videoTitle,
+    lessonCohort: browseData.lessonData._cohort,
+    lessonGuideUrl: content.lessonGuideAssetObjectUrl ?? null,
+    phonicsOutcome: content.phonicsOutcome,
+    actions: browseData.actions,
+    hasMediaClips: mediaClips
+      ? Object.keys(mediaClips).length > 0 &&
+        Object.values(mediaClips).some((key) => key.length > 0)
+      : false,
+    lessonOutline: browseData.lessonData.lessonOutline ?? null,
+    lessonMediaClips: mediaClips,
+    additionalFiles:
+      hasAdditionalFiles && additionalFiles
+        ? getAdditionalFiles(additionalFiles)
+        : null,
+    pathwayTitle: browseData.programmeFields.pathwayDescription ?? null,
+    lessonReleaseDate: content.lessonReleaseDate ?? null,
+    orderInUnit: browseData.orderInUnit ?? 1,
+    unitTotalLessonCount:
+      unitData.supplementaryData?.staticLessonList?.length ??
+      unitData.lessonCount,
+    geoRestricted: browseData.features?.agfGeoRestricted ?? false,
+    loginRequired: browseData.features?.agfLoginRequired ?? false,
+    excludedFromTeachingMaterials,
+    subjectCategories: browseData.unitData.subjectcategories,
+    previousLesson: adjacentLessons?.previousLesson ?? null,
+    nextLesson: adjacentLessons?.nextLesson ?? null,
+  };
+};
+
+const teachersLessonOverviewQuery =
+  (sdk: Sdk) =>
+  async (args: {
+    lessonSlug: string;
+    unitSlug: string;
+    programmeSlug: string;
+  }): Promise<TeachersLessonOverviewPageData> => {
+    const { lessonSlug, unitSlug, programmeSlug } = args;
+
+    const res = await sdk.teachersLessonOverview({
+      lessonSlug,
+      unitSlug,
+      programmeSlug,
+    });
+
+    const restrictedAndHighlyRestrictedWorksList =
+      res.tpcWorks[0]?.works_list ?? [];
+
+    const modifiedBrowseData = applyGenericOverridesAndExceptions<
+      TeachersLessonOverviewQuery["browseData"][number]
+    >({
+      journey: "teacher",
+      // Same CMS exclusions/opt-outs as lessonOverview; QueryNames is schema-driven from oak-curriculum-schema.
+      // TD: add query name to the schema
+      queryName: "lessonOverviewQuery",
+      browseData: res.browseData,
+    });
+
+    if (modifiedBrowseData.length === 0) {
+      throw new OakError({ code: "curriculum-api/not-found" });
+    }
+
+    const modifiedProgrammeFields = getCorrectYear({
+      programmeSlugByYear: modifiedBrowseData[0]?.programme_slug_by_year,
+      programmeFields: modifiedBrowseData[0]?.programme_fields,
+    });
+
+    const browseDataSnake = {
+      ...modifiedBrowseData[0],
+      programme_fields: modifiedProgrammeFields,
+    };
+    const [contentSnake] = res.content;
+
+    if (!contentSnake) {
+      throw new OakError({ code: "curriculum-api/not-found" });
+    }
+
+    if (res.content.length > 1) {
+      const error = new OakError({
+        code: "curriculum-api/uniqueness-assumption-violated",
+      });
+      errorReporter("curriculum-api-2023:teachersLessonOverview")(error, {
+        severity: "warning",
+        ...args,
+        res,
+      });
+    }
+
+    const [unitDataSnake] = res.unitData;
+
+    if (!unitDataSnake) {
+      throw new OakError({ code: "curriculum-api/not-found" });
+    }
+
+    teachersLessonBrowseDataByKsSchema.parse(browseDataSnake);
+    teachersLessonContentSchema.parse({
+      ...contentSnake,
+      additional_files: null,
+    });
+    lessonUnitDataByKsSchema.parse(unitDataSnake);
+
+    const browseData = keysToCamelCase(
+      browseDataSnake,
+    ) as TeachersLessonBrowseDataByKs;
+    const content = keysToCamelCase({
+      ...contentSnake,
+    }) as TeachersLessonOverviewContent;
+    const unitData = keysToCamelCase(unitDataSnake) as LessonUnitDataByKs;
+
+    const excludedFromTeachingMaterials = isExcludedFromTeachingMaterials(
+      browseData.lessonData,
+      restrictedAndHighlyRestrictedWorksList,
+      content,
+    );
+
+    const staticLessonList = unitData.supplementaryData?.staticLessonList;
+    const adjacentLessons = staticLessonList?.length
+      ? getAdjacentLessonsByOrderInUnit(staticLessonList, lessonSlug)
+      : null;
+
+    return transformedTeachersLessonOverviewData(
+      browseData,
+      content,
+      unitData,
+      excludedFromTeachingMaterials,
+      adjacentLessons,
+    );
+  };
+
+export default teachersLessonOverviewQuery;

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import {
+  lessonContentSchema as lessonContentSchemaFull,
+  syntheticUnitvariantLessonsByKsSchema,
+  LessonContentCamel as LessonContentCamelFull,
+  SyntheticUnitvariantLessonsByKsCamel,
+} from "@oaknational/oak-curriculum-schema";
+
+import { baseLessonOverviewSchema } from "@/node-lib/curriculum-api-2023/shared.schema";
+import { QuizQuestion } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { mediaClipsRecordCamelSchema } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
+
+export const teachersLessonContentSchema = lessonContentSchemaFull.omit({
+  _state: true,
+  exit_quiz: true,
+  starter_quiz: true,
+  video_duration: true,
+  is_legacy: true,
+});
+
+type TeachersLessonContentCamel = Omit<
+  LessonContentCamelFull,
+  "state" | "exitQuiz" | "starterQuiz" | "videoDuration"
+>;
+
+export type TeachersLessonOverviewContent = Omit<
+  TeachersLessonContentCamel,
+  "starterQuiz" | "exitQuiz" | "transcriptSentences"
+> & {
+  starterQuiz: QuizQuestion[];
+  exitQuiz: QuizQuestion[];
+  transcriptSentences: string | string[];
+};
+
+export const teachersLessonOverviewDownloads = z.array(
+  z.object({
+    exists: z.boolean().nullable(),
+    type: z.enum([
+      "presentation",
+      "intro-quiz-questions",
+      "intro-quiz-answers",
+      "exit-quiz-questions",
+      "exit-quiz-answers",
+      "worksheet-pdf",
+      "worksheet-pptx",
+      "supplementary-pdf",
+      "supplementary-docx",
+      "curriculum-pdf",
+      "lesson-guide-pdf",
+    ]),
+  }),
+);
+
+export type TeachersLessonOverviewDownloads = z.infer<
+  typeof teachersLessonOverviewDownloads
+>;
+
+export const teachersLessonOverviewAdjacentLessonSchema = z.object({
+  lessonSlug: z.string(),
+  lessonTitle: z.string(),
+  lessonIndex: z
+    .number()
+    .describe("1-based index of the lesson in the unit lesson sequence"),
+});
+
+export type TeachersLessonOverviewAdjacentLesson = z.infer<
+  typeof teachersLessonOverviewAdjacentLessonSchema
+>;
+
+const teachersLessonOverviewBaseSchema = baseLessonOverviewSchema.omit({
+  isLegacy: true,
+});
+
+export const teachersLessonOverviewSchema =
+  teachersLessonOverviewBaseSchema.extend({
+    programmeSlug: z.string(),
+    unitSlug: z.string(),
+    unitTitle: z.string(),
+    keyStageSlug: z.string(),
+    keyStageTitle: z.string(),
+    subjectSlug: z.string(),
+    subjectTitle: z.string(),
+    subjectParent: z.string().nullable(),
+    yearTitle: z.string(),
+    year: z.string(),
+    examBoardTitle: z.string().nullable(),
+    examBoardSlug: z.string().nullable(),
+    downloads: teachersLessonOverviewDownloads,
+    updatedAt: z.string(),
+    additionalFiles: z.array(z.string()).nullable(),
+    lessonMediaClips: mediaClipsRecordCamelSchema.nullable(),
+    lessonReleaseDate: z.string().nullable(),
+    loginRequired: z.boolean(),
+    geoRestricted: z.boolean(),
+    excludedFromTeachingMaterials: z.boolean(),
+    subjectCategories: z
+      .array(z.union([z.string(), z.number(), z.null()]))
+      .nullable(),
+    previousLesson: teachersLessonOverviewAdjacentLessonSchema.nullable(),
+    nextLesson: teachersLessonOverviewAdjacentLessonSchema.nullable(),
+  });
+
+export type TeachersLessonOverviewPageData = z.infer<
+  typeof teachersLessonOverviewSchema
+>;
+
+export default teachersLessonOverviewSchema;
+
+export const teachersLessonBrowseDataByKsSchema =
+  syntheticUnitvariantLessonsByKsSchema.omit({
+    null_unitvariant_id: true,
+    is_legacy: true,
+  });
+
+export type TeachersLessonBrowseDataByKs = Omit<
+  SyntheticUnitvariantLessonsByKsCamel,
+  "nullUnitvariantId" | "isLegacy"
+>;

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema.ts
@@ -69,6 +69,7 @@ export type TeachersLessonOverviewAdjacentLesson = z.infer<
 
 const teachersLessonOverviewBaseSchema = baseLessonOverviewSchema.omit({
   isLegacy: true,
+  legacyCopyrightContent: true,
 });
 
 export const teachersLessonOverviewSchema =


### PR DESCRIPTION
## Description

Music year: 2016

- Adds `nextLesson` and `previousLesson` fields if they exist
- ~~Ticket called for copying and creating a new query, the data was already there so adding it here can help us avoid drift between two copies of a query while we develop the integrated journey.~~
- Copies `lessonOverview` into `teachersLessonOverview` removing everything related to canonical and legacy lesson handling.

```typescript
await teachersLessonOverview(sdk)({
  lessonSlug: "some-lesson-slug",
  unitSlug: "some-unit-slug",
  programmeSlug: "some-programme-slug",
});
```

Result:
```typescript
{
  // ...all the existing lesson overview fields
  previousLesson: {
    lessonSlug: "introducing-fractions",
    lessonTitle: "Introducing fractions",
    lessonIndex: 2,
  },
  nextLesson: {
    lessonSlug: "comparing-fractions",
    lessonTitle: "Comparing fractions",
    lessonIndex: 4,
  },
}
```

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1905lesson-ove-c6e919.vercel.thenational.academy/api/test-teachers-lesson-overview?lessonSlug=developing-a-model-for-atoms&unitSlug=atomic-structure-and-the-periodic-table&programmeSlug=chemistry-secondary-ks4-foundation-aqa
2. You should be able to preview the query results.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
