### PR TITLE
PUPIL-1684 pupil progress and analytics zustand

### DIFF
--- a/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
+++ b/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import { FC } from "react";
+import { OakBox } from "@oaknational/oak-components";
 
 import Seo, { SeoProps } from "@/browser-lib/seo/Seo";
 import { usePupilStores } from "@/components/PupilComponents/Views/ViewHelpers";
@@ -31,7 +32,7 @@ export const PupilLayout: FC<PupilLayoutProps> = (props) => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Seo {...seoProps} />
-      {children}
+      <OakBox $height={"100vh"}>{children}</OakBox>
     </>
   );
 };

--- a/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
+++ b/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
@@ -2,10 +2,19 @@ import Head from "next/head";
 import { FC } from "react";
 
 import Seo, { SeoProps } from "@/browser-lib/seo/Seo";
+import { usePupilStores } from "@/components/PupilComponents/Views/ViewHelpers";
+import {
+  LessonBrowseData,
+  LessonContent,
+} from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
 
 export type PupilLayoutProps = {
   children?: React.ReactNode;
   seoProps: SeoProps;
+  pupilStores?: {
+    browseData: LessonBrowseData;
+    lessonContent: LessonContent;
+  };
 };
 
 /**
@@ -13,7 +22,8 @@ export type PupilLayoutProps = {
  */
 
 export const PupilLayout: FC<PupilLayoutProps> = (props) => {
-  const { seoProps, children } = props;
+  const { seoProps, children, pupilStores } = props;
+  usePupilStores(pupilStores);
 
   return (
     <>

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/index.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/index.ts
@@ -3,3 +3,4 @@ export * from "./getNewLessonSectionHref";
 export * from "./pickNextIncompleteSection";
 export * from "./pickProceedToNextSectionLabel";
 export * from "./pickSectionProgress";
+export * from "./usePupilStores";

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/pickProceedToNextSectionLabel.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/pickProceedToNextSectionLabel.ts
@@ -1,4 +1,4 @@
-import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
 
 export const pickProceedToNextSectionLabel = ({
   lessonStarted,
@@ -7,7 +7,7 @@ export const pickProceedToNextSectionLabel = ({
 }: {
   lessonStarted: boolean;
   isLessonComplete: boolean;
-  sectionResults: ReturnType<typeof useLessonEngineContext>["sectionResults"];
+  sectionResults: LessonSectionResults;
 }) => {
   if (isLessonComplete) return "Lesson review";
   if (lessonStarted) return "Continue lesson";

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
@@ -40,6 +40,7 @@ export const usePupilStores = (params?: UsePupilStoresParams) => {
   const initialiseLessonProgress = usePupilLessonProgress(
     (state) => state.initialiseLessonProgress,
   );
+  const currentLessonSlug = usePupilLessonProgress((state) => state.lessonSlug);
   const { initialisePupilLessonAnalytics } = usePupilLessonAnalytics();
   const pathwayData = useMemo(
     () => (browseData ? getPupilPathwayData(browseData) : null),
@@ -49,6 +50,7 @@ export const usePupilStores = (params?: UsePupilStoresParams) => {
 
   useEffect(() => {
     if (!browseData || !lessonContent) return;
+    if (currentLessonSlug === browseData.lessonSlug) return;
     const initialiseKey = `${browseData.lessonSlug}:${availableSectionsKey}`;
     if (initialiseKeyRef.current === initialiseKey) return;
     initialiseKeyRef.current = initialiseKey;
@@ -63,6 +65,7 @@ export const usePupilStores = (params?: UsePupilStoresParams) => {
     availableSections,
     availableSectionsKey,
     browseData,
+    currentLessonSlug,
     lessonContent,
     initialiseLessonProgress,
   ]);

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import { getPupilPathwayData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import { pickAvailableSectionsForLesson } from "@/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson";
+import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import {
+  LessonBrowseData,
+  LessonContent,
+} from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+
+type UsePupilStoresParams = {
+  browseData: LessonBrowseData;
+  lessonContent: LessonContent;
+};
+
+/**
+ * Initialises pupil lesson stores for the page-based pupil experience flow.
+ *
+ * This hook sets up:
+ * - `PupilLessonProgress` (review sections and progress state)
+ * - `PupilLessonAnalytics` (pathway/context + lesson analytics payload data)
+ *
+ * @param params Optional lesson payload used to initialise both stores.
+ */
+export const usePupilStores = (params?: UsePupilStoresParams) => {
+  const browseData = params?.browseData;
+  const lessonContent = params?.lessonContent;
+  const availableSections = useMemo(
+    () => (lessonContent ? pickAvailableSectionsForLesson(lessonContent) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      lessonContent?.starterQuiz,
+      lessonContent?.exitQuiz,
+      lessonContent?.videoMuxPlaybackId,
+    ],
+  );
+  const availableSectionsKey = availableSections.join("|");
+  const initialiseKeyRef = useRef<string | null>(null);
+  const initialiseLessonProgress = usePupilLessonProgress(
+    (state) => state.initialiseLessonProgress,
+  );
+  const { initialisePupilLessonAnalytics } = usePupilLessonAnalytics();
+  const pathwayData = useMemo(
+    () => (browseData ? getPupilPathwayData(browseData) : null),
+    [browseData],
+  );
+  const analyticsInitialiseKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!browseData || !lessonContent) return;
+    const initialiseKey = `${browseData.lessonSlug}:${availableSectionsKey}`;
+    if (initialiseKeyRef.current === initialiseKey) return;
+    initialiseKeyRef.current = initialiseKey;
+
+    initialiseLessonProgress({
+      lessonSlug: browseData.lessonSlug,
+      lessonReviewSections: availableSections,
+      isReadOnly: false,
+      isHydratingInitialProgress: false,
+    });
+  }, [
+    availableSections,
+    availableSectionsKey,
+    browseData,
+    lessonContent,
+    initialiseLessonProgress,
+  ]);
+
+  useEffect(() => {
+    if (!browseData || !lessonContent || !pathwayData) return;
+    const initialiseKey = browseData.lessonSlug;
+    if (analyticsInitialiseKeyRef.current === initialiseKey) return;
+    analyticsInitialiseKeyRef.current = initialiseKey;
+
+    initialisePupilLessonAnalytics({
+      pupilPathwayData: pathwayData,
+      classroomAssignmentContext: {
+        courseId: null,
+        itemId: null,
+        attachmentId: null,
+        clientEnvironment: "web-browser",
+        classroomAssignmentId: null,
+      },
+      lessonContent,
+    });
+  }, [browseData, initialisePupilLessonAnalytics, lessonContent, pathwayData]);
+};

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import { usePupilLessonAnalyticsStore } from "@/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore";
+
+type InitialisePupilLessonAnalyticsArgs = Omit<
+  Parameters<
+    ReturnType<
+      typeof usePupilLessonAnalyticsStore.getState
+    >["initialisePupilLessonAnalytics"]
+  >[0],
+  "track"
+>;
+
+export const usePupilLessonAnalytics = () => {
+  const { track } = useAnalytics();
+  const initialiseStoreAnalytics = usePupilLessonAnalyticsStore(
+    (state) => state.initialisePupilLessonAnalytics,
+  );
+  const trackSectionStarted = usePupilLessonAnalyticsStore(
+    (state) => state.trackSectionStarted,
+  );
+  const trackLessonAbandoned = usePupilLessonAnalyticsStore(
+    (state) => state.trackLessonAbandoned,
+  );
+
+  const initialisePupilLessonAnalytics = useCallback(
+    (args: InitialisePupilLessonAnalyticsArgs) => {
+      initialiseStoreAnalytics({ ...args, track });
+    },
+    [initialiseStoreAnalytics, track],
+  );
+
+  return {
+    initialisePupilLessonAnalytics,
+    trackSectionStarted,
+    trackLessonAbandoned,
+  };
+};

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
@@ -1,0 +1,298 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+import { usePupilLessonAnalyticsStore } from "@/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore";
+import {
+  getPupilPathwayData,
+  getPupilVideoData,
+  type PupilAnalyticsProviderClassroomContext,
+} from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { sectionResultsFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonSectionResults.fixture";
+
+const lessonContent = lessonContentFixture({});
+const pupilPathwayData = getPupilPathwayData(lessonBrowseDataFixture({}));
+
+const classroomAssignmentContext: PupilAnalyticsProviderClassroomContext = {
+  clientEnvironment: "web-browser",
+  classroomAssignmentId: "assignment-1",
+  courseId: "course-1",
+  itemId: "item-1",
+  attachmentId: "attachment-1",
+};
+
+const expectedAdditionalArgs = {
+  ...pupilPathwayData,
+  analyticsUseCase: "Pupil",
+  clientEnvironment: "web-browser",
+  classroomAssignmentId: "assignment-1",
+  courseId: "course-1",
+  itemId: "item-1",
+  attachmentId: "attachment-1",
+  submissionId: null,
+  teacherLoginHint: null,
+  pupilLoginHint: null,
+};
+
+const expectedVideoData = getPupilVideoData(lessonContent);
+
+const createTrack = () =>
+  ({
+    lessonActivityStartedIntroduction: jest.fn(),
+    lessonActivityStartedStarterQuiz: jest.fn(),
+    lessonActivityStartedLessonVideo: jest.fn(),
+    lessonActivityStartedExitQuiz: jest.fn(),
+    lessonAbandoned: jest.fn(),
+  }) as unknown as jest.Mocked<TrackFns>;
+
+const initialiseStore = ({
+  track = createTrack(),
+  assignmentContext = classroomAssignmentContext,
+  includeLessonContent = true,
+}: {
+  track?: jest.Mocked<TrackFns>;
+  assignmentContext?: PupilAnalyticsProviderClassroomContext;
+  includeLessonContent?: boolean;
+} = {}) => {
+  usePupilLessonAnalyticsStore.getState().initialisePupilLessonAnalytics({
+    track,
+    pupilPathwayData,
+    classroomAssignmentContext: assignmentContext,
+    ...(includeLessonContent ? { lessonContent } : {}),
+  });
+
+  return track;
+};
+
+describe("usePupilLessonAnalyticsStore", () => {
+  beforeEach(() => {
+    usePupilLessonAnalyticsStore.setState({
+      track: null,
+      additionalArgs: null,
+      videoData: null,
+    });
+  });
+
+  it("initialises state with lesson analytics data", () => {
+    const track = initialiseStore();
+
+    expect(usePupilLessonAnalyticsStore.getState()).toEqual(
+      expect.objectContaining({
+        track,
+        additionalArgs: expectedAdditionalArgs,
+        videoData: expectedVideoData,
+      }),
+    );
+  });
+
+  it("does not track section starts or abandoned lessons before initialisation", () => {
+    expect(() => {
+      usePupilLessonAnalyticsStore.getState().trackSectionStarted({
+        section: "intro",
+        sectionResults: {},
+      });
+      usePupilLessonAnalyticsStore.getState().trackLessonAbandoned();
+    }).not.toThrow();
+  });
+
+  it.each([
+    {
+      section: "intro" as const,
+      sectionResults: {},
+      eventName: "lessonActivityStartedIntroduction" as const,
+      payload: {
+        pupilExperienceLessonActivity: "intro",
+      },
+    },
+    {
+      section: "starter-quiz" as const,
+      sectionResults: {
+        "starter-quiz": {
+          ...sectionResultsFixture["starter-quiz"],
+          isComplete: false,
+          grade: 3,
+          numQuestions: 5,
+        },
+      },
+      eventName: "lessonActivityStartedStarterQuiz" as const,
+      payload: {
+        pupilExperienceLessonActivity: "starter-quiz",
+        pupilQuizGrade: 3,
+        pupilQuizNumQuestions: 5,
+        hintAvailable: true,
+      },
+    },
+    {
+      section: "starter-quiz" as const,
+      sectionResults: {},
+      eventName: "lessonActivityStartedStarterQuiz" as const,
+      payload: {
+        pupilExperienceLessonActivity: "starter-quiz",
+        pupilQuizGrade: 0,
+        pupilQuizNumQuestions: 0,
+        hintAvailable: true,
+      },
+    },
+    {
+      section: "exit-quiz" as const,
+      sectionResults: {
+        "exit-quiz": {
+          ...sectionResultsFixture["exit-quiz"],
+          isComplete: false,
+          grade: 4,
+          numQuestions: 6,
+        },
+      },
+      eventName: "lessonActivityStartedExitQuiz" as const,
+      payload: {
+        pupilExperienceLessonActivity: "exit-quiz",
+        pupilQuizGrade: 4,
+        pupilQuizNumQuestions: 6,
+        hintAvailable: true,
+      },
+    },
+    {
+      section: "exit-quiz" as const,
+      sectionResults: {},
+      eventName: "lessonActivityStartedExitQuiz" as const,
+      payload: {
+        pupilExperienceLessonActivity: "exit-quiz",
+        pupilQuizGrade: 0,
+        pupilQuizNumQuestions: 0,
+        hintAvailable: true,
+      },
+    },
+    {
+      section: "video" as const,
+      sectionResults: {
+        video: {
+          ...sectionResultsFixture.video,
+          isComplete: false,
+          duration: 120,
+          played: true,
+        },
+      } as LessonSectionResults,
+      eventName: "lessonActivityStartedLessonVideo" as const,
+      payload: {
+        ...expectedVideoData,
+        pupilExperienceLessonActivity: "video",
+        pupilVideoDurationSeconds: 120,
+        pupilVideoPlayed: true,
+      },
+    },
+    {
+      section: "video" as const,
+      sectionResults: {},
+      eventName: "lessonActivityStartedLessonVideo" as const,
+      payload: {
+        ...expectedVideoData,
+        pupilExperienceLessonActivity: "video",
+        pupilVideoDurationSeconds: 0,
+        pupilVideoPlayed: false,
+      },
+    },
+  ])("tracks an incomplete $section section start", (args) => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackSectionStarted({
+      section: args.section,
+      sectionResults: args.sectionResults,
+    });
+
+    expect(track[args.eventName]).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      ...args.payload,
+    });
+  });
+
+  it("does not track starts for sections that are already complete", () => {
+    const track = initialiseStore();
+
+    [
+      {
+        section: "intro" as const,
+        sectionResults: { intro: sectionResultsFixture.intro },
+      },
+      {
+        section: "starter-quiz" as const,
+        sectionResults: {
+          "starter-quiz": sectionResultsFixture["starter-quiz"],
+        },
+      },
+      {
+        section: "exit-quiz" as const,
+        sectionResults: {
+          "exit-quiz": sectionResultsFixture["exit-quiz"],
+        },
+      },
+      {
+        section: "video" as const,
+        sectionResults: { video: sectionResultsFixture.video },
+      },
+    ].forEach((args) => {
+      usePupilLessonAnalyticsStore.getState().trackSectionStarted(args);
+    });
+
+    expect(track.lessonActivityStartedIntroduction).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedStarterQuiz).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedLessonVideo).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedExitQuiz).not.toHaveBeenCalled();
+  });
+
+  it("does not track starts for review sections", () => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackSectionStarted({
+      section: "review",
+      sectionResults: {},
+    });
+
+    expect(track.lessonActivityStartedIntroduction).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedStarterQuiz).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedLessonVideo).not.toHaveBeenCalled();
+    expect(track.lessonActivityStartedExitQuiz).not.toHaveBeenCalled();
+  });
+
+  it("does not track video starts when video data is unavailable", () => {
+    const track = initialiseStore({ includeLessonContent: false });
+
+    usePupilLessonAnalyticsStore.getState().trackSectionStarted({
+      section: "video",
+      sectionResults: {},
+    });
+
+    expect(track.lessonActivityStartedLessonVideo).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      clientEnvironment: "web-browser" as const,
+      platform: "owa",
+    },
+    {
+      clientEnvironment: "iframe" as const,
+      platform: "google-classroom",
+    },
+  ])(
+    "tracks abandoned lessons with $clientEnvironment core properties",
+    ({ clientEnvironment, platform }) => {
+      const track = initialiseStore({
+        assignmentContext: {
+          ...classroomAssignmentContext,
+          clientEnvironment,
+        },
+      });
+
+      usePupilLessonAnalyticsStore.getState().trackLessonAbandoned();
+
+      expect(track.lessonAbandoned).toHaveBeenCalledWith({
+        ...expectedAdditionalArgs,
+        clientEnvironment,
+        platform,
+        product: "pupil lesson activities",
+        engagementIntent: "use",
+        eventVersion: "2.0.0",
+      });
+    },
+  );
+});

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -1,0 +1,162 @@
+import { create } from "zustand";
+
+import { Platform } from "@/browser-lib/avo/Avo";
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+import type {
+  PupilAnalyticsProviderClassroomContext,
+  PupilPathwayData,
+  PupilVideoData,
+} from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import { getPupilVideoData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import type { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+
+type AdditionalArgs = PupilPathwayData & {
+  analyticsUseCase: "Pupil";
+  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"];
+  classroomAssignmentId: string | null;
+  courseId: string | null;
+  itemId: string | null;
+  attachmentId: string | null;
+  submissionId: string | null;
+  teacherLoginHint: string | null;
+  pupilLoginHint: string | null;
+};
+
+type PupilLessonAnalyticsState = {
+  track: TrackFns | null;
+  additionalArgs: AdditionalArgs | null;
+  videoData: PupilVideoData | null;
+  initialisePupilLessonAnalytics: (args: {
+    track: TrackFns;
+    pupilPathwayData: PupilPathwayData;
+    classroomAssignmentContext: PupilAnalyticsProviderClassroomContext;
+    lessonContent?: LessonContent;
+  }) => void;
+  trackSectionStarted: (args: {
+    section: "intro" | "starter-quiz" | "video" | "exit-quiz" | "review";
+    sectionResults: LessonSectionResults;
+  }) => void;
+  trackLessonAbandoned: () => void;
+};
+
+const getCorePropertyArgs = (
+  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"],
+) =>
+  ({
+    platform:
+      clientEnvironment === "iframe" ? Platform.GOOGLE_CLASSROOM : Platform.OWA,
+    product: "pupil lesson activities",
+    engagementIntent: "use",
+    eventVersion: "2.0.0",
+  }) as const;
+
+export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
+  (set, get) => ({
+    track: null,
+    additionalArgs: null,
+    videoData: null,
+    initialisePupilLessonAnalytics: ({
+      track,
+      pupilPathwayData,
+      classroomAssignmentContext,
+      lessonContent,
+    }) => {
+      const {
+        courseId,
+        itemId,
+        attachmentId,
+        clientEnvironment,
+        classroomAssignmentId,
+      } = classroomAssignmentContext;
+
+      set({
+        track,
+        videoData: lessonContent ? getPupilVideoData(lessonContent) : null,
+        additionalArgs: {
+          ...pupilPathwayData,
+          analyticsUseCase: "Pupil",
+          clientEnvironment,
+          classroomAssignmentId,
+          courseId,
+          itemId,
+          attachmentId,
+          submissionId: null,
+          teacherLoginHint: null,
+          pupilLoginHint: null,
+        },
+      });
+    },
+    trackSectionStarted: ({ section, sectionResults }) => {
+      const { track, additionalArgs, videoData } = get();
+      if (!track || !additionalArgs) return;
+
+      if (section === "intro" && !sectionResults.intro?.isComplete) {
+        const payload: Parameters<
+          TrackFns["lessonActivityStartedIntroduction"]
+        >[0] = {
+          ...additionalArgs,
+          pupilExperienceLessonActivity: section,
+        };
+        track.lessonActivityStartedIntroduction(payload);
+        return;
+      }
+
+      if (
+        section === "starter-quiz" &&
+        !sectionResults["starter-quiz"]?.isComplete
+      ) {
+        const payload: Parameters<
+          TrackFns["lessonActivityStartedStarterQuiz"]
+        >[0] = {
+          ...additionalArgs,
+          pupilExperienceLessonActivity: section,
+          pupilQuizGrade: sectionResults["starter-quiz"]?.grade || 0,
+          pupilQuizNumQuestions:
+            sectionResults["starter-quiz"]?.numQuestions || 0,
+          hintAvailable: true,
+        };
+        track.lessonActivityStartedStarterQuiz(payload);
+        return;
+      }
+
+      if (section === "exit-quiz" && !sectionResults["exit-quiz"]?.isComplete) {
+        const payload: Parameters<
+          TrackFns["lessonActivityStartedExitQuiz"]
+        >[0] = {
+          ...additionalArgs,
+          pupilExperienceLessonActivity: section,
+          pupilQuizGrade: sectionResults["exit-quiz"]?.grade || 0,
+          pupilQuizNumQuestions: sectionResults["exit-quiz"]?.numQuestions || 0,
+          hintAvailable: true,
+        };
+        track.lessonActivityStartedExitQuiz(payload);
+        return;
+      }
+
+      if (section === "video" && !sectionResults.video?.isComplete) {
+        if (!videoData) return;
+        const payload: Parameters<
+          TrackFns["lessonActivityStartedLessonVideo"]
+        >[0] = {
+          ...additionalArgs,
+          ...videoData,
+          pupilExperienceLessonActivity: section,
+          pupilVideoDurationSeconds: sectionResults.video?.duration || 0,
+          pupilVideoPlayed: sectionResults.video?.played || false,
+        };
+        track.lessonActivityStartedLessonVideo(payload);
+      }
+    },
+    trackLessonAbandoned: () => {
+      const { track, additionalArgs } = get();
+      if (!track || !additionalArgs) return;
+
+      const payload: Parameters<TrackFns["lessonAbandoned"]>[0] = {
+        ...additionalArgs,
+        ...getCorePropertyArgs(additionalArgs.clientEnvironment),
+      };
+      track.lessonAbandoned(payload);
+    },
+  }),
+);

--- a/src/context/PupilLessonProgress/PupilLessonProgressStore.test.ts
+++ b/src/context/PupilLessonProgress/PupilLessonProgressStore.test.ts
@@ -1,0 +1,115 @@
+import { createPupilLessonProgressStore } from "./usePupilLessonProgress";
+
+describe("PupilLessonProgressStore", () => {
+  it("initialises lesson state for a lesson slug", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "intro-to-it",
+      lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+    });
+
+    expect(store.getState().lessonSlug).toBe("intro-to-it");
+    expect(store.getState().lessonReviewSections).toEqual([
+      "intro",
+      "starter-quiz",
+      "video",
+      "exit-quiz",
+    ]);
+    expect(store.getState().isLessonComplete).toBe(false);
+  });
+
+  it("preserves progress across repeated initialisation for the same lesson", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "intro-to-it",
+      lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+    });
+    store.getState().completeSection("intro");
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "intro-to-it",
+      lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+    });
+
+    expect(store.getState().sectionResults.intro?.isComplete).toBe(true);
+    expect(store.getState().lessonStarted).toBe(true);
+  });
+
+  it("resets progress when initialising a different lesson slug", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+    });
+    store.getState().completeSection("intro");
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-two",
+      lessonReviewSections: ["intro", "starter-quiz"],
+    });
+
+    expect(store.getState().lessonSlug).toBe("lesson-two");
+    expect(store.getState().sectionResults).toEqual({});
+    expect(store.getState().lessonStarted).toBe(false);
+  });
+
+  it("marks lesson complete when all configured review sections are complete", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["intro", "starter-quiz"],
+    });
+    store.getState().completeSection("intro");
+    expect(store.getState().isLessonComplete).toBe(false);
+    store.getState().completeSection("starter-quiz");
+
+    expect(store.getState().isLessonComplete).toBe(true);
+  });
+
+  it("marks non-video sections incomplete when section results are updated", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["starter-quiz"],
+    });
+    store.getState().completeSection("starter-quiz");
+    expect(store.getState().sectionResults["starter-quiz"]?.isComplete).toBe(
+      true,
+    );
+
+    store.getState().updateSectionInProgressResult("starter-quiz", {
+      grade: 3,
+      numQuestions: 4,
+    });
+
+    expect(store.getState().sectionResults["starter-quiz"]?.isComplete).toBe(
+      false,
+    );
+  });
+
+  it("preserves video completion when video section result is updated", () => {
+    const store = createPupilLessonProgressStore();
+
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["video"],
+    });
+    store.getState().completeSection("video");
+
+    store.getState().updateSectionInProgressResult("video", {
+      duration: 120,
+      muted: false,
+      played: true,
+      signedOpened: false,
+      timeElapsed: 60,
+      transcriptOpened: true,
+    });
+
+    expect(store.getState().sectionResults.video?.isComplete).toBe(true);
+  });
+});

--- a/src/context/PupilLessonProgress/index.ts
+++ b/src/context/PupilLessonProgress/index.ts
@@ -1,0 +1,2 @@
+export * from "./usePupilLessonProgress";
+export * from "./pupilLessonProgressTypes";

--- a/src/context/PupilLessonProgress/pupilLessonProgressHelpers.ts
+++ b/src/context/PupilLessonProgress/pupilLessonProgressHelpers.ts
@@ -1,0 +1,148 @@
+import {
+  IntroResult,
+  LessonReviewSection,
+  LessonSectionResults,
+  PupilLessonProgressDataState,
+  PupilLessonProgressState,
+  QuizResult,
+  VideoResult,
+} from "./pupilLessonProgressTypes";
+
+/**
+ * Creates the serialisable baseline data for a lesson run.
+ * This is reused for first load and explicit reset.
+ * @returns Baseline lesson progress data state.
+ */
+export const getDefaultLessonProgressState =
+  (): PupilLessonProgressDataState => ({
+    lessonSlug: null,
+    lessonReviewSections: [],
+    sectionResults: {},
+    lessonStarted: false,
+    isLessonComplete: false,
+    isReadOnly: false,
+    isHydratingInitialProgress: false,
+  });
+
+/**
+ * Checks whether every review section is currently complete.
+ * @param lessonReviewSections Ordered list of review sections for this lesson.
+ * @param sectionResults Current section results map.
+ * @returns True when all configured review sections are complete.
+ */
+export const getIsLessonComplete = (
+  lessonReviewSections: Readonly<LessonReviewSection[]>,
+  sectionResults: LessonSectionResults,
+) =>
+  lessonReviewSections.every((section) => sectionResults[section]?.isComplete);
+
+/**
+ * Applies completion retention rules after section-result updates.
+ * Video keeps completion once achieved; other sections are marked incomplete on update.
+ * @param section Section being updated.
+ * @param currentIsComplete Existing completion value for the section.
+ * @returns Next completion value for the section.
+ */
+export const getIsCompleteAfterSectionResultUpdate = (
+  section: LessonReviewSection,
+  currentIsComplete?: boolean,
+) => {
+  if (section === "video") return currentIsComplete ?? false;
+  return false;
+};
+
+/**
+ * Derives top-level progress flags from the current section results.
+ * @param lessonReviewSections Ordered list of review sections for this lesson.
+ * @param sectionResults Current section results map.
+ * @returns Derived lesson flags (`lessonStarted`, `isLessonComplete`).
+ */
+export const getLessonProgressFlags = (
+  lessonReviewSections: Readonly<LessonReviewSection[]>,
+  sectionResults: LessonSectionResults,
+) => ({
+  lessonStarted: Object.keys(sectionResults).length > 0,
+  isLessonComplete: getIsLessonComplete(lessonReviewSections, sectionResults),
+});
+
+/**
+ * Returns section results with a target section marked complete.
+ * @param sectionResults Current section results map.
+ * @param section Section to mark complete.
+ * @returns Next section results map.
+ */
+export const createCompletedSectionResults = (
+  sectionResults: LessonSectionResults,
+  section: LessonReviewSection,
+) => ({
+  ...sectionResults,
+  [section]: {
+    ...sectionResults[section],
+    isComplete: true,
+  },
+});
+
+/**
+ * Merges a section result payload while preserving section-specific completion rules.
+ * @param sectionResults Current section results map.
+ * @param section Section being updated.
+ * @param result Partial result payload to merge.
+ * @returns Next section results map.
+ */
+export const createUpdatedSectionResults = (
+  sectionResults: LessonSectionResults,
+  section: LessonReviewSection,
+  result: QuizResult | VideoResult | IntroResult,
+) => {
+  const currentSectionResult = sectionResults[section];
+  return {
+    ...sectionResults,
+    [section]: {
+      ...currentSectionResult,
+      ...result,
+      isComplete: getIsCompleteAfterSectionResultUpdate(
+        section,
+        currentSectionResult?.isComplete,
+      ),
+    },
+  };
+};
+
+/**
+ * Applies lesson identity/settings and recomputes derived flags.
+ * @param state Existing lesson progress state.
+ * @param params Lesson identity, config, and section results.
+ * @returns Next lesson progress state shape with derived flags recalculated.
+ */
+export const createInitialisedLessonState = (
+  state: PupilLessonProgressDataState | PupilLessonProgressState,
+  {
+    lessonSlug,
+    lessonReviewSections,
+    sectionResults,
+    isReadOnly,
+    isHydratingInitialProgress,
+  }: {
+    lessonSlug: string;
+    lessonReviewSections: Readonly<LessonReviewSection[]>;
+    sectionResults: LessonSectionResults;
+    isReadOnly: boolean;
+    isHydratingInitialProgress: boolean;
+  },
+) => {
+  const { lessonStarted, isLessonComplete } = getLessonProgressFlags(
+    lessonReviewSections,
+    sectionResults,
+  );
+
+  return {
+    ...state,
+    lessonSlug,
+    lessonReviewSections,
+    sectionResults,
+    lessonStarted,
+    isLessonComplete,
+    isReadOnly,
+    isHydratingInitialProgress,
+  };
+};

--- a/src/context/PupilLessonProgress/pupilLessonProgressStateActions.ts
+++ b/src/context/PupilLessonProgress/pupilLessonProgressStateActions.ts
@@ -1,0 +1,107 @@
+import {
+  createCompletedSectionResults,
+  createInitialisedLessonState,
+  createUpdatedSectionResults,
+  getDefaultLessonProgressState,
+  getLessonProgressFlags,
+} from "./pupilLessonProgressHelpers";
+import {
+  IntroResult,
+  LessonProgressInitArgs,
+  LessonReviewSection,
+  PupilLessonProgressState,
+  QuizResult,
+  VideoResult,
+} from "./pupilLessonProgressTypes";
+
+/**
+ * Creates the state patch for lesson initialisation.
+ * For new lessons, this returns a reset baseline seeded with incoming lesson data.
+ * For the same lesson, this preserves existing progress and reapplies config flags.
+ * @param state Current lesson progress state.
+ * @param args Initialisation input payload.
+ * @returns State patch for `set(...)`.
+ */
+export const lessonInitialiseAction = (
+  state: PupilLessonProgressState,
+  {
+    lessonSlug,
+    lessonReviewSections,
+    initialSectionResults,
+    isReadOnly = false,
+    isHydratingInitialProgress = false,
+  }: LessonProgressInitArgs,
+) => {
+  const isNewLesson = state.lessonSlug !== lessonSlug;
+
+  if (isNewLesson) {
+    return createInitialisedLessonState(getDefaultLessonProgressState(), {
+      lessonSlug,
+      lessonReviewSections,
+      sectionResults: initialSectionResults ?? {},
+      isReadOnly,
+      isHydratingInitialProgress,
+    });
+  }
+
+  return createInitialisedLessonState(state, {
+    lessonSlug,
+    lessonReviewSections,
+    sectionResults: state.sectionResults,
+    isReadOnly,
+    isHydratingInitialProgress,
+  });
+};
+
+/**
+ * Creates the state patch that marks a section complete.
+ * @param state Current lesson progress state.
+ * @param section Section to mark complete.
+ * @returns State patch for `set(...)`.
+ */
+export const completeSectionAction = (
+  state: PupilLessonProgressState,
+  section: LessonReviewSection,
+) => {
+  const nextSectionResults = createCompletedSectionResults(
+    state.sectionResults,
+    section,
+  );
+
+  return {
+    lessonStarted: true,
+    sectionResults: nextSectionResults,
+    isLessonComplete: getLessonProgressFlags(
+      state.lessonReviewSections,
+      nextSectionResults,
+    ).isLessonComplete,
+  };
+};
+
+/**
+ * Creates the state patch for in-progress section result updates.
+ * @param state Current lesson progress state.
+ * @param section Section to update.
+ * @param result Partial in-progress result payload.
+ * @returns State patch for `set(...)`.
+ */
+export const updateSectionInProgressResultAction = (
+  state: PupilLessonProgressState,
+  section: LessonReviewSection,
+  result: QuizResult | VideoResult | IntroResult,
+) => {
+  const nextSectionResults = createUpdatedSectionResults(
+    state.sectionResults,
+    section,
+    result,
+  );
+
+  return {
+    lessonStarted: true,
+    sectionResults: nextSectionResults,
+    isLessonComplete: getLessonProgressFlags(
+      state.lessonReviewSections,
+      nextSectionResults,
+    ).isLessonComplete,
+  };
+};

--- a/src/context/PupilLessonProgress/pupilLessonProgressTypes.ts
+++ b/src/context/PupilLessonProgress/pupilLessonProgressTypes.ts
@@ -1,0 +1,80 @@
+import { QuestionState } from "@/components/PupilComponents/QuizUtils/questionTypes";
+
+export const allLessonReviewSections = [
+  "intro",
+  "starter-quiz",
+  "video",
+  "exit-quiz",
+] as const;
+
+export type LessonReviewSection = (typeof allLessonReviewSections)[number];
+
+export type QuizResult = {
+  grade: number;
+  numQuestions: number;
+  questionResults?: QuestionState[];
+};
+
+export type VideoResult = {
+  played: boolean;
+  duration: number;
+  timeElapsed: number;
+  muted: boolean;
+  signedOpened: boolean;
+  transcriptOpened: boolean;
+};
+
+export type IntroResult = Partial<{
+  worksheetAvailable: boolean;
+  worksheetDownloaded: boolean;
+  filesDownloaded?: boolean;
+  additionalFilesAvailable?: boolean;
+}>;
+
+export type LessonSectionResults = Partial<{
+  "starter-quiz": { isComplete: boolean } & QuizResult;
+  "exit-quiz": { isComplete: boolean } & QuizResult;
+  video: { isComplete: boolean } & VideoResult;
+  intro: { isComplete: boolean } & IntroResult;
+}>;
+
+export type LessonProgressInitArgs = {
+  lessonSlug: string;
+  lessonReviewSections: Readonly<LessonReviewSection[]>;
+  initialSectionResults?: LessonSectionResults;
+  isReadOnly?: boolean;
+  isHydratingInitialProgress?: boolean;
+};
+
+export type PupilLessonProgressState = {
+  lessonSlug: string | null;
+  lessonReviewSections: Readonly<LessonReviewSection[]>;
+  sectionResults: LessonSectionResults;
+  lessonStarted: boolean;
+  isLessonComplete: boolean;
+  isReadOnly: boolean;
+  isHydratingInitialProgress: boolean;
+  initialiseLessonProgress: (args: LessonProgressInitArgs) => void;
+  markLessonStarted: () => void;
+  completeSection: (section: LessonReviewSection) => void;
+  updateSectionInProgressResult: (
+    section: LessonReviewSection,
+    result: QuizResult | VideoResult | IntroResult,
+  ) => void;
+  updateWorksheetDownloaded: (result: IntroResult) => void;
+  updateAdditionalFilesDownloaded: (result: IntroResult) => void;
+  setHydratingInitialProgress: (isHydrating: boolean) => void;
+  resetLessonProgress: () => void;
+};
+
+export type PupilLessonProgressDataState = Omit<
+  PupilLessonProgressState,
+  | "initialiseLessonProgress"
+  | "markLessonStarted"
+  | "completeSection"
+  | "updateSectionInProgressResult"
+  | "updateWorksheetDownloaded"
+  | "updateAdditionalFilesDownloaded"
+  | "setHydratingInitialProgress"
+  | "resetLessonProgress"
+>;

--- a/src/context/PupilLessonProgress/usePupilLessonProgress.ts
+++ b/src/context/PupilLessonProgress/usePupilLessonProgress.ts
@@ -1,0 +1,60 @@
+import { create, StateCreator } from "zustand";
+import { createStore } from "zustand/vanilla";
+
+import { getDefaultLessonProgressState } from "./pupilLessonProgressHelpers";
+import {
+  completeSectionAction,
+  lessonInitialiseAction,
+  updateSectionInProgressResultAction,
+} from "./pupilLessonProgressStateActions";
+import { PupilLessonProgressState } from "./pupilLessonProgressTypes";
+
+export const createPupilLessonProgressState: StateCreator<
+  PupilLessonProgressState
+> = (set) => ({
+  ...getDefaultLessonProgressState(),
+  initialiseLessonProgress: ({
+    lessonSlug,
+    lessonReviewSections,
+    initialSectionResults,
+    isReadOnly = false,
+    isHydratingInitialProgress = false,
+  }) =>
+    set((state) =>
+      lessonInitialiseAction(state, {
+        lessonSlug,
+        lessonReviewSections,
+        initialSectionResults,
+        isReadOnly,
+        isHydratingInitialProgress,
+      }),
+    ),
+  markLessonStarted: () =>
+    set(() => ({
+      lessonStarted: true,
+    })),
+  completeSection: (section) =>
+    set((state) => completeSectionAction(state, section)),
+  updateSectionInProgressResult: (section, result) =>
+    set((state) => updateSectionInProgressResultAction(state, section, result)),
+  updateWorksheetDownloaded: (result) =>
+    set((state) => updateSectionInProgressResultAction(state, "intro", result)),
+  updateAdditionalFilesDownloaded: (result) =>
+    set((state) => updateSectionInProgressResultAction(state, "intro", result)),
+  setHydratingInitialProgress: (isHydratingInitialProgress) =>
+    set(() => ({
+      isHydratingInitialProgress,
+    })),
+  resetLessonProgress: () => set(() => getDefaultLessonProgressState()),
+});
+
+export const usePupilLessonProgress = create<PupilLessonProgressState>()(
+  createPupilLessonProgressState,
+);
+
+export const createPupilLessonProgressStore = () =>
+  createStore<PupilLessonProgressState>()(createPupilLessonProgressState);
+
+export type PupilLessonProgressStateShape = ReturnType<
+  typeof usePupilLessonProgress.getState
+>;


### PR DESCRIPTION
## Description
Currently the primary method of working through lessons in the pupil experience is driven by the LessonEngineProvider. This provider is based on a React context and handles everything from lesson progress, tracking and page navigation.

This has become overly complex and a spider web of dependencies.

This PR creates 2 new stores in Zustand for lesson progress and pupil analytics. They are independent from each other, and map store functions to individual progress or analytics functions.

This change means that we can break down lesson progression and analytics into smaller functions, group them in directories semantically, and call them from anywhere by importing the zustand store to trigger them. It also means we can pass in higher level objects to the store functions, and rely upon the function definitions in the store to compose the objects we send for tracking.

## Issue(s)
[Notion Ticket](https://www.notion.so/oaknationalacademy/Rewrite-LessonEngineProvider-with-Zustand-33b26cc4e1b180238271dfb943690be1?source=copy_link)

## How to test
Code Review Only - functional testing is being made on the demo branch.


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
