### PR TITLE
PUPIL-1690 lesson variant helpers

### DIFF
--- a/src/pages-helpers/pupil/getLessonShareVariant.test.ts
+++ b/src/pages-helpers/pupil/getLessonShareVariant.test.ts
@@ -1,0 +1,29 @@
+import {
+  getLessonShareVariant,
+  getLessonShareVariantSlug,
+} from "./getLessonShareVariant";
+
+describe("getLessonShareVariant", () => {
+  it("returns the matching lesson share variant", () => {
+    expect(getLessonShareVariant("starter-quiz-only")).toEqual({
+      sections: ["overview", "intro", "starter-quiz"],
+      reviewSections: ["intro", "starter-quiz"],
+    });
+  });
+
+  it("returns null for an unknown variant", () => {
+    expect(getLessonShareVariant("not-a-variant")).toBeNull();
+  });
+});
+
+describe("getLessonShareVariantSlug", () => {
+  it("returns the matching slug from selected lesson sections", () => {
+    expect(
+      getLessonShareVariantSlug(["overview", "intro", "starter-quiz"]),
+    ).toBe("starter-quiz-only");
+  });
+
+  it("returns null when no variant matches exactly", () => {
+    expect(getLessonShareVariantSlug(["overview", "intro"])).toBeNull();
+  });
+});

--- a/src/pages-helpers/pupil/getLessonShareVariant.ts
+++ b/src/pages-helpers/pupil/getLessonShareVariant.ts
@@ -68,7 +68,8 @@ export const getLessonShareVariantSlug = (
         sectionsExclOverviewIntro.includes(section),
       );
       if (!hasAllSections) return null;
-      const hasHideYearGroup = variant.hideYearGroup === hideYearGroup;
+      const hasHideYearGroup =
+        Boolean(variant.hideYearGroup) === Boolean(hideYearGroup);
       if (!hasHideYearGroup) return null;
       return [slug, variant];
     },

--- a/src/pages-helpers/pupil/getLessonShareVariant.ts
+++ b/src/pages-helpers/pupil/getLessonShareVariant.ts
@@ -60,12 +60,14 @@ export const getLessonShareVariantSlug = (
 ): LessonShareVariantSlug | null => {
   const filterOutOverviewIntro = (s: LessonSection): boolean =>
     s !== "overview" && s !== "intro";
-  const sectionsExclOverviewIntro = sections.filter(filterOutOverviewIntro);
+  const sectionsExclOverviewIntro = new Set(
+    sections.filter(filterOutOverviewIntro),
+  );
   const match = Object.entries(PUPIL_LESSON_SHARE_VARIANTS).find(
     ([slug, variant]) => {
       const filteredSections = variant.sections.filter(filterOutOverviewIntro);
       const hasAllSections: boolean = filteredSections.every((section) =>
-        sectionsExclOverviewIntro.includes(section),
+        sectionsExclOverviewIntro.has(section),
       );
       if (!hasAllSections) return null;
       const hasHideYearGroup =

--- a/src/pages-helpers/pupil/getLessonShareVariant.ts
+++ b/src/pages-helpers/pupil/getLessonShareVariant.ts
@@ -1,0 +1,65 @@
+import {
+  LessonSection,
+  LessonReviewSection,
+} from "@/components/PupilComponents/lessonSections";
+
+export type LessonShareVariant = {
+  sections: LessonSection[];
+  reviewSections: LessonReviewSection[];
+  hideYearGroup?: boolean;
+};
+
+export const PUPIL_LESSON_SHARE_VARIANTS: Record<string, LessonShareVariant> = {
+  "starter-quiz-only": {
+    sections: ["overview", "intro", "starter-quiz"],
+    reviewSections: ["intro", "starter-quiz"],
+  },
+  "exit-quiz-only": {
+    sections: ["overview", "intro", "exit-quiz"],
+    reviewSections: ["intro", "exit-quiz"],
+  },
+  "video-only": {
+    sections: ["overview", "intro", "video"],
+    reviewSections: ["intro", "video"],
+  },
+};
+
+export type LessonShareVariantSlug = keyof typeof PUPIL_LESSON_SHARE_VARIANTS;
+
+/**
+ * Returns a lesson share variant if the slug has a matching variant, otherwise returns null
+ * @param lessonShareSlug - the url slug for a share variant
+ */
+export const getLessonShareVariant = (
+  lessonShareSlug: string,
+): LessonShareVariant | null =>
+  PUPIL_LESSON_SHARE_VARIANTS[lessonShareSlug] ?? null;
+
+/**
+ * Checks to see if variant exists with specified parameters (e.g sections and year group) and returns the matching slug
+ * or null if none is found.
+ * Overview and Intro are excluded from the check as they are not independently selectable when sharing a lesson
+ * @param sections - the sections that should be included in the variant
+ * @param hideYearGroup - whether the variant should hide the year group
+ */
+export const getLessonShareVariantSlug = (
+  sections: LessonSection[],
+  hideYearGroup: boolean = false,
+): LessonShareVariantSlug | null => {
+  const filterOutOverviewIntro = (s: LessonSection): boolean =>
+    s !== "overview" && s !== "intro";
+  const sectionsExclOverviewIntro = sections.filter(filterOutOverviewIntro);
+  const match = Object.entries(PUPIL_LESSON_SHARE_VARIANTS).find(
+    ([slug, variant]) => {
+      const filteredSections = variant.sections.filter(filterOutOverviewIntro);
+      const hasAllSections: boolean = filteredSections.every((section) =>
+        sectionsExclOverviewIntro.includes(section),
+      );
+      if (!hasAllSections) return null;
+      const hasHideYearGroup = variant.hideYearGroup === hideYearGroup;
+      if (!hasHideYearGroup) return null;
+      return [slug, variant];
+    },
+  );
+  return match?.[0] ?? null;
+};

--- a/src/pages-helpers/pupil/getLessonShareVariant.ts
+++ b/src/pages-helpers/pupil/getLessonShareVariant.ts
@@ -22,6 +22,18 @@ export const PUPIL_LESSON_SHARE_VARIANTS: Record<string, LessonShareVariant> = {
     sections: ["overview", "intro", "video"],
     reviewSections: ["intro", "video"],
   },
+  "starter-quiz-video": {
+    sections: ["overview", "intro", "starter-quiz", "video"],
+    reviewSections: ["intro", "starter-quiz", "video"],
+  },
+  "quizzes-only": {
+    sections: ["overview", "intro", "starter-quiz", "exit-quiz"],
+    reviewSections: ["intro", "starter-quiz", "exit-quiz"],
+  },
+  "video-exit-quiz": {
+    sections: ["overview", "intro", "video", "exit-quiz"],
+    reviewSections: ["intro", "video", "exit-quiz"],
+  },
 };
 
 export type LessonShareVariantSlug = keyof typeof PUPIL_LESSON_SHARE_VARIANTS;

--- a/src/pages-helpers/pupil/index.ts
+++ b/src/pages-helpers/pupil/index.ts
@@ -1,1 +1,8 @@
 export { extractBaseSlug } from "./extractBaseSlug";
+export {
+  PUPIL_LESSON_SHARE_VARIANTS,
+  getLessonShareVariant,
+  getLessonShareVariantSlug,
+  type LessonShareVariant,
+  type LessonShareVariantSlug,
+} from "./getLessonShareVariant";


### PR DESCRIPTION
## Description
Adds configurations for variants of selection of lesson components that can be shared.

Adds helper functions for:
- Fetch a lesson variant slug by passing in the selected sections to share
- Fetch a variants configuration by passing in a variant slug

## Issue(s)
[Notion Ticket](https://www.notion.so/oaknationalacademy/Add-pupil-experience-variants-route-and-config-33b26cc4e1b1809080a6c28903912196?source=copy_link)

## How to test
Code review only

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
