### PR TITLE
Updated child subject selector LESQ 1974

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.stories.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+import { fn } from "storybook/test";
+
+import { ChildSubjectTierSelector } from "./ChildSubjectTierSelector";
+
+const tiers = [
+  { tier: "Foundation", tierSlug: "foundation" },
+  { tier: "Higher", tierSlug: "higher" },
+];
+
+const childSubjects = [
+  { subject: "Combined Science", subjectSlug: "combined-science" },
+  { subject: "Physics", subjectSlug: "physics" },
+  { subject: "Chemistry", subjectSlug: "chemistry" },
+  { subject: "Biology", subjectSlug: "biology" },
+];
+
+const meta: Meta<typeof ChildSubjectTierSelector> = {
+  tags: ["autodocs"],
+  title: "App/Programmes/ProgrammeDownloads/ChildSubjectTierSelector",
+  component: ChildSubjectTierSelector,
+  argTypes: {
+    tiers: {
+      control: { type: "object" },
+      description: "Foundation and higher as tier options",
+    },
+    childSubjects: {
+      options: ["none", "childSubjects"],
+      mapping: { none: undefined, childSubjects },
+      control: { type: "select" },
+      description: "None or Science",
+    },
+    getTierSubjectValues: {
+      control: { type: "object" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChildSubjectTierSelector>;
+
+export const Default: Story = {
+  render: (args) => <ChildSubjectTierSelector {...args} />,
+  args: {
+    tiers,
+    childSubjects,
+    getTierSubjectValues: fn(),
+  },
+};

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import "@testing-library/jest-dom";
+
+import { ChildSubjectTierSelector } from "./ChildSubjectTierSelector";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+const tiers = [
+  { tier: "Foundation", tierSlug: "foundation" },
+  { tier: "Higher", tierSlug: "higher" },
+];
+
+const childSubjects = [
+  { subject: "Biology", subjectSlug: "biology" },
+  { subject: "Physics", subjectSlug: "physics" },
+  { subject: "Chemistry", subjectSlug: "chemistry" },
+];
+
+const getTierSubjectValues = jest.fn(() => {});
+describe("ChildSubjectTierSelector", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe("KS4 Science", () => {
+    it("renders KS4 Science: both tiers and child subjects are present", () => {
+      const { getByTestId } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+          data-testid="test"
+        />,
+      );
+      expect(getByTestId("tier-selector")).toBeInTheDocument();
+      expect(getByTestId("child-subject-selector")).toBeInTheDocument();
+    });
+
+    it("renders KS4 Science: biology is pre-selected", () => {
+      const { getAllByRole } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+          data-testid="test"
+        />,
+      );
+
+      const biologyRadioButton = getAllByRole("radio")[0];
+      expect(biologyRadioButton).toBeChecked();
+      expect(biologyRadioButton).toHaveAttribute("id", "biology");
+    });
+  });
+
+  describe("KS4 Maths", () => {
+    it("renders KS4 Maths: only tiers are present", () => {
+      const { getByTestId } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          getTierSubjectValues={getTierSubjectValues}
+          data-testid="test"
+        />,
+      );
+      expect(getByTestId("tier-selector")).toBeInTheDocument();
+    });
+
+    it("renders KS4 Maths: foundation is pre-selected", () => {
+      const { getAllByRole } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          getTierSubjectValues={getTierSubjectValues}
+          data-testid="test"
+        />,
+      );
+
+      const foundationRadioBtn = getAllByRole("radio")[0];
+      expect(foundationRadioBtn).toBeChecked();
+      expect(foundationRadioBtn).toHaveAttribute("id", "foundation");
+    });
+    it("renders KS4 Maths: correct number of radios", () => {
+      const { getAllByTestId } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          getTierSubjectValues={getTierSubjectValues}
+          data-testid="test"
+        />,
+      );
+      const tierRadioButtons = getAllByTestId("tier-radio-button");
+      expect(tierRadioButtons).toHaveLength(2);
+      expect(tierRadioButtons[0]).toHaveTextContent("Foundation");
+      expect(tierRadioButtons[1]).toHaveTextContent("Higher");
+    });
+  });
+});

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
@@ -37,7 +37,7 @@ describe("ChildSubjectTierSelector", () => {
     });
 
     it("renders KS4 Science: biology is pre-selected", () => {
-      const { getAllByRole } = renderWithTheme(
+      const { getByRole } = renderWithTheme(
         <ChildSubjectTierSelector
           tiers={tiers}
           childSubjects={childSubjects}
@@ -46,9 +46,8 @@ describe("ChildSubjectTierSelector", () => {
         />,
       );
 
-      const biologyRadioButton = getAllByRole("radio")[0];
+      const biologyRadioButton = getByRole("radio", { name: "Biology" });
       expect(biologyRadioButton).toBeChecked();
-      expect(biologyRadioButton).toHaveAttribute("id", "biology");
     });
 
     it("passes default values when Next is clicked", () => {
@@ -60,7 +59,7 @@ describe("ChildSubjectTierSelector", () => {
         />,
       );
 
-      fireEvent.click(getByRole("button", { name: "Next" }));
+      fireEvent.click(getByRole("button", { name: "Next step" }));
       expect(getTierSubjectValues).toHaveBeenCalledWith(
         "foundation",
         "biology",
@@ -68,7 +67,7 @@ describe("ChildSubjectTierSelector", () => {
     });
 
     it("passes selected tier and subject when Next is clicked", () => {
-      const { getByLabelText, getByRole } = renderWithTheme(
+      const { getByRole } = renderWithTheme(
         <ChildSubjectTierSelector
           tiers={tiers}
           childSubjects={childSubjects}
@@ -76,9 +75,9 @@ describe("ChildSubjectTierSelector", () => {
         />,
       );
 
-      fireEvent.click(getByLabelText("Physics"));
-      fireEvent.click(getByLabelText("Higher"));
-      fireEvent.click(getByRole("button", { name: "Next" }));
+      fireEvent.click(getByRole("radio", { name: "Physics" }));
+      fireEvent.click(getByRole("radio", { name: "Higher" }));
+      fireEvent.click(getByRole("button", { name: "Next step" }));
 
       expect(getTierSubjectValues).toHaveBeenCalledWith("higher", "physics");
     });
@@ -97,7 +96,7 @@ describe("ChildSubjectTierSelector", () => {
     });
 
     it("renders KS4 Maths: foundation is pre-selected", () => {
-      const { getAllByRole } = renderWithTheme(
+      const { getByRole } = renderWithTheme(
         <ChildSubjectTierSelector
           tiers={tiers}
           getTierSubjectValues={getTierSubjectValues}
@@ -105,22 +104,21 @@ describe("ChildSubjectTierSelector", () => {
         />,
       );
 
-      const foundationRadioBtn = getAllByRole("radio")[0];
+      const foundationRadioBtn = getByRole("radio", { name: "Foundation" });
       expect(foundationRadioBtn).toBeChecked();
-      expect(foundationRadioBtn).toHaveAttribute("id", "foundation");
     });
     it("renders KS4 Maths: correct number of radios", () => {
-      const { getAllByTestId } = renderWithTheme(
+      const { getAllByRole } = renderWithTheme(
         <ChildSubjectTierSelector
           tiers={tiers}
           getTierSubjectValues={getTierSubjectValues}
           data-testid="test"
         />,
       );
-      const tierRadioButtons = getAllByTestId("tier-radio-button");
+      const tierRadioButtons = getAllByRole("radio");
       expect(tierRadioButtons).toHaveLength(2);
-      expect(tierRadioButtons[0]).toHaveTextContent("Foundation");
-      expect(tierRadioButtons[1]).toHaveTextContent("Higher");
+      expect(tierRadioButtons[0]).toHaveAccessibleName("Foundation");
+      expect(tierRadioButtons[1]).toHaveAccessibleName("Higher");
     });
 
     it("passes null child subject when no child subjects are provided", () => {
@@ -131,7 +129,7 @@ describe("ChildSubjectTierSelector", () => {
         />,
       );
 
-      fireEvent.click(getByRole("button", { name: "Next" }));
+      fireEvent.click(getByRole("button", { name: "Next step" }));
       expect(getTierSubjectValues).toHaveBeenCalledWith("foundation", null);
     });
   });
@@ -149,7 +147,7 @@ describe("ChildSubjectTierSelector", () => {
       expect(queryByTestId("tier-selector")).not.toBeInTheDocument();
     });
 
-    it("shows singular banner copy when one option group is available", () => {
+    it("shows updated banner copy when one option group is available", () => {
       const { getByText } = renderWithTheme(
         <ChildSubjectTierSelector
           childSubjects={childSubjects}
@@ -159,12 +157,12 @@ describe("ChildSubjectTierSelector", () => {
 
       expect(
         getByText(
-          "Before downloading, choose an option for KS4. The document will still display both KS3 and KS4.",
+          "Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4.",
         ),
       ).toBeInTheDocument();
     });
 
-    it("shows singular banner copy when no option groups are available", () => {
+    it("shows updated banner copy when no option groups are available", () => {
       const { getByText } = renderWithTheme(
         <ChildSubjectTierSelector
           getTierSubjectValues={getTierSubjectValues}
@@ -173,7 +171,7 @@ describe("ChildSubjectTierSelector", () => {
 
       expect(
         getByText(
-          "Before downloading, choose an option for KS4. The document will still display both KS3 and KS4.",
+          "Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4.",
         ),
       ).toBeInTheDocument();
     });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
@@ -146,34 +146,5 @@ describe("ChildSubjectTierSelector", () => {
       expect(getByTestId("child-subject-selector")).toBeInTheDocument();
       expect(queryByTestId("tier-selector")).not.toBeInTheDocument();
     });
-
-    it("shows updated banner copy when one option group is available", () => {
-      const { getByText } = renderWithTheme(
-        <ChildSubjectTierSelector
-          childSubjects={childSubjects}
-          getTierSubjectValues={getTierSubjectValues}
-        />,
-      );
-
-      expect(
-        getByText(
-          "Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("shows updated banner copy when no option groups are available", () => {
-      const { getByText } = renderWithTheme(
-        <ChildSubjectTierSelector
-          getTierSubjectValues={getTierSubjectValues}
-        />,
-      );
-
-      expect(
-        getByText(
-          "Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4.",
-        ),
-      ).toBeInTheDocument();
-    });
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
+import { fireEvent } from "@testing-library/react";
 
 import { ChildSubjectTierSelector } from "./ChildSubjectTierSelector";
 
@@ -49,6 +50,38 @@ describe("ChildSubjectTierSelector", () => {
       expect(biologyRadioButton).toBeChecked();
       expect(biologyRadioButton).toHaveAttribute("id", "biology");
     });
+
+    it("passes default values when Next is clicked", () => {
+      const { getByRole } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      fireEvent.click(getByRole("button", { name: "Next" }));
+      expect(getTierSubjectValues).toHaveBeenCalledWith(
+        "foundation",
+        "biology",
+      );
+    });
+
+    it("passes selected tier and subject when Next is clicked", () => {
+      const { getByLabelText, getByRole } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      fireEvent.click(getByLabelText("Physics"));
+      fireEvent.click(getByLabelText("Higher"));
+      fireEvent.click(getByRole("button", { name: "Next" }));
+
+      expect(getTierSubjectValues).toHaveBeenCalledWith("higher", "physics");
+    });
   });
 
   describe("KS4 Maths", () => {
@@ -88,6 +121,61 @@ describe("ChildSubjectTierSelector", () => {
       expect(tierRadioButtons).toHaveLength(2);
       expect(tierRadioButtons[0]).toHaveTextContent("Foundation");
       expect(tierRadioButtons[1]).toHaveTextContent("Higher");
+    });
+
+    it("passes null child subject when no child subjects are provided", () => {
+      const { getByRole } = renderWithTheme(
+        <ChildSubjectTierSelector
+          tiers={tiers}
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      fireEvent.click(getByRole("button", { name: "Next" }));
+      expect(getTierSubjectValues).toHaveBeenCalledWith("foundation", null);
+    });
+  });
+
+  describe("conditional rendering", () => {
+    it("renders only child subject selector when tiers are missing", () => {
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <ChildSubjectTierSelector
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      expect(getByTestId("child-subject-selector")).toBeInTheDocument();
+      expect(queryByTestId("tier-selector")).not.toBeInTheDocument();
+    });
+
+    it("shows singular banner copy when one option group is available", () => {
+      const { getByText } = renderWithTheme(
+        <ChildSubjectTierSelector
+          childSubjects={childSubjects}
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      expect(
+        getByText(
+          "Before downloading, choose an option for KS4. The document will still display both KS3 and KS4.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("shows singular banner copy when no option groups are available", () => {
+      const { getByText } = renderWithTheme(
+        <ChildSubjectTierSelector
+          getTierSubjectValues={getTierSubjectValues}
+        />,
+      );
+
+      expect(
+        getByText(
+          "Before downloading, choose an option for KS4. The document will still display both KS3 and KS4.",
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
@@ -66,7 +66,7 @@ export const ChildSubjectTierSelector = (
         icon="bell"
         type="alert"
         title="Choose your KS4 downlod options below."
-        message="Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4."
+        message="Before downloading, choose the KS4 options that will change the file you download. The document will still display both KS3 and KS4."
         $mb="spacing-32"
       />
       <OakFlex

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
@@ -1,11 +1,14 @@
 import {
+  OakBox,
   OakFlex,
   OakInlineBanner,
   OakPrimaryButton,
-  OakRadioButton,
+  OakRadioAsButton,
   OakRadioGroup,
 } from "@oaknational/oak-components";
 import React, { useState } from "react";
+
+import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 
 export interface Tier {
   tier: string;
@@ -57,63 +60,78 @@ export const ChildSubjectTierSelector = (
   }
 
   return (
-    <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
+    <OakFlex $flexDirection={"column"}>
       <OakInlineBanner
         isOpen={true}
-        message={`Before downloading, choose ${
-          childSubjectsAvailable && tiersAvailable ? "options" : "an option"
-        } for KS4. The document will still display both KS3 and KS4.`}
-        $maxWidth={"spacing-640"}
+        icon="bell"
+        type="alert"
+        title="Choose your KS4 downlod options below."
+        message="Your subject and tier selections will change the file you download. The document will still display both KS3 and KS4."
+        $mb="spacing-32"
       />
-      {childSubjectsAvailable && (
-        <OakRadioGroup
-          label="Choose subject for KS4 units"
-          name="childSubjectRadio"
-          onChange={handleChildSubjectSelection}
-          $flexDirection={"column"}
-          $gap={"spacing-16"}
-          defaultValue={childSubjectSelected || "combined-science"}
-          data-testid="child-subject-selector"
-        >
-          {childSubjects.map(({ subject, subjectSlug }) => (
-            <OakRadioButton
-              id={subjectSlug}
-              label={subject}
-              value={subjectSlug}
-              data-testid="child-subject-radio-button"
-              key={subjectSlug}
-            />
-          ))}
-        </OakRadioGroup>
-      )}
-      {tiersAvailable && (
-        <OakRadioGroup
-          data-testid="tier-selector"
-          label="Choose learning tier for KS4 units"
-          name="tierRadio"
-          onChange={handleTierSelection}
-          $flexDirection={"column"}
-          $gap={"spacing-16"}
-          defaultValue={tierSelected}
-        >
-          {tiers.map(({ tier, tierSlug }) => (
-            <OakRadioButton
-              id={tierSlug}
-              label={tier}
-              value={tierSlug}
-              data-testid="tier-radio-button"
-              key={tierSlug}
-            />
-          ))}
-        </OakRadioGroup>
-      )}
-      <OakPrimaryButton
-        iconName="arrow-right"
-        isTrailingIcon={true}
-        onClick={handleNextClick}
+      <OakFlex
+        $flexDirection={"column"}
+        $gap="spacing-32"
+        $maxWidth="spacing-240"
       >
-        Next
-      </OakPrimaryButton>
+        {childSubjectsAvailable && (
+          <OakRadioGroup
+            name="childSubjectRadio"
+            onChange={handleChildSubjectSelection}
+            $flexDirection="row"
+            $flexWrap="wrap"
+            $gap="spacing-12"
+            defaultValue={childSubjectSelected || "combined-science"}
+            data-testid="child-subject-selector"
+          >
+            <OakBox as="legend" $font="heading-7" $mb="spacing-24">
+              Choose subject for KS4 units
+            </OakBox>
+            {childSubjects.map(({ subject, subjectSlug }) => (
+              <OakRadioAsButton
+                variant="with-icon"
+                icon={getValidSubjectIconName(subjectSlug)}
+                displayValue={subject}
+                value={subjectSlug}
+                data-testid="child-subject-radio-button"
+                key={subjectSlug}
+              />
+            ))}
+          </OakRadioGroup>
+        )}
+        {tiersAvailable && (
+          <OakRadioGroup
+            data-testid="tier-selector"
+            name="tierRadio"
+            onChange={handleTierSelection}
+            $flexDirection="row"
+            $gap="spacing-12"
+            defaultValue={tierSelected}
+            $flexWrap="wrap"
+          >
+            <OakBox as="legend" $font="heading-7" $mb="spacing-24">
+              Choose learning tier for KS4 units
+            </OakBox>
+            {tiers.map(({ tier, tierSlug }) => (
+              <OakRadioAsButton
+                displayValue={tier}
+                value={tierSlug}
+                data-testid="tier-radio-button"
+                key={tierSlug}
+              />
+            ))}
+          </OakRadioGroup>
+        )}
+      </OakFlex>
+      <OakBox $mt="spacing-48">
+        <OakPrimaryButton
+          iconName="arrow-right"
+          isTrailingIcon={true}
+          onClick={handleNextClick}
+        >
+          Next step
+        </OakPrimaryButton>
+      </OakBox>
     </OakFlex>
   );
 };

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ChildSubjectTierSelector/ChildSubjectTierSelector.tsx
@@ -1,0 +1,119 @@
+import {
+  OakFlex,
+  OakInlineBanner,
+  OakPrimaryButton,
+  OakRadioButton,
+  OakRadioGroup,
+} from "@oaknational/oak-components";
+import React, { useState } from "react";
+
+export interface Tier {
+  tier: string;
+  tierSlug: string;
+}
+export interface Subject {
+  subject: string;
+  subjectSlug: string;
+}
+
+export type ChildSubjectTierSelectorProps = {
+  /* An array of Tier objects containing `tier` and `tierSlug` */
+  tiers?: Tier[];
+  /* An array of Subject objects containing `subject` and `subjectSlug` */
+  childSubjects?: Subject[];
+  /* Callback function which returns the selected tier and subject once the Next button is pressed. */
+  getTierSubjectValues: (
+    tierSlug: string,
+    childSubjectSlug: string | null,
+  ) => void;
+};
+
+export const ChildSubjectTierSelector = (
+  props: ChildSubjectTierSelectorProps,
+) => {
+  const { childSubjects, tiers, getTierSubjectValues } = props;
+
+  const [childSubjectSelected, setChildSubjectSelected] = useState<
+    string | null
+  >(childSubjects?.[0] ? childSubjects[0]?.subjectSlug : null);
+  const [tierSelected, setTierSelected] = useState<string>("foundation");
+
+  const tiersAvailable = tiers && tierSelected.length > 0;
+  const childSubjectsAvailable = childSubjects && childSubjects.length > 0;
+  function handleChildSubjectSelection(
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): void {
+    const childSubjectSlug = e.currentTarget.value;
+    setChildSubjectSelected(childSubjectSlug);
+  }
+
+  function handleTierSelection(e: React.ChangeEvent<HTMLInputElement>): void {
+    const tierSlug = e.currentTarget.value;
+    setTierSelected(tierSlug);
+  }
+
+  function handleNextClick() {
+    getTierSubjectValues(tierSelected, childSubjectSelected);
+  }
+
+  return (
+    <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
+      <OakInlineBanner
+        isOpen={true}
+        message={`Before downloading, choose ${
+          childSubjectsAvailable && tiersAvailable ? "options" : "an option"
+        } for KS4. The document will still display both KS3 and KS4.`}
+        $maxWidth={"spacing-640"}
+      />
+      {childSubjectsAvailable && (
+        <OakRadioGroup
+          label="Choose subject for KS4 units"
+          name="childSubjectRadio"
+          onChange={handleChildSubjectSelection}
+          $flexDirection={"column"}
+          $gap={"spacing-16"}
+          defaultValue={childSubjectSelected || "combined-science"}
+          data-testid="child-subject-selector"
+        >
+          {childSubjects.map(({ subject, subjectSlug }) => (
+            <OakRadioButton
+              id={subjectSlug}
+              label={subject}
+              value={subjectSlug}
+              data-testid="child-subject-radio-button"
+              key={subjectSlug}
+            />
+          ))}
+        </OakRadioGroup>
+      )}
+      {tiersAvailable && (
+        <OakRadioGroup
+          data-testid="tier-selector"
+          label="Choose learning tier for KS4 units"
+          name="tierRadio"
+          onChange={handleTierSelection}
+          $flexDirection={"column"}
+          $gap={"spacing-16"}
+          defaultValue={tierSelected}
+        >
+          {tiers.map(({ tier, tierSlug }) => (
+            <OakRadioButton
+              id={tierSlug}
+              label={tier}
+              value={tierSlug}
+              data-testid="tier-radio-button"
+              key={tierSlug}
+            />
+          ))}
+        </OakRadioGroup>
+      )}
+      <OakPrimaryButton
+        iconName="arrow-right"
+        isTrailingIcon={true}
+        onClick={handleNextClick}
+      >
+        Next
+      </OakPrimaryButton>
+    </OakFlex>
+  );
+};

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
@@ -84,6 +84,21 @@ jest.mock(
     },
   }),
 );
+
+jest.mock(
+  "@/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker",
+  () => ({
+    __esModule: true,
+    default: () => ({
+      schools: [],
+      error: null,
+      schoolPickerInputValue: "",
+      setSchoolPickerInputValue: jest.fn(),
+      selectedSchool: undefined,
+      setSelectedSchool: jest.fn(),
+    }),
+  }),
+);
 const defaultProps = {
   curriculumSelectionSlugs: parseSubjectPhaseSlug("english-secondary-aqa")!,
   curriculumUnitsFormattedData: {
@@ -167,10 +182,10 @@ describe("Programme Downloads", () => {
         "child-subject-radio-button",
       );
       expect(childSubjectRadios).toHaveLength(4);
-      expect(childSubjectRadios[0]).toHaveTextContent("Combined science");
-      expect(childSubjectRadios[1]).toHaveTextContent("Biology");
-      expect(childSubjectRadios[2]).toHaveTextContent("Chemistry");
-      expect(childSubjectRadios[3]).toHaveTextContent("Physics");
+      expect(childSubjectRadios[0]).toHaveAccessibleName("Combined science");
+      expect(childSubjectRadios[1]).toHaveAccessibleName("Biology");
+      expect(childSubjectRadios[2]).toHaveAccessibleName("Chemistry");
+      expect(childSubjectRadios[3]).toHaveAccessibleName("Physics");
     });
   });
   describe("analytics: curriculumResourcesDownloadRefined", () => {
@@ -196,7 +211,7 @@ describe("Programme Downloads", () => {
       await user.click(childSubjectSelector);
       await user.click(tierSelector);
 
-      const nextButton = await findByText("Next");
+      const nextButton = await findByText("Next step");
       await user.click(nextButton);
 
       expect(curriculumResourcesDownloadRefined).toHaveBeenCalledTimes(1);

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -3,7 +3,6 @@
 import {
   OakBox,
   OakDownloadCard,
-  OakDownloadsJourneyChildSubjectTierSelector,
   OakFlex,
   OakGrid,
   OakGridArea,
@@ -30,6 +29,7 @@ import {
   handleSubjectTierSelectionAnalytics,
   trackCurriculumDownload,
 } from "./tracking";
+import { ChildSubjectTierSelector } from "./ChildSubjectTierSelector/ChildSubjectTierSelector";
 
 import {
   CurriculumDownloadsTierSubjectProps,
@@ -273,11 +273,20 @@ export const ProgrammeDownloads = ({
       role="region"
     >
       {subjectTierSelectionVisible === true ? (
-        <OakDownloadsJourneyChildSubjectTierSelector
-          tiers={tiers}
-          childSubjects={childSubjects}
-          getTierSubjectValues={handleTierSubjectSelection}
-        />
+        <OakGrid>
+          <OakGridArea
+            $flexDirection={"column"}
+            $gap={"spacing-48"}
+            $colSpan={[12, 8]}
+            $colStart={[1, 3]}
+          >
+            <ChildSubjectTierSelector
+              tiers={tiers}
+              childSubjects={childSubjects}
+              getTierSubjectValues={handleTierSubjectSelection}
+            />
+          </OakGridArea>
+        </OakGrid>
       ) : (
         <OakGrid>
           <OakGridArea

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -274,12 +274,7 @@ export const ProgrammeDownloads = ({
     >
       {subjectTierSelectionVisible === true ? (
         <OakGrid>
-          <OakGridArea
-            $flexDirection={"column"}
-            $gap={"spacing-48"}
-            $colSpan={[12, 8]}
-            $colStart={[1, 3]}
-          >
+          <OakGridArea $colSpan={[12, 8]} $colStart={[1, 3]}>
             <ChildSubjectTierSelector
               tiers={tiers}
               childSubjects={childSubjects}


### PR DESCRIPTION
## Description

Music year: 1953

- Copies `OakDownloadsJourneyChildSubjectTierSelector` out of oak-components (deprecating PR will be coming next)
- Applies `ChildSubjectTierSelector` as a drop-in replacement in curriculum downloads for the integrated journey
- Adjusts appearance of  `ChildSubjectTierSelector` to match new designs

## How to test


⚠️ You'll need the `teachers-integrated-journey` feature flag

1. Go to https://oak-web-application-website-git-feat-lesq-1974update-chi-b126cc.vercel.thenational.academy/programmes/science-secondary-aqa/download
2. You should see the tier and child subject selection
3. It should function as it does currently

## Screenshots

<img width="1675" height="1578" alt="Screenshot 2026-05-08 at 13 12 41" src="https://github.com/user-attachments/assets/1b3532be-185d-4b5a-ad6e-aa227cb8a10e" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
