### PR TITLE
Remove specialist links from footer

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -6233,20 +6233,6 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       >
                         <a
                           class="c184 "
-                          href="/teachers/specialist/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Specialist
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c183"
-                      >
-                        <a
-                          class="c184 "
                           href="/teachers/key-stages/ks1/subjects"
                         >
                           <span

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -6001,20 +6001,6 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       >
                         <a
                           class="c183 "
-                          href="/teachers/specialist/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Specialist
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c182"
-                      >
-                        <a
-                          class="c183 "
                           href="/teachers/key-stages/ks1/subjects"
                         >
                           <span

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -6573,20 +6573,6 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       >
                         <a
                           class="c214 "
-                          href="/teachers/specialist/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Specialist
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c213"
-                      >
-                        <a
-                          class="c214 "
                           href="/teachers/key-stages/ks1/subjects"
                         >
                           <span

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -6060,20 +6060,6 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       >
                         <a
                           class="c191 "
-                          href="/teachers/specialist/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Specialist
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c190"
-                      >
-                        <a
-                          class="c191 "
                           href="/teachers/key-stages/ks1/subjects"
                         >
                           <span

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -3761,20 +3761,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       >
                         <a
                           class="c76 "
-                          href="/teachers/specialist/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Specialist
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
                           href="/teachers/key-stages/ks1/subjects"
                         >
                           <span

--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
@@ -58,11 +58,6 @@ const footerSections: FooterSections = {
         }),
       },
       {
-        text: "Specialist",
-        type: "link",
-        href: "/teachers/specialist/subjects",
-      },
-      {
         text: "Key stage 1",
         type: "link",
         href: resolveOakHref({ page: "subject-index", keyStageSlug: "ks1" }),


### PR DESCRIPTION
## Description

Removes links to specialist pages from the footer.

There weren't any other active links to specialist pages that I could find. There's one in the old burger menu, which will soon be removed from the site.

## Issue(s)

[Fixes #LESQ-1960](https://www.notion.so/oaknationalacademy/Remove-the-Specialist-link-from-the-site-footer-in-OWA-34a26cc4e1b180639756e8e5849b9189)

## How to test

1. Go to [the homepage](https://oak-web-application-website-git-feat-lesq-1960rm-special-464475.vercel.thenational.academy/)
2. The specialist links should not appear in the footer

## Screenshots

How it used to look :
<img width="1105" height="529" alt="Screenshot 2026-04-22 at 12 07 30" src="https://github.com/user-attachments/assets/f6ab5564-d6f0-49f6-b442-ad15560ae738" />

How it should now look:
<img width="1105" height="546" alt="Screenshot 2026-04-22 at 12 06 59" src="https://github.com/user-attachments/assets/3a4cf646-083f-499d-8d31-450c51202209" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
