### PR TITLE
feat(LESQ-1927): update explainer path to /curriculum-explainer

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.test.tsx
@@ -113,9 +113,9 @@ describe("ProgrammeView", () => {
   });
   it("renders the correct tab content for overview", () => {
     usePathnameMock.mockReturnValue(
-      "/programmes/science-secondary-aqa/overview",
+      "/programmes/science-secondary-aqa/curriculum-explainer",
     );
-    render(<ProgrammeView {...defaultProps} tabSlug="overview" />);
+    render(<ProgrammeView {...defaultProps} tabSlug="curriculum-explainer" />);
     const heading = screen.getByRole("heading", { name: "Aims and purpose" });
     expect(heading).toBeInTheDocument();
   });
@@ -132,7 +132,7 @@ describe("ProgrammeView", () => {
     const overviewTabButton = screen.getByRole("link", { name: "Explainer" });
     const user = userEvent.setup();
     await user.click(overviewTabButton);
-    expect(pushSpy).toHaveBeenCalledWith(null, "", "overview");
+    expect(pushSpy).toHaveBeenCalledWith(null, "", "curriculum-explainer");
   });
 
   describe("non-curriculum subjects", () => {
@@ -149,7 +149,12 @@ describe("ProgrammeView", () => {
 
     it("calls notFound when the overview tab is active", () => {
       expect(() =>
-        render(<ProgrammeView {...nonCurriculumProps} tabSlug="overview" />),
+        render(
+          <ProgrammeView
+            {...nonCurriculumProps}
+            tabSlug="curriculum-explainer"
+          />,
+        ),
       ).toThrow("NEXT_HTTP_ERROR_FALLBACK;404");
     });
   });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeView.tsx
@@ -216,7 +216,7 @@ const TabContent = ({
         ks4Options={ks4Options}
       />
     );
-  } else if (tabSlug === "overview") {
+  } else if (tabSlug === "curriculum-explainer") {
     if (!curriculumCMSInfo) {
       notFound();
     }

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/tabSchema.test.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/tabSchema.test.ts
@@ -12,7 +12,7 @@ describe("tabSchema", () => {
   });
   it("returns a tab slug from a valid tab name", () => {
     const result = tabNameToSlug["Explainer"];
-    expect(result).toEqual("overview");
+    expect(result).toEqual("curriculum-explainer");
   });
   it.each(TAB_SLUGS)(
     "returns correctly for isTabSlug when it is a tab slug",

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/tabSchema.ts
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/tabSchema.ts
@@ -1,18 +1,18 @@
 export const TAB_NAMES = ["Unit sequence", "Explainer", "Download"] as const;
 export type TabName = (typeof TAB_NAMES)[number];
 
-export const TAB_SLUGS = ["units", "overview", "download"] as const;
+export const TAB_SLUGS = ["units", "curriculum-explainer", "download"] as const;
 export type TabSlug = (typeof TAB_SLUGS)[number];
 
 export const tabSlugToName: Record<TabSlug, TabName> = {
   units: "Unit sequence",
-  overview: "Explainer",
+  "curriculum-explainer": "Explainer",
   download: "Download",
 };
 
 export const tabNameToSlug: Record<TabName, TabSlug> = {
   "Unit sequence": "units",
-  Explainer: "overview",
+  Explainer: "curriculum-explainer",
   Download: "download",
 };
 


### PR DESCRIPTION
## Description

* Moves the explainer tab to `/curriculum-explainer` under the integrated journey
* No redirects from the original URL, its just gone.

## How to test

⚠️ You'll need the `teachers-integrated-journey` feature flag

1. Go to https://oak-web-application-website-git-feat-lesq-1927explainer-path.vercel.thenational.academy/programmes/maths-secondary/units
2. Click "Explainer"
3. You should be taken to `/programmes/maths-secondary/curriculum-explainer`
4. You should see the explainer content.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
