### PR TITLE
Group units by subject category for English LESQ-1897

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.test.tsx
@@ -65,21 +65,6 @@ describe("ProgrammeUnitList", () => {
     expect(screen.getByRole("link", { name: /Unit Two/i })).toBeInTheDocument();
   });
 
-  it("adds subject_category to unit links when a category is selected", () => {
-    render(
-      <ProgrammeUnitList
-        {...defaultProps}
-        filters={createFilter({ subjectCategories: ["humanities"] })}
-      />,
-    );
-
-    const unitOneLink = screen.getByRole("link", { name: /Unit One/i });
-    expect(unitOneLink).toHaveAttribute(
-      "href",
-      expect.stringContaining("subject_category=humanities"),
-    );
-  });
-
   it("renders getSubjectCategoryMessage when units array is empty", () => {
     render(<ProgrammeUnitList {...defaultProps} units={[]} />);
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/UnitSequence/UnitList.tsx
@@ -97,9 +97,6 @@ export function ProgrammeUnitList({
             page: "integrated-unit-overview",
             unitSlug: option.slug ?? unit.slug,
             programmeSlug,
-            query: {
-              subject_category: filters.subjectCategories.at(0),
-            },
           }),
           showBorder: true,
           onClickLink: () => onClick(unit, isHighlighted),
@@ -123,9 +120,6 @@ export function ProgrammeUnitList({
             page: "integrated-unit-overview",
             unitSlug: unit.slug,
             programmeSlug,
-            query: {
-              subject_category: filters.subjectCategories.at(0),
-            },
           })}
           onClickLink={() => onClick(unit, isHighlighted)}
           lessonCount={isOptionalityUnitCard ? undefined : unit.lessons?.length}

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/page.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/page.test.tsx
@@ -120,24 +120,6 @@ describe("UnitPage", () => {
     expect(mockTeachersUnitOverview).toHaveBeenCalledWith({
       programmeSlug: defaultParams.subjectPhaseSlug,
       unitSlug: defaultParams.unitSlug,
-      subjectCategorySlug: undefined,
-    });
-  });
-
-  it("passes subject category from query params to data fetch", async () => {
-    featureFlagMock.mockResolvedValue(true);
-
-    await UnitPage({
-      params: Promise.resolve(defaultParams),
-      searchParams: Promise.resolve({
-        subject_category: "number-and-place-value",
-      }),
-    });
-
-    expect(mockTeachersUnitOverview).toHaveBeenCalledWith({
-      programmeSlug: defaultParams.subjectPhaseSlug,
-      unitSlug: defaultParams.unitSlug,
-      subjectCategorySlug: "number-and-place-value",
     });
   });
 
@@ -186,20 +168,5 @@ describe("generateMetadata", () => {
     expect(result.twitter?.title).toBe(
       "Geometry KS2 | Y4 Maths Lesson Resources",
     );
-  });
-
-  it("passes subject category query param to metadata data fetch", async () => {
-    mockTeachersUnitOverview.mockResolvedValue(unitOverviewFixture);
-
-    await generateMetadata({
-      params: Promise.resolve(defaultParams),
-      searchParams: Promise.resolve({ subject_category: "statistics" }),
-    });
-
-    expect(mockTeachersUnitOverview).toHaveBeenCalledWith({
-      programmeSlug: defaultParams.subjectPhaseSlug,
-      unitSlug: defaultParams.unitSlug,
-      subjectCategorySlug: "statistics",
-    });
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/page.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/page.tsx
@@ -19,15 +19,10 @@ import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 type LessonsPageParams = { subjectPhaseSlug: string; unitSlug: string };
 
 const getCachedUnitData = cache(
-  async (
-    subjectPhaseSlug: string,
-    unitSlug: string,
-    subjectCategorySlug?: string,
-  ) => {
+  async (subjectPhaseSlug: string, unitSlug: string) => {
     return curriculumApi2023.teachersUnitOverview({
       programmeSlug: subjectPhaseSlug,
       unitSlug,
-      subjectCategorySlug,
     });
   },
 );
@@ -36,14 +31,9 @@ export async function generateMetadata(
   props: AppPageProps<LessonsPageParams>,
 ): Promise<Metadata> {
   const { subjectPhaseSlug, unitSlug } = await props.params;
-  const searchParams = await props.searchParams;
 
   try {
-    const data = await getCachedUnitData(
-      subjectPhaseSlug,
-      unitSlug,
-      searchParams?.subject_category?.toString(),
-    );
+    const data = await getCachedUnitData(subjectPhaseSlug, unitSlug);
     const { unitTitle, keyStageSlug, year, subjectTitle } = data;
 
     const title = `${unitTitle} ${keyStageSlug.toUpperCase()} | Y${year} ${subjectTitle} Lesson Resources`;
@@ -71,12 +61,7 @@ const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
   }
 
   const { subjectPhaseSlug: programmeSlug, unitSlug } = await props.params;
-  const searchParams = await props.searchParams;
-  const data = await getCachedUnitData(
-    programmeSlug,
-    unitSlug,
-    searchParams?.subject_category?.toString(),
-  );
+  const data = await getCachedUnitData(programmeSlug, unitSlug);
   const subjectIconName = `subject-${data.subjectSlug}` as SubjectIcon;
 
   const subjectPhaseSlug = getTeacherSubjectPhaseSlug({

--- a/src/node-lib/curriculum-api-2023/generated/sdk.ts
+++ b/src/node-lib/curriculum-api-2023/generated/sdk.ts
@@ -21143,11 +21143,10 @@ export type TeachersSitemapQuery = { __typename?: 'query_root', keyStages: Array
 export type TeachersUnitOverviewQueryVariables = Exact<{
   programmeSlug: Scalars['String']['input'];
   unitSlug: Scalars['String']['input'];
-  subjectCategorySlug?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type TeachersUnitOverviewQuery = { __typename?: 'query_root', lessons: Array<{ __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0', lesson_data?: any | null, lesson_slug?: string | null, programme_fields?: any | null, programme_slug_by_year?: any | null, null_unitvariant_id?: number | null, unit_slug?: string | null, unitvariant_id?: number | null, unit_data?: any | null, programme_slug?: string | null, actions?: any | null, features?: any | null, order_in_unit?: number | null, static_lesson_list?: any | null }>, unitsInOtherProgrammes: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', programme_slug?: string | null, programme_fields?: any | null }>, unitSequence: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', actions?: any | null, unitSlug?: string | null, unitTitle?: any | null, unitDescription?: any | null, unitOrder?: any | null, yearOrder?: any | null, year?: any | null, subjectCategories?: any | null, optionalityTitle?: any | null, isSwimming?: any | null, nullUnitvariantId?: number | null }>, matchingSubjectCategories: Array<{ __typename?: 'published_mv_curriculum_sequence_b_13_0_21', subjectCategories?: any | null }>, threads: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', threads?: any | null }> };
+export type TeachersUnitOverviewQuery = { __typename?: 'query_root', lessons: Array<{ __typename?: 'published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0', lesson_data?: any | null, lesson_slug?: string | null, programme_fields?: any | null, programme_slug_by_year?: any | null, null_unitvariant_id?: number | null, unit_slug?: string | null, unitvariant_id?: number | null, unit_data?: any | null, programme_slug?: string | null, actions?: any | null, features?: any | null, order_in_unit?: number | null, static_lesson_list?: any | null }>, unitsInOtherProgrammes: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', programme_slug?: string | null, programme_fields?: any | null }>, unitSequence: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', actions?: any | null, unitSlug?: string | null, unitTitle?: any | null, unitDescription?: any | null, unitOrder?: any | null, yearOrder?: any | null, year?: any | null, subjectCategories?: any | null, optionalityTitle?: any | null, isSwimming?: any | null, nullUnitvariantId?: number | null }>, threads: Array<{ __typename?: 'published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0', threads?: any | null }> };
 
 export type TopNavQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -22362,7 +22361,7 @@ export const TeachersSitemapDocument = gql`
 }
     `;
 export const TeachersUnitOverviewDocument = gql`
-    query teachersUnitOverview($programmeSlug: String!, $unitSlug: String!, $subjectCategorySlug: String) {
+    query teachersUnitOverview($programmeSlug: String!, $unitSlug: String!) {
   lessons: published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0(
     where: {unit_slug: {_eq: $unitSlug}, programme_slug: {_eq: $programmeSlug}, is_legacy: {_eq: false}}
   ) {
@@ -22400,12 +22399,6 @@ export const TeachersUnitOverviewDocument = gql`
     isSwimming: features(path: "pe_swimming")
     nullUnitvariantId: null_unitvariant_id
     actions
-  }
-  matchingSubjectCategories: published_mv_curriculum_sequence_b_13_0_21(
-    where: {subjectcategories: {_contains: [{slug: $subjectCategorySlug}]}}
-    limit: 1
-  ) {
-    subjectCategories: subjectcategories
   }
   threads: published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0(
     where: {unit_slug: {_eq: $unitSlug}, programme_slug: {_eq: $programmeSlug}, is_legacy: {_eq: false}}

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.test.ts
@@ -439,6 +439,110 @@ describe("getUnitCounts", () => {
     expect(result.unitCount).toBe(2);
     expect(result.unitIndex).toBe(2);
   });
+
+  it("filters to overlapping subject categories when subject category grouping is enabled", () => {
+    const sequence: UnitSequence = [
+      {
+        unitSlug: "grammar-1",
+        unitTitle: "Grammar 1",
+        unitDescription: null,
+        unitOrder: 1,
+        nullUnitvariantId: 1,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Grammar"],
+        actions: {
+          subject_category_actions: {
+            group_by_subjectcategory: true,
+            all_disabled: false,
+            default_category_id: 1,
+          },
+        },
+      },
+      {
+        unitSlug: "grammar-2",
+        unitTitle: "Grammar 2",
+        unitDescription: null,
+        unitOrder: 2,
+        nullUnitvariantId: 2,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Grammar"],
+        actions: null,
+      },
+      {
+        unitSlug: "writing-1",
+        unitTitle: "Writing 1",
+        unitDescription: null,
+        unitOrder: 3,
+        nullUnitvariantId: 3,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Writing"],
+        actions: null,
+      },
+    ];
+
+    const result = getUnitCounts({
+      unitSequenceData: sequence,
+      nullUnitvariantId: 1,
+    });
+
+    expect(result.unitCount).toBe(2);
+    expect(result.unitIndex).toBe(1);
+  });
+
+  it("does not filter by subject category when grouping is disabled", () => {
+    const sequence: UnitSequence = [
+      {
+        unitSlug: "grammar-1",
+        unitTitle: "Grammar 1",
+        unitDescription: null,
+        unitOrder: 1,
+        nullUnitvariantId: 1,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Grammar"],
+        actions: {
+          subject_category_actions: {
+            group_by_subjectcategory: false,
+            all_disabled: false,
+            default_category_id: 1,
+          },
+        },
+      },
+      {
+        unitSlug: "grammar-2",
+        unitTitle: "Grammar 2",
+        unitDescription: null,
+        unitOrder: 2,
+        nullUnitvariantId: 2,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Grammar"],
+        actions: null,
+      },
+      {
+        unitSlug: "writing-1",
+        unitTitle: "Writing 1",
+        unitDescription: null,
+        unitOrder: 3,
+        nullUnitvariantId: 3,
+        yearOrder: 1,
+        year: "7",
+        subjectCategories: ["Writing"],
+        actions: null,
+      },
+    ];
+
+    const result = getUnitCounts({
+      unitSequenceData: sequence,
+      nullUnitvariantId: 1,
+    });
+
+    expect(result.unitCount).toBe(3);
+    expect(result.unitIndex).toBe(1);
+  });
 });
 
 describe("getAdjacentUnits", () => {

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.ts
@@ -140,11 +140,9 @@ export const getAdjacentUnits = ({
 export const getUnitCounts = ({
   unitSequenceData,
   nullUnitvariantId,
-  currentSubjectCategoryTitle,
 }: {
   unitSequenceData: UnitSequence;
   nullUnitvariantId: number;
-  currentSubjectCategoryTitle?: string;
 }) => {
   const currentUnit = unitSequenceData.find(
     (u) => u.nullUnitvariantId === nullUnitvariantId,
@@ -154,13 +152,8 @@ export const getUnitCounts = ({
   }
 
   const isCurrentUnitSwimming = currentUnit.isSwimming === true;
-
-  // Units can belong to multiple subject categories. We pass that down through
-  // the query so that we can filter accordingly
-  const currentSubjectCategory = currentUnit.subjectCategories?.find(
-    (subjectCategoryTitle) =>
-      subjectCategoryTitle === currentSubjectCategoryTitle,
-  );
+  const shouldGroupBySubjectCategory =
+    currentUnit.actions?.subject_category_actions?.group_by_subjectcategory;
 
   const unitsForYear = unitSequenceData
     .reduce((acc: UnitSequence, unit) => {
@@ -171,17 +164,20 @@ export const getUnitCounts = ({
       return acc;
     }, [])
     .filter((u) => {
+      // Keep only units that intersect with the current unit on at least
+      // one subject category.
+      // !IMPORTANT: This will break if currentUnit belongs to multiple subject categories
+      if (shouldGroupBySubjectCategory) {
+        return u.subjectCategories?.some((category) =>
+          currentUnit.subjectCategories?.includes(category),
+        );
+      }
+      return true;
+    })
+    .filter((u) => {
       // Swimming units are grouped across all years; all other units are grouped by year.
       if (isCurrentUnitSwimming) {
         return u.isSwimming === true;
-      }
-
-      // Exclude units that don't belong to the current subject category.
-      if (
-        currentSubjectCategory &&
-        !u.subjectCategories?.includes(currentSubjectCategory)
-      ) {
-        return false;
       }
 
       // Exclude swimming units from all years.
@@ -205,7 +201,6 @@ export const getPackagedUnit = ({
   unitSequenceData,
   unitsInOtherProgrammes,
   threads,
-  currentSubjectCategoryTitle,
 }: {
   packagedUnitData: PackagedUnitData;
   unitLessons: LessonListSchema;
@@ -214,7 +209,6 @@ export const getPackagedUnit = ({
   unitSequenceData: UnitSequence;
   unitsInOtherProgrammes: UnitsInOtherProgrammes;
   threads: Threads;
-  currentSubjectCategoryTitle?: string;
 }): TeachersUnitOverviewData => {
   const {
     programmeFields,
@@ -260,7 +254,6 @@ export const getPackagedUnit = ({
   const { unitCount, unitIndex } = getUnitCounts({
     unitSequenceData,
     nullUnitvariantId,
-    currentSubjectCategoryTitle,
   });
 
   const threadItems = threads

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.gql
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.gql
@@ -1,7 +1,6 @@
 query teachersUnitOverview(
   $programmeSlug: String!
   $unitSlug: String!
-  $subjectCategorySlug: String
 ) {
   lessons: published_mv_synthetic_unitvariant_lessons_by_keystage_18_0_0(
     where: {
@@ -44,14 +43,6 @@ query teachersUnitOverview(
     isSwimming: features(path: "pe_swimming")
     nullUnitvariantId: null_unitvariant_id
     actions
-  }
-  matchingSubjectCategories: published_mv_curriculum_sequence_b_13_0_21(
-    where: {
-      subjectcategories: { _contains: [{ slug: $subjectCategorySlug }] }
-    }
-    limit: 1
-  ) {
-    subjectCategories: subjectcategories
   }
   threads: published_mv_synthetic_unitvariants_with_lesson_ids_by_keystage_18_0_0(
     where: {

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.query.test.ts
@@ -80,23 +80,6 @@ export const unitsInOtherProgrammesFixture = [
   },
 ];
 
-const matchingSubjectCategoriesFixture = [
-  {
-    subjectCategories: [
-      {
-        id: 1,
-        title: "Theology",
-        slug: "theology",
-      },
-      {
-        id: 2,
-        title: "Philosophy",
-        slug: "philosophy",
-      },
-    ],
-  },
-];
-
 export const threadsFixture: Threads = [
   {
     threads: [
@@ -172,7 +155,6 @@ describe("teachersUnitOverview", () => {
             lessons: [],
             unitSequence: unitSequenceFixture,
             unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-            matchingSubjectCategories: matchingSubjectCategoriesFixture,
             threads: [],
           }),
         ),
@@ -190,7 +172,6 @@ describe("teachersUnitOverview", () => {
           lessons: [syntheticUnitvariantLessonsByKsFixture()],
           unitSequence: unitSequenceFixture,
           unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-          matchingSubjectCategories: matchingSubjectCategoriesFixture,
           threads: [],
         }),
       ),
@@ -267,7 +248,6 @@ describe("teachersUnitOverview", () => {
           lessons: [unitPageFixture2, unitPageFixture],
           unitSequence: unitSequenceFixture,
           unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-          matchingSubjectCategories: matchingSubjectCategoriesFixture,
           threads: [],
         }),
       ),
@@ -300,7 +280,6 @@ describe("teachersUnitOverview", () => {
             ],
             unitSequence: unitSequenceFixture,
             unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-            matchingSubjectCategories: matchingSubjectCategoriesFixture,
             threads: threadsFixture,
           }),
         ),
@@ -311,7 +290,7 @@ describe("teachersUnitOverview", () => {
     }).rejects.toThrow(`lesson_slug`);
   });
 
-  it("filters unit counts when subjectCategorySlug is provided", async () => {
+  it("filters unit counts when subject category grouping is enabled on current unit", async () => {
     const res = await teachersUnitOverviewQuery({
       ...sdk,
       teachersUnitOverview: jest.fn(() =>
@@ -321,6 +300,13 @@ describe("teachersUnitOverview", () => {
             {
               ...unitSequenceFixture[0]!,
               subjectCategories: ["Theology"],
+              actions: {
+                subject_category_actions: {
+                  group_by_subjectcategory: true,
+                  all_disabled: false,
+                  default_category_id: 1,
+                },
+              },
             },
             {
               ...unitSequenceFixture[1]!,
@@ -332,25 +318,30 @@ describe("teachersUnitOverview", () => {
             },
           ],
           unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-          matchingSubjectCategories: matchingSubjectCategoriesFixture,
           threads: [],
         }),
       ),
     })({
       programmeSlug: "programme-slug",
       unitSlug: "unit-slug",
-      subjectCategorySlug: "theology",
     });
 
     expect(res.unitCount).toBe(2);
     expect(res.unitIndex).toBe(1);
   });
 
-  it("does not filter unit counts by subject category when matchingSubjectCategories is empty", async () => {
+  it("does not filter unit counts by subject category when grouping is disabled", async () => {
     const unitSequenceWithCategories = [
       {
         ...unitSequenceFixture[0]!,
         subjectCategories: ["Theology"],
+        actions: {
+          subject_category_actions: {
+            group_by_subjectcategory: false,
+            all_disabled: false,
+            default_category_id: 1,
+          },
+        },
       },
       {
         ...unitSequenceFixture[1]!,
@@ -369,14 +360,12 @@ describe("teachersUnitOverview", () => {
           lessons: [syntheticUnitvariantLessonsByKsFixture()],
           unitSequence: unitSequenceWithCategories,
           unitsInOtherProgrammes: unitsInOtherProgrammesFixture,
-          matchingSubjectCategories: [],
           threads: [],
         }),
       ),
     })({
       programmeSlug: "programme-slug",
       unitSlug: "unit-slug",
-      subjectCategorySlug: "theology",
     });
 
     expect(res.unitCount).toBe(3);

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.query.ts
@@ -4,7 +4,6 @@ import {
   unitSequenceResponseSchema,
   PackagedUnitData,
   unitsInOtherProgrammesResponseSchema,
-  subjectCategoriesSchema,
   threadsResponseSchema,
 } from "./teachersUnitOverview.schema";
 import { getPackagedUnit, getTransformedLessons } from "./helpers";
@@ -17,18 +16,12 @@ import { applyGenericOverridesAndExceptions } from "@/node-lib/curriculum-api-20
 type TeachersUnitOverviewQueryArgs = {
   programmeSlug: string;
   unitSlug: string;
-  subjectCategorySlug?: string;
 };
 
 const teachersUnitOverviewQuery =
   (sdk: Sdk) => async (args: TeachersUnitOverviewQueryArgs) => {
-    const {
-      lessons,
-      unitSequence,
-      unitsInOtherProgrammes,
-      matchingSubjectCategories,
-      threads,
-    } = await sdk.teachersUnitOverview(args);
+    const { lessons, unitSequence, unitsInOtherProgrammes, threads } =
+      await sdk.teachersUnitOverview(args);
 
     const parsedUnitSequence = unitSequenceResponseSchema.parse(unitSequence);
     const parsedUnitsInOtherProgrammes =
@@ -53,16 +46,6 @@ const teachersUnitOverviewQuery =
     const containsLoginRequiredLessons = modifiedLessons.some(
       (lesson) => lesson.features?.agf__login_required === true,
     );
-    const parsedMatchingSubjectCategories = subjectCategoriesSchema.parse(
-      matchingSubjectCategories?.[0]?.subjectCategories,
-    );
-
-    // We receive the subject category slug, but need to map it to the subject category title
-    // to be able to intersect with the subject categories on the unit sequence 😮‍💨
-    const currentSubjectCategoryTitle = parsedMatchingSubjectCategories?.find(
-      (category) => category.slug === args.subjectCategorySlug,
-    )?.title;
-
     const parsedModifiedLessons =
       modifiedLessonsResponseSchemaArray.parse(modifiedLessons);
 
@@ -98,7 +81,6 @@ const teachersUnitOverviewQuery =
       unitSequenceData: parsedUnitSequence,
       unitsInOtherProgrammes: parsedUnitsInOtherProgrammes,
       threads: parsedThreads,
-      currentSubjectCategoryTitle,
     });
 
     return unitOverviewDataSchema.parse(packagedUnit);


### PR DESCRIPTION
## Description

Music year: 2009

Fixes the case when clicking next or previous unit on the unit overview page, would drop the subject category param which would cause the unit counts to include the entire subject. This only applies to English which has the `group_by_subjectcategory` action applied.

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1897unit-count-fba4e9.vercel.thenational.academy/programmes/english-secondary-aqa/units
2. Click on a unit
3. You should see an accurate unit count for the unit's subject category "Language" | "Literature"


**⚠️  Note!**

This alters the behaviour of other subjects where we were previously forwarding the subject category as a query param which applied a filter to the count.

E.g. RE

1. Go to https://oak-web-application-website-git-feat-lesq-1897unit-count-fba4e9.vercel.thenational.academy/programmes/religious-education-secondary-aqa/units
2. Filter by category "Philosophy"
3. Click the first unit in year 7
4. Unit count is 6 including all categories for the year
5. Click next the unit is a "Theology" unit

here unit count is now inclusive of all lessons within the unit's year regardless of subject categories. This is consistent with the behaviour of the Next+Previous links on the page.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
