### PR TITLE
Handle English + swimming idiosyncrasies in programme header LESQ 1798

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.stories.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.stories.tsx
@@ -22,54 +22,15 @@ const meta: Meta<typeof ProgrammeHeader> = {
       },
       options: [undefined, 1, 2, 3, 4, 5, 6],
     },
-    subjectTitle: {
+    heading: {
       control: {
         type: "text",
       },
     },
-    phaseTitle: {
+    useSubduedBackground: {
       control: {
-        type: "text",
+        type: "boolean",
       },
-    },
-    schoolYear: {
-      control: {
-        type: "select",
-      },
-      options: [
-        undefined,
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-      ],
-    },
-    keyStage: {
-      control: {
-        type: "select",
-      },
-      options: [undefined, "ks1", "ks2", "ks3", "ks4"],
-    },
-    examboardTitle: {
-      control: {
-        type: "select",
-      },
-      options: [
-        undefined,
-        "AQA",
-        "Edexcel",
-        "Edexcel B",
-        "Eduqas",
-        "OCR",
-        "WJEC",
-      ],
     },
     summary: {
       control: {
@@ -86,12 +47,9 @@ const meta: Meta<typeof ProgrammeHeader> = {
     controls: {
       include: [
         "subject",
-        "background",
-        "subjectTitle",
-        "phaseTitle",
-        "schoolYear",
-        "keyStage",
-        "examboardTitle",
+        "backgroundColorLevel",
+        "heading",
+        "useSubduedBackground",
         "summary",
         "bullets",
       ],
@@ -112,9 +70,9 @@ type Story = StoryObj<typeof ProgrammeHeader>;
 
 export const Default: Story = {
   args: {
+    layoutVariant: "large",
     subject: "english",
-    subjectTitle: "English",
-    phaseTitle: "Primary",
+    heading: "English primary",
     summary:
       "This is a programme header component that displays content alongside a large subject illustration. On mobile, the image appears above the content, and on desktop, the image is displayed to the right. Text should wrap with balance for better readability.",
     bullets: ["Item 1", "Item 2", "Item 3"],
@@ -123,10 +81,9 @@ export const Default: Story = {
 
 export const WithSchoolYear: Story = {
   args: {
+    layoutVariant: "large",
     subject: "science",
-    subjectTitle: "Science",
-    phaseTitle: "Secondary",
-    schoolYear: "9",
+    heading: "Science year 9",
     summary:
       "This example demonstrates the component with a school year specified. When a school year is provided, the heading format changes to include 'year X' instead of the phase title.",
     bullets: [
@@ -139,10 +96,9 @@ export const WithSchoolYear: Story = {
 
 export const WithKeyStage: Story = {
   args: {
+    layoutVariant: "large",
     subject: "maths",
-    subjectTitle: "Maths",
-    phaseTitle: "Primary",
-    keyStage: "ks2",
+    heading: "Maths KS2",
     summary:
       "This example demonstrates the component with a key stage specified. When a key stage is provided, the heading format changes to include 'KS1', 'KS2', 'KS3', or 'KS4' instead of the phase title.",
     bullets: [
@@ -155,10 +111,9 @@ export const WithKeyStage: Story = {
 
 export const WithExamboard: Story = {
   args: {
+    layoutVariant: "large",
     subject: "science",
-    subjectTitle: "Science",
-    phaseTitle: "Secondary",
-    examboardTitle: "AQA",
+    heading: "Science secondary AQA",
     summary:
       "This example demonstrates the component with an exam board specified. When an exam board is provided with KS4 or years 10-11, it appears in the heading after the key stage or year.",
     bullets: [
@@ -171,11 +126,9 @@ export const WithExamboard: Story = {
 
 export const WithSchoolYearAndExamboard: Story = {
   args: {
+    layoutVariant: "large",
     subject: "maths",
-    subjectTitle: "Maths",
-    phaseTitle: "Secondary",
-    schoolYear: "10",
-    examboardTitle: "Edexcel",
+    heading: "Maths year 10 Edexcel",
     summary:
       "This example demonstrates the component with both a school year and exam board. For years 10 and 11, the exam board appears after the year in the heading.",
     bullets: [

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.test.tsx
@@ -2,23 +2,13 @@ import React from "react";
 import "@testing-library/jest-dom";
 
 import { subjectHeroImages } from "./getSubjectHeroImageUrl";
-import {
-  ProgrammeHeader,
-  pickSubjectTitleFromFilters,
-} from "./ProgrammeHeader";
+import { ProgrammeHeader } from "./ProgrammeHeader";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import { createFilter } from "@/fixtures/curriculum/filters";
-import { createYearData } from "@/fixtures/curriculum/yearData";
-import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
-import { createChildSubject } from "@/fixtures/curriculum/childSubject";
-import { createUnit } from "@/fixtures/curriculum/unit";
-import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 const baseProps = {
   subject: "music" as const,
-  subjectTitle: "Science",
-  phaseTitle: "Secondary",
+  heading: "Science secondary",
   summary: "Test content for the programme header.",
   bullets: ["Bullet 1", "Bullet 2"],
   layoutVariant: "large" as const,
@@ -41,7 +31,7 @@ describe("ProgrammeHeader", () => {
   });
 
   describe("heading", () => {
-    it("renders heading with subjectTitle and phaseTitle when schoolYear is not provided", () => {
+    it("renders the provided heading", () => {
       const { getByRole } = renderWithTheme(<ProgrammeHeader {...baseProps} />);
 
       expect(getByRole("heading", { level: 1 })).toHaveTextContent(
@@ -49,9 +39,9 @@ describe("ProgrammeHeader", () => {
       );
     });
 
-    it("renders heading with subjectTitle and schoolYear when schoolYear is provided", () => {
+    it("renders provided heading for year copy", () => {
       const { getByRole } = renderWithTheme(
-        <ProgrammeHeader {...baseProps} schoolYear="9" />,
+        <ProgrammeHeader {...baseProps} heading="Science year 9" />,
       );
 
       expect(getByRole("heading", { level: 1 })).toHaveTextContent(
@@ -59,335 +49,14 @@ describe("ProgrammeHeader", () => {
       );
     });
 
-    it("renders heading with Primary phase title correctly", () => {
+    it("renders provided heading for primary copy", () => {
       const { getByRole } = renderWithTheme(
-        <ProgrammeHeader
-          {...baseProps}
-          subjectTitle="English"
-          phaseTitle="Primary"
-        />,
+        <ProgrammeHeader {...baseProps} heading="English primary" />,
       );
 
       expect(getByRole("heading", { level: 1 })).toHaveTextContent(
         "English primary",
       );
-    });
-  });
-});
-
-describe("pickSubjectTitleFromFilters", () => {
-  const defaultSubjectTitle = "Science";
-
-  const createDataWithChildSubjects = (): CurriculumUnitsFormattedData => ({
-    yearData: {
-      "7": createYearData({
-        units: [createUnit({ slug: "test1", year: "7" })],
-        // NOTE: childSubjects filter is only displayed when there are 2+ options
-        // at a given keystage. `byKeyStageSlug` drops childSubjects when there is only 1.
-        childSubjects: [
-          createChildSubject({ subject_slug: "physics" }),
-          createChildSubject({ subject_slug: "biology" }),
-        ],
-      }),
-    },
-    threadOptions: [],
-    yearOptions: ["7"],
-    keystages: [],
-  });
-
-  const createDataWithSubjectCategories = (): CurriculumUnitsFormattedData => ({
-    yearData: {
-      "7": createYearData({
-        units: [createUnit({ slug: "test1", year: "7" })],
-        subjectCategories: [
-          createSubjectCategory({ id: 1, slug: "biology", title: "Biology" }),
-        ],
-      }),
-    },
-    threadOptions: [],
-    yearOptions: ["7"],
-    keystages: [],
-  });
-
-  const createDataWithBothDisplayed = (): CurriculumUnitsFormattedData => ({
-    yearData: {
-      // KS2: subjectCategories are displayed when there are no childSubjects at that key stage.
-      "3": createYearData({
-        units: [createUnit({ slug: "test-ks2", year: "3" })],
-        subjectCategories: [
-          createSubjectCategory({
-            id: 1,
-            slug: "chemistry",
-            title: "Chemistry",
-          }),
-        ],
-      }),
-      // KS3: childSubjects are displayed when there are 2+ options at that key stage.
-      "7": createYearData({
-        units: [createUnit({ slug: "test-ks3", year: "7" })],
-        childSubjects: [
-          createChildSubject({ subject_slug: "chemistry" }),
-          createChildSubject({ subject_slug: "physics" }),
-        ],
-      }),
-    },
-    threadOptions: [],
-    yearOptions: ["3", "7"],
-    keystages: [],
-  });
-
-  const createDataWithNeither = (): CurriculumUnitsFormattedData => ({
-    yearData: {
-      "7": createYearData({
-        units: [createUnit({ slug: "test1", year: "7" })],
-      }),
-    },
-    threadOptions: [],
-    yearOptions: ["7"],
-    keystages: [],
-  });
-
-  describe("when subjectCategoriesDisplayed and subjectCategories === 'all'", () => {
-    it("returns the default subjectTitle", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: ["all"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-  });
-
-  describe("when there is only one childSubject and one subjectCategories and they are equal", () => {
-    it("returns childSubject title when both are displayed and equal", () => {
-      const data = createDataWithBothDisplayed();
-      const filters = createFilter({
-        childSubjects: ["chemistry"],
-        subjectCategories: ["chemistry"],
-        years: ["3", "7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe("Chemistry");
-    });
-  });
-
-  describe("when childSubjectsDisplayed is false and subjectCategoriesDisplayed is true", () => {
-    it("returns subjectCategory title when it has an item", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: ["biology"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe("Biology");
-    });
-
-    it("returns the default subjectTitle when subjectCategory is 'all'", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: ["all"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-  });
-
-  describe("when subjectCategoriesDisplayed is false and childSubjectsDisplayed is true", () => {
-    it("returns childSubject title when it has an item", () => {
-      const data = createDataWithChildSubjects();
-      const filters = createFilter({
-        childSubjects: ["physics"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe("Physics");
-    });
-  });
-
-  describe("edge cases", () => {
-    it("returns the default subjectTitle when no filters are applied", () => {
-      const data = createDataWithNeither();
-      const filters = createFilter({
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when multiple childSubjects are selected", () => {
-      const data = createDataWithChildSubjects();
-      const filters = createFilter({
-        childSubjects: ["physics", "chemistry"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when multiple subjectCategories are selected", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: ["biology", "chemistry"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when childSubjectsDisplayed is true but childSubject is undefined", () => {
-      const data = createDataWithChildSubjects();
-      const filters = createFilter({
-        childSubjects: [],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when subjectCategoriesDisplayed is true but subjectCategory is undefined", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: [],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when both are displayed but values don't match", () => {
-      const data: CurriculumUnitsFormattedData = {
-        yearData: {
-          // KS2: subjectCategories displayed
-          "3": createYearData({
-            units: [createUnit({ slug: "test-ks2", year: "3" })],
-            subjectCategories: [
-              createSubjectCategory({
-                id: 1,
-                slug: "biology",
-                title: "Biology",
-              }),
-            ],
-          }),
-          // KS3: childSubjects displayed (2+ options)
-          "7": createYearData({
-            units: [createUnit({ slug: "test-ks3", year: "7" })],
-            childSubjects: [
-              createChildSubject({ subject_slug: "physics" }),
-              createChildSubject({ subject_slug: "chemistry" }),
-            ],
-          }),
-        },
-        threadOptions: [],
-        yearOptions: ["3", "7"],
-        keystages: [],
-      };
-      const filters = createFilter({
-        childSubjects: ["physics"],
-        subjectCategories: ["biology"],
-        years: ["3", "7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when childSubject slug is not found in data", () => {
-      const data = createDataWithChildSubjects();
-      const filters = createFilter({
-        childSubjects: ["nonexistent"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
-    });
-
-    it("returns the default subjectTitle when subjectCategory slug is not found in data", () => {
-      const data = createDataWithSubjectCategories();
-      const filters = createFilter({
-        subjectCategories: ["nonexistent"],
-        years: ["7"],
-      });
-
-      const result = pickSubjectTitleFromFilters(
-        defaultSubjectTitle,
-        data,
-        filters,
-      );
-
-      expect(result).toBe(defaultSubjectTitle);
     });
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.test.tsx
@@ -76,6 +76,8 @@ describe("ProgrammeHeader", () => {
 });
 
 describe("pickSubjectTitleFromFilters", () => {
+  const defaultSubjectTitle = "Science";
+
   const createDataWithChildSubjects = (): CurriculumUnitsFormattedData => ({
     yearData: {
       "7": createYearData({
@@ -146,16 +148,20 @@ describe("pickSubjectTitleFromFilters", () => {
   });
 
   describe("when subjectCategoriesDisplayed and subjectCategories === 'all'", () => {
-    it("returns null", () => {
+    it("returns the default subjectTitle", () => {
       const data = createDataWithSubjectCategories();
       const filters = createFilter({
         subjectCategories: ["all"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
   });
 
@@ -168,7 +174,11 @@ describe("pickSubjectTitleFromFilters", () => {
         years: ["3", "7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
       expect(result).toBe("Chemistry");
     });
@@ -182,21 +192,29 @@ describe("pickSubjectTitleFromFilters", () => {
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
       expect(result).toBe("Biology");
     });
 
-    it("returns null when subjectCategory is 'all'", () => {
+    it("returns the default subjectTitle when subjectCategory is 'all'", () => {
       const data = createDataWithSubjectCategories();
       const filters = createFilter({
         subjectCategories: ["all"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
   });
 
@@ -208,73 +226,97 @@ describe("pickSubjectTitleFromFilters", () => {
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
       expect(result).toBe("Physics");
     });
   });
 
   describe("edge cases", () => {
-    it("returns null when no filters are applied", () => {
+    it("returns the default subjectTitle when no filters are applied", () => {
       const data = createDataWithNeither();
       const filters = createFilter({
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when multiple childSubjects are selected", () => {
+    it("returns the default subjectTitle when multiple childSubjects are selected", () => {
       const data = createDataWithChildSubjects();
       const filters = createFilter({
         childSubjects: ["physics", "chemistry"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when multiple subjectCategories are selected", () => {
+    it("returns the default subjectTitle when multiple subjectCategories are selected", () => {
       const data = createDataWithSubjectCategories();
       const filters = createFilter({
         subjectCategories: ["biology", "chemistry"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when childSubjectsDisplayed is true but childSubject is undefined", () => {
+    it("returns the default subjectTitle when childSubjectsDisplayed is true but childSubject is undefined", () => {
       const data = createDataWithChildSubjects();
       const filters = createFilter({
         childSubjects: [],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when subjectCategoriesDisplayed is true but subjectCategory is undefined", () => {
+    it("returns the default subjectTitle when subjectCategoriesDisplayed is true but subjectCategory is undefined", () => {
       const data = createDataWithSubjectCategories();
       const filters = createFilter({
         subjectCategories: [],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when both are displayed but values don't match", () => {
+    it("returns the default subjectTitle when both are displayed but values don't match", () => {
       const data: CurriculumUnitsFormattedData = {
         yearData: {
           // KS2: subjectCategories displayed
@@ -307,33 +349,45 @@ describe("pickSubjectTitleFromFilters", () => {
         years: ["3", "7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when childSubject slug is not found in data", () => {
+    it("returns the default subjectTitle when childSubject slug is not found in data", () => {
       const data = createDataWithChildSubjects();
       const filters = createFilter({
         childSubjects: ["nonexistent"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
 
-    it("returns null when subjectCategory slug is not found in data", () => {
+    it("returns the default subjectTitle when subjectCategory slug is not found in data", () => {
       const data = createDataWithSubjectCategories();
       const filters = createFilter({
         subjectCategories: ["nonexistent"],
         years: ["7"],
       });
 
-      const result = pickSubjectTitleFromFilters(data, filters);
+      const result = pickSubjectTitleFromFilters(
+        defaultSubjectTitle,
+        data,
+        filters,
+      );
 
-      expect(result).toBeNull();
+      expect(result).toBe(defaultSubjectTitle);
     });
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.tsx
@@ -81,12 +81,13 @@ export const ProgrammeHeader = (props: ProgrammeHeaderProps) => {
 
 /**
  * Picks a subject title from filters based on childSubjects and subjectCategories.
- * Returns the selected value if exactly one filter is active, otherwise null.
+ * Returns the selected value if exactly one filter is active, otherwise subjectTitle.
  */
 export function pickSubjectTitleFromFilters(
+  defaultSubjectTitle: string,
   data: CurriculumUnitsFormattedData,
   filters: CurriculumFilters,
-): string | null {
+): string {
   const childSubjectsDisplayed = shouldDisplayFilter(
     data,
     filters,
@@ -122,9 +123,9 @@ export function pickSubjectTitleFromFilters(
   const childSubjectSlug = childSubject?.subject_slug;
   const subjectCategorySlug = subjectCategory?.slug;
 
-  // When subjectCategoriesDisplayed and subjectCategories === "all" return null
+  // When subjectCategoriesDisplayed and subjectCategories === "all" return default subjectTitle
   if (subjectCategoriesDisplayed && subjectCategorySlug === "all") {
-    return null;
+    return defaultSubjectTitle;
   }
 
   // When both filters are displayed and selected, check if they match
@@ -142,8 +143,8 @@ export function pickSubjectTitleFromFilters(
     ) {
       return childSubject.subject;
     }
-    // Both are selected but don't match - return null
-    return null;
+    // Both are selected but don't match - return default subjectTitle
+    return defaultSubjectTitle;
   }
 
   // Return subjectCategory when subjectCategories is the only subject filter displayed
@@ -163,7 +164,7 @@ export function pickSubjectTitleFromFilters(
     return childSubject.subject;
   }
 
-  return null;
+  return defaultSubjectTitle;
 }
 
 /**

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/ProgrammeHeader.tsx
@@ -1,16 +1,8 @@
 "use client";
 import React from "react";
-import { capitalize } from "lodash";
 
 import { SubjectName, getSubjectHeroImageUrl } from "./getSubjectHeroImageUrl";
 
-import { CurriculumFilters } from "@/utils/curriculum/types";
-import {
-  childSubjectForFilter,
-  subjectCategoryForFilter,
-  shouldDisplayFilter,
-} from "@/utils/curriculum/filteringApp";
-import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import {
   Header,
   LargeHeaderProps,
@@ -20,32 +12,7 @@ export type ProgrammeHeaderProps = Omit<
   LargeHeaderProps,
   "heading" | "heroImage"
 > & {
-  /**
-   * The title of the subject of the programme.
-   */
-  subjectTitle: string;
-  /**
-   * The title of the phase of the programme.
-   *
-   * E.g. 'Primary' or 'Secondary'
-   */
-  phaseTitle: string;
-  /**
-   * The title of the examboard of the programme.
-   *
-   * E.g 'AQA'
-   */
-  examboardTitle?: string;
-  /**
-   * Key stage
-   */
-  keyStage?: string;
-  /**
-   * School year
-   *
-   * E.g '7'
-   */
-  schoolYear?: string;
+  heading: string;
   /**
    * The subject of the programme.
    */
@@ -53,149 +20,9 @@ export type ProgrammeHeaderProps = Omit<
 };
 
 export const ProgrammeHeader = (props: ProgrammeHeaderProps) => {
-  const {
-    subject,
-    subjectTitle,
-    phaseTitle,
-    schoolYear,
-    keyStage,
-    examboardTitle,
-  } = props;
+  const { subject, heading } = props;
 
   const subjectHeroImage = getSubjectHeroImageUrl(subject);
 
-  return (
-    <Header
-      {...props}
-      heroImage={subjectHeroImage}
-      heading={getProgrammeTitle(
-        subjectTitle,
-        phaseTitle,
-        schoolYear,
-        keyStage,
-        examboardTitle,
-      )}
-    />
-  );
+  return <Header {...props} heroImage={subjectHeroImage} heading={heading} />;
 };
-
-/**
- * Picks a subject title from filters based on childSubjects and subjectCategories.
- * Returns the selected value if exactly one filter is active, otherwise subjectTitle.
- */
-export function pickSubjectTitleFromFilters(
-  defaultSubjectTitle: string,
-  data: CurriculumUnitsFormattedData,
-  filters: CurriculumFilters,
-): string {
-  const childSubjectsDisplayed = shouldDisplayFilter(
-    data,
-    filters,
-    "childSubjects",
-  );
-  const subjectCategoriesDisplayed = shouldDisplayFilter(
-    data,
-    filters,
-    "subjectCategories",
-  );
-
-  // Filters can be present even when they are not applied. If the UI is hiding
-  // a filter, ignore its value entirely for our purposes.
-  const appliedChildSubjects = childSubjectsDisplayed
-    ? filters.childSubjects
-    : [];
-  const appliedSubjectCategories = subjectCategoriesDisplayed
-    ? filters.subjectCategories
-    : [];
-
-  // Only proceed if exactly one filter is selected in each category
-  const hasSingleChildSubject = appliedChildSubjects.length === 1;
-  const hasSingleSubjectCategory = appliedSubjectCategories.length === 1;
-
-  // Get the actual objects from data (returns undefined if not found or empty)
-  const childSubject = hasSingleChildSubject
-    ? childSubjectForFilter(data, filters)
-    : undefined;
-  const subjectCategory = hasSingleSubjectCategory
-    ? subjectCategoryForFilter(data, filters)
-    : undefined;
-
-  const childSubjectSlug = childSubject?.subject_slug;
-  const subjectCategorySlug = subjectCategory?.slug;
-
-  // When subjectCategoriesDisplayed and subjectCategories === "all" return default subjectTitle
-  if (subjectCategoriesDisplayed && subjectCategorySlug === "all") {
-    return defaultSubjectTitle;
-  }
-
-  // When both filters are displayed and selected, check if they match
-  if (
-    hasSingleChildSubject &&
-    hasSingleSubjectCategory &&
-    childSubjectsDisplayed &&
-    subjectCategoriesDisplayed
-  ) {
-    // Both are selected and they match - return childSubject title
-    if (
-      childSubject &&
-      subjectCategory &&
-      childSubjectSlug === subjectCategorySlug
-    ) {
-      return childSubject.subject;
-    }
-    // Both are selected but don't match - return default subjectTitle
-    return defaultSubjectTitle;
-  }
-
-  // Return subjectCategory when subjectCategories is the only subject filter displayed
-  // and subjectCategory is not "all"
-  if (
-    !childSubjectsDisplayed &&
-    subjectCategoriesDisplayed &&
-    subjectCategory &&
-    subjectCategorySlug &&
-    subjectCategorySlug !== "all"
-  ) {
-    return subjectCategory.title;
-  }
-
-  // Return childSubject title when childSubjects is the only subject filter displayed
-  if (!subjectCategoriesDisplayed && childSubjectsDisplayed && childSubject) {
-    return childSubject.subject;
-  }
-
-  return defaultSubjectTitle;
-}
-
-/**
- * Returns the title of the programme
- *
- * Combines the subject title, phase title, school year, key stage, and examboard title into a single string.
- */
-function getProgrammeTitle(
-  subjectTitle: string,
-  phaseTitle: string,
-  schoolYear?: string | null,
-  keyStage?: string,
-  examboardTitle?: string,
-) {
-  const parts: Array<string | undefined> = [capitalize(subjectTitle)];
-
-  if (schoolYear) {
-    parts.push(`year ${schoolYear}`);
-
-    if (schoolYear === "10" || schoolYear === "11") {
-      parts.push(examboardTitle);
-    }
-  } else if (keyStage) {
-    parts.push(keyStage?.toUpperCase());
-
-    if (keyStage === "ks4") {
-      parts.push(examboardTitle);
-    }
-  } else {
-    parts.push(phaseTitle?.toLowerCase(), examboardTitle);
-  }
-
-  return parts.filter(Boolean).join(" ");
-}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -178,6 +178,58 @@ describe("buildProgrammeHeading", () => {
     expect(result).toBe("Science year 9");
   });
 
+  it("uses (all years) when schoolYear is all-years", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "all-years": createYearData({
+          units: [createUnit({ slug: "test-all-years", year: "7" })],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["all-years"],
+      keystages: [],
+    };
+    const filters = createFilter({ years: ["all-years"] });
+
+    const result = buildProgrammeHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      phaseTitle: "Secondary",
+      schoolYear: "all-years",
+    });
+
+    expect(result).toBe("Science (all years)");
+  });
+
+  it("returns shared groupAs title when selected years match", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "3": createYearData({
+          units: [createUnit({ slug: "test-3", year: "3" })],
+          groupAs: "Swimming and water safety",
+        }),
+        "4": createYearData({
+          units: [createUnit({ slug: "test-4", year: "4" })],
+          groupAs: "Swimming and water safety",
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["3", "4"],
+      keystages: [],
+    };
+    const filters = createFilter({ years: ["3", "4"] });
+
+    const result = buildProgrammeHeading({
+      subjectTitle: "PE",
+      data,
+      filters,
+      phaseTitle: "Primary",
+    });
+
+    expect(result).toBe("Swimming and water safety primary");
+  });
+
   it("returns default subject title for subject category all", () => {
     const data = createDataWithSubjectCategories();
     const filters = createFilter({

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -69,6 +69,7 @@ describe("buildProgrammeHeading", () => {
   ): CurriculumUnitsFormattedData => ({
     yearData: {
       [schoolYear]: createYearData({
+        keystage: "ks4",
         units: [
           createUnit({
             slug: `test-${schoolYear}`,
@@ -347,7 +348,7 @@ describe("buildProgrammeHeading", () => {
       examboardTitle: "AQA",
     });
 
-    expect(result).toBe("English Year 10 Language AQA");
+    expect(result).toBe("English Language year 10 AQA");
   });
 
   it("uses space-separated subject and category for grouped year 10", () => {
@@ -364,7 +365,7 @@ describe("buildProgrammeHeading", () => {
       schoolYear: "10",
     });
 
-    expect(result).toBe("English Year 10 Language");
+    expect(result).toBe("English Language year 10");
   });
 
   it("uses grouped ks4 order for year 11", () => {
@@ -384,7 +385,7 @@ describe("buildProgrammeHeading", () => {
       examboardTitle: "AQA",
     });
 
-    expect(result).toBe("English Year 11 Language AQA");
+    expect(result).toBe("English Language year 11 AQA");
   });
 
   it("uses colon separator when prefixing subject category in primary years", () => {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -267,47 +267,21 @@ describe("buildProgrammeHeading", () => {
     expect(result).toBe("English Year 10 Language AQA");
   });
 
-  it("returns prefixed category title for grouped non-ks4 headings", () => {
-    const data: CurriculumUnitsFormattedData = {
-      yearData: {
-        "8": createYearData({
-          units: [
-            createUnit({
-              slug: "test-8",
-              year: "8",
-              actions: {
-                subject_category_actions: {
-                  group_by_subjectcategory: true,
-                },
-              },
-            }),
-          ],
-          subjectCategories: [
-            createSubjectCategory({
-              id: 1,
-              slug: "language",
-              title: "Language",
-            }),
-          ],
-        }),
-      },
-      threadOptions: [],
-      yearOptions: ["8"],
-      keystages: [],
-    };
+  it("uses space-separated subject and category for grouped year 10", () => {
+    const data = createGroupedData("10");
     const filters = createFilter({
       subjectCategories: ["language"],
-      years: ["8"],
+      years: ["10"],
     });
 
     const result = buildHeading({
       subjectTitle: "English",
       data,
       filters,
-      schoolYear: "8",
+      schoolYear: "10",
     });
 
-    expect(result).toBe("English: Language year 8");
+    expect(result).toBe("English Year 10 Language");
   });
 
   it("uses grouped ks4 order for year 11", () => {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -243,6 +243,41 @@ describe("buildProgrammeHeading", () => {
     expect(result).toBe("Science year 7");
   });
 
+  it("formats subject title when all category is selected and data includes the synthetic all slug", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "7": createYearData({
+          units: [createUnit({ slug: "test1", year: "7" })],
+          subjectCategories: [
+            createSubjectCategory({ id: -1, slug: "all", title: "All" }),
+            createSubjectCategory({ id: 1, slug: "biology", title: "Biology" }),
+            createSubjectCategory({
+              id: 2,
+              slug: "chemistry",
+              title: "Chemistry",
+            }),
+          ],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["7"],
+      keystages: [],
+    };
+    const filters = createFilter({
+      subjectCategories: ["all"],
+      years: ["7"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Science year 7");
+  });
+
   it("returns child subject title when both filters are shown and equal", () => {
     const data = createDataWithBothDisplayed();
     const filters = createFilter({

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -80,10 +80,6 @@ describe("buildProgrammeHeading", () => {
             },
           }),
         ],
-        childSubjects: [
-          createChildSubject({ subject_slug: "english" }),
-          createChildSubject({ subject_slug: "drama" }),
-        ],
         subjectCategories: [
           createSubjectCategory({
             id: 1,
@@ -354,5 +350,166 @@ describe("buildProgrammeHeading", () => {
     });
 
     expect(result).toBe("English Year 11 Language AQA");
+  });
+
+  it("uses colon separator when prefixing subject category in primary years", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "3": createYearData({
+          units: [
+            createUnit({
+              slug: "test-3",
+              year: "3",
+              actions: {
+                subject_category_actions: {
+                  group_by_subjectcategory: true,
+                },
+              },
+            }),
+          ],
+          subjectCategories: [
+            createSubjectCategory({
+              id: 1,
+              slug: "grammar",
+              title: "Grammar",
+            }),
+          ],
+        }),
+        "4": createYearData({
+          units: [createUnit({ slug: "test-4", year: "4" })],
+          subjectCategories: [
+            createSubjectCategory({
+              id: 1,
+              slug: "grammar",
+              title: "Grammar",
+            }),
+          ],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["3", "4"],
+      keystages: [],
+    };
+    const filters = createFilter({
+      subjectCategories: ["grammar"],
+      years: ["3", "4"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "English",
+      data,
+      filters,
+      schoolYear: "3",
+    });
+
+    expect(result).toBe("English: Grammar year 3");
+  });
+
+  it("falls back to subject title when child subject and subject category are both applied but do not match", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "7": createYearData({
+          units: [createUnit({ slug: "test-ks3", year: "7" })],
+          childSubjects: [
+            createChildSubject({ subject_slug: "chemistry" }),
+            createChildSubject({ subject_slug: "physics" }),
+          ],
+        }),
+        "10": createYearData({
+          units: [createUnit({ slug: "test-ks4", year: "10" })],
+          subjectCategories: [
+            createSubjectCategory({
+              id: 1,
+              slug: "chemistry",
+              title: "Chemistry",
+            }),
+          ],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["7", "10"],
+      keystages: [],
+    };
+    const filters = createFilter({
+      childSubjects: ["physics"],
+      subjectCategories: ["chemistry"],
+      years: ["7", "10"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Science year 7");
+  });
+
+  it("formats KS4 headings as subject, year, then examboard when not grouped by subject category", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "10": createYearData({
+          units: [createUnit({ slug: "test-10", year: "10" })],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["10"],
+      keystages: [],
+    };
+    const filters = createFilter({ years: ["10"] });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "10",
+      examboardTitle: "AQA",
+    });
+
+    expect(result).toBe("Science year 10 AQA");
+  });
+
+  it("does not append examboard for non-ks4 key stage headings", () => {
+    const data = createDataWithChildSubjects();
+    const filters = createFilter({ years: ["7"] });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      keyStage: "ks3",
+      examboardTitle: "AQA",
+    });
+
+    expect(result).toBe("Science KS3");
+  });
+
+  it("ignores groupAs title when not every selected year has matching groupAs", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "3": createYearData({
+          units: [createUnit({ slug: "test-3", year: "3" })],
+          groupAs: "Swimming and water safety",
+        }),
+        "4": createYearData({
+          units: [createUnit({ slug: "test-4", year: "4" })],
+          groupAs: null,
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["3", "4"],
+      keystages: [],
+    };
+    const filters = createFilter({ years: ["3", "4"] });
+
+    const result = buildHeading({
+      subjectTitle: "PE",
+      data,
+      filters,
+      phaseTitle: "Primary",
+    });
+
+    expect(result).toBe("PE primary");
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -348,7 +348,7 @@ describe("buildProgrammeHeading", () => {
       examboardTitle: "AQA",
     });
 
-    expect(result).toBe("English Language year 10 AQA");
+    expect(result).toBe("English language year 10 AQA");
   });
 
   it("uses space-separated subject and category for grouped year 10", () => {
@@ -365,7 +365,7 @@ describe("buildProgrammeHeading", () => {
       schoolYear: "10",
     });
 
-    expect(result).toBe("English Language year 10");
+    expect(result).toBe("English language year 10");
   });
 
   it("uses grouped ks4 order for year 11", () => {
@@ -385,7 +385,7 @@ describe("buildProgrammeHeading", () => {
       examboardTitle: "AQA",
     });
 
-    expect(result).toBe("English Language year 11 AQA");
+    expect(result).toBe("English language year 11 AQA");
   });
 
   it("uses colon separator when prefixing subject category in primary years", () => {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.test.tsx
@@ -1,0 +1,332 @@
+import "@testing-library/jest-dom";
+
+import { buildProgrammeHeading } from "./buildProgrammeHeading";
+
+import { createFilter } from "@/fixtures/curriculum/filters";
+import { createYearData } from "@/fixtures/curriculum/yearData";
+import { createSubjectCategory } from "@/fixtures/curriculum/subjectCategories";
+import { createChildSubject } from "@/fixtures/curriculum/childSubject";
+import { createUnit } from "@/fixtures/curriculum/unit";
+import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+
+describe("buildProgrammeHeading", () => {
+  const createDataWithChildSubjects = (): CurriculumUnitsFormattedData => ({
+    yearData: {
+      "7": createYearData({
+        units: [createUnit({ slug: "test1", year: "7" })],
+        childSubjects: [
+          createChildSubject({ subject_slug: "physics" }),
+          createChildSubject({ subject_slug: "biology" }),
+        ],
+      }),
+    },
+    threadOptions: [],
+    yearOptions: ["7"],
+    keystages: [],
+  });
+
+  const createDataWithSubjectCategories = (): CurriculumUnitsFormattedData => ({
+    yearData: {
+      "7": createYearData({
+        units: [createUnit({ slug: "test1", year: "7" })],
+        subjectCategories: [
+          createSubjectCategory({ id: 1, slug: "biology", title: "Biology" }),
+        ],
+      }),
+    },
+    threadOptions: [],
+    yearOptions: ["7"],
+    keystages: [],
+  });
+
+  const createDataWithBothDisplayed = (): CurriculumUnitsFormattedData => ({
+    yearData: {
+      "3": createYearData({
+        units: [createUnit({ slug: "test-ks2", year: "3" })],
+        subjectCategories: [
+          createSubjectCategory({
+            id: 1,
+            slug: "chemistry",
+            title: "Chemistry",
+          }),
+        ],
+      }),
+      "7": createYearData({
+        units: [createUnit({ slug: "test-ks3", year: "7" })],
+        childSubjects: [
+          createChildSubject({ subject_slug: "chemistry" }),
+          createChildSubject({ subject_slug: "physics" }),
+        ],
+      }),
+    },
+    threadOptions: [],
+    yearOptions: ["3", "7"],
+    keystages: [],
+  });
+
+  const createGroupedData = (
+    schoolYear: "10" | "11",
+  ): CurriculumUnitsFormattedData => ({
+    yearData: {
+      [schoolYear]: createYearData({
+        units: [
+          createUnit({
+            slug: `test-${schoolYear}`,
+            year: schoolYear,
+            actions: {
+              subject_category_actions: {
+                group_by_subjectcategory: true,
+              },
+            },
+          }),
+        ],
+        childSubjects: [
+          createChildSubject({ subject_slug: "english" }),
+          createChildSubject({ subject_slug: "drama" }),
+        ],
+        subjectCategories: [
+          createSubjectCategory({
+            id: 1,
+            slug: "language",
+            title: "Language",
+          }),
+        ],
+      }),
+    },
+    threadOptions: [],
+    yearOptions: [schoolYear],
+    keystages: [],
+  });
+
+  const buildHeading = ({
+    subjectTitle,
+    data,
+    filters,
+    schoolYear,
+    keyStage,
+    examboardTitle,
+    phaseTitle = "Secondary",
+  }: {
+    subjectTitle: string;
+    data: CurriculumUnitsFormattedData;
+    filters: ReturnType<typeof createFilter>;
+    schoolYear?: string;
+    keyStage?: string;
+    examboardTitle?: string;
+    phaseTitle?: string;
+  }) =>
+    buildProgrammeHeading({
+      subjectTitle,
+      data,
+      filters,
+      phaseTitle,
+      schoolYear,
+      keyStage,
+      examboardTitle,
+    });
+
+  it("uses phase title when school year and key stage are absent", () => {
+    const data = createDataWithChildSubjects();
+    const filters = createFilter({ years: ["7"] });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      phaseTitle: "Secondary",
+    });
+
+    expect(result).toBe("Science secondary");
+  });
+
+  it("uses key stage and examboard when keyStage is ks4", () => {
+    const data = createDataWithChildSubjects();
+    const filters = createFilter({ years: ["7"] });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      keyStage: "ks4",
+      examboardTitle: "AQA",
+    });
+
+    expect(result).toBe("Science KS4 AQA");
+  });
+
+  it("keeps existing year formatting for non-grouped year 9", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "9": createYearData({
+          units: [createUnit({ slug: "test-9", year: "9" })],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["9"],
+      keystages: [],
+    };
+    const filters = createFilter({ years: ["9"] });
+
+    const result = buildProgrammeHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      phaseTitle: "Secondary",
+      schoolYear: "9",
+    });
+
+    expect(result).toBe("Science year 9");
+  });
+
+  it("returns default subject title for subject category all", () => {
+    const data = createDataWithSubjectCategories();
+    const filters = createFilter({
+      subjectCategories: ["all"],
+      years: ["7"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Science year 7");
+  });
+
+  it("returns child subject title when both filters are shown and equal", () => {
+    const data = createDataWithBothDisplayed();
+    const filters = createFilter({
+      childSubjects: ["chemistry"],
+      subjectCategories: ["chemistry"],
+      years: ["3", "7"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Chemistry year 7");
+  });
+
+  it("returns subject category title when it is the only shown subject filter", () => {
+    const data = createDataWithSubjectCategories();
+    const filters = createFilter({
+      subjectCategories: ["biology"],
+      years: ["7"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Biology year 7");
+  });
+
+  it("returns child subject title when it is the only shown subject filter", () => {
+    const data = createDataWithChildSubjects();
+    const filters = createFilter({
+      childSubjects: ["physics"],
+      years: ["7"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "Science",
+      data,
+      filters,
+      schoolYear: "7",
+    });
+
+    expect(result).toBe("Physics year 7");
+  });
+
+  it("uses grouped ks4 order for year 10", () => {
+    const data = createGroupedData("10");
+    const filters = createFilter({
+      childSubjects: ["english"],
+      subjectCategories: ["language"],
+      years: ["10"],
+    });
+
+    const result = buildProgrammeHeading({
+      subjectTitle: "English",
+      data,
+      filters,
+      phaseTitle: "Secondary",
+      schoolYear: "10",
+      examboardTitle: "AQA",
+    });
+
+    expect(result).toBe("English Year 10 Language AQA");
+  });
+
+  it("returns prefixed category title for grouped non-ks4 headings", () => {
+    const data: CurriculumUnitsFormattedData = {
+      yearData: {
+        "8": createYearData({
+          units: [
+            createUnit({
+              slug: "test-8",
+              year: "8",
+              actions: {
+                subject_category_actions: {
+                  group_by_subjectcategory: true,
+                },
+              },
+            }),
+          ],
+          subjectCategories: [
+            createSubjectCategory({
+              id: 1,
+              slug: "language",
+              title: "Language",
+            }),
+          ],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["8"],
+      keystages: [],
+    };
+    const filters = createFilter({
+      subjectCategories: ["language"],
+      years: ["8"],
+    });
+
+    const result = buildHeading({
+      subjectTitle: "English",
+      data,
+      filters,
+      schoolYear: "8",
+    });
+
+    expect(result).toBe("English: Language year 8");
+  });
+
+  it("uses grouped ks4 order for year 11", () => {
+    const data = createGroupedData("11");
+    const filters = createFilter({
+      childSubjects: ["english"],
+      subjectCategories: ["language"],
+      years: ["11"],
+    });
+
+    const result = buildProgrammeHeading({
+      subjectTitle: "English",
+      data,
+      filters,
+      phaseTitle: "Secondary",
+      schoolYear: "11",
+      examboardTitle: "AQA",
+    });
+
+    expect(result).toBe("English Year 11 Language AQA");
+  });
+});

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -14,12 +14,36 @@ type SubjectTitleSelection = {
   shouldPrefixSubjectCategoryWithSubject: boolean;
 };
 
-function isAllSeconary(keyStages: string[]): boolean {
+function isAllSecondary(keyStages: string[]): boolean {
   if (keyStages.length === 0) return false;
 
   return keyStages.every(
     (keyStage) => keyStage === "ks3" || keyStage === "ks4",
   );
+}
+
+function getSharedGroupAsTitle(
+  data: CurriculumUnitsFormattedData,
+  selectedYears: string[],
+): string | null {
+  const groupAsValues = selectedYears
+    .map((year) => data.yearData[year]?.groupAs)
+    .filter((groupAs): groupAs is string => Boolean(groupAs));
+
+  if (groupAsValues.length !== selectedYears.length) {
+    return null;
+  }
+
+  const [firstGroupAs] = groupAsValues;
+  if (!firstGroupAs) {
+    return null;
+  }
+
+  const allShareGroupAs = groupAsValues.every(
+    (groupAs) => groupAs === firstGroupAs,
+  );
+
+  return allShareGroupAs ? firstGroupAs : null;
 }
 
 function getSubjectTitleSelection(
@@ -34,7 +58,7 @@ function getSubjectTitleSelection(
     .map((year) => data.yearData[year]?.keystage)
     .filter((keyStage): keyStage is string => Boolean(keyStage));
   // We're not using ":" for secondary English, only primary
-  const subjectCategorySeparator = isAllSeconary(selectedKeyStages)
+  const subjectCategorySeparator = isAllSecondary(selectedKeyStages)
     ? " "
     : ": ";
   const shouldPrefixSubjectCategoryWithSubject = selectedYears.some((year) =>
@@ -43,6 +67,16 @@ function getSubjectTitleSelection(
         unit.actions?.subject_category_actions?.group_by_subjectcategory,
     ),
   );
+  const sharedGroupAsTitle = getSharedGroupAsTitle(data, selectedYears);
+
+  // Return groupAs when every selected year resolves to the same non-empty value.
+  // This is used for swimming units.
+  if (sharedGroupAsTitle) {
+    return {
+      title: sharedGroupAsTitle,
+      shouldPrefixSubjectCategoryWithSubject,
+    };
+  }
 
   const childSubjectsDisplayed = shouldDisplayFilter(
     data,
@@ -197,7 +231,11 @@ export function buildProgrammeHeading({
   const parts: Array<string | undefined> = [selectedSubjectTitle];
 
   if (schoolYear) {
-    parts.push(`year ${schoolYear}`);
+    if (schoolYear === "all-years") {
+      parts.push("(all years)");
+    } else {
+      parts.push(`year ${schoolYear}`);
+    }
 
     if (isKs4SchoolYear) {
       parts.push(examboardTitle);

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -14,6 +14,14 @@ type SubjectTitleSelection = {
   shouldPrefixSubjectCategoryWithSubject: boolean;
 };
 
+function isAllSeconary(keyStages: string[]): boolean {
+  if (keyStages.length === 0) return false;
+
+  return keyStages.every(
+    (keyStage) => keyStage === "ks3" || keyStage === "ks4",
+  );
+}
+
 function getSubjectTitleSelection(
   subjectTitle: string,
   data: CurriculumUnitsFormattedData,
@@ -22,6 +30,13 @@ function getSubjectTitleSelection(
   const formattedSubjectTitle = upperFirst(subjectTitle);
   const selectedYears =
     filters.years.length > 0 ? filters.years : data.yearOptions;
+  const selectedKeyStages = selectedYears
+    .map((year) => data.yearData[year]?.keystage)
+    .filter((keyStage): keyStage is string => Boolean(keyStage));
+  // We're not using ":" for secondary English, only primary
+  const subjectCategorySeparator = isAllSeconary(selectedKeyStages)
+    ? " "
+    : ": ";
   const shouldPrefixSubjectCategoryWithSubject = selectedYears.some((year) =>
     data.yearData[year]?.units.some(
       (unit) =>
@@ -97,7 +112,7 @@ function getSubjectTitleSelection(
       selectedSubjectCategoryTitle
     ) {
       return {
-        title: `${formattedSubjectTitle}: ${selectedSubjectCategoryTitle}`,
+        title: `${formattedSubjectTitle}${subjectCategorySeparator}${selectedSubjectCategoryTitle}`,
         selectedSubjectCategoryTitle,
         shouldPrefixSubjectCategoryWithSubject,
       };
@@ -112,7 +127,7 @@ function getSubjectTitleSelection(
   if (!childSubjectsDisplayed && selectedSubjectCategoryTitle) {
     if (shouldPrefixSubjectCategoryWithSubject) {
       return {
-        title: `${formattedSubjectTitle}: ${selectedSubjectCategoryTitle}`,
+        title: `${formattedSubjectTitle}${subjectCategorySeparator}${selectedSubjectCategoryTitle}`,
         selectedSubjectCategoryTitle,
         shouldPrefixSubjectCategoryWithSubject,
       };

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -10,7 +10,6 @@ import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/ta
 
 type SubjectTitleSelection = {
   title: string;
-  selectedSubjectCategoryTitle?: string;
   shouldPrefixSubjectCategoryWithSubject: boolean;
 };
 
@@ -224,7 +223,6 @@ function selectionForSingleChildAndCategory(
   ) {
     return {
       title: ctx.childSubject.subject,
-      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
       shouldPrefixSubjectCategoryWithSubject:
         ctx.shouldPrefixSubjectCategoryWithSubject,
     };
@@ -236,7 +234,6 @@ function selectionForSingleChildAndCategory(
   ) {
     return {
       title: createSubjectWithCategoryTitle(ctx),
-      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
       shouldPrefixSubjectCategoryWithSubject:
         ctx.shouldPrefixSubjectCategoryWithSubject,
     };
@@ -256,7 +253,6 @@ function selectionForHiddenChildSubjects(
   if (ctx.shouldPrefixSubjectCategoryWithSubject) {
     return {
       title: createSubjectWithCategoryTitle(ctx),
-      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
       shouldPrefixSubjectCategoryWithSubject:
         ctx.shouldPrefixSubjectCategoryWithSubject,
     };
@@ -264,7 +260,6 @@ function selectionForHiddenChildSubjects(
 
   return {
     title: ctx.selectedSubjectCategoryTitle,
-    selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
     shouldPrefixSubjectCategoryWithSubject:
       ctx.shouldPrefixSubjectCategoryWithSubject,
   };
@@ -346,28 +341,12 @@ export function buildProgrammeHeading({
   keyStage,
   examboardTitle,
 }: BuildProgrammeHeadingArgs): string {
-  const {
-    title: selectedSubjectTitle,
-    selectedSubjectCategoryTitle,
-    shouldPrefixSubjectCategoryWithSubject,
-  } = getSubjectTitleSelection(subjectTitle, data, filters);
-  const formattedSubjectTitle = upperFirst(subjectTitle);
+  const { title: selectedSubjectTitle } = getSubjectTitleSelection(
+    subjectTitle,
+    data,
+    filters,
+  );
   const isKs4SchoolYear = schoolYear === "10" || schoolYear === "11";
-
-  if (
-    isKs4SchoolYear &&
-    shouldPrefixSubjectCategoryWithSubject &&
-    selectedSubjectCategoryTitle
-  ) {
-    return [
-      formattedSubjectTitle,
-      `Year ${schoolYear}`,
-      selectedSubjectCategoryTitle,
-      examboardTitle,
-    ]
-      .filter(Boolean)
-      .join(" ");
-  }
 
   const parts: Array<string | undefined> = [selectedSubjectTitle];
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -14,6 +14,39 @@ type SubjectTitleSelection = {
   shouldPrefixSubjectCategoryWithSubject: boolean;
 };
 
+type SubjectTitleContext = {
+  // Original and display formatted subject names used by different rules.
+  subjectTitle: string;
+  formattedSubjectTitle: string;
+
+  // Controls English style "Subject Category" heading construction.
+  shouldPrefixSubjectCategoryWithSubject: boolean;
+  subjectCategorySeparator: string;
+
+  // Visibility of filters in the current data/filter state.
+  childSubjectsDisplayed: boolean;
+  subjectCategoriesDisplayed: boolean;
+
+  // Whether each filter is narrowed to a single value.
+  hasSingleChildSubject: boolean;
+  hasSingleSubjectCategory: boolean;
+
+  // Resolved entities/slugs for single value selections.
+  childSubject?: ReturnType<typeof childSubjectForFilter>;
+  subjectCategory?: ReturnType<typeof subjectCategoryForFilter>;
+  childSubjectSlug?: string;
+  subjectCategorySlug?: string;
+
+  // Human readable category title to surface in headings, excluding "all".
+  selectedSubjectCategoryTitle?: string;
+
+  // Common override title (e.g. Swimming and water safety for PE), if available.
+  sharedGroupAsTitle: string | null;
+};
+
+/**
+ * Checks if all the given key stages are secondary.
+ */
 function isAllSecondary(keyStages: string[]): boolean {
   if (keyStages.length === 0) return false;
 
@@ -22,6 +55,10 @@ function isAllSecondary(keyStages: string[]): boolean {
   );
 }
 
+/**
+ * Gets the common groupAs override title for the given units and filters.
+ * This is used for swimming units.
+ */
 function getSharedGroupAsTitle(
   data: CurriculumUnitsFormattedData,
   selectedYears: string[],
@@ -46,11 +83,11 @@ function getSharedGroupAsTitle(
   return allShareGroupAs ? firstGroupAs : null;
 }
 
-function getSubjectTitleSelection(
+function buildSubjectTitleContext(
   subjectTitle: string,
   data: CurriculumUnitsFormattedData,
   filters: CurriculumFilters,
-): SubjectTitleSelection {
+): SubjectTitleContext {
   const formattedSubjectTitle = upperFirst(subjectTitle);
   const selectedYears =
     filters.years.length > 0 ? filters.years : data.yearOptions;
@@ -69,24 +106,11 @@ function getSubjectTitleSelection(
   );
   const sharedGroupAsTitle = getSharedGroupAsTitle(data, selectedYears);
 
-  // Return groupAs when every selected year resolves to the same non-empty value.
-  // This is used for swimming units.
-  if (sharedGroupAsTitle) {
-    return {
-      title: sharedGroupAsTitle,
-      shouldPrefixSubjectCategoryWithSubject,
-    };
-  }
-
-  const childSubjectsDisplayed = shouldDisplayFilter(
-    data,
-    filters,
-    "childSubjects",
+  const childSubjectsDisplayed = Boolean(
+    shouldDisplayFilter(data, filters, "childSubjects"),
   );
-  const subjectCategoriesDisplayed = shouldDisplayFilter(
-    data,
-    filters,
-    "subjectCategories",
+  const subjectCategoriesDisplayed = Boolean(
+    shouldDisplayFilter(data, filters, "subjectCategories"),
   );
 
   const appliedChildSubjects = childSubjectsDisplayed
@@ -96,6 +120,7 @@ function getSubjectTitleSelection(
     ? filters.subjectCategories
     : [];
 
+  // I don't think we ever allow multiple selections in the UI but the data allows for it.
   const hasSingleChildSubject = appliedChildSubjects.length === 1;
   const hasSingleSubjectCategory = appliedSubjectCategories.length === 1;
 
@@ -116,82 +141,187 @@ function getSubjectTitleSelection(
       ? subjectCategory.title
       : undefined;
 
-  // When "All" is selected, show the subject title
-  if (subjectCategoriesDisplayed && subjectCategorySlug === "all") {
-    return {
-      title: subjectTitle,
-      shouldPrefixSubjectCategoryWithSubject,
-    };
+  return {
+    subjectTitle,
+    formattedSubjectTitle,
+    shouldPrefixSubjectCategoryWithSubject,
+    subjectCategorySeparator,
+    childSubjectsDisplayed,
+    subjectCategoriesDisplayed,
+    hasSingleChildSubject,
+    hasSingleSubjectCategory,
+    childSubject,
+    subjectCategory,
+    childSubjectSlug,
+    subjectCategorySlug,
+    selectedSubjectCategoryTitle,
+    sharedGroupAsTitle,
+  };
+}
+
+function createSubjectWithCategoryTitle(ctx: SubjectTitleContext) {
+  return `${ctx.formattedSubjectTitle}${ctx.subjectCategorySeparator}${ctx.selectedSubjectCategoryTitle}`;
+}
+
+function createDefaultSubjectTitleSelection(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection {
+  return {
+    title: ctx.formattedSubjectTitle,
+    shouldPrefixSubjectCategoryWithSubject:
+      ctx.shouldPrefixSubjectCategoryWithSubject,
+  };
+}
+
+// Highest-priority override: use shared groupAs title when all selected years agree.
+function selectionForSharedGroupAs(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection | null {
+  if (!ctx.sharedGroupAsTitle) {
+    return null;
   }
 
-  // Special-case the most constrained state so we can avoid redundant headings.
+  return {
+    title: ctx.sharedGroupAsTitle,
+    shouldPrefixSubjectCategoryWithSubject:
+      ctx.shouldPrefixSubjectCategoryWithSubject,
+  };
+}
+
+// Handles explicit "all" category selection by reverting to the base subject title.
+function selectionForAllSubjectCategory(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection | null {
+  if (!ctx.subjectCategoriesDisplayed || ctx.subjectCategorySlug !== "all") {
+    return null;
+  }
+
+  return {
+    title: ctx.subjectTitle,
+    shouldPrefixSubjectCategoryWithSubject:
+      ctx.shouldPrefixSubjectCategoryWithSubject,
+  };
+}
+
+// Resolves the most constrained state where both filters are visible and have a single selected value.
+function selectionForSingleChildAndCategory(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection | null {
+  const hasSingleFiltersDisplayed =
+    ctx.hasSingleChildSubject &&
+    ctx.hasSingleSubjectCategory &&
+    ctx.childSubjectsDisplayed &&
+    ctx.subjectCategoriesDisplayed;
+
+  if (!hasSingleFiltersDisplayed) {
+    return null;
+  }
+
   if (
-    hasSingleChildSubject &&
-    hasSingleSubjectCategory &&
-    childSubjectsDisplayed &&
-    subjectCategoriesDisplayed
+    ctx.childSubject &&
+    ctx.subjectCategory &&
+    ctx.childSubjectSlug === ctx.subjectCategorySlug
   ) {
-    // If both filters resolve to the same slug, show the child subject once rather than duplicating labels.
-    if (
-      childSubject &&
-      subjectCategory &&
-      childSubjectSlug === subjectCategorySlug
-    ) {
-      return {
-        title: childSubject.subject,
-        selectedSubjectCategoryTitle,
-        shouldPrefixSubjectCategoryWithSubject,
-      };
-    }
-
-    // Otherwise show subject + category
-    // Needed for English where we display both subject and subject category
-    if (
-      shouldPrefixSubjectCategoryWithSubject &&
-      selectedSubjectCategoryTitle
-    ) {
-      return {
-        title: `${formattedSubjectTitle}${subjectCategorySeparator}${selectedSubjectCategoryTitle}`,
-        selectedSubjectCategoryTitle,
-        shouldPrefixSubjectCategoryWithSubject,
-      };
-    }
-
     return {
-      title: formattedSubjectTitle,
-      shouldPrefixSubjectCategoryWithSubject,
+      title: ctx.childSubject.subject,
+      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
+      shouldPrefixSubjectCategoryWithSubject:
+        ctx.shouldPrefixSubjectCategoryWithSubject,
     };
   }
 
-  // When child subjects are hidden, the category becomes the most specific visible selection.
-  if (!childSubjectsDisplayed && selectedSubjectCategoryTitle) {
-    // For English where we display both subject and subject category
-    if (shouldPrefixSubjectCategoryWithSubject) {
-      return {
-        title: `${formattedSubjectTitle}${subjectCategorySeparator}${selectedSubjectCategoryTitle}`,
-        selectedSubjectCategoryTitle,
-        shouldPrefixSubjectCategoryWithSubject,
-      };
-    }
+  if (
+    ctx.shouldPrefixSubjectCategoryWithSubject &&
+    ctx.selectedSubjectCategoryTitle
+  ) {
     return {
-      title: selectedSubjectCategoryTitle,
-      selectedSubjectCategoryTitle,
-      shouldPrefixSubjectCategoryWithSubject,
+      title: createSubjectWithCategoryTitle(ctx),
+      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
+      shouldPrefixSubjectCategoryWithSubject:
+        ctx.shouldPrefixSubjectCategoryWithSubject,
     };
   }
 
-  // When categories are hidden but child subjects are shown, use the selected child subject as the heading.
-  if (!subjectCategoriesDisplayed && childSubjectsDisplayed && childSubject) {
+  return createDefaultSubjectTitleSelection(ctx);
+}
+
+// Applies when child subjects are hidden, making category the most specific visible label.
+function selectionForHiddenChildSubjects(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection | null {
+  if (ctx.childSubjectsDisplayed || !ctx.selectedSubjectCategoryTitle) {
+    return null;
+  }
+
+  if (ctx.shouldPrefixSubjectCategoryWithSubject) {
     return {
-      title: childSubject.subject,
-      shouldPrefixSubjectCategoryWithSubject,
+      title: createSubjectWithCategoryTitle(ctx),
+      selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
+      shouldPrefixSubjectCategoryWithSubject:
+        ctx.shouldPrefixSubjectCategoryWithSubject,
     };
   }
 
   return {
-    title: formattedSubjectTitle,
-    shouldPrefixSubjectCategoryWithSubject,
+    title: ctx.selectedSubjectCategoryTitle,
+    selectedSubjectCategoryTitle: ctx.selectedSubjectCategoryTitle,
+    shouldPrefixSubjectCategoryWithSubject:
+      ctx.shouldPrefixSubjectCategoryWithSubject,
   };
+}
+
+// Applies when categories are hidden and a child subject is the most specific visible label.
+function selectionForHiddenSubjectCategories(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection | null {
+  if (
+    ctx.subjectCategoriesDisplayed ||
+    !ctx.childSubjectsDisplayed ||
+    !ctx.childSubject
+  ) {
+    return null;
+  }
+
+  return {
+    title: ctx.childSubject.subject,
+    shouldPrefixSubjectCategoryWithSubject:
+      ctx.shouldPrefixSubjectCategoryWithSubject,
+  };
+}
+
+/**
+ * Resolves the most specific subject title selection for the given context in order of precedence.
+ */
+function resolveSubjectTitleSelection(
+  ctx: SubjectTitleContext,
+): SubjectTitleSelection {
+  const sharedGroupAsSelection = selectionForSharedGroupAs(ctx);
+  if (sharedGroupAsSelection) return sharedGroupAsSelection;
+
+  const allSubjectCategorySelection = selectionForAllSubjectCategory(ctx);
+  if (allSubjectCategorySelection) return allSubjectCategorySelection;
+
+  const singleChildAndCategorySelection =
+    selectionForSingleChildAndCategory(ctx);
+  if (singleChildAndCategorySelection) return singleChildAndCategorySelection;
+
+  const hiddenChildSubjectsSelection = selectionForHiddenChildSubjects(ctx);
+  if (hiddenChildSubjectsSelection) return hiddenChildSubjectsSelection;
+
+  const hiddenSubjectCategoriesSelection =
+    selectionForHiddenSubjectCategories(ctx);
+  if (hiddenSubjectCategoriesSelection) return hiddenSubjectCategoriesSelection;
+
+  return createDefaultSubjectTitleSelection(ctx);
+}
+
+function getSubjectTitleSelection(
+  subjectTitle: string,
+  data: CurriculumUnitsFormattedData,
+  filters: CurriculumFilters,
+): SubjectTitleSelection {
+  const context = buildSubjectTitleContext(subjectTitle, data, filters);
+  return resolveSubjectTitleSelection(context);
 }
 
 type BuildProgrammeHeadingArgs = {
@@ -204,6 +334,9 @@ type BuildProgrammeHeadingArgs = {
   examboardTitle?: string;
 };
 
+/**
+ * Builds a programme heading for the given units and filters.
+ */
 export function buildProgrammeHeading({
   subjectTitle,
   data,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -188,7 +188,7 @@ function selectionForSharedGroupAs(
   };
 }
 
-// Handles explicit "all" category selection by reverting to the base subject title.
+// Handles explicit "all" category selection by reverting to the formatted base subject title.
 function selectionForAllSubjectCategory(
   ctx: SubjectTitleContext,
 ): SubjectTitleSelection | null {
@@ -197,7 +197,7 @@ function selectionForAllSubjectCategory(
   }
 
   return {
-    title: ctx.subjectTitle,
+    title: ctx.formattedSubjectTitle,
     shouldPrefixSubjectCategoryWithSubject:
       ctx.shouldPrefixSubjectCategoryWithSubject,
   };

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -116,6 +116,7 @@ function getSubjectTitleSelection(
       ? subjectCategory.title
       : undefined;
 
+  // When "All" is selected, show the subject title
   if (subjectCategoriesDisplayed && subjectCategorySlug === "all") {
     return {
       title: subjectTitle,
@@ -123,12 +124,14 @@ function getSubjectTitleSelection(
     };
   }
 
+  // Special-case the most constrained state so we can avoid redundant headings.
   if (
     hasSingleChildSubject &&
     hasSingleSubjectCategory &&
     childSubjectsDisplayed &&
     subjectCategoriesDisplayed
   ) {
+    // If both filters resolve to the same slug, show the child subject once rather than duplicating labels.
     if (
       childSubject &&
       subjectCategory &&
@@ -141,6 +144,8 @@ function getSubjectTitleSelection(
       };
     }
 
+    // Otherwise show subject + category
+    // Needed for English where we display both subject and subject category
     if (
       shouldPrefixSubjectCategoryWithSubject &&
       selectedSubjectCategoryTitle
@@ -158,7 +163,9 @@ function getSubjectTitleSelection(
     };
   }
 
+  // When child subjects are hidden, the category becomes the most specific visible selection.
   if (!childSubjectsDisplayed && selectedSubjectCategoryTitle) {
+    // For English where we display both subject and subject category
     if (shouldPrefixSubjectCategoryWithSubject) {
       return {
         title: `${formattedSubjectTitle}${subjectCategorySeparator}${selectedSubjectCategoryTitle}`,
@@ -173,6 +180,7 @@ function getSubjectTitleSelection(
     };
   }
 
+  // When categories are hidden but child subjects are shown, use the selected child subject as the heading.
   if (!subjectCategoriesDisplayed && childSubjectsDisplayed && childSubject) {
     return {
       title: childSubject.subject,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -1,0 +1,201 @@
+import { upperFirst } from "lodash";
+
+import { CurriculumFilters } from "@/utils/curriculum/types";
+import {
+  childSubjectForFilter,
+  subjectCategoryForFilter,
+  shouldDisplayFilter,
+} from "@/utils/curriculum/filteringApp";
+import { CurriculumUnitsFormattedData } from "@/pages-helpers/curriculum/docx/tab-helpers";
+
+type SubjectTitleSelection = {
+  title: string;
+  selectedSubjectCategoryTitle?: string;
+  shouldPrefixSubjectCategoryWithSubject: boolean;
+};
+
+function getSubjectTitleSelection(
+  subjectTitle: string,
+  data: CurriculumUnitsFormattedData,
+  filters: CurriculumFilters,
+): SubjectTitleSelection {
+  const formattedSubjectTitle = upperFirst(subjectTitle);
+  const selectedYears =
+    filters.years.length > 0 ? filters.years : data.yearOptions;
+  const shouldPrefixSubjectCategoryWithSubject = selectedYears.some((year) =>
+    data.yearData[year]?.units.some(
+      (unit) =>
+        unit.actions?.subject_category_actions?.group_by_subjectcategory,
+    ),
+  );
+
+  const childSubjectsDisplayed = shouldDisplayFilter(
+    data,
+    filters,
+    "childSubjects",
+  );
+  const subjectCategoriesDisplayed = shouldDisplayFilter(
+    data,
+    filters,
+    "subjectCategories",
+  );
+
+  const appliedChildSubjects = childSubjectsDisplayed
+    ? filters.childSubjects
+    : [];
+  const appliedSubjectCategories = subjectCategoriesDisplayed
+    ? filters.subjectCategories
+    : [];
+
+  const hasSingleChildSubject = appliedChildSubjects.length === 1;
+  const hasSingleSubjectCategory = appliedSubjectCategories.length === 1;
+
+  const childSubject = hasSingleChildSubject
+    ? childSubjectForFilter(data, filters)
+    : undefined;
+  const subjectCategory = hasSingleSubjectCategory
+    ? subjectCategoryForFilter(data, filters)
+    : undefined;
+
+  const childSubjectSlug = childSubject?.subject_slug;
+  const subjectCategorySlug = subjectCategory?.slug;
+  const selectedSubjectCategoryTitle =
+    subjectCategoriesDisplayed &&
+    subjectCategory &&
+    subjectCategorySlug &&
+    subjectCategorySlug !== "all"
+      ? subjectCategory.title
+      : undefined;
+
+  if (subjectCategoriesDisplayed && subjectCategorySlug === "all") {
+    return {
+      title: subjectTitle,
+      shouldPrefixSubjectCategoryWithSubject,
+    };
+  }
+
+  if (
+    hasSingleChildSubject &&
+    hasSingleSubjectCategory &&
+    childSubjectsDisplayed &&
+    subjectCategoriesDisplayed
+  ) {
+    if (
+      childSubject &&
+      subjectCategory &&
+      childSubjectSlug === subjectCategorySlug
+    ) {
+      return {
+        title: childSubject.subject,
+        selectedSubjectCategoryTitle,
+        shouldPrefixSubjectCategoryWithSubject,
+      };
+    }
+
+    if (
+      shouldPrefixSubjectCategoryWithSubject &&
+      selectedSubjectCategoryTitle
+    ) {
+      return {
+        title: `${formattedSubjectTitle}: ${selectedSubjectCategoryTitle}`,
+        selectedSubjectCategoryTitle,
+        shouldPrefixSubjectCategoryWithSubject,
+      };
+    }
+
+    return {
+      title: formattedSubjectTitle,
+      shouldPrefixSubjectCategoryWithSubject,
+    };
+  }
+
+  if (!childSubjectsDisplayed && selectedSubjectCategoryTitle) {
+    if (shouldPrefixSubjectCategoryWithSubject) {
+      return {
+        title: `${formattedSubjectTitle}: ${selectedSubjectCategoryTitle}`,
+        selectedSubjectCategoryTitle,
+        shouldPrefixSubjectCategoryWithSubject,
+      };
+    }
+    return {
+      title: selectedSubjectCategoryTitle,
+      selectedSubjectCategoryTitle,
+      shouldPrefixSubjectCategoryWithSubject,
+    };
+  }
+
+  if (!subjectCategoriesDisplayed && childSubjectsDisplayed && childSubject) {
+    return {
+      title: childSubject.subject,
+      shouldPrefixSubjectCategoryWithSubject,
+    };
+  }
+
+  return {
+    title: formattedSubjectTitle,
+    shouldPrefixSubjectCategoryWithSubject,
+  };
+}
+
+type BuildProgrammeHeadingArgs = {
+  subjectTitle: string;
+  data: CurriculumUnitsFormattedData;
+  filters: CurriculumFilters;
+  phaseTitle: string;
+  schoolYear?: string | null;
+  keyStage?: string;
+  examboardTitle?: string;
+};
+
+export function buildProgrammeHeading({
+  subjectTitle,
+  data,
+  filters,
+  phaseTitle,
+  schoolYear,
+  keyStage,
+  examboardTitle,
+}: BuildProgrammeHeadingArgs): string {
+  const {
+    title: selectedSubjectTitle,
+    selectedSubjectCategoryTitle,
+    shouldPrefixSubjectCategoryWithSubject,
+  } = getSubjectTitleSelection(subjectTitle, data, filters);
+  const formattedSubjectTitle = upperFirst(subjectTitle);
+  const isKs4SchoolYear = schoolYear === "10" || schoolYear === "11";
+
+  if (
+    isKs4SchoolYear &&
+    shouldPrefixSubjectCategoryWithSubject &&
+    selectedSubjectCategoryTitle
+  ) {
+    return [
+      formattedSubjectTitle,
+      `Year ${schoolYear}`,
+      selectedSubjectCategoryTitle,
+      examboardTitle,
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  const parts: Array<string | undefined> = [selectedSubjectTitle];
+
+  if (schoolYear) {
+    parts.push(`year ${schoolYear}`);
+
+    if (isKs4SchoolYear) {
+      parts.push(examboardTitle);
+    }
+  } else if (keyStage) {
+    parts.push(keyStage.toUpperCase());
+
+    if (keyStage === "ks4") {
+      parts.push(examboardTitle);
+    }
+  } else {
+    parts.push(phaseTitle.toLowerCase(), examboardTitle);
+  }
+
+  return parts.filter(Boolean).join(" ");
+}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -330,7 +330,49 @@ type BuildProgrammeHeadingArgs = {
 };
 
 /**
- * Builds a programme heading for the given units and filters.
+ * Builds a curriculum programme heading that adapts to the current filter context.
+ *
+ * Business Logic:
+ *
+ * 1. Subject Title Selection (in priority order):
+ *    - Uses shared `groupAs` override if all selected years agree
+ *      (e.g. "Swimming and water safety" for PE)
+ *    - Reverts to base subject when "all" category is explicitly selected
+ *    - When both child subject and category filters are visible with single selections:
+ *      * If slugs match -> use child subject name
+ *      * If prefix required (e.g., English) -> combine subject + category
+ *      * Otherwise -> use base subject
+ *    - When child subjects are hidden -> show category
+ *      (with subject prefix and context-specific separator if applicable)
+ *    - When categories are hidden -> show child subject
+ *    - Default -> formatted base subject title
+ *
+ * 2. Heading Assembly:
+ *    - With `schoolYear`: "{subject} year {N} [{examboard}]" or "{subject} (all years)"
+ *      * Exam board is only included for KS4
+ *    - With `keyStage`: "{subject} {KS} [{examboard}]"
+ *      * Exam board is only included for KS4
+ *    - Without year/keyStage: "{subject} {phase} [{examboard}]"
+ *
+ * @example
+ * // Swimming override for PE
+ * "Swimming and water safety (all years)"
+ *
+ * @example
+ * // Primary English with category
+ * "English: Handwriting year 3"
+ *
+ * @example
+ * // Secondary with exam board
+ * "Maths year 10 AQA"
+ *
+ * @example
+ * // Key stage level
+ * "Science KS3"
+ *
+ * @example
+ * // Subject + phase when no year or key stage
+ * "Science secondary"
  */
 export function buildProgrammeHeading({
   subjectTitle,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeHeader/buildProgrammeHeading.ts
@@ -43,6 +43,16 @@ type SubjectTitleContext = {
   sharedGroupAsTitle: string | null;
 };
 
+type SubjectTitleContextWithCategory = SubjectTitleContext & {
+  selectedSubjectCategoryTitle: string;
+};
+
+function hasSelectedSubjectCategoryTitle(
+  ctx: SubjectTitleContext,
+): ctx is SubjectTitleContextWithCategory {
+  return Boolean(ctx.selectedSubjectCategoryTitle);
+}
+
 /**
  * Checks if all the given key stages are secondary.
  */
@@ -158,8 +168,13 @@ function buildSubjectTitleContext(
   };
 }
 
-function createSubjectWithCategoryTitle(ctx: SubjectTitleContext) {
-  return `${ctx.formattedSubjectTitle}${ctx.subjectCategorySeparator}${ctx.selectedSubjectCategoryTitle}`;
+function createSubjectWithCategoryTitle(ctx: SubjectTitleContextWithCategory) {
+  const categoryTitle =
+    ctx.subjectCategorySeparator === " "
+      ? ctx.selectedSubjectCategoryTitle.toLowerCase()
+      : ctx.selectedSubjectCategoryTitle;
+
+  return `${ctx.formattedSubjectTitle}${ctx.subjectCategorySeparator}${categoryTitle}`;
 }
 
 function createDefaultSubjectTitleSelection(
@@ -230,7 +245,7 @@ function selectionForSingleChildAndCategory(
 
   if (
     ctx.shouldPrefixSubjectCategoryWithSubject &&
-    ctx.selectedSubjectCategoryTitle
+    hasSelectedSubjectCategoryTitle(ctx)
   ) {
     return {
       title: createSubjectWithCategoryTitle(ctx),
@@ -246,7 +261,7 @@ function selectionForSingleChildAndCategory(
 function selectionForHiddenChildSubjects(
   ctx: SubjectTitleContext,
 ): SubjectTitleSelection | null {
-  if (ctx.childSubjectsDisplayed || !ctx.selectedSubjectCategoryTitle) {
+  if (ctx.childSubjectsDisplayed || !hasSelectedSubjectCategoryTitle(ctx)) {
     return null;
   }
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
@@ -13,10 +13,8 @@ import {
   isTabSlug,
 } from "../tabSchema";
 
-import {
-  ProgrammeHeader,
-  pickSubjectTitleFromFilters,
-} from "./ProgrammeHeader/ProgrammeHeader";
+import { ProgrammeHeader } from "./ProgrammeHeader/ProgrammeHeader";
+import { buildProgrammeHeading } from "./ProgrammeHeader/buildProgrammeHeading";
 import {
   UnitSequenceView,
   UnitSequenceViewProps,
@@ -115,6 +113,15 @@ export const ProgrammeView = ({
   const selectedKeystageSlug = filters.keystages.find(
     (ks) => searchParams?.get("keystages") === ks,
   );
+  const heading = buildProgrammeHeading({
+    subjectTitle,
+    data: curriculumUnitsFormattedData,
+    filters,
+    phaseTitle,
+    schoolYear,
+    keyStage: selectedKeystageSlug,
+    examboardTitle,
+  });
 
   // Ensure the active tab matches the one in the latest pathname
   const pathname = usePathname();
@@ -132,15 +139,7 @@ export const ProgrammeView = ({
       <ProgrammeHeader
         layoutVariant="large"
         subject={subjectSlug as SubjectHeroImageName}
-        subjectTitle={pickSubjectTitleFromFilters(
-          subjectTitle,
-          curriculumUnitsFormattedData,
-          filters,
-        )}
-        phaseTitle={phaseTitle}
-        examboardTitle={examboardTitle}
-        keyStage={selectedKeystageSlug}
-        schoolYear={schoolYear}
+        heading={heading}
         summary={subjectPhaseSanityData?.bodyCopy}
         bullets={subjectPhaseSanityData?.bullets}
       />

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
@@ -132,10 +132,11 @@ export const ProgrammeView = ({
       <ProgrammeHeader
         layoutVariant="large"
         subject={subjectSlug as SubjectHeroImageName}
-        subjectTitle={
-          pickSubjectTitleFromFilters(curriculumUnitsFormattedData, filters) ??
-          subjectTitle
-        }
+        subjectTitle={pickSubjectTitleFromFilters(
+          subjectTitle,
+          curriculumUnitsFormattedData,
+          filters,
+        )}
         phaseTitle={phaseTitle}
         examboardTitle={examboardTitle}
         keyStage={selectedKeystageSlug}


### PR DESCRIPTION
## Description

Music year: 1977

- Applies English only subject+category formatting
- Applies special swimming PE treatment using `groupAs` 
- Decouples heading construction from `ProgrammeHeader` so we can potentially use it elsewhere for SEO etc. and to make unit testing manageable

## How to test

1. Go to:

https://oak-web-application-website-git-feat-lesq-1798header-imp-b77cb1.vercel.thenational.academy/programmes/physical-education-primary-ks2/units

and

https://oak-web-application-website-git-feat-lesq-1798header-imp-b77cb1.vercel.thenational.academy/programmes/english-secondary-aqa/units

then

https://oak-web-application-website-git-feat-lesq-1798header-imp-b77cb1.vercel.thenational.academy/programmes/english-primary/units

2. You should see a nicely formatted programme heading that meets all expectations

## Screenshots
<img width="1329" height="815" alt="Screenshot 2026-04-20 at 14 50 58" src="https://github.com/user-attachments/assets/3da437e9-a126-4d90-9fb0-05f518a80faf" />
<img width="1373" height="911" alt="Screenshot 2026-04-21 at 12 58 09" src="https://github.com/user-attachments/assets/6703e03b-f41f-4c27-86c1-44ed104d8421" />
<img width="1471" height="667" alt="Screenshot 2026-04-20 at 14 50 18" src="https://github.com/user-attachments/assets/4573179a-fa65-4c67-a804-4416f55df554" />
<img width="1473" height="690" alt="Screenshot 2026-04-20 at 14 49 54" src="https://github.com/user-attachments/assets/5f784d72-0300-41f7-acb4-f2b3647be79d" />



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
- [ ]  Primary:
    - [ ]  ‘English: ’ text added to all categories and years in `english-primary`
    - [ ]  Examples:
        - [ ]  All year group: **English:** **Handwriting primary**
        - [ ]  Year 1: **English:** **Handwriting year 1**
- [ ]  Secondary:
    - [ ]  ~~All Year: Displays **English Language and Literature Secondary**~~ _there is no way to select both Language and Literature, Language is defaulted to on open_
        - [ ]  ~~No exam board if possible~~
    - [ ]  Year 7: Displays **English year 7** (No change to current behaviour)
    - [ ]  Year 8 Displays **English year 8** (No change to current behaviour)
    - [ ]  Year 9: Displays **English year 9** (No change to current behaviour)
    - [ ]  Year 10: Displays **English [Category] year 10 [Exam board]**
    - [ ]  Year 11: Displays **English [Category] year 11 [Exam board]**
- [ ]  PE category to show ‘**Swimming and water safety (all years)’**