### PR TITLE
feat(LESQ-1957): exclude core from GCSE pathway

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.test.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.test.ts
@@ -80,7 +80,7 @@ describe("getProgrammeData", () => {
         ks4OptionSlug: null,
         includeNonCurriculum: true,
         excludeUnitsWithNoPublishedLessons: true,
-        excludeCoreUnits: false,
+        excludeCoreUnits: true,
       });
       expect(mockApi.curriculumPhaseOptions).toHaveBeenCalled();
     });
@@ -248,6 +248,38 @@ describe("getProgrammeData", () => {
 
       expect(result?.curriculumPhaseOptions.subjects[0]?.ks4_options).toEqual([
         { title: "AQA", slug: "aqa" },
+      ]);
+    });
+
+    it("should not exclude core units when ks4 option slug is core", async () => {
+      const mockApi = createMockCurriculumApi({
+        curriculumPhaseOptions: jest.fn().mockResolvedValue([
+          {
+            title: "Maths",
+            slug: "maths",
+            phases: [{ title: "Secondary", slug: "secondary" }],
+            ks4_options: [
+              { title: "AQA", slug: "aqa" },
+              { title: "Core", slug: "core" },
+            ],
+            keystages: [],
+          },
+        ]),
+      });
+
+      const result = await getProgrammeData(mockApi, "maths-secondary-core");
+
+      expect(mockApi.curriculumSequence).toHaveBeenCalledWith({
+        subjectSlug: "maths",
+        phaseSlug: "secondary",
+        ks4OptionSlug: "core",
+        includeNonCurriculum: true,
+        excludeUnitsWithNoPublishedLessons: true,
+        excludeCoreUnits: false,
+      });
+      expect(result?.curriculumPhaseOptions.subjects[0]?.ks4_options).toEqual([
+        { title: "AQA", slug: "aqa" },
+        { title: "Core", slug: "core" },
       ]);
     });
   });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.test.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.test.ts
@@ -80,6 +80,7 @@ describe("getProgrammeData", () => {
         ks4OptionSlug: null,
         includeNonCurriculum: true,
         excludeUnitsWithNoPublishedLessons: true,
+        excludeCoreUnits: false,
       });
       expect(mockApi.curriculumPhaseOptions).toHaveBeenCalled();
     });
@@ -223,7 +224,31 @@ describe("getProgrammeData", () => {
         ks4OptionSlug: "aqa",
         includeNonCurriculum: true,
         excludeUnitsWithNoPublishedLessons: true,
+        excludeCoreUnits: true,
       });
+    });
+
+    it("should remove core ks4 option when excludeCoreUnits is true", async () => {
+      const mockApi = createMockCurriculumApi({
+        curriculumPhaseOptions: jest.fn().mockResolvedValue([
+          {
+            title: "Maths",
+            slug: "maths",
+            phases: [{ title: "Secondary", slug: "secondary" }],
+            ks4_options: [
+              { title: "AQA", slug: "aqa" },
+              { title: "Core", slug: "core" },
+            ],
+            keystages: [],
+          },
+        ]),
+      });
+
+      const result = await getProgrammeData(mockApi, "maths-secondary-aqa");
+
+      expect(result?.curriculumPhaseOptions.subjects[0]?.ks4_options).toEqual([
+        { title: "AQA", slug: "aqa" },
+      ]);
     });
   });
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.ts
@@ -5,7 +5,6 @@ import {
 } from "@/node-lib/curriculum-api-2023";
 import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 import { filterValidCurriculumPhaseOptions } from "@/pages-helpers/curriculum/docx/tab-helpers";
-import { isExamboardSlug } from "@/pages-helpers/pupil/options-pages/options-pages-helpers";
 
 // Helper function to sort units consistently
 const sortUnits = (units: CurriculumUnit[]): CurriculumUnit[] => {
@@ -40,11 +39,9 @@ export async function getProgrammeData(
     return null;
   }
 
-  // We exclude core units when an examboard is selected
+  // We exclude core units when the ks4 option is not core
   // TD: after the integrated journey launches we should make this the default in the query
-  const excludeCoreUnits = isExamboardSlug(
-    subjectPhaseKeystageSlugs.ks4OptionSlug,
-  );
+  const excludeCoreUnits = subjectPhaseKeystageSlugs.ks4OptionSlug !== "core";
 
   const [programmeUnitsData, curriculumUnitsData, originalSubjects] =
     await Promise.all([

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/getProgrammeData.ts
@@ -1,9 +1,11 @@
 import {
+  CurriculumPhaseOptions,
   CurriculumUnit,
   type CurriculumApi,
 } from "@/node-lib/curriculum-api-2023";
 import { parseSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 import { filterValidCurriculumPhaseOptions } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { isExamboardSlug } from "@/pages-helpers/pupil/options-pages/options-pages-helpers";
 
 // Helper function to sort units consistently
 const sortUnits = (units: CurriculumUnit[]): CurriculumUnit[] => {
@@ -20,6 +22,14 @@ const sortUnits = (units: CurriculumUnit[]): CurriculumUnit[] => {
   return sorted;
 };
 
+const excludeCoreFromSubjects = (subjects: CurriculumPhaseOptions) => {
+  return subjects.map((subject) => ({
+    ...subject,
+    ks4_options:
+      subject.ks4_options?.filter(({ slug }) => slug !== "core") ?? null,
+  }));
+};
+
 export async function getProgrammeData(
   curriculumApi2023: CurriculumApi,
   subjectPhaseSlug: string,
@@ -30,8 +40,14 @@ export async function getProgrammeData(
     return null;
   }
 
-  const [programmeUnitsData, curriculumUnitsData, subjects] = await Promise.all(
-    [
+  // We exclude core units when an examboard is selected
+  // TD: after the integrated journey launches we should make this the default in the query
+  const excludeCoreUnits = isExamboardSlug(
+    subjectPhaseKeystageSlugs.ks4OptionSlug,
+  );
+
+  const [programmeUnitsData, curriculumUnitsData, originalSubjects] =
+    await Promise.all([
       curriculumApi2023.curriculumOverview({
         subjectSlug: subjectPhaseKeystageSlugs.subjectSlug,
         phaseSlug: subjectPhaseKeystageSlugs.phaseSlug,
@@ -41,13 +57,19 @@ export async function getProgrammeData(
         ...subjectPhaseKeystageSlugs,
         includeNonCurriculum: true,
         excludeUnitsWithNoPublishedLessons: true,
+        excludeCoreUnits,
       }),
       curriculumApi2023.curriculumPhaseOptions({ includeNonCurriculum: true }),
-    ],
-  );
+    ]);
+
+  let subjects = filterValidCurriculumPhaseOptions(originalSubjects);
+
+  if (excludeCoreUnits) {
+    subjects = excludeCoreFromSubjects(subjects);
+  }
 
   const curriculumPhaseOptions = {
-    subjects: filterValidCurriculumPhaseOptions(subjects),
+    subjects,
     tab: "units" as const,
   };
 

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.query.test.tsx
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.query.test.tsx
@@ -2,6 +2,8 @@ import sdk from "../../sdk";
 
 import curriculumSequenceQuery from "./curriculumSequence.query";
 
+import { createUnit } from "@/fixtures/curriculum/unit";
+
 describe("curriculum sequence query", () => {
   test("throws params incorrect error if slugs are blank", async () => {
     await expect(async () => {
@@ -27,5 +29,117 @@ describe("curriculum sequence query", () => {
         ks4OptionSlug: "aqa",
       });
     }).rejects.toThrow(`Resource not found`);
+  });
+
+  test("includes core pathway by default for non-examboard ks4 options", async () => {
+    const curriculumSequenceMock = jest.fn(() =>
+      Promise.resolve({
+        units: [
+          createUnit({
+            slug: "unit-1",
+            pathway_slug: "gcse",
+          }),
+        ],
+      }),
+    );
+
+    await curriculumSequenceQuery({
+      ...sdk,
+      curriculumSequence: curriculumSequenceMock,
+    })({
+      subjectSlug: "english",
+      phaseSlug: "secondary",
+      ks4OptionSlug: "gcse",
+    });
+
+    expect(curriculumSequenceMock).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        _and: expect.arrayContaining([
+          {
+            _or: expect.arrayContaining([
+              { pathway_slug: { _eq: "gcse" } },
+              { pathway_slug: { _eq: "core" } },
+              { pathway_slug: { _is_null: true } },
+            ]),
+          },
+        ]),
+      }),
+    });
+  });
+
+  test("excludes core pathway when excludeCoreUnits is true", async () => {
+    const curriculumSequenceMock = jest.fn(() =>
+      Promise.resolve({
+        units: [
+          createUnit({
+            slug: "unit-1",
+            pathway_slug: "gcse",
+          }),
+        ],
+      }),
+    );
+
+    await curriculumSequenceQuery({
+      ...sdk,
+      curriculumSequence: curriculumSequenceMock,
+    })({
+      subjectSlug: "english",
+      phaseSlug: "secondary",
+      ks4OptionSlug: "gcse",
+      excludeCoreUnits: true,
+    });
+
+    expect(curriculumSequenceMock).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        _and: expect.arrayContaining([
+          {
+            _or: [
+              { pathway_slug: { _eq: "gcse" } },
+              { pathway_slug: { _is_null: true } },
+            ],
+          },
+        ]),
+      }),
+    });
+  });
+
+  test("excludes core pathway for examboard queries when excludeCoreUnits is true", async () => {
+    const curriculumSequenceMock = jest.fn(() =>
+      Promise.resolve({
+        units: [
+          createUnit({
+            slug: "unit-1",
+            examboard_slug: "aqa",
+          }),
+        ],
+      }),
+    );
+
+    await curriculumSequenceQuery({
+      ...sdk,
+      curriculumSequence: curriculumSequenceMock,
+    })({
+      subjectSlug: "english",
+      phaseSlug: "secondary",
+      ks4OptionSlug: "aqa",
+      excludeCoreUnits: true,
+    });
+
+    expect(curriculumSequenceMock).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        _and: expect.arrayContaining([
+          {
+            _and: expect.arrayContaining([
+              {
+                _or: [
+                  { pathway_slug: { _neq: "core" } },
+                  { pathway_slug: { _is_null: true } },
+                ],
+              },
+            ]),
+          },
+        ]),
+      }),
+    });
   });
 });

--- a/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/curriculumSequence/curriculumSequence.query.ts
@@ -17,12 +17,17 @@ const curriculumSequenceQuery =
      * If true, will exclude units that have no published lessons
      */
     excludeUnitsWithNoPublishedLessons?: boolean;
+    /**
+     * If true, units with pathway_slug "core" are excluded.
+     */
+    excludeCoreUnits?: boolean;
   }) => {
     const {
       subjectSlug,
       phaseSlug,
       ks4OptionSlug,
       excludeUnitsWithNoPublishedLessons,
+      excludeCoreUnits = false,
     } = args;
     if (!subjectSlug || !phaseSlug) {
       throw new OakError({ code: "curriculum-api/params-incorrect" });
@@ -45,27 +50,49 @@ const curriculumSequenceQuery =
 
     const examboardSlug = isExamboard ? ks4OptionSlug : null;
     const pathwaySlug = !isExamboard ? ks4OptionSlug : null;
+    const excludeCorePathwayCondition = {
+      _or: [
+        { pathway_slug: { _neq: "core" } },
+        { pathway_slug: { _is_null: true } },
+      ],
+    };
+    const includeCorePathwayCondition = { pathway_slug: { _eq: "core" } };
 
-    const examboardCondition = examboardSlug
-      ? {
-          _or: [
-            { examboard_slug: { _eq: examboardSlug } },
-            {
-              _and: [{ examboard_slug: { _is_null: true } }],
-            },
-          ],
-        }
-      : { examboard_slug: { _is_null: true } };
+    let examboardCondition: Published_Mv_Curriculum_Sequence_B_13_0_21_Bool_Exp =
+      {
+        examboard_slug: { _is_null: true },
+      };
+    if (examboardSlug) {
+      const examboardConditions: Published_Mv_Curriculum_Sequence_B_13_0_21_Bool_Exp[] =
+        [
+          {
+            _or: [
+              { examboard_slug: { _eq: examboardSlug } },
+              { _and: [{ examboard_slug: { _is_null: true } }] },
+            ],
+          },
+        ];
+      if (excludeCoreUnits) {
+        examboardConditions.push(excludeCorePathwayCondition);
+      }
+      examboardCondition = { _and: examboardConditions };
+    }
 
-    const pathwayCondition = pathwaySlug
-      ? {
-          _or: [
-            { pathway_slug: { _eq: pathwaySlug } },
-            { pathway_slug: { _eq: "core" } },
-            { pathway_slug: { _is_null: true } },
-          ],
-        }
-      : { pathway_slug: { _is_null: true } };
+    let pathwayCondition: Published_Mv_Curriculum_Sequence_B_13_0_21_Bool_Exp =
+      {
+        pathway_slug: { _is_null: true },
+      };
+    if (pathwaySlug) {
+      const pathwayConditions: Published_Mv_Curriculum_Sequence_B_13_0_21_Bool_Exp[] =
+        [
+          { pathway_slug: { _eq: pathwaySlug } },
+          { pathway_slug: { _is_null: true } },
+        ];
+      if (!excludeCoreUnits) {
+        pathwayConditions.push(includeCorePathwayCondition);
+      }
+      pathwayCondition = { _or: pathwayConditions };
+    }
 
     const where: Published_Mv_Curriculum_Sequence_B_13_0_21_Bool_Exp = {
       ...baseWhere,


### PR DESCRIPTION
## Description

Music year: 1967

the default for the query is to display core units when no pathway is specified. We're using the presence of an examboard slug to imply a GCSE pathway. So we now exclude core units in this case.

To maintain backward compatibility with the Curriculum visualiser which displays both GCSE and Core together we're adding this as an optional parameter `excludeCoreUnits` to the query 

## How to test

**Integrated journey**
1. Go to https://oak-web-application-website-git-feat-lesq-1957exclude-co-fdf2af.vercel.thenational.academy/programmes/computing-secondary-aqa/units?years=10
2. You should not see core in the year filters

**Curriculum visualiser**
1. Go to https://oak-web-application-website-git-feat-lesq-1957exclude-co-fdf2af.vercel.thenational.academy/teachers/curriculum/computing-secondary-aqa/units
2. You should still see both GCSE and Core in the year filters 

## Screenshots

<img width="1578" height="1566" alt="Screenshot 2026-04-27 at 11 39 42" src="https://github.com/user-attachments/assets/805d67bc-be89-4751-9714-d9aa03d5c637" />

<img width="1277" height="1471" alt="Screenshot 2026-04-27 at 11 42 52" src="https://github.com/user-attachments/assets/08079589-ab44-4534-adad-4d250a105c0d" />



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
