### PR TITLE
Add complex copyright banner to unit page LESQ-1952

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/UnitView.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { OakBox } from "@oaknational/oak-components";
+
 import UnitHeader from "./UnitHeader/UnitHeader";
 import { Breadcrumbs } from "./Breadcrumbs/Breadcrumbs";
 import { UnitOverviewContent } from "./UnitOverviewContent/UnitOverviewContent";
@@ -9,6 +11,7 @@ import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
 import { SubjectIcon } from "@/components/TeacherComponents/Header/Header";
 import { useUnitDownloadButtonState } from "@/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton";
 import { getUnitDownloadFileId } from "@/utils/getUnitDownloadFileId";
+import ComplexCopyrightRestrictionBanner from "@/components/TeacherComponents/ComplexCopyrightRestrictionBanner/ComplexCopyrightRestrictionBanner";
 
 export type UnitPageProps = TeachersUnitOverviewData;
 
@@ -57,6 +60,18 @@ export const UnitView = (props: UnitPageProps) => {
         }
         downloadButtonState={downloadButtonState}
       />
+      <OakBox $ph="spacing-40">
+        <OakBox $mh="auto" $width={"100%"} $maxWidth={"spacing-1280"}>
+          <ComplexCopyrightRestrictionBanner
+            isGeorestricted={props.containsGeorestrictedLessons}
+            isLoginRequired={props.containsLoginRequiredLessons}
+            componentType="lesson_listing"
+            unitName={props.unitTitle}
+            unitSlug={props.unitSlug}
+            $mv="spacing-80"
+          />
+        </OakBox>
+      </OakBox>
       <UnitOverviewContent
         programmeSlug={props.programmeSlug}
         unitSlug={props.unitSlug}

--- a/src/components/TeacherComponents/ComplexCopyrightRestrictionBanner/ComplexCopyrightRestrictionBanner.tsx
+++ b/src/components/TeacherComponents/ComplexCopyrightRestrictionBanner/ComplexCopyrightRestrictionBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { ComponentProps, useEffect } from "react";
 import { SignUpButton } from "@clerk/nextjs";
 import {
   OakLink,
@@ -21,23 +21,30 @@ import {
 } from "@/utils/copyrightLinks";
 import { useComplexCopyright } from "@/hooks/useComplexCopyright";
 
-export type ComplexCopyrightRestrictionBannerProps = {
-  isGeorestricted?: boolean;
-  isLoginRequired?: boolean;
-  componentType?: ComponentTypeValueType;
-  unitName?: string | null;
-  unitSlug?: string | null;
-  lessonName?: string | null;
-  lessonSlug?: string | null;
-  lessonReleaseDate?: string | null;
-  isLessonLegacy?: boolean;
-};
+type InnerCopyrightBannerProps = Omit<
+  ComponentProps<typeof OakInlineBanner>,
+  "message" | "isOpen"
+>;
+
+export type ComplexCopyrightRestrictionBannerProps =
+  InnerCopyrightBannerProps & {
+    isGeorestricted?: boolean;
+    isLoginRequired?: boolean;
+    componentType?: ComponentTypeValueType;
+    unitName?: string | null;
+    unitSlug?: string | null;
+    lessonName?: string | null;
+    lessonSlug?: string | null;
+    lessonReleaseDate?: string | null;
+    isLessonLegacy?: boolean;
+  };
 
 const SignedOutCopyrightBanner = ({
   showOnboardingLink,
   isGeorestricted,
   isUnit,
-}: {
+  ...rest
+}: InnerCopyrightBannerProps & {
   showOnboardingLink: boolean;
   isGeorestricted: boolean;
   isUnit: boolean;
@@ -93,11 +100,17 @@ const SignedOutCopyrightBanner = ({
           )}
         </OakP>
       }
+      {...rest}
     />
   );
 };
 
-const SignedInGeorestrictedBanner = ({ isUnit }: { isUnit: boolean }) => (
+const SignedInGeorestrictedBanner = ({
+  isUnit,
+  ...rest
+}: InnerCopyrightBannerProps & {
+  isUnit: boolean;
+}) => (
   <OakInlineBanner
     type="info"
     $maxWidth={"spacing-960"}
@@ -119,6 +132,7 @@ const SignedInGeorestrictedBanner = ({ isUnit }: { isUnit: boolean }) => (
         <OakLink href={COPYRIGHT_CONTACT_US_LINK}>contact us.</OakLink>
       </OakP>
     }
+    {...rest}
   />
 );
 
@@ -135,6 +149,7 @@ const ComplexCopyrightRestrictionBanner = (
     lessonSlug,
     lessonReleaseDate,
     isLessonLegacy,
+    ...rest
   } = props;
 
   const {
@@ -192,12 +207,13 @@ const ComplexCopyrightRestrictionBanner = (
     showSignedInNotOnboarded;
 
   return showGeoBlocked ? (
-    <SignedInGeorestrictedBanner isUnit={isUnit} />
+    <SignedInGeorestrictedBanner isUnit={isUnit} {...rest} />
   ) : showSignedOutCopyrightBanner ? (
     <SignedOutCopyrightBanner
       showOnboardingLink={showSignedInNotOnboarded}
       isGeorestricted={isGeorestricted ?? false}
       isUnit={isUnit}
+      {...rest}
     />
   ) : null;
 };


### PR DESCRIPTION
## Description

Music year: 1987

Adds the complex copyright banner to the unit page.

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-1952copyright-606020.vercel.thenational.academy/programmes/music-secondary-ks4-aqa/units/intro-to-pop-music/lessons
2. While signed out you should see a neutral banner requiring you sign in
3. Sign in
4. The banner should be gone
5. Go to France, sign up
6. Open the page and you should see an info banner telling you the unit is geo restriced.

## Screenshots

<img width="906" height="1356" alt="Screenshot 2026-05-07 at 14 25 25" src="https://github.com/user-attachments/assets/38c44857-dfc1-4407-8422-fa442e218357" />

<img width="1326" height="1612" alt="Screenshot 2026-05-07 at 14 26 52" src="https://github.com/user-attachments/assets/6735a748-de02-449f-8406-dd598d0c9438" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
