### PR TITLE
fix(LESQ-2015): media page blowing up on empty transcript

### DIFF
--- a/src/utils/handleTranscript.test.ts
+++ b/src/utils/handleTranscript.test.ts
@@ -25,6 +25,11 @@ describe("removeWebVttCharacters ", () => {
     expect(result[0]).toBe("Heathcliff");
     expect(result[1]).toBe("It's me.");
   });
+
+  it("returns an empty array when no first sentence is provided", () => {
+    const result = removeWebVttCharacters([]);
+    expect(result).toEqual([]);
+  });
 });
 
 describe("formatSentences", () => {

--- a/src/utils/handleTranscript.ts
+++ b/src/utils/handleTranscript.ts
@@ -67,10 +67,13 @@ export const formatSentences = (
 export const removeWebVttCharacters = (
   sentences: Array<string>,
 ): Array<string> => {
+  if (!sentences[0]) {
+    return [];
+  }
   // The opening sentence of the vtt file is wrapped in <v ->> </v>
   // Some <v> tags have data enclosed,i.e. <v Instructor> this allows removal of the v tag in full
   // I'm not sure why but we want to remove it
-  let sentence1 = sentences[0]!;
+  let sentence1 = sentences[0];
   const startTagEnd = sentence1.indexOf(">") + 1;
   if (startTagEnd > 0) {
     sentence1 = sentence1.substring(startTagEnd);


### PR DESCRIPTION
## Description

Music year: 1977


Fixes #

An empty transcript file was causing the page to blow because the logic expected at least one character to be present.

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2015empty-trans-3629a3.vercel.thenational.academy/teachers/programmes/music-primary-ks2/units/playing-together-polyrhythms-as-part-of-an-ensemble/lessons/introducing-beatboxing-vocal-percussion/media?video=270429
2. The page should render
3. You shouldn't see the transcript toggle


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
