### PR TITLE
Feat/lesq 1977/curric downloads success [LESQ-1977]

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -24,6 +24,8 @@ import {
 } from "react";
 import { Controller, ControllerRenderProps } from "react-hook-form";
 
+import { DownloadSuccessHeader } from "../../../units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader";
+
 import {
   handleSubjectTierSelectionAnalytics,
   trackCurriculumDownload,
@@ -35,7 +37,6 @@ import {
 } from "@/pages-helpers/curriculum/docx/tab-helpers";
 import { CurriculumOverviewMVData } from "@/node-lib/curriculum-api-2023";
 import errorReporter from "@/common-lib/error-reporter";
-import CurricSuccessMessage from "@/components/CurriculumComponents/CurricSuccessMessage";
 import { DOWNLOAD_TYPE_LABELS } from "@/components/CurriculumComponents/CurriculumDownloadView/helper";
 import { downloadFileFromUrl } from "@/components/SharedComponents/helpers/downloadFileFromUrl";
 import { DownloadPageWithAccordionContent } from "@/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion";
@@ -236,19 +237,11 @@ export const ProgrammeDownloads = ({
 
   if (isDone) {
     return (
-      // TODO: use DownloadSuccessHeader
-      <OakBox $pv={["spacing-48"]}>
-        <CurricSuccessMessage
-          title="Thanks for downloading"
-          message="We hope you find the resources useful. Click the question mark in the bottom-right corner to share your feedback."
-          buttonProps={{
-            label: "Back to downloads",
-            onClick: () => {
-              setIsDone(false);
-            },
-          }}
-        />
-      </OakBox>
+      <DownloadSuccessHeader
+        onBackClick={() => setIsDone(false)}
+        backgroundColorLevel={undefined}
+        returnTo="downloads"
+      />
     );
   }
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader.test.tsx
@@ -6,10 +6,17 @@ import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
 const render = renderWithTheme;
 
+jest.mock("@oaknational/oak-consent-client", () => ({
+  __esModule: true,
+  useOakConsent: () => ({
+    getConsent: jest.fn().mockReturnValue("granted"),
+  }),
+}));
+
 describe("DownloadSuccessHeader", () => {
   it("passes href to the back link", () => {
     const testHref = "/programmes/english/key-stage-3";
-    render(<DownloadSuccessHeader href={testHref} />);
+    render(<DownloadSuccessHeader href={testHref} returnTo="lesson" />);
 
     const backLink = screen.getByRole("link", { name: "Back to lesson" });
     expect(backLink).toBeInTheDocument();
@@ -17,7 +24,7 @@ describe("DownloadSuccessHeader", () => {
   });
 
   it("renders the success message", () => {
-    render(<DownloadSuccessHeader href="/programmes" />);
+    render(<DownloadSuccessHeader href="/programmes" returnTo="lesson" />);
 
     expect(
       screen.getByRole("heading", { name: "Thanks for downloading!" }),
@@ -25,7 +32,7 @@ describe("DownloadSuccessHeader", () => {
   });
 
   it("renders the feedback prompt", () => {
-    render(<DownloadSuccessHeader href="/programmes" />);
+    render(<DownloadSuccessHeader href="/programmes" returnTo="lesson" />);
 
     expect(
       screen.getByText(
@@ -35,7 +42,7 @@ describe("DownloadSuccessHeader", () => {
   });
 
   it("renders the font installation instructions", () => {
-    render(<DownloadSuccessHeader href="/programmes" />);
+    render(<DownloadSuccessHeader href="/programmes" returnTo="lesson" />);
 
     expect(
       screen.getByRole("link", {
@@ -45,7 +52,7 @@ describe("DownloadSuccessHeader", () => {
   });
 
   it("renders the font installation link with correct href", () => {
-    render(<DownloadSuccessHeader href="/programmes" />);
+    render(<DownloadSuccessHeader href="/programmes" returnTo="lesson" />);
 
     const fontLink = screen.getByRole("link", {
       name: /install the Google Fonts 'Lexend' and 'Kalam'/,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader.tsx
@@ -8,31 +8,38 @@ import {
   OakSpan,
   OakTertiaryInvertedButton,
 } from "@oaknational/oak-components";
+import { useOakConsent } from "@oaknational/oak-consent-client";
 
-import { Header } from "@/components/TeacherComponents/Header/Header";
+import {
+  Header,
+  HeaderProps,
+} from "@/components/TeacherComponents/Header/Header";
 import { getCloudinaryImageUrl } from "@/utils/getCloudinaryImageUrl";
 import { resolveOakHref } from "@/common-lib/urls";
+import { ServicePolicyMap } from "@/browser-lib/cookie-consent/ServicePolicyMap";
 
 const DOWNLOAD_SUCCESS_IMG_URL =
   "v1777386544/svg-illustrations/download-confirmation-Illustration_z1sczk.svg";
 
 type DownloadSuccessHeaderProps = {
-  href: string;
+  href?: string;
   onBackClick?: () => void;
-  /** We only show the help message if the user has consented to the Gleap cookie */
-  showHelpMessage?: boolean;
+  backgroundColorLevel?: HeaderProps["backgroundColorLevel"];
+  returnTo: "lesson" | "downloads";
 };
 
-export function DownloadSuccessHeader({
-  href,
-  onBackClick,
-  showHelpMessage = true,
-}: Readonly<DownloadSuccessHeaderProps>) {
+export function DownloadSuccessHeader(
+  props: Readonly<DownloadSuccessHeaderProps>,
+) {
+  /** We only show the help message if the user has consented to the Gleap cookie */
+  const { getConsent } = useOakConsent();
+  const cookiesNotAccepted = getConsent(ServicePolicyMap.GLEAP) === "denied";
+
   return (
     <Header
       layoutVariant="large"
       useSubduedBackground
-      headerSlot={<BackLink href={href} onBackClick={onBackClick} />}
+      headerSlot={<BackLinkButton {...props} />}
       heading="Thanks for downloading!"
       summary={
         <OakFlex $flexDirection="column" $gap={"spacing-24"}>
@@ -40,10 +47,10 @@ export function DownloadSuccessHeader({
             We hope you find the resources useful. Click the question mark in
             the bottom-right corner to share your feedback.{" "}
           </OakP>
-          <InstallFontsInstructions showHelpMessage={showHelpMessage} />
+          <InstallFontsInstructions showHelpMessage={!cookiesNotAccepted} />
         </OakFlex>
       }
-      backgroundColorLevel={1}
+      backgroundColorLevel={props.backgroundColorLevel}
       heroImage={getCloudinaryImageUrl(DOWNLOAD_SUCCESS_IMG_URL)}
     />
   );
@@ -79,21 +86,18 @@ function InstallFontsInstructions({
   );
 }
 
-function BackLink({
-  href,
-  onBackClick,
-}: Readonly<{ href: string; onBackClick?: () => void }>) {
+function BackLinkButton(props: Readonly<DownloadSuccessHeaderProps>) {
   return (
     <OakBox>
       <OakTertiaryInvertedButton
-        element={Link}
-        href={href}
+        element={props.href ? Link : "button"}
+        href={props.href ?? undefined}
         aria-label={"Back to lesson"}
         iconName={"arrow-left"}
         isTrailingIcon={false}
-        onClick={onBackClick}
+        onClick={props.onBackClick}
       >
-        Back to lesson
+        Back to {props.returnTo}
       </OakTertiaryInvertedButton>
     </OakBox>
   );

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
@@ -8,7 +8,6 @@ import {
   OakIcon,
   OakSpan,
 } from "@oaknational/oak-components";
-import { useOakConsent } from "@oaknational/oak-consent-client";
 
 import { LessonList } from "@/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/LessonList";
 import { DownloadSuccessHeader } from "@/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader";
@@ -18,7 +17,6 @@ import UnitDownloadButton, {
 import { resolveOakHref } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import type { LessonListSchema } from "@/node-lib/curriculum-api-2023/shared.schema";
-import { ServicePolicyMap } from "@/browser-lib/cookie-consent/ServicePolicyMap";
 import { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
 
 type DownloadSuccessViewLesson = {
@@ -78,9 +76,6 @@ export function DownloadSuccessView({
     (l) => "geoRestricted" in l && l.geoRestricted,
   );
 
-  const { getConsent } = useOakConsent();
-  const cookiesNotAccepted = getConsent(ServicePolicyMap.GLEAP) === "denied";
-
   return (
     <>
       <DownloadSuccessHeader
@@ -90,7 +85,6 @@ export function DownloadSuccessView({
           programmeSlug,
           unitSlug,
         })}
-        showHelpMessage={!cookiesNotAccepted}
         onBackClick={() =>
           onwardContentSelected({
             lessonName: lessonTitle,
@@ -102,6 +96,8 @@ export function DownloadSuccessView({
             lessonReleaseDate: lessonReleaseDate,
           })
         }
+        backgroundColorLevel={1}
+        returnTo="lesson"
       />
       <OakBox $ph={["spacing-20", "spacing-40"]}>
         <OakGrid

--- a/src/components/TeacherComponents/Header/Header.tsx
+++ b/src/components/TeacherComponents/Header/Header.tsx
@@ -16,7 +16,7 @@ import {
   OakTagFunctional,
 } from "@oaknational/oak-components";
 
-type HeaderProps = {
+export type HeaderProps = {
   /**
    * Top level heading
    */


### PR DESCRIPTION
## Description

Music year: 1990

- Update `DownloadSuccessHeader` to be suitable for lesson or curriculum downloads
- Add success header when curriculum download succeeds
- Back link refreshes the download page to view download options again

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1977curric-dow-e3dc1b.vercel.thenational.academy/programmes/science-secondary-aqa/download
2. Click on the Download button
3. You should see the success header appear after the download succeeds

## Screenshots
<img width="1400" height="676" alt="Screenshot 2026-05-07 at 11 28 14" src="https://github.com/user-attachments/assets/11a8b28c-b449-43b4-9fc2-cc936bcb701b" />


