### PR TITLE
Remove Rule of law curriculum links LESQ-2012

### DIFF
--- a/src/components/TeacherComponents/LessonList/LessonList.test.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonList.test.tsx
@@ -169,4 +169,32 @@ describe("components/ Lesson List", () => {
       "/teachers/curriculum/science-secondary-ocr/units",
     );
   });
+  test('it does not render a "curriculum-units" link for rule of law', async () => {
+    render(
+      <LessonList
+        paginationProps={mockPaginationProps}
+        subjectSlug={"rule-of-law"}
+        keyStageSlug={"ks2"}
+        headingTag={"h2"}
+        currentPageItems={lessonsWithUnitData}
+        unitTitle={"Unit title"}
+        lessonCount={4}
+        onClick={onClick}
+        lessonCountHeader={`Lessons (${lessons.length})`}
+        programmeSlug="rule-of-law-primary-ks2"
+        yearTitle="All years"
+        subjectTitle="Rule of law"
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByText(
+        /Explore this all years rule of law unit to find free lesson teaching resources, including/i,
+      ),
+    );
+
+    const curriculumText = screen.getByText(/rule of law curriculum/i);
+    expect(curriculumText).toBeInTheDocument();
+    expect(curriculumText.closest("a")).toBeNull();
+  });
 });

--- a/src/components/TeacherComponents/LessonList/LessonListSeoHelper.tsx
+++ b/src/components/TeacherComponents/LessonList/LessonListSeoHelper.tsx
@@ -37,7 +37,8 @@ export const LessonListSeoHelper = ({
     ? convertSubjectToSlug(parentSubject)
     : subjectSlug;
 
-  const hideCurriculumLink = subjectSlug === "financial-education";
+  const hideCurriculumLink =
+    subjectSlug === "financial-education" || subjectSlug === "rule-of-law";
 
   return (
     <OakBox $mb="spacing-72">

--- a/src/components/TeacherComponents/UnitList/UnitList.test.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.test.tsx
@@ -228,6 +228,27 @@ describe("components/UnitList", () => {
 
     expect(curriculumDownloadLink).not.toBeInTheDocument;
   });
+  test("does not render a curriculum download button for rule of law", () => {
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <UnitList
+          {...unitListingFixture({
+            phase: "primary",
+            subjectSlug: "rule-of-law",
+          })}
+          paginationProps={mockPaginationProps}
+          currentPageItems={unitListingFixture().units}
+          onClick={onClick}
+        />
+      </OakThemeProvider>,
+    );
+
+    const curriculumDownloadLink = screen.queryByRole("link", {
+      name: "Full primary curriculum",
+    });
+
+    expect(curriculumDownloadLink).not.toBeInTheDocument();
+  });
 
   test("renders Swimming units", () => {
     render(

--- a/src/components/TeacherComponents/UnitList/UnitList.tsx
+++ b/src/components/TeacherComponents/UnitList/UnitList.tsx
@@ -168,7 +168,10 @@ const UnitList: FC<UnitListProps> = (props) => {
   );
   const hasNewAndLegacyUnitsInProgramme = hasLegacyUnits && hasNewUnits;
 
-  const hideNewCurriculumDownloadButton = subjectSlug === "financial-education";
+  const hideNewCurriculumDownloadButton = [
+    "financial-education",
+    "rule-of-law",
+  ].includes(subjectSlug);
 
   const [saveButtonElementId, setSaveButtonElementId] = useState<
     string | undefined

--- a/src/components/TeacherComponents/helpers/seoTextHelpers/seoText.helpers.test.ts
+++ b/src/components/TeacherComponents/helpers/seoTextHelpers/seoText.helpers.test.ts
@@ -13,6 +13,12 @@ describe("seoText helpers", () => {
 
       expect(phase).toEqual("secondary");
     });
+
+    it("should return an empty string for an invalid year", () => {
+      const phase = getPhase("All years");
+
+      expect(phase).toEqual("");
+    });
   });
 
   describe("formatSubjectName", () => {

--- a/src/components/TeacherComponents/helpers/seoTextHelpers/seoText.helpers.ts
+++ b/src/components/TeacherComponents/helpers/seoTextHelpers/seoText.helpers.ts
@@ -2,7 +2,11 @@ export const getPhase = (year: string) => {
   const match = /\d+/.exec(year);
   const yearNumber = match ? Number(match[0]) : null;
 
-  return yearNumber && yearNumber < 7 ? "primary" : "secondary";
+  if (!yearNumber) {
+    return "";
+  }
+
+  return yearNumber < 7 ? "primary" : "secondary";
 };
 
 export const formatSubjectName = (subject: string) => {


### PR DESCRIPTION
## Description

Music year: 2019

- Removes curriculum links from rule-of-law lesson list and SEO accordion
- Stops defaulting "All years" to "secondary" phase in SEO text helper

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2012rule-of-law-c44c5d.vercel.thenational.academy/teachers/programmes/rule-of-law-primary-ks1/units
2. You should not see a link to "Full primary curriculum" in the lesson list header
3. Click a unit
4. Expand the SEO accordion
5. there should no longer be a link to the rule of law curriculum (matches financial educations)

## Screenshots

How it used to look (delete if n/a):

<img width="1114" height="616" alt="Screenshot 2026-05-06 at 10 30 02" src="https://github.com/user-attachments/assets/7bcd0344-3f38-474a-b9b0-d6551a4618f2" />
<img width="1117" height="236" alt="Screenshot 2026-05-06 at 10 29 51" src="https://github.com/user-attachments/assets/b0059385-81d5-413b-a2fe-8c5b4044f099" />

How it should now look:
<img width="1126" height="615" alt="Screenshot 2026-05-06 at 10 29 43" src="https://github.com/user-attachments/assets/7b4ca7c1-06c6-4003-8ca5-14e526b0b08f" />
<img width="1083" height="254" alt="Screenshot 2026-05-06 at 10 29 34" src="https://github.com/user-attachments/assets/b4d50c34-52c5-41bb-81c3-711b2959326e" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
