### PR TITLE
Lesson side menu LESQ 1909

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import {
+  CurrentSectionIdProvider,
+  useCurrentSectionId,
+} from "./CurrentSectionIdProvider";
+
+describe("CurrentSectionIdProvider", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <CurrentSectionIdProvider>{children}</CurrentSectionIdProvider>
+  );
+
+  beforeEach(() => {
+    window.location.hash = "";
+  });
+
+  it("exposes null after mount when there is no hash", async () => {
+    const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+  });
+
+  it("syncs the fragment from the URL after mount", async () => {
+    window.location.hash = "#worksheet";
+
+    const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBe("worksheet");
+    });
+  });
+
+  it("updates when the hash changes", async () => {
+    const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+
+    act(() => {
+      window.location.hash = "#quiz";
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("quiz");
+    });
+  });
+
+  it("treats an empty hash as null", async () => {
+    window.location.hash = "#";
+
+    const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+  });
+});

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
@@ -71,16 +71,26 @@ describe("pickSectionClosestToReferenceLine", () => {
       mockSection("lesson-details", -5),
       mockSection("video", 40),
     ];
-    expect(pickSectionClosestToReferenceLine(nodes)).toBe("lesson-details");
+    expect(pickSectionClosestToReferenceLine(nodes, -1)).toBe("lesson-details");
   });
 
   it("can select a section below the top when it is closer", () => {
     const nodes = [mockSection("a", 80), mockSection("b", 400)];
-    expect(pickSectionClosestToReferenceLine(nodes)).toBe("a");
+    expect(pickSectionClosestToReferenceLine(nodes, -1)).toBe("a");
+  });
+
+  it("returns null when sentinel is in viewport", () => {
+    const nodes = [mockSection("a", -50), mockSection("b", 160)];
+    expect(pickSectionClosestToReferenceLine(nodes, 10)).toBeNull();
+  });
+
+  it("can select sections when sentinel is above viewport", () => {
+    const nodes = [mockSection("a", -50), mockSection("b", 160)];
+    expect(pickSectionClosestToReferenceLine(nodes, -10)).toBe("a");
   });
 
   it("returns null when there are no sections", () => {
-    expect(pickSectionClosestToReferenceLine([])).toBeNull();
+    expect(pickSectionClosestToReferenceLine([], -1)).toBeNull();
   });
 });
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.test.tsx
@@ -3,16 +3,103 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 
 import {
   CurrentSectionIdProvider,
+  pickSectionClosestToReferenceLine,
   useCurrentSectionId,
 } from "./CurrentSectionIdProvider";
 
+function makeRect(top: number) {
+  return {
+    top,
+    bottom: top + 40,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 40,
+    x: 0,
+    y: top,
+    toJSON() {
+      return {};
+    },
+  };
+}
+
+function mockIntersectionObserver() {
+  let ioCallback: IntersectionObserverCallback | undefined;
+  const observe = jest.fn();
+  const disconnect = jest.fn();
+  const unobserve = jest.fn();
+
+  const ioSpy = jest
+    .spyOn(globalThis, "IntersectionObserver")
+    .mockImplementation((cb: IntersectionObserverCallback) => {
+      ioCallback = cb;
+      return {
+        observe,
+        disconnect,
+        unobserve,
+        takeRecords: () => [],
+      } as unknown as IntersectionObserver;
+    });
+
+  return {
+    trigger: () => ioCallback?.([], {} as IntersectionObserver),
+    observe,
+    disconnect,
+    unobserve,
+    restore: () => ioSpy.mockRestore(),
+  };
+}
+
+function flushRafAndDebounceTimers() {
+  // 1) RAF callback scheduled by IO trigger
+  jest.runOnlyPendingTimers();
+  // 2) debounce timeout
+  jest.runOnlyPendingTimers();
+}
+
+describe("pickSectionClosestToReferenceLine", () => {
+  function mockSection(id: string, top: number): HTMLElement {
+    const el = document.createElement("div");
+    el.id = id;
+    el.getBoundingClientRect = jest.fn(() => makeRect(top));
+    return el;
+  }
+
+  it("returns the section whose top is closest to top of the viewport", () => {
+    const nodes = [
+      mockSection("slide-deck", -20),
+      mockSection("lesson-details", -5),
+      mockSection("video", 40),
+    ];
+    expect(pickSectionClosestToReferenceLine(nodes)).toBe("lesson-details");
+  });
+
+  it("can select a section below the top when it is closer", () => {
+    const nodes = [mockSection("a", 80), mockSection("b", 400)];
+    expect(pickSectionClosestToReferenceLine(nodes)).toBe("a");
+  });
+
+  it("returns null when there are no sections", () => {
+    expect(pickSectionClosestToReferenceLine([])).toBeNull();
+  });
+});
+
 describe("CurrentSectionIdProvider", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   const wrapper = ({ children }: { children: ReactNode }) => (
     <CurrentSectionIdProvider>{children}</CurrentSectionIdProvider>
   );
 
   beforeEach(() => {
-    window.location.hash = "";
+    globalThis.location.hash = "";
+    document.body.replaceChildren();
   });
 
   it("exposes null after mount when there is no hash", async () => {
@@ -23,17 +110,23 @@ describe("CurrentSectionIdProvider", () => {
     });
   });
 
-  it("syncs the fragment from the URL after mount", async () => {
-    window.location.hash = "#worksheet";
+  it("does not derive current section from URL hash alone", async () => {
+    globalThis.location.hash = "#worksheet";
 
     const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current).toBe("worksheet");
+      expect(result.current).toBeNull();
     });
   });
 
-  it("updates when the hash changes", async () => {
+  it("recomputes current section when hash changes", async () => {
+    const section = document.createElement("div");
+    section.id = "quiz";
+    section.className = "anchor-section";
+    section.getBoundingClientRect = jest.fn(() => makeRect(10));
+    document.body.append(section);
+
     const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
 
     await waitFor(() => {
@@ -41,8 +134,8 @@ describe("CurrentSectionIdProvider", () => {
     });
 
     act(() => {
-      window.location.hash = "#quiz";
-      window.dispatchEvent(new HashChangeEvent("hashchange"));
+      globalThis.location.hash = "#quiz";
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
     });
 
     await waitFor(() => {
@@ -51,12 +144,126 @@ describe("CurrentSectionIdProvider", () => {
   });
 
   it("treats an empty hash as null", async () => {
-    window.location.hash = "#";
+    globalThis.location.hash = "#";
 
     const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
 
     await waitFor(() => {
       expect(result.current).toBeNull();
     });
+  });
+
+  it("recomputes from section proximity when IntersectionObserver fires", async () => {
+    const ioMock = mockIntersectionObserver();
+
+    const a = document.createElement("div");
+    a.id = "slide-deck";
+    a.className = "anchor-section";
+    a.getBoundingClientRect = jest.fn(() => makeRect(120));
+
+    const b = document.createElement("div");
+    b.id = "lesson-details";
+    b.className = "anchor-section";
+    b.getBoundingClientRect = jest.fn(() => makeRect(400));
+
+    document.body.append(a, b);
+
+    try {
+      const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe("slide-deck");
+      });
+
+      act(() => {
+        a.getBoundingClientRect = jest.fn(() => makeRect(-30));
+        b.getBoundingClientRect = jest.fn(() => makeRect(15));
+        ioMock.trigger();
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe("lesson-details");
+      });
+
+      act(() => {
+        b.getBoundingClientRect = jest.fn(() => makeRect(-2));
+        ioMock.trigger();
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe("lesson-details");
+      });
+    } finally {
+      ioMock.restore();
+    }
+  });
+
+  it("updates the address bar with replaceState after scroll when the section changes", async () => {
+    const replaceStateSpy = jest.spyOn(history, "replaceState");
+    const ioMock = mockIntersectionObserver();
+
+    const a = document.createElement("div");
+    a.id = "a";
+    a.className = "anchor-section";
+    a.getBoundingClientRect = jest.fn(() => makeRect(100));
+
+    const b = document.createElement("div");
+    b.id = "b";
+    b.className = "anchor-section";
+    b.getBoundingClientRect = jest.fn(() => makeRect(400));
+
+    document.body.append(a, b);
+
+    renderHook(() => useCurrentSectionId(), { wrapper });
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      a.getBoundingClientRect = jest.fn(() => makeRect(-20));
+      b.getBoundingClientRect = jest.fn(() => makeRect(80));
+      ioMock.trigger();
+      flushRafAndDebounceTimers();
+    });
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      expect.stringMatching(/#a$/),
+    );
+
+    act(() => {
+      b.getBoundingClientRect = jest.fn(() => makeRect(-1));
+      ioMock.trigger();
+      flushRafAndDebounceTimers();
+    });
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      expect.stringMatching(/#b$/),
+    );
+
+    replaceStateSpy.mockRestore();
+    ioMock.restore();
+  });
+
+  it("removes the hash when current section becomes null", async () => {
+    globalThis.location.hash = "#worksheet";
+    const replaceStateSpy = jest.spyOn(history, "replaceState");
+
+    const { result } = renderHook(() => useCurrentSectionId(), { wrapper });
+
+    act(() => {
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+      flushRafAndDebounceTimers();
+    });
+    expect(result.current).toBeNull();
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      expect.not.stringContaining("#"),
+    );
+
+    replaceStateSpy.mockRestore();
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
@@ -17,12 +17,23 @@ const HASH_SYNC_DEBOUNCE_MS = 250;
 
 /**
  * Picks the section whose top edge is closest to the top of the viewport.
+ * Sections that are too far below the viewport reference line are ignored.
+ * The lower bound is based on the first section's vertical document position.
  */
 export function pickSectionClosestToReferenceLine(
   sections: readonly Element[],
+  sentinelTop: number,
 ): string | null {
   let closestId: string | null = null;
   let closestDistance = Number.POSITIVE_INFINITY;
+
+  /**
+   * If the sentinel is in viewport, don't pick a section since
+   * the content is not at the top of the page.
+   */
+  if (sentinelTop > 0) {
+    return null;
+  }
 
   for (const el of sections) {
     const top = el.getBoundingClientRect().top;
@@ -66,6 +77,7 @@ export type CurrentSectionIdProviderProps = {
 export function CurrentSectionIdProvider({
   children,
 }: Readonly<CurrentSectionIdProviderProps>) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const [currentSectionId, setCurrentSectionId] = useState<string | null>(null);
   const rafRef = useRef<number>(0);
   const hashSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -74,6 +86,7 @@ export function CurrentSectionIdProvider({
   const updateSectionId = useCallback(() => {
     const nextSectionId = pickSectionClosestToReferenceLine(
       sectionsRef.current,
+      sentinelRef.current?.getBoundingClientRect().top ?? 0,
     );
 
     // Debounce the URL hash sync
@@ -119,6 +132,7 @@ export function CurrentSectionIdProvider({
 
   return (
     <CurrentSectionIdContext.Provider value={currentSectionId}>
+      <div ref={sentinelRef} />
       {children}
     </CurrentSectionIdContext.Provider>
   );

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
@@ -2,32 +2,120 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
 
 const CurrentSectionIdContext = createContext<string | null>(null);
 
+const ANCHOR_SECTION_SELECTOR = ".anchor-section[id]";
+const HASH_SYNC_DEBOUNCE_MS = 250;
+
 /**
- * Provides the current section ID to children.
+ * Picks the section whose top edge is closest to the top of the viewport.
+ */
+export function pickSectionClosestToReferenceLine(
+  sections: readonly Element[],
+): string | null {
+  let closestId: string | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const el of sections) {
+    const top = el.getBoundingClientRect().top;
+    const distance = Math.abs(top);
+
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestId = el.id;
+    }
+  }
+
+  return closestId;
+}
+
+/**
+ * Sync fragment to address bar
+ */
+function replaceUrlHashWithSectionId(sectionId: string | null) {
+  const { hash } = globalThis.location;
+  const currentSectionId = hash.slice(1) || null;
+
+  if (currentSectionId === sectionId) {
+    return;
+  }
+  let path = `${globalThis.location.pathname}${globalThis.location.search}`;
+
+  if (sectionId) {
+    path += `#${sectionId}`;
+  }
+
+  history.replaceState(null, "", path);
+}
+
+export type CurrentSectionIdProviderProps = {
+  children: ReactNode;
+};
+
+/**
+ * Tracks the current lesson section for anchor navigation
  */
 export function CurrentSectionIdProvider({
   children,
-}: {
-  children: ReactNode;
-}) {
+}: Readonly<CurrentSectionIdProviderProps>) {
   const [currentSectionId, setCurrentSectionId] = useState<string | null>(null);
+  const rafRef = useRef<number>(0);
+  const hashSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionsRef = useRef<HTMLElement[]>([]);
+
+  const updateSectionId = useCallback(() => {
+    const nextSectionId = pickSectionClosestToReferenceLine(
+      sectionsRef.current,
+    );
+
+    // Debounce the URL hash sync
+    if (hashSyncTimeoutRef.current !== null) {
+      globalThis.clearTimeout(hashSyncTimeoutRef.current);
+    }
+    hashSyncTimeoutRef.current = globalThis.setTimeout(() => {
+      replaceUrlHashWithSectionId(nextSectionId);
+    }, HASH_SYNC_DEBOUNCE_MS);
+
+    setCurrentSectionId(nextSectionId);
+  }, []);
 
   useEffect(() => {
-    function syncFromLocation() {
-      setCurrentSectionId(window.location.hash.slice(1) || null);
+    sectionsRef.current = Array.from(
+      document.querySelectorAll<HTMLElement>(ANCHOR_SECTION_SELECTOR),
+    );
+
+    globalThis.addEventListener("hashchange", updateSectionId);
+
+    const observer = new IntersectionObserver(
+      () => {
+        rafRef.current = requestAnimationFrame(updateSectionId);
+      },
+      {
+        threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+      },
+    );
+
+    for (const el of sectionsRef.current) {
+      observer.observe(el);
     }
-    syncFromLocation();
-    window.addEventListener("hashchange", syncFromLocation);
-    return () => window.removeEventListener("hashchange", syncFromLocation);
-  }, []);
+
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(rafRef.current);
+      if (hashSyncTimeoutRef.current !== null) {
+        globalThis.clearTimeout(hashSyncTimeoutRef.current);
+      }
+      globalThis.removeEventListener("hashchange", updateSectionId);
+    };
+  }, [updateSectionId]);
 
   return (
     <CurrentSectionIdContext.Provider value={currentSectionId}>

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/CurrentSectionIdProvider.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+const CurrentSectionIdContext = createContext<string | null>(null);
+
+/**
+ * Provides the current section ID to children.
+ */
+export function CurrentSectionIdProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [currentSectionId, setCurrentSectionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    function syncFromLocation() {
+      setCurrentSectionId(window.location.hash.slice(1) || null);
+    }
+    syncFromLocation();
+    window.addEventListener("hashchange", syncFromLocation);
+    return () => window.removeEventListener("hashchange", syncFromLocation);
+  }, []);
+
+  return (
+    <CurrentSectionIdContext.Provider value={currentSectionId}>
+      {children}
+    </CurrentSectionIdContext.Provider>
+  );
+}
+
+export function useCurrentSectionId(): string | null {
+  return useContext(CurrentSectionIdContext);
+}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
@@ -27,6 +27,7 @@ export default function LessonOverviewSideNav(
       $pr={["spacing-16"]}
       $position="sticky"
       $top="spacing-56"
+      $width="100%"
     >
       <LessonOverviewSideNavAnchorLinks
         {...props}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
@@ -3,15 +3,20 @@
 import type { ComponentProps } from "react";
 import { OakFlex } from "@oaknational/oak-components";
 
+import { useCurrentSectionId } from "./CurrentSectionIdProvider";
+
 import LessonOverviewSideNavAnchorLinks from "@/components/TeacherComponents/LessonOverviewSideNavAnchorLinks";
 
-type LessonOverviewSideNavProps = ComponentProps<
-  typeof LessonOverviewSideNavAnchorLinks
+type LessonOverviewSideNavProps = Omit<
+  ComponentProps<typeof LessonOverviewSideNavAnchorLinks>,
+  "currentSectionId"
 >;
 
 export default function LessonOverviewSideNav(
   props: Readonly<LessonOverviewSideNavProps>,
 ) {
+  const currentSectionId = useCurrentSectionId();
+
   return (
     <OakFlex
       as="nav"
@@ -23,7 +28,10 @@ export default function LessonOverviewSideNav(
       $position="sticky"
       $top="spacing-56"
     >
-      <LessonOverviewSideNavAnchorLinks {...props} />
+      <LessonOverviewSideNavAnchorLinks
+        {...props}
+        currentSectionId={currentSectionId}
+      />
     </OakFlex>
   );
 }

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonOverviewSideNav.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { OakFlex } from "@oaknational/oak-components";
+
+import LessonOverviewSideNavAnchorLinks from "@/components/TeacherComponents/LessonOverviewSideNavAnchorLinks";
+
+type LessonOverviewSideNavProps = ComponentProps<
+  typeof LessonOverviewSideNavAnchorLinks
+>;
+
+export default function LessonOverviewSideNav(
+  props: Readonly<LessonOverviewSideNavProps>,
+) {
+  return (
+    <OakFlex
+      as="nav"
+      aria-label="page navigation"
+      $flexDirection="column"
+      $alignItems="flex-start"
+      $gap={["spacing-8"]}
+      $pr={["spacing-16"]}
+      $position="sticky"
+      $top="spacing-56"
+    >
+      <LessonOverviewSideNavAnchorLinks {...props} />
+    </OakFlex>
+  );
+}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -160,41 +160,16 @@ export default function LessonView(
             />
           </OakGridArea>
           <OakGridArea $colSpan={[12, 8, 8]} id="lesson-content">
-            <OakBox
-              id="slide-deck"
-              style={{ height: 500 }}
-              className="anchor-section"
-            >
-              <OakHeading tag="h2">Slide deck</OakHeading>
-            </OakBox>
-            <OakBox
-              id="lesson-details"
-              style={{ height: 500 }}
-              className="anchor-section"
-            >
-              <OakHeading tag="h2">Lesson details</OakHeading>
-            </OakBox>
-            <OakBox
-              id="video"
-              style={{ height: 500 }}
-              className="anchor-section"
-            >
-              <OakHeading tag="h2">Video</OakHeading>
-            </OakBox>
-            <OakBox
-              id="worksheet"
-              style={{ height: 500 }}
-              className="anchor-section"
-            >
-              <OakHeading tag="h2">Worksheet</OakHeading>
-            </OakBox>
-            <OakBox
-              id="quiz"
-              style={{ height: 500 }}
-              className="anchor-section"
-            >
-              <OakHeading tag="h2">Quiz</OakHeading>
-            </OakBox>
+            {pageLinks.map((pageLink) => (
+              <OakBox
+                key={pageLink.anchorId}
+                id={pageLink.anchorId}
+                style={{ height: 500 }}
+                className="anchor-section"
+              >
+                <OakHeading tag="h2">{pageLink.label}</OakHeading>
+              </OakBox>
+            ))}
           </OakGridArea>
           <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
             <PreviousNextNav

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -21,6 +21,7 @@ import {
 import { DownloadResourceButtonNameValueType } from "@/browser-lib/avo/Avo";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { getAnalyticsBrowseData } from "@/components/TeacherComponents/helpers/getAnalyticsBrowseData";
+import SkipLink from "@/components/CurriculumComponents/OakComponentsKitchen/SkipLink";
 
 export default function LessonView(
   props: Readonly<TeachersLessonOverviewPageData>,
@@ -129,7 +130,16 @@ export default function LessonView(
           <OakGridArea
             $colSpan={[12, 4, 4]}
             $display={["none", "block", "block"]}
+            $position="relative"
           >
+            <OakBox
+              $position="absolute"
+              $zIndex="in-front"
+              $top="spacing-0"
+              $left="spacing-0"
+            >
+              <SkipLink href="#lesson-content">Skip to lesson content</SkipLink>
+            </OakBox>
             <LessonOverviewSideNav
               links={pageLinks}
               contentRestricted={contentRestricted}
@@ -149,7 +159,7 @@ export default function LessonView(
               }}
             />
           </OakGridArea>
-          <OakGridArea $colSpan={[12, 8, 8]}>
+          <OakGridArea $colSpan={[12, 8, 8]} id="lesson-content">
             <OakBox
               id="slide-deck"
               style={{ height: 500 }}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -116,17 +116,17 @@ export default function LessonView(
   const showDownloadAll = hasDownloadableAssets && !contentRestricted;
 
   return (
-    <OakBox $ph="spacing-40">
-      <OakGrid
-        $cg="spacing-16"
-        $rg="spacing-56"
-        $mb={["spacing-0", "spacing-48", "spacing-48"]}
-        $mh="auto"
-        $mt={["spacing-48", "spacing-56"]}
-        $width={"100%"}
-        $maxWidth={"spacing-1280"}
-      >
-        <CurrentSectionIdProvider>
+    <CurrentSectionIdProvider>
+      <OakBox $ph="spacing-40">
+        <OakGrid
+          $cg="spacing-16"
+          $rg="spacing-56"
+          $mb={["spacing-0", "spacing-48", "spacing-48"]}
+          $mh="auto"
+          $mt={["spacing-48", "spacing-56"]}
+          $width={"100%"}
+          $maxWidth={"spacing-1280"}
+        >
           <OakGridArea
             $colSpan={[12, 4, 4]}
             $display={["none", "block", "block"]}
@@ -196,42 +196,42 @@ export default function LessonView(
               <OakHeading tag="h2">Quiz</OakHeading>
             </OakBox>
           </OakGridArea>
-        </CurrentSectionIdProvider>
-        <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
-          <PreviousNextNav
-            backgroundColorLevel={1}
-            navItemType="lesson"
-            previous={
-              previousLesson
-                ? {
-                    href: resolveOakHref({
-                      page: "integrated-lesson-overview",
-                      programmeSlug,
-                      unitSlug,
-                      lessonSlug: previousLesson.lessonSlug,
-                    }),
-                    title: previousLesson.lessonTitle,
-                    index: previousLesson.lessonIndex,
-                  }
-                : undefined
-            }
-            next={
-              nextLesson
-                ? {
-                    href: resolveOakHref({
-                      page: "integrated-lesson-overview",
-                      programmeSlug,
-                      unitSlug,
-                      lessonSlug: nextLesson.lessonSlug,
-                    }),
-                    title: nextLesson.lessonTitle,
-                    index: nextLesson.lessonIndex,
-                  }
-                : undefined
-            }
-          />
-        </OakGridArea>
-      </OakGrid>
-    </OakBox>
+          <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
+            <PreviousNextNav
+              backgroundColorLevel={1}
+              navItemType="lesson"
+              previous={
+                previousLesson
+                  ? {
+                      href: resolveOakHref({
+                        page: "integrated-lesson-overview",
+                        programmeSlug,
+                        unitSlug,
+                        lessonSlug: previousLesson.lessonSlug,
+                      }),
+                      title: previousLesson.lessonTitle,
+                      index: previousLesson.lessonIndex,
+                    }
+                  : undefined
+              }
+              next={
+                nextLesson
+                  ? {
+                      href: resolveOakHref({
+                        page: "integrated-lesson-overview",
+                        programmeSlug,
+                        unitSlug,
+                        lessonSlug: nextLesson.lessonSlug,
+                      }),
+                      title: nextLesson.lessonTitle,
+                      index: nextLesson.lessonIndex,
+                    }
+                  : undefined
+              }
+            />
+          </OakGridArea>
+        </OakGrid>
+      </OakBox>
+    </CurrentSectionIdProvider>
   );
 }

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -7,6 +7,7 @@ import {
   OakHeading,
 } from "@oaknational/oak-components";
 
+import { CurrentSectionIdProvider } from "./CurrentSectionIdProvider";
 import LessonOverviewSideNav from "./LessonOverviewSideNav";
 
 import PreviousNextNav from "@/components/TeacherComponents/PreviousNextNav/PreviousNextNav";
@@ -17,7 +18,6 @@ import {
   getMediaClipLabel,
   getPageLinksWithSubheadingsForLesson,
 } from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
-import { checkIfResourceHasLegacyCopyright } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/downloadsLegacyCopyright";
 import { DownloadResourceButtonNameValueType } from "@/browser-lib/avo/Avo";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { getAnalyticsBrowseData } from "@/components/TeacherComponents/helpers/getAnalyticsBrowseData";
@@ -125,47 +125,68 @@ export default function LessonView(
         $width={"100%"}
         $maxWidth={"spacing-1280"}
       >
-        <OakGridArea
-          $colSpan={[12, 4, 4]}
-          $display={["none", "block", "block"]}
-        >
-          <LessonOverviewSideNav
-            links={pageLinks}
-            contentRestricted={contentRestricted}
-            downloadAllButtonProps={{
-              lessonSlug,
-              programmeSlug,
-              unitSlug,
-              showDownloadAll,
-              onClickDownloadAll: () => {
-                trackDownloadResourceButtonClicked("all");
-              },
-              geoRestricted,
-              loginRequired,
-              expired,
-              isSpecialist: false,
-              isCanonical: false,
-            }}
-            currentSectionId={null}
-          />
-        </OakGridArea>
-        <OakGridArea $colSpan={[12, 8, 8]}>
-          <OakBox id="slide-deck" style={{ height: 500 }}>
-            <OakHeading tag="h2">Slide deck</OakHeading>
-          </OakBox>
-          <OakBox id="lesson-details" style={{ height: 500 }}>
-            <OakHeading tag="h2">Lesson details</OakHeading>
-          </OakBox>
-          <OakBox id="video" style={{ height: 500 }}>
-            <OakHeading tag="h2">Video</OakHeading>
-          </OakBox>
-          <OakBox id="worksheet" style={{ height: 500 }}>
-            <OakHeading tag="h2">Worksheet</OakHeading>
-          </OakBox>
-          <OakBox id="quiz" style={{ height: 500 }}>
-            <OakHeading tag="h2">Quiz</OakHeading>
-          </OakBox>
-        </OakGridArea>
+        <CurrentSectionIdProvider>
+          <OakGridArea
+            $colSpan={[12, 4, 4]}
+            $display={["none", "block", "block"]}
+          >
+            <LessonOverviewSideNav
+              links={pageLinks}
+              contentRestricted={contentRestricted}
+              downloadAllButtonProps={{
+                lessonSlug,
+                programmeSlug,
+                unitSlug,
+                showDownloadAll,
+                onClickDownloadAll: () => {
+                  trackDownloadResourceButtonClicked("all");
+                },
+                geoRestricted,
+                loginRequired,
+                expired,
+                isSpecialist: false,
+                isCanonical: false,
+              }}
+            />
+          </OakGridArea>
+          <OakGridArea $colSpan={[12, 8, 8]}>
+            <OakBox
+              id="slide-deck"
+              style={{ height: 500 }}
+              className="anchor-section"
+            >
+              <OakHeading tag="h2">Slide deck</OakHeading>
+            </OakBox>
+            <OakBox
+              id="lesson-details"
+              style={{ height: 500 }}
+              className="anchor-section"
+            >
+              <OakHeading tag="h2">Lesson details</OakHeading>
+            </OakBox>
+            <OakBox
+              id="video"
+              style={{ height: 500 }}
+              className="anchor-section"
+            >
+              <OakHeading tag="h2">Video</OakHeading>
+            </OakBox>
+            <OakBox
+              id="worksheet"
+              style={{ height: 500 }}
+              className="anchor-section"
+            >
+              <OakHeading tag="h2">Worksheet</OakHeading>
+            </OakBox>
+            <OakBox
+              id="quiz"
+              style={{ height: 500 }}
+              className="anchor-section"
+            >
+              <OakHeading tag="h2">Quiz</OakHeading>
+            </OakBox>
+          </OakGridArea>
+        </CurrentSectionIdProvider>
         <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
           <PreviousNextNav
             backgroundColorLevel={1}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -1,16 +1,119 @@
 "use client";
 
-import { OakBox, OakGrid, OakGridArea } from "@oaknational/oak-components";
+import {
+  OakBox,
+  OakGrid,
+  OakGridArea,
+  OakHeading,
+} from "@oaknational/oak-components";
+
+import LessonOverviewSideNav from "./LessonOverviewSideNav";
 
 import PreviousNextNav from "@/components/TeacherComponents/PreviousNextNav/PreviousNextNav";
 import { resolveOakHref } from "@/common-lib/urls";
 import type { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
+import { useComplexCopyright } from "@/hooks/useComplexCopyright";
+import {
+  getMediaClipLabel,
+  getPageLinksWithSubheadingsForLesson,
+} from "@/components/TeacherComponents/helpers/lessonHelpers/lesson.helpers";
+import { checkIfResourceHasLegacyCopyright } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/downloadsLegacyCopyright";
+import { DownloadResourceButtonNameValueType } from "@/browser-lib/avo/Avo";
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import { getAnalyticsBrowseData } from "@/components/TeacherComponents/helpers/getAnalyticsBrowseData";
 
-export default function LessonView({
-  programmeSlug,
-  unitSlug,
-  ...data
-}: Readonly<TeachersLessonOverviewPageData>) {
+export default function LessonView(
+  props: Readonly<TeachersLessonOverviewPageData>,
+) {
+  const {
+    programmeSlug,
+    unitSlug,
+    lessonSlug,
+    subjectSlug,
+    previousLesson,
+    nextLesson,
+    loginRequired,
+    geoRestricted,
+    expired,
+    downloads,
+    lessonReleaseDate,
+    lessonTitle,
+    keyStageTitle,
+    keyStageSlug,
+    subjectTitle,
+    unitTitle,
+    year,
+    yearTitle,
+    examBoardTitle,
+    tierTitle,
+    pathwayTitle,
+  } = props;
+
+  const {
+    showSignedOutGeoRestricted,
+    showSignedOutLoginRequired,
+    showGeoBlocked,
+    showSignedInNotOnboarded,
+  } = useComplexCopyright({
+    loginRequired,
+    geoRestricted,
+  });
+
+  const contentRestricted =
+    showSignedOutGeoRestricted ||
+    showSignedOutLoginRequired ||
+    showGeoBlocked ||
+    showSignedInNotOnboarded;
+
+  const mediaClipLabel = subjectSlug
+    ? getMediaClipLabel(subjectSlug)
+    : "Video & audio clips";
+
+  const pageLinks = getPageLinksWithSubheadingsForLesson(
+    props,
+    null,
+    mediaClipLabel,
+  );
+
+  const hasDownloadableAssets = downloads.some((d) => d.exists === true);
+
+  const { track } = useAnalytics();
+
+  const browsePathwayData = getAnalyticsBrowseData({
+    keyStageSlug,
+    keyStageTitle,
+    subjectSlug,
+    subjectTitle,
+    unitSlug,
+    unitTitle,
+    year,
+    yearTitle,
+    examBoardTitle,
+    tierTitle,
+    pathwayTitle,
+    lessonSlug,
+    lessonName: lessonTitle,
+    lessonReleaseDate,
+    isLegacy: false,
+  });
+
+  const trackDownloadResourceButtonClicked = (
+    downloadResourceButtonName: DownloadResourceButtonNameValueType,
+  ) => {
+    track.lessonResourceDownloadStarted({
+      platform: "owa",
+      product: "teacher lesson resources",
+      engagementIntent: "use",
+      componentType: "lesson_download_button",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Teacher",
+      downloadResourceButtonName,
+      ...browsePathwayData,
+    });
+  };
+
+  const showDownloadAll = hasDownloadableAssets && !contentRestricted;
+
   return (
     <OakBox $ph="spacing-40">
       <OakGrid
@@ -22,36 +125,76 @@ export default function LessonView({
         $width={"100%"}
         $maxWidth={"spacing-1280"}
       >
+        <OakGridArea
+          $colSpan={[12, 4, 4]}
+          $display={["none", "block", "block"]}
+        >
+          <LessonOverviewSideNav
+            links={pageLinks}
+            contentRestricted={contentRestricted}
+            downloadAllButtonProps={{
+              lessonSlug,
+              programmeSlug,
+              unitSlug,
+              showDownloadAll,
+              onClickDownloadAll: () => {
+                trackDownloadResourceButtonClicked("all");
+              },
+              geoRestricted,
+              loginRequired,
+              expired,
+              isSpecialist: false,
+              isCanonical: false,
+            }}
+            currentSectionId={null}
+          />
+        </OakGridArea>
+        <OakGridArea $colSpan={[12, 8, 8]}>
+          <OakBox id="slide-deck" style={{ height: 500 }}>
+            <OakHeading tag="h2">Slide deck</OakHeading>
+          </OakBox>
+          <OakBox id="lesson-details" style={{ height: 500 }}>
+            <OakHeading tag="h2">Lesson details</OakHeading>
+          </OakBox>
+          <OakBox id="video" style={{ height: 500 }}>
+            <OakHeading tag="h2">Video</OakHeading>
+          </OakBox>
+          <OakBox id="worksheet" style={{ height: 500 }}>
+            <OakHeading tag="h2">Worksheet</OakHeading>
+          </OakBox>
+          <OakBox id="quiz" style={{ height: 500 }}>
+            <OakHeading tag="h2">Quiz</OakHeading>
+          </OakBox>
+        </OakGridArea>
         <OakGridArea $colSpan={12} $rowStart={[3, 2]} $mb={"spacing-48"}>
           <PreviousNextNav
             backgroundColorLevel={1}
-            currentIndex={data.orderInUnit ?? undefined}
             navItemType="lesson"
             previous={
-              data.previousLesson
+              previousLesson
                 ? {
                     href: resolveOakHref({
                       page: "integrated-lesson-overview",
                       programmeSlug,
                       unitSlug,
-                      lessonSlug: data.previousLesson.lessonSlug,
+                      lessonSlug: previousLesson.lessonSlug,
                     }),
-                    title: data.previousLesson.lessonTitle,
-                    index: data.previousLesson.lessonIndex,
+                    title: previousLesson.lessonTitle,
+                    index: previousLesson.lessonIndex,
                   }
                 : undefined
             }
             next={
-              data.nextLesson
+              nextLesson
                 ? {
                     href: resolveOakHref({
                       page: "integrated-lesson-overview",
                       programmeSlug,
                       unitSlug,
-                      lessonSlug: data.nextLesson.lessonSlug,
+                      lessonSlug: nextLesson.lessonSlug,
                     }),
-                    title: data.nextLesson.lessonTitle,
-                    index: data.nextLesson.lessonIndex,
+                    title: nextLesson.lessonTitle,
+                    index: nextLesson.lessonIndex,
                   }
                 : undefined
             }

--- a/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.test.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.test.tsx
@@ -3,7 +3,7 @@ import {
   OakUiRoleToken,
 } from "@oaknational/oak-components";
 
-import { LessonOverviewHeaderDownloadAllButton } from "./LessonOverviewHeaderDownloadAllButton";
+import { LessonOverviewDownloadAllButton } from "./LessonOverviewDownloadAllButton";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import lessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/lessonOverview.fixture";
@@ -59,7 +59,7 @@ const baseProps = {
 
 const render = renderWithProviders();
 
-describe("LessonOverviewHeaderDownloadAllButton", () => {
+describe("LessonOverviewDownloadAllButton", () => {
   beforeEach(() => {
     mockFeatureFlagEnabled.mockReturnValueOnce(false);
   });
@@ -71,7 +71,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
 
   it("renders the download button with correct text", () => {
     const { getByTestId, getByText } = render(
-      <LessonOverviewHeaderDownloadAllButton {...baseProps} />,
+      <LessonOverviewDownloadAllButton {...baseProps} />,
     );
 
     const downloadButton = getByTestId("download-all-button");
@@ -86,7 +86,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
 
   it("does not render when expired is true", () => {
     const { queryByTestId } = render(
-      <LessonOverviewHeaderDownloadAllButton {...baseProps} expired={true} />,
+      <LessonOverviewDownloadAllButton {...baseProps} expired={true} />,
     );
 
     expect(queryByTestId("download-all-button")).not.toBeInTheDocument();
@@ -94,7 +94,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
 
   it("does not render when showDownloadAll is false", () => {
     const { queryByTestId } = render(
-      <LessonOverviewHeaderDownloadAllButton
+      <LessonOverviewDownloadAllButton
         {...baseProps}
         showDownloadAll={false}
       />,
@@ -106,7 +106,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
   it("renders a sign up button when downloads are restricted", () => {
     mockUseComplexCopyright = signedOutLoginRequired;
     const { getByTestId } = render(
-      <LessonOverviewHeaderDownloadAllButton {...baseProps} />,
+      <LessonOverviewDownloadAllButton {...baseProps} />,
     );
     const downloadButton = getByTestId("download-all-button");
     expect(downloadButton).not.toHaveAttribute("href");
@@ -116,7 +116,7 @@ describe("LessonOverviewHeaderDownloadAllButton", () => {
   it("does not render anything when geoBlocked", () => {
     mockUseComplexCopyright = signedInGeoBlocked;
     const { getByTestId } = render(
-      <LessonOverviewHeaderDownloadAllButton {...baseProps} />,
+      <LessonOverviewDownloadAllButton {...baseProps} />,
     );
     const downloadButton = getByTestId("download-all-button");
     expect(downloadButton).not.toBeVisible();

--- a/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.tsx
@@ -43,31 +43,34 @@ export const LessonOverviewDownloadAllButton: FC<
     return null;
   }
 
-  const href =
-    programmeSlug && unitSlug && isSpecialist
-      ? resolveOakHref({
-          page: "specialist-lesson-downloads",
-          lessonSlug,
-          unitSlug,
-          programmeSlug,
-          downloads: "downloads",
-          query: { preselected },
-        })
-      : programmeSlug && unitSlug && !isSpecialist && !isCanonical
-        ? resolveOakHref({
-            page: "lesson-downloads",
-            lessonSlug,
-            unitSlug,
-            programmeSlug,
-            downloads: "downloads",
-            query: { preselected },
-          })
-        : resolveOakHref({
-            page: "lesson-downloads-canonical",
-            lessonSlug,
-            downloads: "downloads",
-            query: { preselected },
-          });
+  let href: string;
+
+  if (programmeSlug && unitSlug && isSpecialist) {
+    href = resolveOakHref({
+      page: "specialist-lesson-downloads",
+      lessonSlug,
+      unitSlug,
+      programmeSlug,
+      downloads: "downloads",
+      query: { preselected },
+    });
+  } else if (programmeSlug && unitSlug && !isSpecialist && !isCanonical) {
+    href = resolveOakHref({
+      page: "lesson-downloads",
+      lessonSlug,
+      unitSlug,
+      programmeSlug,
+      downloads: "downloads",
+      query: { preselected },
+    });
+  } else {
+    href = resolveOakHref({
+      page: "lesson-downloads-canonical",
+      lessonSlug,
+      downloads: "downloads",
+      query: { preselected },
+    });
+  }
 
   return (
     <LoginRequiredButton

--- a/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton.tsx
@@ -4,7 +4,7 @@ import { LessonOverviewHeaderProps } from "@/components/TeacherComponents/Lesson
 import { resolveOakHref } from "@/common-lib/urls";
 import LoginRequiredButton from "@/components/TeacherComponents/LoginRequiredButton/LoginRequiredButton";
 
-export type LessonOverviewHeaderDownloadAllButtonProps = Pick<
+export type LessonOverviewDownloadAllButtonProps = Pick<
   LessonOverviewHeaderProps,
   | "expired"
   | "showDownloadAll"
@@ -19,8 +19,8 @@ export type LessonOverviewHeaderDownloadAllButtonProps = Pick<
 > &
   Pick<ComponentProps<typeof LoginRequiredButton>, "sizeVariant" | "width">;
 
-export const LessonOverviewHeaderDownloadAllButton: FC<
-  LessonOverviewHeaderDownloadAllButtonProps
+export const LessonOverviewDownloadAllButton: FC<
+  LessonOverviewDownloadAllButtonProps
 > = (props) => {
   const {
     expired,

--- a/src/components/TeacherComponents/LessonOverviewDownloadAllButton/index.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDownloadAllButton/index.tsx
@@ -1,0 +1,1 @@
+export { LessonOverviewDownloadAllButton } from "./LessonOverviewDownloadAllButton";

--- a/src/components/TeacherComponents/LessonOverviewDownloadAndShareButtons/LessonOverviewDownloadAndShareButtons.tsx
+++ b/src/components/TeacherComponents/LessonOverviewDownloadAndShareButtons/LessonOverviewDownloadAndShareButtons.tsx
@@ -3,7 +3,7 @@ import { OakUL, OakLI } from "@oaknational/oak-components";
 
 import { LessonOverviewCreateWithAiDropdown } from "../LessonOverviewCreateWithAiDropdown";
 
-import { LessonOverviewHeaderDownloadAllButton } from "@/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton";
+import { LessonOverviewDownloadAllButton } from "@/components/TeacherComponents/LessonOverviewDownloadAllButton";
 import { LessonOverviewHeaderProps } from "@/components/TeacherComponents/LessonOverviewHeader";
 
 interface LessonOverviewDownloadAndShareButtonsProps
@@ -22,7 +22,7 @@ export const LessonOverviewDownloadAndShareButtons: FC<
     $gap={["spacing-24", "spacing-16"]}
   >
     <OakLI $listStyle={"none"}>
-      <LessonOverviewHeaderDownloadAllButton {...props} />
+      <LessonOverviewDownloadAllButton {...props} />
     </OakLI>
     {shareButtons}
     {!excludedFromTeachingMaterials && (

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { ComponentProps, FC } from "react";
 
 import { LessonOverviewHeaderProps } from "@/components/TeacherComponents/LessonOverviewHeader";
 import { resolveOakHref } from "@/common-lib/urls";
@@ -16,7 +16,8 @@ export type LessonOverviewHeaderDownloadAllButtonProps = Pick<
   | "isCanonical"
   | "geoRestricted"
   | "loginRequired"
->;
+> &
+  Pick<ComponentProps<typeof LoginRequiredButton>, "sizeVariant" | "width">;
 
 export const LessonOverviewHeaderDownloadAllButton: FC<
   LessonOverviewHeaderDownloadAllButtonProps
@@ -32,6 +33,8 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
     isCanonical,
     geoRestricted,
     loginRequired,
+    sizeVariant = "small",
+    width = "spacing-160",
   } = props;
 
   const preselected = "all";
@@ -80,13 +83,13 @@ export const LessonOverviewHeaderDownloadAllButton: FC<
         shouldHidewhenGeoRestricted: true,
         href: href,
       }}
-      sizeVariant="small"
+      sizeVariant={sizeVariant}
       element="a"
       data-testid="download-all-button"
       iconName="download"
       isTrailingIcon
       aria-label="Download all"
-      width={"spacing-160"}
+      width={width}
     />
   );
 };

--- a/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/index.tsx
+++ b/src/components/TeacherComponents/LessonOverviewHeaderDownloadAllButton/index.tsx
@@ -1,1 +1,0 @@
-export { LessonOverviewHeaderDownloadAllButton } from "./LessonOverviewHeaderDownloadAllButton";

--- a/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
@@ -1,9 +1,11 @@
 import { FC } from "react";
 import {
+  OakBox,
   OakFlex,
   OakLI,
   OakSideMenuNavLink,
   OakUL,
+  useMediaQuery,
 } from "@oaknational/oak-components";
 
 import { getContainerId } from "../LessonItemContainer/LessonItemContainer";
@@ -31,6 +33,8 @@ const LessonOverviewSideNavAnchorLinks: FC<
   contentRestricted,
   downloadAllButtonProps,
 }) => {
+  const isDesktop = useMediaQuery("desktop");
+
   return (
     <OakFlex $flexDirection="column" $gap="spacing-32">
       <OakUL $reset $display="flex" $gap="spacing-16" $flexDirection="column">
@@ -65,11 +69,13 @@ const LessonOverviewSideNavAnchorLinks: FC<
         })}
       </OakUL>
 
-      <LessonOverviewDownloadAllButton
-        {...downloadAllButtonProps}
-        width="fit-content"
-        sizeVariant="large"
-      />
+      <OakBox $ml="spacing-16">
+        <LessonOverviewDownloadAllButton
+          {...downloadAllButtonProps}
+          width="fit-content"
+          sizeVariant={isDesktop ? "large" : "small"}
+        />
+      </OakBox>
     </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
@@ -5,7 +5,6 @@ import {
   OakLI,
   OakSideMenuNavLink,
   OakUL,
-  useMediaQuery,
 } from "@oaknational/oak-components";
 
 import { getContainerId } from "../LessonItemContainer/LessonItemContainer";
@@ -33,8 +32,6 @@ const LessonOverviewSideNavAnchorLinks: FC<
   contentRestricted,
   downloadAllButtonProps,
 }) => {
-  const isDesktop = useMediaQuery("desktop");
-
   return (
     <OakFlex $flexDirection="column" $gap="spacing-32">
       <OakUL $reset $display="flex" $gap="spacing-16" $flexDirection="column">
@@ -69,11 +66,18 @@ const LessonOverviewSideNavAnchorLinks: FC<
         })}
       </OakUL>
 
-      <OakBox $ml="spacing-16">
+      <OakBox $ml="spacing-16" $display={["block", "block", "none"]}>
         <LessonOverviewDownloadAllButton
           {...downloadAllButtonProps}
           width="fit-content"
-          sizeVariant={isDesktop ? "large" : "small"}
+          sizeVariant="small"
+        />
+      </OakBox>
+      <OakBox $ml="spacing-16" $display={["none", "none", "block"]}>
+        <LessonOverviewDownloadAllButton
+          {...downloadAllButtonProps}
+          width="fit-content"
+          sizeVariant="large"
         />
       </OakBox>
     </OakFlex>

--- a/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
@@ -8,9 +8,9 @@ import {
 
 import { getContainerId } from "../LessonItemContainer/LessonItemContainer";
 import {
-  LessonOverviewHeaderDownloadAllButton,
-  LessonOverviewHeaderDownloadAllButtonProps,
-} from "../LessonOverviewHeaderDownloadAllButton/LessonOverviewHeaderDownloadAllButton";
+  LessonOverviewDownloadAllButton,
+  LessonOverviewDownloadAllButtonProps,
+} from "../LessonOverviewDownloadAllButton/LessonOverviewDownloadAllButton";
 
 type LessonOverviewSideNavAnchorLinksProps = {
   contentRestricted: boolean;
@@ -20,7 +20,7 @@ type LessonOverviewSideNavAnchorLinksProps = {
     anchorId: string;
     subheading?: string;
   }[];
-  downloadAllButtonProps: LessonOverviewHeaderDownloadAllButtonProps;
+  downloadAllButtonProps: LessonOverviewDownloadAllButtonProps;
 };
 
 const LessonOverviewSideNavAnchorLinks: FC<
@@ -65,7 +65,7 @@ const LessonOverviewSideNavAnchorLinks: FC<
         })}
       </OakUL>
 
-      <LessonOverviewHeaderDownloadAllButton
+      <LessonOverviewDownloadAllButton
         {...downloadAllButtonProps}
         width="fit-content"
         sizeVariant="large"

--- a/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
+++ b/src/components/TeacherComponents/LessonOverviewSideNavAnchorLinks/LessonOverviewSideNavAnchorLinks.tsx
@@ -1,5 +1,10 @@
 import { FC } from "react";
-import { OakLI, OakSideMenuNavLink, OakUL } from "@oaknational/oak-components";
+import {
+  OakFlex,
+  OakLI,
+  OakSideMenuNavLink,
+  OakUL,
+} from "@oaknational/oak-components";
 
 import { getContainerId } from "../LessonItemContainer/LessonItemContainer";
 import {
@@ -27,38 +32,45 @@ const LessonOverviewSideNavAnchorLinks: FC<
   downloadAllButtonProps,
 }) => {
   return (
-    <OakUL $reset $display="flex" $gap="spacing-16" $flexDirection="column">
-      {links.map((link, index) => {
-        const { label, anchorId, subheading } = link;
+    <OakFlex $flexDirection="column" $gap="spacing-32">
+      <OakUL $reset $display="flex" $gap="spacing-16" $flexDirection="column">
+        {links.map((link, index) => {
+          const { label, anchorId, subheading } = link;
 
-        const linkRestricted =
-          contentRestricted && anchorId !== "lesson-details";
-        const targetId = linkRestricted ? "restricted-content" : anchorId;
+          const linkRestricted =
+            contentRestricted && anchorId !== "lesson-details";
+          const targetId = linkRestricted ? "restricted-content" : anchorId;
 
-        const isCurrent = anchorId === currentSectionId;
-        const item = {
-          heading: label,
-          href: `#${targetId}`,
-          subheading,
-        };
+          const isCurrent = anchorId === currentSectionId;
+          const item = {
+            heading: label,
+            href: `#${targetId}`,
+            subheading,
+          };
 
-        return (
-          <OakLI key={`${label}-${index}`}>
-            <OakSideMenuNavLink
-              onClick={() => {
-                document.getElementById(anchorId)?.scrollIntoView();
-                document.getElementById(getContainerId(anchorId))?.focus();
-              }}
-              item={item}
-              isSelected={isCurrent}
-              $pt={"spacing-8"}
-              $pb={"spacing-8"}
-            />
-          </OakLI>
-        );
-      })}
-      <LessonOverviewHeaderDownloadAllButton {...downloadAllButtonProps} />
-    </OakUL>
+          return (
+            <OakLI key={`${label}-${index}`}>
+              <OakSideMenuNavLink
+                onClick={() => {
+                  document.getElementById(anchorId)?.scrollIntoView();
+                  document.getElementById(getContainerId(anchorId))?.focus();
+                }}
+                item={item}
+                isSelected={isCurrent}
+                $pt={"spacing-8"}
+                $pb={"spacing-8"}
+              />
+            </OakLI>
+          );
+        })}
+      </OakUL>
+
+      <LessonOverviewHeaderDownloadAllButton
+        {...downloadAllButtonProps}
+        width="fit-content"
+        sizeVariant="large"
+      />
+    </OakFlex>
   );
 };
 


### PR DESCRIPTION
## Description

Music year: 1954

- Adds the side menu to the lesson overview page
- Scrolling updates the menu highlight and hash in the address bar
- Placeholder sections for now pending the real content (only a few hard coded to demo/test the behaviour)
- Jump link on top of the menu that skips to the lesson content.

## How to test
⚠️ You'll need the `teachers-integrated-journey` feature flag

1. Go to https://oak-web-application-website-git-feat-lesq-1909side-menu.vercel.thenational.academy/programmes/science-secondary-ks3/units/forces/lessons/what-forces-do
2. Click on items in the side menu
3. You should jump to the corresponding section

## Screenshots
<img width="1656" height="1774" alt="Screenshot 2026-04-15 at 15 40 00" src="https://github.com/user-attachments/assets/66a71fc1-42d3-4f96-b665-2f00489de7fc" />

<img width="938" height="1774" alt="Screenshot 2026-04-15 at 15 40 11" src="https://github.com/user-attachments/assets/a46b1d71-72ec-464a-a625-04c1c9108552" />

<img width="1656" height="1774" alt="Screenshot 2026-04-15 at 15 40 06" src="https://github.com/user-attachments/assets/7fd709f2-2f02-4784-94ea-2289437b22d9" />

<img width="612" height="1774" alt="Screenshot 2026-04-15 at 15 40 15" src="https://github.com/user-attachments/assets/10ff953c-5eee-47ad-b801-4e8d8f389315" />



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
- [ ]  Nav menu works the same as the current journey
    - [ ]  hashes for each section
    - [ ]  scroll correct section into view when clicking / tabbing the nav menu
    - [ ]  a url with a section hash lands in the correct place
- [ ]  Skip link appears when tabbing into page
    - [ ]  At the top of the nav menu
    - [ ]  Clicking the link takes you to the top of the resources section
