### PR TITLE
Fix/pupil 1732 pupil video transcript

### DIFF
--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
@@ -2,6 +2,7 @@ import { requestLessonResources } from "./requestLessonResources";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { getCaptionsFromFile } from "@/utils/handleTranscript";
 
 jest.mock("@/utils/handleTranscript", () => {
   return {
@@ -48,5 +49,55 @@ describe("requestLessonResources", () => {
     });
 
     expect(res).toEqual(["This is a sentence.", "This is another sentence."]);
+  });
+
+  it("for non-legacy lessons it uses MV transcript when present (no GCS fetch)", async () => {
+    const transcriptSentences = ["Sentence one.", "Sentence two."];
+
+    const res = await requestLessonResources({
+      lessonContent: lessonContentFixture({
+        isLegacy: false,
+        videoTitle: "some-video-title",
+        transcriptSentences,
+      }),
+    });
+
+    expect(getCaptionsFromFile).not.toHaveBeenCalled();
+    expect(res).toEqual(transcriptSentences);
+  });
+
+  it("for non-legacy lessons it formats MV transcript string when present (no GCS fetch)", async () => {
+    const transcriptSentences = "This is a sentence. This is another sentence.";
+
+    const res = await requestLessonResources({
+      lessonContent: lessonContentFixture({
+        isLegacy: false,
+        videoTitle: "some-video-title",
+        transcriptSentences,
+      }),
+    });
+
+    expect(getCaptionsFromFile).not.toHaveBeenCalled();
+    expect(res).toEqual(["This is a sentence.", "This is another sentence."]);
+  });
+
+  it("for non-legacy lessons it fetches transcript from GCS when MV transcript is missing", async () => {
+    (getCaptionsFromFile as jest.Mock).mockResolvedValueOnce([
+      "From GCS one.",
+      "From GCS two.",
+    ]);
+
+    const res = await requestLessonResources({
+      lessonContent: lessonContentFixture({
+        isLegacy: false,
+        videoTitle: "video-title-matching-gcs",
+        transcriptSentences: null,
+      }),
+    });
+
+    expect(getCaptionsFromFile).toHaveBeenCalledWith(
+      "video-title-matching-gcs.vtt",
+    );
+    expect(res).toEqual(["From GCS one.", "From GCS two."]);
   });
 });

--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.test.ts
@@ -91,7 +91,7 @@ describe("requestLessonResources", () => {
       lessonContent: lessonContentFixture({
         isLegacy: false,
         videoTitle: "video-title-matching-gcs",
-        transcriptSentences: null,
+        transcriptSentences: undefined,
       }),
     });
 

--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
@@ -1,6 +1,21 @@
 import { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
 import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
+const getTranscriptSentencesFromMv = (
+  transcriptSentences: LessonContent["transcriptSentences"],
+): string[] | null => {
+  if (!transcriptSentences) {
+    return null;
+  }
+
+  if (Array.isArray(transcriptSentences)) {
+    return transcriptSentences;
+  }
+
+  const splitTranscript = transcriptSentences.split(/\r?\n/);
+  return formatSentences(splitTranscript);
+};
+
 export const requestLessonResources = async ({
   lessonContent,
 }: {
@@ -9,9 +24,16 @@ export const requestLessonResources = async ({
   // For new content we need to fetch the captions file from gCloud and parse the result to generate
   // the transcript sentences.
 
+  const mvTranscriptSentences = getTranscriptSentencesFromMv(
+    lessonContent.transcriptSentences,
+  );
+  if (mvTranscriptSentences) {
+    return mvTranscriptSentences;
+  }
+
   if (lessonContent.videoTitle && !lessonContent.isLegacy) {
     return getCaptionsFromFile(`${lessonContent.videoTitle}.vtt`);
   }
 
-  return formatSentences(lessonContent.transcriptSentences || []);
+  return [];
 };

--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
@@ -9,7 +9,7 @@ const getTranscriptSentencesFromMv = (
   }
 
   if (Array.isArray(transcriptSentences)) {
-    return transcriptSentences;
+    return formatSentences(transcriptSentences);
   }
 
   const splitTranscript = transcriptSentences.split(/\r?\n/);

--- a/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
+++ b/src/components/PupilComponents/pupilUtils/requestLessonResources.ts
@@ -1,7 +1,7 @@
 import { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
 import { formatSentences, getCaptionsFromFile } from "@/utils/handleTranscript";
 
-const getTranscriptSentencesFromMv = (
+const getFormattedTranscriptSentences = (
   transcriptSentences: LessonContent["transcriptSentences"],
 ): string[] | null => {
   if (!transcriptSentences) {
@@ -24,7 +24,7 @@ export const requestLessonResources = async ({
   // For new content we need to fetch the captions file from gCloud and parse the result to generate
   // the transcript sentences.
 
-  const mvTranscriptSentences = getTranscriptSentencesFromMv(
+  const mvTranscriptSentences = getFormattedTranscriptSentences(
     lessonContent.transcriptSentences,
   );
   if (mvTranscriptSentences) {


### PR DESCRIPTION
## Description

Prefer MV transcript over GCS captions for non-legacy pupil lessons when transcriptSentences is present
Normalise MV transcript arrays by formatting/splitting into sentences for consistent rendering
Add unit tests covering MV transcript present (array + string) and fallback to GCS when MV transcript is missing

Music year: 1970

- Prefer MV transcript over GCS captions for pupil lessons: if lessonContent.transcriptSentences is present, use it instead of fetching ${videoTitle}.vtt from GCS.
- Fallback to GCS only when MV transcript is missing (non-legacy lessons with a videoTitle).
- Normalise/format MV transcripts consistently: handle transcriptSentences as either string or string[], and format/split into sentence strings.

## Issue(s)

Fixes #[PUPIL-1732](https://www.notion.so/oaknationalacademy/Pupil-video-transcript-missing-when-GCS-caption-filename-doesn-t-match-video_title-34b26cc4e1b180c7a68bd3f789c76f7a?source=copy_link)

## How to test

1. Go to https://oak-web-application-website-git-fix-pupil-1732-pupil-vid-0448e3.vercel.thenational.academy/pupils/programmes/computing-secondary-year-7/units/computer-networks-and-data-transmission/lessons/an-introduction-to-computer-networks/video
2. Check the lesson transcript displays and renders as multiple sentences (not one combined blob)

## Screenshots

How it used to look:
<img width="1784" height="1276" alt="Screenshot 2026-04-27 at 11 18 07" src="https://github.com/user-attachments/assets/e9ef5e7e-a20d-44ef-b0e4-f46c6dd8a5c2" />

How it should now look:
<img width="1757" height="1185" alt="Screenshot 2026-04-27 at 11 19 06" src="https://github.com/user-attachments/assets/43b26b2d-833f-4143-9e0b-8823ea0b4606" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
