### PR TITLE
Fix/lesq 1981/duplicate citizenship selector [LESQ-1981]

### DIFF
--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.test.ts
@@ -1381,6 +1381,40 @@ describe("getProgrammeToggles", () => {
     ]);
   });
 
+  it("does not include options from other pathways", () => {
+    const allProgrammes = [
+      {
+        programme_slug: "citizenship-secondary-ks4-core",
+        programme_fields: programmeFieldsFixture({
+          overrides: {
+            subject: "Citizenship",
+            keystage_slug: "ks4",
+            subject_slug: "citizenship",
+            examboard_slug: "aqa",
+            pathway_slug: "core",
+          },
+        }),
+      },
+      {
+        programme_slug: "citizenship-secondary-ks4-gcse",
+        programme_fields: programmeFieldsFixture({
+          overrides: {
+            subject: "Citizenship",
+            keystage_slug: "ks4",
+            subject_slug: "citizenship",
+            examboard_slug: "aqa",
+            pathway_slug: "gcse",
+          },
+        }),
+      },
+    ];
+    const result = getProgrammeToggles(
+      "citizenship-secondary-ks4-gcse",
+      allProgrammes,
+    );
+    expect(result.subjectOptionToggles).toEqual([]);
+  });
+
   it("sorts subject toggles", () => {
     const allProgrammes = [
       {

--- a/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.ts
+++ b/src/node-lib/curriculum-api-2023/queries/teachersUnitOverview/helpers.ts
@@ -320,7 +320,9 @@ export const getProgrammeToggles = (
           programme.programme_fields.subject_slug ===
             currentProgramme.programme_fields.subject_slug &&
           programme.programme_fields.examboard_slug ===
-            currentProgramme.programme_fields.examboard_slug,
+            currentProgramme.programme_fields.examboard_slug &&
+          programme.programme_fields.pathway_slug ===
+            currentProgramme.programme_fields.pathway_slug,
       )
       .filter(hasTierFields)
       .toSorted((a, b) => sortTiers(a.programme_fields, b.programme_fields))
@@ -337,7 +339,9 @@ export const getProgrammeToggles = (
         programme.programme_fields.examboard_slug ===
           currentProgramme.programme_fields.examboard_slug &&
         programme.programme_fields.tier_slug ===
-          currentProgramme.programme_fields.tier_slug,
+          currentProgramme.programme_fields.tier_slug &&
+        programme.programme_fields.pathway_slug ===
+          currentProgramme.programme_fields.pathway_slug,
     )
     .toSorted((a, b) =>
       sortChildSubjects(a.programme_fields, b.programme_fields),


### PR DESCRIPTION
## Description

Music year: 2008

- update programme toggles to compare against pathway when generating cross subject / tier options

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]programmes/citizenship-secondary-ks4-gcse/units/should-the-uk-be-called-a-democracy/lessons
2. You should not see a filter section for Exam Subject on the left of the page content

## Screenshots

How it used to look: 
  
<img width="800" alt="Screenshot 2026-05-11 at 10 56 17" src="https://github.com/user-attachments/assets/9bd34a26-a5d6-4652-b889-eab389bbea3a" />

How it should now look:

<img width="800" alt="Screenshot 2026-05-11 at 10 55 28" src="https://github.com/user-attachments/assets/dd4a677d-2f3c-4c1e-b769-f426f75f48b9" />
