### PR TITLE
Footer next prev buttons LESQ 1910

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
@@ -94,7 +94,7 @@ export function ProgrammeUnitList({
             isOptionalityUnit: false,
           }),
           href: resolveOakHref({
-            page: "unit-page",
+            page: "integrated-lesson-index",
             unitSlug: option.slug ?? unit.slug,
             programmeSlug,
             query: {
@@ -120,7 +120,7 @@ export function ProgrammeUnitList({
           isHighlighted={isHighlighted}
           tags={getTagsForUnitCard(unit)}
           href={resolveOakHref({
-            page: "unit-page",
+            page: "integrated-lesson-index",
             unitSlug: unit.slug,
             programmeSlug,
             query: {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
@@ -96,7 +96,7 @@ export function ProgrammeUnitList({
           href: resolveOakHref({
             page: "unit-page",
             unitSlug: option.slug ?? unit.slug,
-            subjectPhaseSlug: programmeSlug,
+            programmeSlug,
             query: {
               subject_category: filters.subjectCategories.at(0),
             },
@@ -122,7 +122,7 @@ export function ProgrammeUnitList({
           href={resolveOakHref({
             page: "unit-page",
             unitSlug: unit.slug,
-            subjectPhaseSlug: programmeSlug,
+            programmeSlug,
             query: {
               subject_category: filters.subjectCategories.at(0),
             },

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.test.tsx
@@ -113,7 +113,7 @@ describe("LessonList", () => {
     expect(firstLessonLink).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "lesson-overview",
+        page: "lesson-page",
         programmeSlug: defaultProps.programmeSlug,
         unitSlug: defaultProps.unitSlug,
         lessonSlug: "lesson-1",
@@ -122,7 +122,7 @@ describe("LessonList", () => {
     expect(secondLessonLink).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "lesson-overview",
+        page: "lesson-page",
         programmeSlug: defaultProps.programmeSlug,
         unitSlug: defaultProps.unitSlug,
         lessonSlug: "lesson-2",

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.test.tsx
@@ -113,7 +113,7 @@ describe("LessonList", () => {
     expect(firstLessonLink).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "lesson-page",
+        page: "integrated-lesson-overview",
         programmeSlug: defaultProps.programmeSlug,
         unitSlug: defaultProps.unitSlug,
         lessonSlug: "lesson-1",
@@ -122,7 +122,7 @@ describe("LessonList", () => {
     expect(secondLessonLink).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "lesson-page",
+        page: "integrated-lesson-overview",
         programmeSlug: defaultProps.programmeSlug,
         unitSlug: defaultProps.unitSlug,
         lessonSlug: "lesson-2",

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.tsx
@@ -198,7 +198,7 @@ const LessonList = ({
                   title={lesson.lessonTitle}
                   subcopy={<LessonSubcopy lesson={lesson} />}
                   href={resolveOakHref({
-                    page: "lesson-overview",
+                    page: "lesson-page",
                     programmeSlug,
                     unitSlug,
                     lessonSlug: lesson.lessonSlug,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList/LessonList.tsx
@@ -198,7 +198,7 @@ const LessonList = ({
                   title={lesson.lessonTitle}
                   subcopy={<LessonSubcopy lesson={lesson} />}
                   href={resolveOakHref({
-                    page: "lesson-page",
+                    page: "integrated-lesson-overview",
                     programmeSlug,
                     unitSlug,
                     lessonSlug: lesson.lessonSlug,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.test.tsx
@@ -86,7 +86,7 @@ describe("ProgrammeToggles", () => {
     expect(foundation).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "unit-page",
+        page: "integrated-lesson-index",
         programmeSlug: "maths-secondary-ks4-foundation",
         unitSlug: "algebra",
       }),
@@ -95,7 +95,7 @@ describe("ProgrammeToggles", () => {
     expect(higher).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "unit-page",
+        page: "integrated-lesson-index",
         programmeSlug: "maths-secondary-ks4-higher",
         unitSlug: "algebra",
       }),
@@ -125,7 +125,7 @@ describe("ProgrammeToggles", () => {
     expect(biology).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "unit-page",
+        page: "integrated-lesson-index",
         programmeSlug: "biology-secondary-ks4-foundation-aqa",
         unitSlug: "cells",
       }),
@@ -134,7 +134,7 @@ describe("ProgrammeToggles", () => {
     expect(combinedScience).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "unit-page",
+        page: "integrated-lesson-index",
         programmeSlug: "combined-science-secondary-ks4-foundation-aqa",
         unitSlug: "cells",
       }),

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.test.tsx
@@ -87,7 +87,7 @@ describe("ProgrammeToggles", () => {
       "href",
       resolveOakHref({
         page: "unit-page",
-        subjectPhaseSlug: "maths-secondary-ks4-foundation",
+        programmeSlug: "maths-secondary-ks4-foundation",
         unitSlug: "algebra",
       }),
     );
@@ -96,7 +96,7 @@ describe("ProgrammeToggles", () => {
       "href",
       resolveOakHref({
         page: "unit-page",
-        subjectPhaseSlug: "maths-secondary-ks4-higher",
+        programmeSlug: "maths-secondary-ks4-higher",
         unitSlug: "algebra",
       }),
     );
@@ -126,7 +126,7 @@ describe("ProgrammeToggles", () => {
       "href",
       resolveOakHref({
         page: "unit-page",
-        subjectPhaseSlug: "biology-secondary-ks4-foundation-aqa",
+        programmeSlug: "biology-secondary-ks4-foundation-aqa",
         unitSlug: "cells",
       }),
     );
@@ -135,7 +135,7 @@ describe("ProgrammeToggles", () => {
       "href",
       resolveOakHref({
         page: "unit-page",
-        subjectPhaseSlug: "combined-science-secondary-ks4-foundation-aqa",
+        programmeSlug: "combined-science-secondary-ks4-foundation-aqa",
         unitSlug: "cells",
       }),
     );

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.tsx
@@ -50,7 +50,7 @@ const ProgrammeToggleOption = ({
     : undefined;
 
   const href = resolveOakHref({
-    page: "unit-page",
+    page: "integrated-lesson-index",
     programmeSlug,
     unitSlug,
   });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/ProgrammeToggles.tsx
@@ -51,7 +51,7 @@ const ProgrammeToggleOption = ({
 
   const href = resolveOakHref({
     page: "unit-page",
-    subjectPhaseSlug: programmeSlug,
+    programmeSlug,
     unitSlug,
   });
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -179,7 +179,7 @@ const UnitNavButtons = ({
           href={resolveOakHref({
             page: "unit-page",
             unitSlug: prevUnit.slug,
-            subjectPhaseSlug: programmeSlug,
+            programmeSlug,
           })}
           iconOverride={
             <OakIcon
@@ -199,7 +199,7 @@ const UnitNavButtons = ({
           href={resolveOakHref({
             page: "unit-page",
             unitSlug: nextUnit.slug,
-            subjectPhaseSlug: programmeSlug,
+            programmeSlug,
           })}
           isTrailingIcon
           iconOverride={

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -177,7 +177,7 @@ const UnitNavButtons = ({
         <OakSmallPrimaryInvertedButton
           element="a"
           href={resolveOakHref({
-            page: "unit-page",
+            page: "integrated-lesson-index",
             unitSlug: prevUnit.slug,
             programmeSlug,
           })}
@@ -197,7 +197,7 @@ const UnitNavButtons = ({
         <OakSmallPrimaryInvertedButton
           element="a"
           href={resolveOakHref({
-            page: "unit-page",
+            page: "integrated-lesson-index",
             unitSlug: nextUnit.slug,
             programmeSlug,
           })}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
@@ -158,7 +158,7 @@ export const UnitView = ({
               prevUnit
                 ? {
                     href: resolveOakHref({
-                      page: "unit-page",
+                      page: "integrated-lesson-index",
                       programmeSlug,
                       unitSlug: prevUnit.slug,
                     }),
@@ -170,7 +170,7 @@ export const UnitView = ({
               nextUnit
                 ? {
                     href: resolveOakHref({
-                      page: "unit-page",
+                      page: "integrated-lesson-index",
                       programmeSlug,
                       unitSlug: nextUnit.slug,
                     }),

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
@@ -159,7 +159,7 @@ export const UnitView = ({
                 ? {
                     href: resolveOakHref({
                       page: "unit-page",
-                      subjectPhaseSlug: programmeSlug,
+                      programmeSlug,
                       unitSlug: prevUnit.slug,
                     }),
                     title: prevUnit.title,
@@ -171,7 +171,7 @@ export const UnitView = ({
                 ? {
                     href: resolveOakHref({
                       page: "unit-page",
-                      subjectPhaseSlug: programmeSlug,
+                      programmeSlug,
                       unitSlug: nextUnit.slug,
                     }),
                     title: nextUnit.title,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from "@testing-library/react";
+
+import LessonView from "./LessonView";
+
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import teachersLessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/teachersLessonOverview.fixture";
+
+const render = renderWithProviders();
+
+const baseProps = teachersLessonOverviewFixture();
+
+describe("LessonView", () => {
+  it("renders previous and next lesson links when adjacent lessons exist", () => {
+    render(
+      <LessonView
+        {...baseProps}
+        previousLesson={{
+          lessonSlug: "lesson-2",
+          lessonTitle: "Previous lesson",
+          lessonIndex: 2,
+        }}
+        nextLesson={{
+          lessonSlug: "lesson-4",
+          lessonTitle: "Next lesson",
+          lessonIndex: 4,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /Previous lesson/i }),
+    ).toHaveAttribute(
+      "href",
+      "/programmes/biology-secondary-ks3/units/cells/lessons/lesson-2",
+    );
+    expect(screen.getByRole("link", { name: /Next lesson/i })).toHaveAttribute(
+      "href",
+      "/programmes/biology-secondary-ks3/units/cells/lessons/lesson-4",
+    );
+  });
+
+  it("does not render lesson nav links when adjacent lessons are missing", () => {
+    render(
+      <LessonView {...baseProps} previousLesson={null} nextLesson={null} />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /Previous lesson/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Next lesson/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders previous and next lesson links when orderInUnit is null", () => {
+    render(
+      <LessonView
+        {...baseProps}
+        orderInUnit={null}
+        previousLesson={{
+          lessonSlug: "lesson-2",
+          lessonTitle: "Previous lesson",
+          lessonIndex: 2,
+        }}
+        nextLesson={{
+          lessonSlug: "lesson-4",
+          lessonTitle: "Next lesson",
+          lessonIndex: 4,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /Previous lesson/i }),
+    ).toHaveAttribute(
+      "href",
+      "/programmes/biology-secondary-ks3/units/cells/lessons/lesson-2",
+    );
+    expect(screen.getByRole("link", { name: /Next lesson/i })).toHaveAttribute(
+      "href",
+      "/programmes/biology-secondary-ks3/units/cells/lessons/lesson-4",
+    );
+  });
+});

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -31,7 +31,7 @@ export default function LessonView({
               data.previousLesson
                 ? {
                     href: resolveOakHref({
-                      page: "lesson-page",
+                      page: "integrated-lesson-overview",
                       programmeSlug,
                       unitSlug,
                       lessonSlug: data.previousLesson.lessonSlug,
@@ -45,7 +45,7 @@ export default function LessonView({
               data.nextLesson
                 ? {
                     href: resolveOakHref({
-                      page: "lesson-page",
+                      page: "integrated-lesson-overview",
                       programmeSlug,
                       unitSlug,
                       lessonSlug: data.nextLesson.lessonSlug,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { OakBox, OakGrid, OakGridArea } from "@oaknational/oak-components";
+
+import PreviousNextNav from "@/components/TeacherComponents/PreviousNextNav/PreviousNextNav";
+import type { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
+
+// TODO: make this an oak href
+function integratedTeachersLessonHref(
+  programmeSlug: string,
+  unitSlug: string,
+  targetLessonSlug: string,
+) {
+  return `/programmes/${programmeSlug}/units/${unitSlug}/lessons/${targetLessonSlug}`;
+}
+
+export default function LessonView({
+  programmeSlug,
+  unitSlug,
+  ...data
+}: Readonly<TeachersLessonOverviewPageData>) {
+  return (
+    <OakBox $ph="spacing-40">
+      <OakGrid
+        $cg="spacing-16"
+        $rg="spacing-56"
+        $mb={["spacing-0", "spacing-48", "spacing-48"]}
+        $mh="auto"
+        $mt={["spacing-48", "spacing-56"]}
+        $width={"100%"}
+        $maxWidth={"spacing-1280"}
+      >
+        <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
+          <PreviousNextNav
+            backgroundColorLevel={1}
+            currentIndex={data.orderInUnit ?? undefined}
+            navItemType="lesson"
+            previous={
+              data.previousLesson
+                ? {
+                    href: integratedTeachersLessonHref(
+                      programmeSlug,
+                      unitSlug,
+                      data.previousLesson.lessonSlug,
+                    ),
+                    title: data.previousLesson.lessonTitle,
+                  }
+                : undefined
+            }
+            next={
+              data.nextLesson
+                ? {
+                    href: integratedTeachersLessonHref(
+                      programmeSlug,
+                      unitSlug,
+                      data.nextLesson.lessonSlug,
+                    ),
+                    title: data.nextLesson.lessonTitle,
+                  }
+                : undefined
+            }
+          />
+        </OakGridArea>
+      </OakGrid>
+    </OakBox>
+  );
+}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -44,6 +44,7 @@ export default function LessonView({
                       data.previousLesson.lessonSlug,
                     ),
                     title: data.previousLesson.lessonTitle,
+                    index: data.previousLesson.lessonIndex,
                   }
                 : undefined
             }
@@ -56,6 +57,7 @@ export default function LessonView({
                       data.nextLesson.lessonSlug,
                     ),
                     title: data.nextLesson.lessonTitle,
+                    index: data.nextLesson.lessonIndex,
                   }
                 : undefined
             }

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -3,16 +3,8 @@
 import { OakBox, OakGrid, OakGridArea } from "@oaknational/oak-components";
 
 import PreviousNextNav from "@/components/TeacherComponents/PreviousNextNav/PreviousNextNav";
+import { resolveOakHref } from "@/common-lib/urls";
 import type { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
-
-// TODO: make this an oak href
-function integratedTeachersLessonHref(
-  programmeSlug: string,
-  unitSlug: string,
-  targetLessonSlug: string,
-) {
-  return `/programmes/${programmeSlug}/units/${unitSlug}/lessons/${targetLessonSlug}`;
-}
 
 export default function LessonView({
   programmeSlug,
@@ -38,11 +30,12 @@ export default function LessonView({
             previous={
               data.previousLesson
                 ? {
-                    href: integratedTeachersLessonHref(
+                    href: resolveOakHref({
+                      page: "lesson-page",
                       programmeSlug,
                       unitSlug,
-                      data.previousLesson.lessonSlug,
-                    ),
+                      lessonSlug: data.previousLesson.lessonSlug,
+                    }),
                     title: data.previousLesson.lessonTitle,
                     index: data.previousLesson.lessonIndex,
                   }
@@ -51,11 +44,12 @@ export default function LessonView({
             next={
               data.nextLesson
                 ? {
-                    href: integratedTeachersLessonHref(
+                    href: resolveOakHref({
+                      page: "lesson-page",
                       programmeSlug,
                       unitSlug,
-                      data.nextLesson.lessonSlug,
-                    ),
+                      lessonSlug: data.nextLesson.lessonSlug,
+                    }),
                     title: data.nextLesson.lessonTitle,
                     index: data.nextLesson.lessonIndex,
                   }

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 
+import LessonView from "./Components/LessonView";
+
 import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
 import withPageErrorHandling, {
   AppPageProps,
@@ -111,7 +113,7 @@ const InnerLessonPage = async (props: AppPageProps<LessonPageParams>) => {
 
   const data = await getCachedLessonData(programmeSlug, unitSlug, lessonSlug);
 
-  return <div>{data.lessonTitle}</div>;
+  return <LessonView {...data} />;
 };
 
 const LessonPage = withPageErrorHandling(InnerLessonPage, "lesson-page::app");

--- a/src/common-lib/urls/urls.test.ts
+++ b/src/common-lib/urls/urls.test.ts
@@ -126,10 +126,10 @@ describe("urls.ts", () => {
         "/teachers/programmes/primary-ks2-maths/units/geometry-349/lessons/semi-circles-48",
       );
     });
-    it("Lesson page", () => {
+    it("Integrated lesson overview", () => {
       expect(
         resolveOakHref({
-          page: "lesson-page",
+          page: "integrated-lesson-overview",
           programmeSlug: "maths-secondary-year-10-aqa",
           unitSlug: "algebra-123",
           lessonSlug: "solving-equations-456",

--- a/src/common-lib/urls/urls.test.ts
+++ b/src/common-lib/urls/urls.test.ts
@@ -126,6 +126,18 @@ describe("urls.ts", () => {
         "/teachers/programmes/primary-ks2-maths/units/geometry-349/lessons/semi-circles-48",
       );
     });
+    it("Lesson page", () => {
+      expect(
+        resolveOakHref({
+          page: "lesson-page",
+          programmeSlug: "maths-secondary-year-10-aqa",
+          unitSlug: "algebra-123",
+          lessonSlug: "solving-equations-456",
+        }),
+      ).toBe(
+        "/programmes/maths-secondary-year-10-aqa/units/algebra-123/lessons/solving-equations-456",
+      );
+    });
     it("Lesson downloads", () => {
       expect(
         resolveOakHref({

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -118,16 +118,16 @@ export type LessonListingLinkProps = {
   programmeSlug: string;
   unitSlug: string;
 };
-export type UnitPageLinkProps = {
-  page: "unit-page";
+export type IntegratedLessonListingLinkProps = {
+  page: "integrated-lesson-index";
   programmeSlug: string;
   unitSlug: string;
   query?: {
     subject_category?: string;
   };
 };
-export type LessonPageLinkProps = {
-  page: "lesson-page";
+export type IntegratedLessonOverviewLinkProps = {
+  page: "integrated-lesson-overview";
   programmeSlug: string;
   unitSlug: string;
   lessonSlug: string;
@@ -457,8 +457,8 @@ export type OakLinkProps =
   | SpecialistLessonOverviewLinkProps
   | LessonOverviewCanonicalLinkProps
   | LessonListingLinkProps
-  | UnitPageLinkProps
-  | LessonPageLinkProps
+  | IntegratedLessonListingLinkProps
+  | IntegratedLessonOverviewLinkProps
   | SpecialistLessonListingLinkProps
   | UnitListingLinkProps
   | SpecialistUnitListingLinkProps
@@ -841,18 +841,18 @@ export const OAK_PAGES: {
     configType: "internal",
     pageType: "lesson-index",
   }),
-  "unit-page": createOakPageConfig({
+  "integrated-lesson-index": createOakPageConfig({
     pathPattern: "/programmes/:programmeSlug/units/:unitSlug/lessons",
     analyticsPageName: "Lesson Listing",
     configType: "internal",
-    pageType: "unit-page",
+    pageType: "integrated-lesson-index",
   }),
-  "lesson-page": createOakPageConfig({
+  "integrated-lesson-overview": createOakPageConfig({
     pathPattern:
       "/programmes/:programmeSlug/units/:unitSlug/lessons/:lessonSlug",
     analyticsPageName: "Lesson",
     configType: "internal",
-    pageType: "lesson-page",
+    pageType: "integrated-lesson-overview",
   }),
   "specialist-lesson-index": createOakPageConfig({
     pathPattern:

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -120,11 +120,17 @@ export type LessonListingLinkProps = {
 };
 export type UnitPageLinkProps = {
   page: "unit-page";
-  subjectPhaseSlug: string;
+  programmeSlug: string;
   unitSlug: string;
   query?: {
     subject_category?: string;
   };
+};
+export type LessonPageLinkProps = {
+  page: "lesson-page";
+  programmeSlug: string;
+  unitSlug: string;
+  lessonSlug: string;
 };
 export type SpecialistLessonListingLinkProps = Omit<
   LessonListingLinkProps,
@@ -452,6 +458,7 @@ export type OakLinkProps =
   | LessonOverviewCanonicalLinkProps
   | LessonListingLinkProps
   | UnitPageLinkProps
+  | LessonPageLinkProps
   | SpecialistLessonListingLinkProps
   | UnitListingLinkProps
   | SpecialistUnitListingLinkProps
@@ -835,10 +842,17 @@ export const OAK_PAGES: {
     pageType: "lesson-index",
   }),
   "unit-page": createOakPageConfig({
-    pathPattern: "/programmes/:subjectPhaseSlug/units/:unitSlug/lessons",
+    pathPattern: "/programmes/:programmeSlug/units/:unitSlug/lessons",
     analyticsPageName: "Lesson Listing",
     configType: "internal",
     pageType: "unit-page",
+  }),
+  "lesson-page": createOakPageConfig({
+    pathPattern:
+      "/programmes/:programmeSlug/units/:unitSlug/lessons/:lessonSlug",
+    analyticsPageName: "Lesson",
+    configType: "internal",
+    pageType: "lesson-page",
   }),
   "specialist-lesson-index": createOakPageConfig({
     pathPattern:

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
@@ -64,7 +64,7 @@ export default function PreviousNextItem({
   backgroundColorLevel,
 }: Readonly<PreviousNextItemProps>) {
   return (
-    <OakFocusIndicator $borderRadius={"border-radius-l"}>
+    <OakFocusIndicator $borderRadius={"border-radius-l"} $minHeight={"100%"}>
       <StyledFlexContainer
         $borderRadius={"border-radius-l"}
         $borderColor={"border-neutral-lighter"}
@@ -77,6 +77,7 @@ export default function PreviousNextItem({
         href={href}
         $color={"text-primary"}
         rel={navDirection}
+        $minHeight={"100%"}
       >
         {Boolean(index) && (
           <OakFlex
@@ -97,9 +98,11 @@ export default function PreviousNextItem({
             {index}
           </OakFlex>
         )}
-        <OakTypography $font={"body-3-bold"}>{title}</OakTypography>
+        <OakTypography $font={"body-3-bold"} $mb={"spacing-12"}>
+          {title}
+        </OakTypography>
         <OakFlex
-          $mt={"spacing-12"}
+          $mt={"auto"}
           $justifyContent={navDirection === "next" ? "flex-end" : "flex-start"}
           $alignItems={"center"}
           $gap={"spacing-12"}

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
@@ -82,7 +82,11 @@ export default function PreviousNextItem({
             $borderRadius={"border-radius-circle"}
             $font={"heading-7"}
             $pa={"spacing-12"}
-            $background={`bg-decorative${backgroundColorLevel}-subdued`}
+            $background={
+              backgroundColorLevel === 1
+                ? "bg-decorative1-main"
+                : `bg-decorative${backgroundColorLevel}-subdued`
+            }
             $justifyContent={"center"}
             $alignItems={"center"}
             $width={"spacing-32"}

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
@@ -76,6 +76,7 @@ export default function PreviousNextItem({
         as={Link}
         href={href}
         $color={"text-primary"}
+        rel={navDirection}
       >
         {Boolean(index) && (
           <OakFlex

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextNav.test.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextNav.test.tsx
@@ -73,4 +73,59 @@ describe("PreviousNextNav", () => {
     const previousIndex = screen.getByTestId("nav-item-index");
     expect(previousIndex).toHaveTextContent("4");
   });
+  it("uses previous.index over currentIndex when both are set", () => {
+    render(
+      <PreviousNextNav
+        navItemType="lesson"
+        backgroundColorLevel={3}
+        currentIndex={3}
+        previous={{
+          title: "Mock prev lesson",
+          href: "testUrl",
+          index: 10,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("nav-item-index")).toHaveTextContent("10");
+  });
+  it("uses next.index over currentIndex when both are set", () => {
+    render(
+      <PreviousNextNav
+        navItemType="lesson"
+        backgroundColorLevel={3}
+        currentIndex={3}
+        next={{
+          title: "Mock next lesson",
+          href: "testUrl",
+          index: 99,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("nav-item-index")).toHaveTextContent("99");
+  });
+  it("uses explicit previous.index and next.index over currentIndex when all are set", () => {
+    render(
+      <PreviousNextNav
+        navItemType="lesson"
+        backgroundColorLevel={3}
+        currentIndex={3}
+        previous={{
+          title: "Mock prev lesson",
+          href: "testUrl",
+          index: 10,
+        }}
+        next={{
+          title: "Mock next lesson",
+          href: "testUrl",
+          index: 99,
+        }}
+      />,
+    );
+
+    const indices = screen.getAllByTestId("nav-item-index");
+    expect(indices[0]).toHaveTextContent("10");
+    expect(indices[1]).toHaveTextContent("99");
+  });
 });

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextNav.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextNav.tsx
@@ -21,6 +21,7 @@ export type PreviousNextNavProps = {
   previous?: {
     href: string;
     title: string;
+    index?: number;
   };
   /**
    * Properties for the Next nav item
@@ -28,6 +29,7 @@ export type PreviousNextNavProps = {
   next?: {
     href: string;
     title: string;
+    index?: number;
   };
 };
 
@@ -44,7 +46,9 @@ export default function PreviousNextNav(props: Readonly<PreviousNextNavProps>) {
             href={previous.href}
             backgroundColorLevel={backgroundColorLevel}
             title={previous.title}
-            index={currentIndex ? currentIndex - 1 : undefined}
+            index={
+              previous.index ?? (currentIndex ? currentIndex - 1 : undefined)
+            }
           />
         </OakGridArea>
       )}
@@ -56,7 +60,7 @@ export default function PreviousNextNav(props: Readonly<PreviousNextNavProps>) {
             href={next.href}
             backgroundColorLevel={backgroundColorLevel}
             title={next.title}
-            index={currentIndex ? currentIndex + 1 : undefined}
+            index={next.index ?? (currentIndex ? currentIndex + 1 : undefined)}
           />
         </OakGridArea>
       )}

--- a/src/node-lib/curriculum-api-2023/fixtures/teachersLessonOverview.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/teachersLessonOverview.fixture.ts
@@ -1,0 +1,82 @@
+import lessonMediaClipsFixtures from "./lessonMediaClips.fixture";
+import { quizQuestions } from "./quizElements.fixture";
+
+import type { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
+
+const teachersLessonOverviewFixture = (
+  partial?: Partial<TeachersLessonOverviewPageData>,
+): TeachersLessonOverviewPageData => {
+  return {
+    expired: false,
+    unitTitle: "Cells",
+    programmeSlug: "biology-secondary-ks3",
+    unitSlug: "cells",
+    lessonSlug: "lesson-3-structure-of-cells",
+    lessonTitle: "Structure of cells",
+    keyStageSlug: "ks3",
+    keyStageTitle: "Key Stage 3",
+    subjectSlug: "biology",
+    subjectTitle: "Biology",
+    subjectParent: null,
+    yearTitle: "Year 7",
+    year: "7",
+    examBoardTitle: null,
+    examBoardSlug: null,
+    misconceptionsAndCommonMistakes: [{ response: "", misconception: "" }],
+    lessonEquipmentAndResources: null,
+    teacherTips: null,
+    loginRequired: false,
+    geoRestricted: false,
+    keyLearningPoints: [
+      {
+        keyLearningPoint:
+          "Cells are the basic unit of life and contain specialised structures.",
+      },
+    ],
+    pupilLessonOutcome:
+      "You can describe the main parts of a cell and their functions.",
+    lessonKeywords: [
+      {
+        keyword: "nucleus",
+        description: "the control centre of the cell",
+      },
+    ],
+    contentGuidance: [],
+    supervisionLevel: null,
+    additionalMaterialUrl: null,
+    presentationUrl: null,
+    worksheetUrl: null,
+    isWorksheetLandscape: false,
+    hasLegacyCopyrightMaterial: false,
+    videoMuxPlaybackId: null,
+    videoWithSignLanguageMuxPlaybackId: null,
+    transcriptSentences: ["this is a sentence", "this is another sentence"],
+    starterQuiz: quizQuestions,
+    exitQuiz: quizQuestions,
+    downloads: [
+      { exists: true, type: "intro-quiz-answers" },
+      { exists: true, type: "intro-quiz-questions" },
+      { exists: true, type: "exit-quiz-answers" },
+      { exists: true, type: "exit-quiz-questions" },
+      { exists: true, type: "worksheet-pdf" },
+      { exists: true, type: "worksheet-pptx" },
+      { exists: true, type: "presentation" },
+    ],
+    updatedAt: "2024-09-29T14:00:00.000Z",
+    lessonGuideUrl: null,
+    hasMediaClips: false,
+    lessonMediaClips: lessonMediaClipsFixtures().mediaClips,
+    additionalFiles: ["file1", "file2"],
+    lessonOutline: [{ lessonOutline: "This is the lesson outline" }],
+    lessonReleaseDate: "2024-09-29T14:00:00.000Z",
+    orderInUnit: 3,
+    unitTotalLessonCount: 6,
+    excludedFromTeachingMaterials: false,
+    subjectCategories: null,
+    previousLesson: null,
+    nextLesson: null,
+    ...partial,
+  };
+};
+
+export default teachersLessonOverviewFixture;

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.test.ts
@@ -90,9 +90,9 @@ describe("teachersLessonOverview()", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
           [
-            { slug: "a", title: "A", order: 1 },
-            { slug: "b", title: "B", order: 2 },
-            { slug: "c", title: "C", order: 3 },
+            { slug: "a", title: "A", order: 1, _state: "published" },
+            { slug: "b", title: "B", order: 2, _state: "published" },
+            { slug: "c", title: "C", order: 3, _state: "published" },
           ],
           "b",
         ),
@@ -114,8 +114,8 @@ describe("teachersLessonOverview()", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
           [
-            { slug: "a", title: "A", order: 1 },
-            { slug: "b", title: "B", order: 2 },
+            { slug: "a", title: "A", order: 1, _state: "published" },
+            { slug: "b", title: "B", order: 2, _state: "published" },
           ],
           "a",
         ),
@@ -130,8 +130,8 @@ describe("teachersLessonOverview()", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
           [
-            { slug: "a", title: "A", order: 1 },
-            { slug: "b", title: "B", order: 2 },
+            { slug: "a", title: "A", order: 1, _state: "published" },
+            { slug: "b", title: "B", order: 2, _state: "published" },
           ],
           "b",
         ),
@@ -148,7 +148,7 @@ describe("teachersLessonOverview()", () => {
     it("returns both null when current slug is not in the list", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
-          [{ slug: "a", title: "A", order: 1 }],
+          [{ slug: "a", title: "A", order: 1, _state: "published" }],
           "missing",
         ),
       ).toEqual({ previousLesson: null, nextLesson: null });
@@ -158,9 +158,9 @@ describe("teachersLessonOverview()", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
           [
-            { slug: "lesson-c", title: "C", order: 3 },
-            { slug: "lesson-a", title: "A", order: 1 },
-            { slug: "lesson-b", title: "B", order: 2 },
+            { slug: "lesson-c", title: "C", order: 3, _state: "published" },
+            { slug: "lesson-a", title: "A", order: 1, _state: "published" },
+            { slug: "lesson-b", title: "B", order: 2, _state: "published" },
           ],
           "lesson-b",
         ),
@@ -182,9 +182,9 @@ describe("teachersLessonOverview()", () => {
       expect(
         getAdjacentLessonsByOrderInUnit(
           [
-            { slug: "zebra", title: "Z", order: 1 },
-            { slug: "alpha", title: "A", order: 1 },
-            { slug: "mike", title: "M", order: 2 },
+            { slug: "zebra", title: "Z", order: 1, _state: "published" },
+            { slug: "alpha", title: "A", order: 1, _state: "published" },
+            { slug: "mike", title: "M", order: 2, _state: "published" },
           ],
           "zebra",
         ),
@@ -199,6 +199,53 @@ describe("teachersLessonOverview()", () => {
           lessonTitle: "M",
           lessonIndex: 3,
         },
+      });
+    });
+
+    it("skips non-published lessons for next/prev but keeps 1-based index from full unit order", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "l1", title: "L1", order: 1, _state: "published" },
+            { slug: "l2", title: "L2", order: 2, _state: "published" },
+            { slug: "l3", title: "L3", order: 3, _state: "published" },
+            { slug: "l4", title: "L4", order: 4, _state: "published" },
+            { slug: "l5", title: "L5", order: 5, _state: "new" },
+            { slug: "l6", title: "L6", order: 6, _state: "published" },
+          ],
+          "l4",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "l3",
+          lessonTitle: "L3",
+          lessonIndex: 3,
+        },
+        nextLesson: {
+          lessonSlug: "l6",
+          lessonTitle: "L6",
+          lessonIndex: 6,
+        },
+      });
+    });
+
+    it("skips non-published lessons when scanning for previous", () => {
+      expect(
+        getAdjacentLessonsByOrderInUnit(
+          [
+            { slug: "l1", title: "L1", order: 1, _state: "published" },
+            { slug: "l2", title: "L2", order: 2, _state: "new" },
+            { slug: "l3", title: "L3", order: 3, _state: "published" },
+          ],
+          "l3",
+        ),
+      ).toEqual({
+        previousLesson: {
+          lessonSlug: "l1",
+          lessonTitle: "L1",
+          lessonIndex: 1,
+        },
+        nextLesson: null,
       });
     });
   });
@@ -384,6 +431,98 @@ describe("teachersLessonOverview()", () => {
       lessonSlug: "lesson-c",
       lessonTitle: "Lesson C",
       lessonIndex: 3,
+    });
+  });
+
+  test("skips non-published static lessons for adjacent links but uses full-sequence lessonIndex", async () => {
+    const browseRow = syntheticUnitvariantLessonsByKsFixture({
+      overrides: {
+        lesson_slug: "lesson-4",
+        unit_slug: unitSlugTest,
+        programme_slug: programmeSlugTest,
+        order_in_unit: 4,
+        programme_slug_by_year: [programmeSlugTest],
+      },
+    });
+    const content = lessonContentFixture({
+      overrides: { exit_quiz: [], starter_quiz: [] },
+    });
+    const unitData = {
+      lesson_count: 6,
+      supplementary_data: {
+        unit_order: 1,
+        static_lesson_list: [
+          {
+            slug: "lesson-1",
+            order: 1,
+            title: "Lesson 1",
+            _state: "published",
+            lesson_uid: "uid-1",
+          },
+          {
+            slug: "lesson-2",
+            order: 2,
+            title: "Lesson 2",
+            _state: "published",
+            lesson_uid: "uid-2",
+          },
+          {
+            slug: "lesson-3",
+            order: 3,
+            title: "Lesson 3",
+            _state: "published",
+            lesson_uid: "uid-3",
+          },
+          {
+            slug: "lesson-4",
+            order: 4,
+            title: "Lesson 4",
+            _state: "published",
+            lesson_uid: "uid-4",
+          },
+          {
+            slug: "lesson-5",
+            order: 5,
+            title: "Lesson 5",
+            _state: "draft",
+            lesson_uid: "uid-5",
+          },
+          {
+            slug: "lesson-6",
+            order: 6,
+            title: "Lesson 6",
+            _state: "published",
+            lesson_uid: "uid-6",
+          },
+        ],
+      },
+    };
+
+    const lesson = await teachersLessonOverview({
+      ...sdk,
+      teachersLessonOverview: jest.fn(() =>
+        Promise.resolve({
+          browseData: [browseRow],
+          content: [content],
+          unitData: [unitData],
+          tpcWorks: [],
+        }),
+      ),
+    })({
+      lessonSlug: "lesson-4",
+      unitSlug: unitSlugTest,
+      programmeSlug: programmeSlugTest,
+    });
+
+    expect(lesson.previousLesson).toEqual({
+      lessonSlug: "lesson-3",
+      lessonTitle: "Lesson 3",
+      lessonIndex: 3,
+    });
+    expect(lesson.nextLesson).toEqual({
+      lessonSlug: "lesson-6",
+      lessonTitle: "Lesson 6",
+      lessonIndex: 6,
     });
   });
 

--- a/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.query.ts
@@ -47,25 +47,35 @@ export function getAdjacentLessonsByOrderInUnit(
     return { previousLesson: null, nextLesson: null };
   }
 
-  const previousLesson = sortedRows[idx - 1] ?? null;
-  const nextLesson = sortedRows[idx + 1] ?? null;
+  let previousLesson: TeachersLessonOverviewAdjacentLesson | null = null;
+  // Find the previous published lesson
+  for (let j = idx - 1; j >= 0; j--) {
+    const row = sortedRows[j];
+    if (row?._state === "published") {
+      previousLesson = {
+        lessonSlug: row.slug,
+        lessonTitle: row.title,
+        lessonIndex: j + 1,
+      };
+      break;
+    }
+  }
 
-  return {
-    previousLesson: previousLesson
-      ? {
-          lessonSlug: previousLesson.slug,
-          lessonTitle: previousLesson.title,
-          lessonIndex: idx,
-        }
-      : null,
-    nextLesson: nextLesson
-      ? {
-          lessonSlug: nextLesson.slug,
-          lessonTitle: nextLesson.title,
-          lessonIndex: idx + 2,
-        }
-      : null,
-  };
+  let nextLesson: TeachersLessonOverviewAdjacentLesson | null = null;
+  // Find the next published lesson
+  for (let j = idx + 1; j < sortedRows.length; j++) {
+    const row = sortedRows[j];
+    if (row?._state === "published") {
+      nextLesson = {
+        lessonSlug: row.slug,
+        lessonTitle: row.title,
+        lessonIndex: j + 1,
+      };
+      break;
+    }
+  }
+
+  return { previousLesson, nextLesson };
 }
 
 export const getDownloadsArray = (content: {


### PR DESCRIPTION
## Description

Music year: 1979

- Adds Next+Previous lesson links to the foot of the new lesson page
- Skips unpublished lessons
- Uses the same component and layout as the unit page.
- Links to lessons from the unit page point to the new page.

https://www.notion.so/oaknationalacademy/I-want-previous-next-lesson-footer-buttons-33b26cc4e1b1800796d4d7676f5044a5?source=copy_link

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1910footer-nex-dac470.vercel.thenational.academy/programmes/english-primary-ks2/units/no-country-and-frizzy-graphic-novels-exploring-identity-and-belonging/lessons/exploring-themes-in-no-country-ff
2. You should see the Next+Previous unit links
3. You should be able to navigate through the unit with unpublished lessons skipped.

## Screenshots

<img width="707" height="1320" alt="Screenshot 2026-04-13 at 12 21 41" src="https://github.com/user-attachments/assets/4de99800-97fb-43cd-96db-3f80d55de131" />
<img width="1004" height="1320" alt="Screenshot 2026-04-13 at 12 21 37" src="https://github.com/user-attachments/assets/738a4456-6f9e-4310-ab42-6194a11c6866" />
<img width="1518" height="1320" alt="Screenshot 2026-04-13 at 12 21 29" src="https://github.com/user-attachments/assets/7be71954-a023-484b-8249-b33f20400b7c" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
