### PR TITLE
fix(LESQ-1985): breadcrumbs overflowing container

### DIFF
--- a/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.tsx
@@ -5,6 +5,7 @@ import {
   OakIcon,
   OakSecondaryLink,
   OakFocusIndicator,
+  parseSpacing,
 } from "@oaknational/oak-components";
 
 import { BreadcrumbJsonLd } from "@/browser-lib/seo/getJsonLd";
@@ -33,7 +34,7 @@ const BreadcrumbsLi = styled.li`
 `;
 
 const BreadcrumbConstrainer = styled.div`
-  margin-right: 12px;
+  margin-right: ${parseSpacing("spacing-12")};
   ${ellipsis}
 `;
 
@@ -50,6 +51,8 @@ export type BreadcrumbsProps = {
 // To fix ellipsis showing in firefox unecessarily
 const StyledLink = styled(OakSecondaryLink)`
   display: block;
+  margin-right: ${parseSpacing("spacing-12")};
+  ${ellipsis}
 `;
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({ breadcrumbs }) => {
@@ -77,13 +80,11 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ breadcrumbs }) => {
                   $minWidth={0}
                   $maxWidth="100%"
                 >
-                  <BreadcrumbConstrainer>
-                    {disabled ? (
-                      <>{label}</>
-                    ) : (
-                      <StyledLink href={href}>{label}</StyledLink>
-                    )}
-                  </BreadcrumbConstrainer>
+                  {disabled ? (
+                    <BreadcrumbConstrainer>{label}</BreadcrumbConstrainer>
+                  ) : (
+                    <StyledLink href={href}>{label}</StyledLink>
+                  )}
                 </OakFocusIndicator>
               </BreadcrumbsLi>
             );

--- a/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/SharedComponents/Breadcrumbs/Breadcrumbs.tsx
@@ -72,7 +72,11 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ breadcrumbs }) => {
                     $height={"spacing-20"}
                   />
                 )}
-                <OakFocusIndicator $borderRadius={"border-radius-s"}>
+                <OakFocusIndicator
+                  $borderRadius={"border-radius-s"}
+                  $minWidth={0}
+                  $maxWidth="100%"
+                >
                   <BreadcrumbConstrainer>
                     {disabled ? (
                       <>{label}</>


### PR DESCRIPTION
## Description

Music year: 1969


`OakFocusIndicator ` wasn't constraining the contents so it would overflow 

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-1985breadcrumb-8eea46.vercel.thenational.academy/teachers/programmes/maths-secondary-ks4-higher/units/algebraic-manipulation/lessons/checking-and-securing-understanding-of-factorising on mobile
2. You should see truncated breadcrumbs

## Screenshots

**before**
<img width="400" alt="localhost_3000_teachers_programmes_maths-secondary-ks4-higher_units_algebraic-manipulation_lessons_checking-and-securing-understanding-of-factorising(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/8f0ccbc9-f732-4604-982a-8a90e7f3d11d" />

**after**
<img width="400" alt="localhost_3000_teachers_programmes_maths-secondary-ks4-higher_units_algebraic-manipulation_lessons_checking-and-securing-understanding-of-factorising(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/f63e94ac-f36a-428d-b30f-8181d2a8c795" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
