### PR TITLE
PUPIL-1691 lesson shared variant pages

### DIFF
--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.test.tsx
@@ -1,0 +1,116 @@
+import "@testing-library/jest-dom";
+
+import PupilLessonExitQuizNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz";
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: { getProps: () => Promise<unknown> }) => buildPageProps(args),
+}));
+
+jest.mock("@/pages-helpers/pupil/lessons-pages/new/QuizPageContent", () => ({
+  QuizPageContent: ({ section }: { section: string }) => (
+    <div data-testid="quiz-page-content">{section}</div>
+  ),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pupil-layout">{children}</div>
+  ),
+}));
+
+beforeEach(() => {
+  getPropsMock.mockReset();
+  buildPageProps.mockReset();
+});
+
+describe("pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz", () => {
+  describe("page component", () => {
+    it("renders the QuizPageContent inside the PupilLayout", () => {
+      const { getByTestId } = renderWithTheme(
+        <PupilLessonExitQuizNewPage
+          browseData={lessonBrowseDataFixture({})}
+          lessonContent={lessonContentFixture({})}
+          backUrl={null}
+          hasWorksheet={false}
+          worksheetInfo={null}
+          hasAdditionalFiles={false}
+          additionalFiles={null}
+          variant={null}
+          initialSection="exit-quiz"
+          pageType="canonical"
+        />,
+      );
+
+      expect(getByTestId("pupil-layout")).toBeInTheDocument();
+      expect(getByTestId("quiz-page-content")).toHaveTextContent("exit-quiz");
+    });
+  });
+
+  describe("getStaticProps", () => {
+    it("returns notFound when the variant is invalid", async () => {
+      const result = await getStaticProps({
+        params: { lessonSlug: "lesson-1", variant: "not-a-real-variant" },
+      } as never);
+
+      expect(result).toEqual({ notFound: true });
+      expect(getPropsMock).not.toHaveBeenCalled();
+    });
+
+    it("delegates to getPageProps with an exit-quiz-bound context", async () => {
+      buildPageProps.mockResolvedValue({ props: { ok: true } });
+      getPropsMock.mockReturnValue("getProps-result");
+
+      const ctx = {
+        params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+      } as never;
+
+      const result = await getStaticProps(ctx);
+
+      expect(getPropsMock).toHaveBeenCalledWith({
+        page: "canonical",
+        context: expect.objectContaining({
+          params: expect.objectContaining({
+            lessonSlug: "lesson-1",
+            section: "exit-quiz",
+          }),
+        }),
+      });
+      expect(buildPageProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: "pupils-lesson-new-exit-quiz::getStaticProps",
+          context: ctx,
+          getProps: "getProps-result",
+        }),
+      );
+      expect(result).toEqual({ props: { ok: true } });
+    });
+
+    it("passes undefined params through when context.params is missing", async () => {
+      buildPageProps.mockResolvedValue({ props: {} });
+      getPropsMock.mockReturnValue("getProps-result");
+
+      await getStaticProps({
+        params: { variant: "quizzes-only" },
+      } as never);
+
+      expect(getPropsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({ params: expect.anything() }),
+        }),
+      );
+    });
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.test.ts
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.test.ts
@@ -1,0 +1,31 @@
+import type { GetServerSidePropsContext } from "next";
+
+import { getServerSideProps } from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]";
+
+describe("pages/pupils/lessons/[lessonSlug]/shared/[variant] index", () => {
+  it("redirects to the overview page preserving the query string", async () => {
+    const result = await getServerSideProps({
+      resolvedUrl: "/pupils/lessons/lesson-1/shared/abc?utm=foo",
+    } as GetServerSidePropsContext);
+
+    expect(result).toEqual({
+      redirect: {
+        destination: "/pupils/lessons/lesson-1/shared/abc/overview?utm=foo",
+        permanent: false,
+      },
+    });
+  });
+
+  it("redirects to the overview page when there is no query string", async () => {
+    const result = await getServerSideProps({
+      resolvedUrl: "/pupils/lessons/lesson-1/shared/abc",
+    } as GetServerSidePropsContext);
+
+    expect(result).toEqual({
+      redirect: {
+        destination: "/pupils/lessons/lesson-1/shared/abc/overview",
+        permanent: false,
+      },
+    });
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
@@ -1,0 +1,148 @@
+import "@testing-library/jest-dom";
+import { fireEvent } from "@testing-library/react";
+
+import PupilLessonIntroNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro";
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { getDefaultLessonProgressState } from "@/context/PupilLessonProgress/pupilLessonProgressHelpers";
+
+const routerPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ asPath: "/intro", push: routerPush }),
+}));
+
+const track = {
+  trackSectionStarted: jest.fn(),
+  trackLessonStarted: jest.fn(),
+  trackLessonCompleted: jest.fn(),
+  trackIntroCompleted: jest.fn(),
+  trackIntroAbandoned: jest.fn(),
+  trackWorksheetDownloaded: jest.fn(),
+};
+jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
+  usePupilLessonAnalytics: () => track,
+}));
+
+const startWorksheet = jest.fn();
+jest.mock("@/components/PupilViews/PupilIntro/useWorksheetDownload", () => ({
+  useWorksheetDownload: () => ({
+    startDownload: startWorksheet,
+    isDownloading: false,
+  }),
+}));
+
+const startFiles = jest.fn();
+jest.mock(
+  "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload",
+  () => ({
+    useAdditionalFilesDownload: () => ({
+      startAdditionalFilesDownload: startFiles,
+      isAdditionalFilesDownloading: false,
+    }),
+  }),
+);
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: unknown) => buildPageProps(args),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const render = renderWithProvidersByName(["oakTheme"]);
+
+const renderPage = (
+  props: Partial<React.ComponentProps<typeof PupilLessonIntroNewPage>> = {},
+) =>
+  render(
+    <PupilLessonIntroNewPage
+      browseData={lessonBrowseDataFixture({})}
+      lessonContent={lessonContentFixture({})}
+      backUrl={null}
+      hasWorksheet={false}
+      worksheetInfo={null}
+      hasAdditionalFiles={false}
+      additionalFiles={null}
+      variant={null}
+      initialSection="intro"
+      pageType="canonical"
+      {...props}
+    />,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  usePupilLessonProgress.setState(getDefaultLessonProgressState());
+  usePupilLessonProgress.getState().initialiseLessonProgress({
+    lessonSlug: "lesson-1",
+    lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+  });
+});
+
+describe("intro page", () => {
+  it("completes the section and navigates on proceed", () => {
+    const { getByTestId } = renderPage();
+    fireEvent.click(getByTestId("proceed-to-next-section"));
+    expect(track.trackIntroCompleted).toHaveBeenCalledTimes(1);
+    expect(
+      usePupilLessonProgress.getState().sectionResults.intro?.isComplete,
+    ).toBe(true);
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks intro abandoned when the back link is clicked", () => {
+    const { getByLabelText } = renderPage();
+    fireEvent.click(getByLabelText("Back"));
+    expect(track.trackIntroAbandoned).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers worksheet and additional file downloads", () => {
+    const { getByText } = renderPage({
+      hasWorksheet: true,
+      worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
+      hasAdditionalFiles: true,
+      additionalFiles: [
+        {
+          assetId: "a",
+          mediaObject: { displayName: "f", bytes: 1, url: "/a" },
+        },
+      ] as never,
+    });
+    fireEvent.click(getByText(/Download worksheet/));
+    fireEvent.click(getByText("Download file"));
+    expect(startWorksheet).toHaveBeenCalledTimes(1);
+    expect(startFiles).toHaveBeenCalledTimes(1);
+    expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns notFound from getStaticProps when the variant is invalid", async () => {
+    expect(
+      await getStaticProps({ params: { variant: "no" } } as never),
+    ).toEqual({ notFound: true });
+  });
+
+  it("calls getPageProps with an intro-bound context", async () => {
+    buildPageProps.mockResolvedValue({ props: {} });
+    await getStaticProps({
+      params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+    } as never);
+    expect(getPropsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          params: expect.objectContaining({ section: "intro" }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.test.tsx
@@ -1,0 +1,262 @@
+import "@testing-library/jest-dom";
+import { fireEvent } from "@testing-library/react";
+
+import PupilLessonOverviewNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview";
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { getDefaultLessonProgressState } from "@/context/PupilLessonProgress/pupilLessonProgressHelpers";
+
+const routerPush = jest.fn();
+const routerReplace = jest.fn();
+const routerBack = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    asPath: "/pupils/lessons/lesson-1/shared/abc/overview?utm=x",
+    push: routerPush,
+    replace: routerReplace,
+    back: routerBack,
+  }),
+}));
+
+const assignmentSearchParams = {
+  isClassroomAssignment: false as boolean,
+  classroomAssignmentChecked: true,
+};
+jest.mock("@/hooks/useAssignmentSearchParams", () => ({
+  useAssignmentSearchParams: () => assignmentSearchParams,
+}));
+
+const analyticsFns = {
+  trackSectionStarted: jest.fn(),
+  trackLessonStarted: jest.fn(),
+  trackLessonAbandoned: jest.fn(),
+  trackContentGuidanceAccepted: jest.fn(),
+  trackContentGuidanceDeclined: jest.fn(),
+};
+jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
+  usePupilLessonAnalytics: () => analyticsFns,
+}));
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: unknown) => buildPageProps(args),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pupil-layout">{children}</div>
+  ),
+}));
+
+jest.mock(
+  "@/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal",
+  () => ({
+    PupilLessonOverviewContentGuidanceModal: (props: {
+      onAccept: (args: unknown) => void;
+      onDecline: (args: unknown) => void;
+    }) => (
+      <div>
+        <button
+          data-testid="cg-accept"
+          onClick={() => props.onAccept({ contentGuidanceLabel: "violence" })}
+        />
+        <button
+          data-testid="cg-decline"
+          onClick={() => props.onDecline({ contentGuidanceLabel: "violence" })}
+        />
+      </div>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/components/PupilComponents/PupilRedirectedOverlay/PupilRedirectedOverlay",
+  () => ({
+    PupilRedirectedOverlay: (props: {
+      onLoaded: (isShowing: boolean) => void;
+      onClose: () => void;
+    }) => (
+      <div>
+        <button
+          data-testid="overlay-loaded"
+          onClick={() => props.onLoaded(false)}
+        />
+        <button data-testid="overlay-close" onClick={() => props.onClose()} />
+      </div>
+    ),
+  }),
+);
+
+const render = renderWithProvidersByName(["oakTheme"]);
+
+const renderPage = (overrides: { backUrl?: string | null } = {}) =>
+  render(
+    <PupilLessonOverviewNewPage
+      browseData={lessonBrowseDataFixture({})}
+      lessonContent={lessonContentFixture({})}
+      backUrl={"backUrl" in overrides ? (overrides.backUrl ?? null) : "/back"}
+      hasWorksheet={false}
+      worksheetInfo={null}
+      hasAdditionalFiles={false}
+      additionalFiles={null}
+      variant={null}
+      initialSection="overview"
+      pageType="canonical"
+    />,
+  );
+
+beforeEach(() => {
+  routerPush.mockReset();
+  routerReplace.mockReset();
+  routerBack.mockReset();
+  Object.values(analyticsFns).forEach((fn) => fn.mockReset());
+  getPropsMock.mockReset();
+  buildPageProps.mockReset();
+  assignmentSearchParams.isClassroomAssignment = false;
+  assignmentSearchParams.classroomAssignmentChecked = true;
+  usePupilLessonProgress.setState(getDefaultLessonProgressState());
+  usePupilLessonProgress.getState().initialiseLessonProgress({
+    lessonSlug: "lesson-1",
+    lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+  });
+});
+
+describe("pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview", () => {
+  describe("page component", () => {
+    it("renders the overview view inside the PupilLayout", () => {
+      const { getByTestId } = renderPage();
+      expect(getByTestId("pupil-layout")).toBeInTheDocument();
+      expect(getByTestId("proceed-to-next-section")).toBeInTheDocument();
+    });
+
+    it("hides the back button when the lesson is opened from Google Classroom", () => {
+      assignmentSearchParams.isClassroomAssignment = true;
+      const { queryByText } = renderPage();
+      expect(queryByText("View all lessons")).not.toBeInTheDocument();
+    });
+
+    it("starts the lesson and navigates on proceed", () => {
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("proceed-to-next-section"));
+      expect(analyticsFns.trackLessonStarted).toHaveBeenCalledTimes(1);
+      expect(analyticsFns.trackSectionStarted).toHaveBeenCalled();
+      expect(usePupilLessonProgress.getState().lessonStarted).toBe(true);
+      expect(routerPush).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not double-track lesson start when already started", () => {
+      usePupilLessonProgress.setState({ lessonStarted: true });
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("proceed-to-next-section"));
+      expect(analyticsFns.trackLessonStarted).not.toHaveBeenCalled();
+    });
+
+    it("tracks the lesson as abandoned when leaving an incomplete lesson", () => {
+      const { getByText } = renderPage();
+      fireEvent.click(getByText("View all lessons"));
+      expect(analyticsFns.trackLessonAbandoned).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not track lesson abandoned when leaving an already complete lesson", () => {
+      usePupilLessonProgress.setState({ isLessonComplete: true });
+      const { getByText } = renderPage();
+      fireEvent.click(getByText("View all lessons"));
+      expect(analyticsFns.trackLessonAbandoned).not.toHaveBeenCalled();
+    });
+
+    it("tracks section starts when clicking a section in the sections nav", () => {
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("intro"));
+      expect(analyticsFns.trackLessonStarted).toHaveBeenCalledTimes(1);
+      expect(analyticsFns.trackSectionStarted).toHaveBeenCalled();
+    });
+
+    it("dismisses content guidance and tracks accept", () => {
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("cg-accept"));
+      expect(usePupilLessonProgress.getState().contentGuidanceDismissed).toBe(
+        true,
+      );
+      expect(analyticsFns.trackContentGuidanceAccepted).toHaveBeenCalled();
+    });
+
+    it("posts a closeIframe message when declining inside Google Classroom", () => {
+      assignmentSearchParams.isClassroomAssignment = true;
+      const postMessage = jest.fn();
+      const parentSpy = jest
+        .spyOn(globalThis.window, "parent", "get")
+        .mockReturnValue({ postMessage } as never);
+
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("cg-decline"));
+
+      expect(analyticsFns.trackContentGuidanceDeclined).toHaveBeenCalled();
+      expect(postMessage).toHaveBeenCalledWith(
+        { type: "Classroom", action: "closeIframe" },
+        "https://classroom.google.com",
+      );
+      parentSpy.mockRestore();
+    });
+
+    it("uses router.replace when declining and a backUrl is available", () => {
+      const { getByTestId } = renderPage({ backUrl: "/somewhere-back" });
+      fireEvent.click(getByTestId("cg-decline"));
+      expect(routerReplace).toHaveBeenCalledWith("/somewhere-back");
+    });
+
+    it("falls back to router.back when declining without a backUrl", () => {
+      const { getByTestId } = renderPage({ backUrl: null });
+      fireEvent.click(getByTestId("cg-decline"));
+      expect(routerBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders without throwing when redirect overlay callbacks fire", () => {
+      const { getByTestId } = renderPage();
+      fireEvent.click(getByTestId("overlay-loaded"));
+      fireEvent.click(getByTestId("overlay-close"));
+      expect(getByTestId("proceed-to-next-section")).toBeInTheDocument();
+    });
+  });
+
+  describe("getStaticProps", () => {
+    it("returns notFound when the variant is invalid", async () => {
+      const res = await getStaticProps({
+        params: { lessonSlug: "lesson-1", variant: "no-variant" },
+      } as never);
+      expect(res).toEqual({ notFound: true });
+    });
+
+    it("delegates to getPageProps with an overview-bound context", async () => {
+      buildPageProps.mockResolvedValue({ props: { ok: true } });
+      getPropsMock.mockReturnValue("getProps-result");
+
+      const result = await getStaticProps({
+        params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+      } as never);
+
+      expect(getPropsMock).toHaveBeenCalledWith({
+        page: "canonical",
+        context: expect.objectContaining({
+          params: expect.objectContaining({ section: "overview" }),
+        }),
+      });
+      expect(result).toEqual({ props: { ok: true } });
+    });
+
+    it("passes undefined params when context.params is missing", async () => {
+      buildPageProps.mockResolvedValue({ props: {} });
+      getPropsMock.mockReturnValue("getProps-result");
+      await getStaticProps({ params: { variant: "quizzes-only" } } as never);
+      expect(getPropsMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.test.tsx
@@ -1,0 +1,149 @@
+import "@testing-library/jest-dom";
+import { fireEvent, waitFor } from "@testing-library/react";
+
+import PupilLessonReviewNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review";
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { getDefaultLessonProgressState } from "@/context/PupilLessonProgress/pupilLessonProgressHelpers";
+
+const routerPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ asPath: "/review", push: routerPush }),
+}));
+
+jest.mock("@/hooks/useAssignmentSearchParams", () => ({
+  useAssignmentSearchParams: () => ({
+    isClassroomAssignment: false,
+    classroomAssignmentChecked: true,
+  }),
+}));
+
+const logAttempt = jest.fn();
+jest.mock("@/hooks/useOakPupil", () => ({
+  useOakPupil: () => ({ logAttempt }),
+}));
+
+const track = {
+  trackLessonSummaryReviewed: jest.fn(),
+  trackActivityResultsShared: jest.fn(),
+};
+jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
+  usePupilLessonAnalytics: () => track,
+}));
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: unknown) => buildPageProps(args),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const writeText = jest.fn();
+Object.defineProperty(globalThis.navigator, "clipboard", {
+  configurable: true,
+  value: { writeText },
+});
+
+const render = renderWithProvidersByName(["oakTheme"]);
+
+const renderPage = () =>
+  render(
+    <PupilLessonReviewNewPage
+      browseData={lessonBrowseDataFixture({})}
+      lessonContent={lessonContentFixture({ starterQuiz: [], exitQuiz: [] })}
+      backUrl="/back"
+      hasWorksheet={false}
+      worksheetInfo={null}
+      hasAdditionalFiles={false}
+      additionalFiles={null}
+      variant={null}
+      initialSection="review"
+      pageType="canonical"
+    />,
+  );
+
+const completeAllSections = () => {
+  usePupilLessonProgress.setState({
+    sectionResults: {
+      intro: { isComplete: true },
+      "starter-quiz": {
+        isComplete: true,
+        grade: 1,
+        numQuestions: 1,
+        questionResults: [{ mode: "feedback", grade: 1, offerHint: false }],
+      },
+      "exit-quiz": {
+        isComplete: true,
+        grade: 0,
+        numQuestions: 1,
+        questionResults: [{ mode: "feedback", grade: 0, offerHint: true }],
+      },
+    },
+    isLessonComplete: true,
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  usePupilLessonProgress.setState(getDefaultLessonProgressState());
+  usePupilLessonProgress.getState().initialiseLessonProgress({
+    lessonSlug: "lesson-1",
+    lessonReviewSections: ["intro", "starter-quiz", "exit-quiz"],
+  });
+});
+
+describe("review page", () => {
+  it("stores the attempt and tracks the summary on render when the lesson is complete", () => {
+    completeAllSections();
+    logAttempt.mockReturnValue("attempt-1");
+    renderPage();
+    expect(logAttempt).toHaveBeenCalledWith(expect.anything(), true);
+    expect(track.trackLessonSummaryReviewed).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects to the overview when the lesson is not yet complete", () => {
+    renderPage();
+    expect(routerPush.mock.calls[0]?.[0]).toContain("overview");
+  });
+
+  it("copies the share link and tracks results sharing", async () => {
+    completeAllSections();
+    logAttempt.mockReturnValueOnce("attempt-1");
+    logAttempt.mockReturnValueOnce("share-id");
+    const { getByText } = renderPage();
+    fireEvent.click(getByText("Copy link"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(track.trackActivityResultsShared).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns notFound from getStaticProps when the variant is invalid", async () => {
+    expect(
+      await getStaticProps({ params: { variant: "no" } } as never),
+    ).toEqual({ notFound: true });
+  });
+
+  it("calls getPageProps with a review-bound context", async () => {
+    buildPageProps.mockResolvedValue({ props: {} });
+    await getStaticProps({
+      params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+    } as never);
+    expect(getPropsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          params: expect.objectContaining({ section: "review" }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.test.tsx
@@ -1,0 +1,116 @@
+import "@testing-library/jest-dom";
+
+import PupilLessonStarterQuizNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz";
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: { getProps: () => Promise<unknown> }) => buildPageProps(args),
+}));
+
+jest.mock("@/pages-helpers/pupil/lessons-pages/new/QuizPageContent", () => ({
+  QuizPageContent: ({ section }: { section: string }) => (
+    <div data-testid="quiz-page-content">{section}</div>
+  ),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pupil-layout">{children}</div>
+  ),
+}));
+
+beforeEach(() => {
+  getPropsMock.mockReset();
+  buildPageProps.mockReset();
+});
+
+describe("pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz", () => {
+  describe("page component", () => {
+    it("renders the QuizPageContent inside the PupilLayout", () => {
+      const { getByTestId } = renderWithTheme(
+        <PupilLessonStarterQuizNewPage
+          browseData={lessonBrowseDataFixture({})}
+          lessonContent={lessonContentFixture({})}
+          backUrl={null}
+          hasWorksheet={false}
+          worksheetInfo={null}
+          hasAdditionalFiles={false}
+          additionalFiles={null}
+          variant={null}
+          initialSection="starter-quiz"
+          pageType="canonical"
+        />,
+      );
+
+      expect(getByTestId("pupil-layout")).toBeInTheDocument();
+      expect(getByTestId("quiz-page-content")).toHaveTextContent(
+        "starter-quiz",
+      );
+    });
+  });
+
+  describe("getStaticProps", () => {
+    it("returns notFound when the variant is invalid", async () => {
+      const result = await getStaticProps({
+        params: { lessonSlug: "lesson-1", variant: "not-a-real-variant" },
+      } as never);
+
+      expect(result).toEqual({ notFound: true });
+      expect(getPropsMock).not.toHaveBeenCalled();
+    });
+
+    it("delegates to getPageProps with a starter-quiz-bound context", async () => {
+      buildPageProps.mockResolvedValue({ props: { ok: true } });
+      getPropsMock.mockReturnValue("getProps-result");
+
+      const ctx = {
+        params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+      } as never;
+
+      const result = await getStaticProps(ctx);
+
+      expect(getPropsMock).toHaveBeenCalledWith({
+        page: "canonical",
+        context: expect.objectContaining({
+          params: expect.objectContaining({
+            lessonSlug: "lesson-1",
+            section: "starter-quiz",
+          }),
+        }),
+      });
+      expect(buildPageProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: "pupils-lesson-new-starter-quiz::getStaticProps",
+          context: ctx,
+          getProps: "getProps-result",
+        }),
+      );
+      expect(result).toEqual({ props: { ok: true } });
+    });
+
+    it("falls back to undefined params when context.params is missing", async () => {
+      buildPageProps.mockResolvedValue({ props: {} });
+      getPropsMock.mockReturnValue("getProps-result");
+
+      await getStaticProps({ params: { variant: "quizzes-only" } } as never);
+
+      expect(getPropsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({ params: expect.anything() }),
+        }),
+      );
+    });
+  });
+});

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import "@/__tests__/__helpers__/ResizeObserverMock";
+import PupilLessonVideoNewPage, {
+  getStaticProps,
+} from "@/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video";
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+import { lessonBrowseDataFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonBrowseData.fixture";
+import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/lessonContent.fixture";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { getDefaultLessonProgressState } from "@/context/PupilLessonProgress/pupilLessonProgressHelpers";
+
+const routerPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ asPath: "/video", push: routerPush }),
+}));
+
+const track = {
+  trackSectionStarted: jest.fn(),
+  trackLessonStarted: jest.fn(),
+  trackLessonCompleted: jest.fn(),
+  trackVideoCompleted: jest.fn(),
+  trackVideoAbandoned: jest.fn(),
+};
+jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
+  usePupilLessonAnalytics: () => track,
+}));
+
+jest.mock(
+  "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload",
+  () => ({
+    useAdditionalFilesDownload: () => ({
+      startAdditionalFilesDownload: jest.fn(),
+      isAdditionalFilesDownloading: false,
+    }),
+  }),
+);
+
+const getPropsMock = jest.fn();
+const buildPageProps = jest.fn();
+jest.mock("@/pages-helpers/pupil/lessons-pages/getProps", () => ({
+  getProps: (...args: unknown[]) => getPropsMock(...args),
+}));
+jest.mock("@/node-lib/getPageProps", () => ({
+  __esModule: true,
+  default: (args: unknown) => buildPageProps(args),
+}));
+
+jest.mock("@/components/PupilComponents/PupilLayout/PupilLayout", () => ({
+  PupilLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/components/SharedComponents/VideoPlayer/VideoPlayer", () => ({
+  __esModule: true,
+  default: (props: {
+    userEventCallback: (args: {
+      event: string;
+      timeElapsed: number;
+      duration: number;
+      muted: boolean;
+    }) => void;
+  }) => (
+    <button
+      data-testid="emit-video-event"
+      onClick={() =>
+        props.userEventCallback({
+          event: "play",
+          timeElapsed: 30,
+          duration: 60,
+          muted: false,
+        })
+      }
+    />
+  ),
+}));
+
+const render = renderWithProvidersByName(["oakTheme"]);
+
+const renderPage = (
+  props: Partial<React.ComponentProps<typeof PupilLessonVideoNewPage>> = {},
+) =>
+  render(
+    <PupilLessonVideoNewPage
+      browseData={lessonBrowseDataFixture({})}
+      lessonContent={lessonContentFixture({})}
+      backUrl={null}
+      hasWorksheet={false}
+      worksheetInfo={null}
+      hasAdditionalFiles={false}
+      additionalFiles={null}
+      variant={null}
+      initialSection="video"
+      pageType="canonical"
+      {...props}
+    />,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  usePupilLessonProgress.setState(getDefaultLessonProgressState());
+  usePupilLessonProgress.getState().initialiseLessonProgress({
+    lessonSlug: "lesson-1",
+    lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+  });
+});
+
+describe("video page", () => {
+  it("completes the video and navigates on proceed", () => {
+    const { getByTestId } = renderPage();
+    fireEvent.click(getByTestId("proceed-to-next-section"));
+    expect(track.trackVideoCompleted).toHaveBeenCalledTimes(1);
+    expect(
+      usePupilLessonProgress.getState().sectionResults.video?.isComplete,
+    ).toBe(true);
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks video abandoned when the back link is clicked", () => {
+    const { getByLabelText } = renderPage();
+    fireEvent.click(getByLabelText("Back to overview"));
+    expect(track.trackVideoAbandoned).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists video state from the player event callback", () => {
+    const { getByTestId } = renderPage();
+    fireEvent.click(getByTestId("emit-video-event"));
+    const video = usePupilLessonProgress.getState().sectionResults.video;
+    expect(video?.played).toBe(true);
+    expect(video?.duration).toBe(60);
+  });
+
+  it("returns notFound from getStaticProps when the variant is invalid", async () => {
+    expect(
+      await getStaticProps({ params: { variant: "no" } } as never),
+    ).toEqual({ notFound: true });
+  });
+
+  it("calls getPageProps with a video-bound context", async () => {
+    buildPageProps.mockResolvedValue({ props: {} });
+    await getStaticProps({
+      params: { lessonSlug: "lesson-1", variant: "quizzes-only" },
+    } as never);
+    expect(getPropsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          params: expect.objectContaining({ section: "video" }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/browser-lib/mathjax/MathJaxWrap.tsx
+++ b/src/browser-lib/mathjax/MathJaxWrap.tsx
@@ -2,9 +2,15 @@
 import { MathJax } from "better-react-mathjax";
 import React from "react";
 
-const MathJaxWrap = ({ children }: { children: React.ReactNode }) => {
+const MathJaxWrap = ({
+  children,
+  inline,
+}: {
+  children: React.ReactNode;
+  inline?: boolean;
+}) => {
   return (
-    <MathJax hideUntilTypeset="every" dynamic>
+    <MathJax hideUntilTypeset="every" dynamic inline={inline}>
       {children}
     </MathJax>
   );

--- a/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
+++ b/src/components/PupilComponents/PupilLayout/PupilLayout.tsx
@@ -8,6 +8,7 @@ import {
   LessonBrowseData,
   LessonContent,
 } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { LessonShareVariant } from "@/pages-helpers/pupil";
 
 export type PupilLayoutProps = {
   children?: React.ReactNode;
@@ -15,6 +16,7 @@ export type PupilLayoutProps = {
   pupilStores?: {
     browseData: LessonBrowseData;
     lessonContent: LessonContent;
+    variant: LessonShareVariant | null;
   };
 };
 

--- a/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
+++ b/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
@@ -1,10 +1,17 @@
 import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
 
 import { QuizCorrectAnswers } from "./QuizCorrectAnswers";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { QuestionState } from "@/components/PupilComponents/QuizUtils/questionTypes";
 import { imageObject } from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+
+jest.mock("@/browser-lib/mathjax/MathJaxWrap", () => ({
+  MathJaxWrap: ({ children }: { children: ReactNode }) => (
+    <span data-testid="mathjax-wrap">{children}</span>
+  ),
+}));
 
 const baseState: QuestionState = {
   mode: "feedback",
@@ -80,5 +87,23 @@ describe("QuizCorrectAnswers", () => {
     );
     expect(getByText(/Correct answer:/)).toBeInTheDocument();
     expect(getByText(/earth/)).toBeInTheDocument();
+  });
+
+  it("renders string answers through MathJax wrappers", () => {
+    const { getByText, getAllByTestId } = renderWithTheme(
+      <QuizCorrectAnswers
+        questionState={{
+          mode: "feedback",
+          grade: 0,
+          offerHint: false,
+          correctAnswer: ["\\(x + 1\\)", "\\(x + 2\\)"],
+        }}
+      />,
+    );
+
+    expect(getByText("Correct answers:")).toBeInTheDocument();
+    expect(getByText("\\(x + 1\\)")).toBeInTheDocument();
+    expect(getByText("\\(x + 2\\)")).toBeInTheDocument();
+    expect(getAllByTestId("mathjax-wrap")).toHaveLength(2);
   });
 });

--- a/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
+++ b/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.test.tsx
@@ -43,7 +43,7 @@ describe("QuizCorrectAnswers", () => {
   });
 
   it("renders multiple correct answers joined by commas", () => {
-    const { getByText } = renderWithTheme(
+    const { getByText, getAllByTestId } = renderWithTheme(
       <QuizCorrectAnswers
         questionState={{
           ...baseState,
@@ -52,11 +52,14 @@ describe("QuizCorrectAnswers", () => {
       />,
     );
     expect(getByText(/Correct answers:/)).toBeInTheDocument();
-    expect(getByText(/earth, wind, fire/)).toBeInTheDocument();
+    expect(getByText("earth")).toBeInTheDocument();
+    expect(getByText("wind")).toBeInTheDocument();
+    expect(getByText("fire")).toBeInTheDocument();
+    expect(getAllByTestId("mathjax-wrap")).toHaveLength(3);
   });
 
   it("filters out non-string entries when joining multiple answers", () => {
-    const { getByText } = renderWithTheme(
+    const { getByText, queryByText, getAllByTestId } = renderWithTheme(
       <QuizCorrectAnswers
         questionState={{
           ...baseState,
@@ -64,7 +67,10 @@ describe("QuizCorrectAnswers", () => {
         }}
       />,
     );
-    expect(getByText(/earth, fire/)).toBeInTheDocument();
+    expect(getByText("earth")).toBeInTheDocument();
+    expect(getByText("fire")).toBeInTheDocument();
+    expect(queryByText("wind")).not.toBeInTheDocument();
+    expect(getAllByTestId("mathjax-wrap")).toHaveLength(2);
   });
 
   it("renders nothing when the array's first item is an image object", () => {

--- a/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.tsx
+++ b/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.tsx
@@ -21,7 +21,7 @@ export const QuizCorrectAnswers = ({ questionState }: Props) => {
       (answer) =>
         answer != null &&
         !isString(answer) &&
-        Object.prototype.hasOwnProperty.call(answer, "imageObject"),
+        Object.hasOwn(answer, "imageObject"),
     );
 
     if (hasImageAnswer) return null;

--- a/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.tsx
+++ b/src/components/PupilComponents/QuizQuestions/QuizCorrectAnswers/QuizCorrectAnswers.tsx
@@ -1,50 +1,57 @@
+import { Fragment } from "react";
 import { OakCodeRenderer, OakSpan } from "@oaknational/oak-components";
 import { isString } from "lodash";
 
 import { QuestionState } from "@/components/PupilComponents/QuizUtils/questionTypes";
+import { MathJaxWrap } from "@/browser-lib/mathjax/MathJaxWrap";
 
 type Props = {
   questionState?: QuestionState;
 };
 
 export const QuizCorrectAnswers = ({ questionState }: Props) => {
-  const feedbackText = (() => {
-    switch (true) {
-      case questionState &&
-        Array.isArray(questionState.correctAnswer) &&
-        Object.prototype.hasOwnProperty.call(
-          questionState.correctAnswer[0],
-          "imageObject",
-        ):
-        return null;
-      case questionState &&
-        Array.isArray(questionState.correctAnswer) &&
-        questionState.correctAnswer.length > 1:
-        return (
-          "Correct answers: " +
-          (
-            questionState.correctAnswer.filter(
-              (answer) => isString(answer) && answer?.trim() !== "",
-            ) as string[]
-          ).join(", ")
-        );
-      case questionState && Array.isArray(questionState.correctAnswer):
-        return (
-          "Correct answer: " +
-          questionState.correctAnswer.filter((answer) => isString(answer))[0]
-        );
-      case questionState && typeof questionState.correctAnswer === "string":
-        return `Correct answer: ${questionState.correctAnswer}`;
-      default:
-        return null;
-    }
-  })();
+  const correctAnswer = questionState?.correctAnswer;
 
-  if (!feedbackText) return null;
+  // Nothing should be rendered when the question has no text answer to show.
+  if (!correctAnswer) return null;
+
+  if (Array.isArray(correctAnswer)) {
+    // Image answers are already rendered elsewhere, so do not duplicate them here.
+    const hasImageAnswer = correctAnswer.some(
+      (answer) =>
+        answer != null &&
+        !isString(answer) &&
+        Object.prototype.hasOwnProperty.call(answer, "imageObject"),
+    );
+
+    if (hasImageAnswer) return null;
+  }
+
+  // Only non-empty string answers can be displayed in the bottom feedback bar.
+  const answers = Array.isArray(correctAnswer)
+    ? correctAnswer.filter(
+        (answer): answer is string => isString(answer) && answer.trim() !== "",
+      )
+    : [correctAnswer].filter(
+        (answer): answer is string => isString(answer) && answer.trim() !== "",
+      );
+
+  // Avoid rendering just the label when all answer values were empty or unsupported.
+  if (answers.length === 0) return null;
+
+  const label = answers.length > 1 ? "Correct answers:" : "Correct answer:";
 
   return (
     <OakSpan $color="text-primary" $font="body-2">
-      <OakCodeRenderer string={feedbackText} $font="code-3" />
+      <OakSpan>{label} </OakSpan>
+      {answers.map((answer, index) => (
+        <Fragment key={`${answer}-${index}`}>
+          {index > 0 && <OakSpan>, </OakSpan>}
+          <MathJaxWrap inline>
+            <OakCodeRenderer string={answer} $font="code-3" />
+          </MathJaxWrap>
+        </Fragment>
+      ))}
     </OakSpan>
   );
 };

--- a/src/components/PupilComponents/QuizQuestions/QuizRenderer/QuizRenderer.tsx
+++ b/src/components/PupilComponents/QuizQuestions/QuizRenderer/QuizRenderer.tsx
@@ -131,6 +131,7 @@ export const QuizRenderer = ({
     >
       {currentQuestionData && (
         <OakBox
+          key={`${currentQuestionData.questionUid}-${currentQuestionIndex}`}
           as="form"
           id={formId}
           onSubmit={handleSubmit}

--- a/src/components/PupilComponents/Views/PupilLessonIntro/PupilLessonIntroAdditionalFileItem/PupilLessonIntroAdditionalFileItem.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonIntro/PupilLessonIntroAdditionalFileItem/PupilLessonIntroAdditionalFileItem.tsx
@@ -16,7 +16,7 @@ export const PupilLessonIntroAdditionalFileItem = ({
   const extension = url.split(".").pop();
 
   return (
-    <OakLI>
+    <OakLI $listStyle="none">
       <OakFlex $flexDirection="column">
         <OakSpan>{displayName}</OakSpan>
         <OakSpan>{`${convertBytesToMegabytes(bytes)} (${extension?.toUpperCase()})`}</OakSpan>

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.stories.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+
+import { PupilLessonOverviewContentGuidanceModal } from "./PupilLessonOverviewContentGuidanceModal";
+
+const meta = {
+  component: PupilLessonOverviewContentGuidanceModal,
+  decorators: [
+    (StoryComponent) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <StoryComponent />
+      </OakThemeProvider>
+    ),
+  ],
+  args: {
+    redirectOverlayCleared: true,
+    contentGuidanceDismissed: false,
+    isClassroomAssignment: false,
+    onAccept: () => {},
+    onDecline: () => {},
+  },
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 520,
+      },
+    },
+  },
+} satisfies Meta<typeof PupilLessonOverviewContentGuidanceModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ContentGuidance: Story = {
+  args: {
+    supervisionLevel: "Adult supervision recommended.",
+    ageRestriction: null,
+    contentGuidance: [
+      {
+        contentguidanceLabel: "Depiction",
+        contentguidanceArea: "Violence",
+        contentguidanceDescription: "Contains references to conflict.",
+      },
+      {
+        contentguidanceLabel: "Themes",
+        contentguidanceArea: "Loss",
+        contentguidanceDescription: "Discusses bereavement in context.",
+      },
+    ],
+  },
+};
+
+export const AgeRestrictionOnly: Story = {
+  args: {
+    contentGuidance: null,
+    supervisionLevel: null,
+    ageRestriction: "7_and_above",
+  },
+};
+
+export const ClassroomAssignment: Story = {
+  args: {
+    ...ContentGuidance.args,
+    isClassroomAssignment: true,
+  },
+};

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.test.tsx
@@ -1,0 +1,130 @@
+import userEvent from "@testing-library/user-event";
+
+import { PupilLessonOverviewContentGuidanceModal } from "./PupilLessonOverviewContentGuidanceModal";
+
+import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
+import { ContentGuidanceWarningValueType } from "@/browser-lib/avo/Avo";
+
+const render = renderWithProvidersByName(["oakTheme"]);
+
+const contentGuidance = [
+  {
+    contentguidanceLabel: "Scenes of conflict",
+    contentguidanceArea: "Violence",
+    contentguidanceDescription: "Contains references to conflict.",
+  },
+];
+
+const defaultProps = {
+  redirectOverlayCleared: true,
+  contentGuidanceDismissed: false,
+  contentGuidance,
+  supervisionLevel: "Adult supervision recommended",
+  ageRestriction: null,
+  isClassroomAssignment: false,
+  onAccept: jest.fn(),
+  onDecline: jest.fn(),
+};
+
+describe("PupilLessonOverviewContentGuidanceModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders content guidance when the redirected overlay has cleared", () => {
+    render(<PupilLessonOverviewContentGuidanceModal {...defaultProps} />);
+
+    const dialog = document.querySelector('[role="alertdialog"]');
+
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("Scenes of conflict");
+    expect(dialog).toHaveTextContent("Adult supervision recommended");
+  });
+
+  it("does not render before the redirected overlay has cleared", () => {
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        redirectOverlayCleared={false}
+      />,
+    );
+
+    expect(
+      document.querySelector('[role="alertdialog"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render once content guidance has been dismissed", () => {
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        contentGuidanceDismissed
+      />,
+    );
+
+    expect(
+      document.querySelector('[role="alertdialog"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onAccept with tracking args", async () => {
+    const user = userEvent.setup();
+    const onAccept = jest.fn();
+
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        onAccept={onAccept}
+      />,
+    );
+
+    await user.click(document.querySelector('[data-testid="acceptButton"]')!);
+
+    expect(onAccept).toHaveBeenCalledWith({
+      supervisionLevel: "Adult supervision recommended",
+      contentGuidanceWarning: "Violence" as ContentGuidanceWarningValueType,
+      ageRestriction: "all",
+    });
+  });
+
+  it("calls onDecline with tracking args", async () => {
+    const user = userEvent.setup();
+    const onDecline = jest.fn();
+
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        onDecline={onDecline}
+      />,
+    );
+
+    await user.click(document.querySelector('[data-testid="declineButton"]')!);
+
+    expect(onDecline).toHaveBeenCalledWith({
+      supervisionLevel: "Adult supervision recommended",
+      contentGuidanceWarning: "Violence" as ContentGuidanceWarningValueType,
+      ageRestriction: "all",
+    });
+  });
+
+  it("renders default guidance for age restricted lessons without content guidance", () => {
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        contentGuidance={null}
+        supervisionLevel={null}
+        ageRestriction="7_and_above"
+      />,
+    );
+
+    const dialog = document.querySelector('[role="alertdialog"]');
+
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent(
+      "To view this lesson, you must be in year 7 and above",
+    );
+    expect(dialog).toHaveTextContent(
+      "Speak to an adult before starting this lesson.",
+    );
+  });
+});

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import {
+  OakPupilContentGuidance,
+  OakPupilJourneyContentGuidance,
+  OakPupilJourneyContentGuidanceProps,
+} from "@oaknational/oak-components";
+
+import { ContentGuidanceWarningValueType } from "@/browser-lib/avo/Avo";
+import { getAgeRestrictionString } from "@/components/PupilComponents/Views/ViewHelpers";
+
+export type ContentGuidanceTrackingArgs = {
+  supervisionLevel: string;
+  contentGuidanceWarning: ContentGuidanceWarningValueType;
+  ageRestriction: string;
+};
+
+type PupilLessonOverviewContentGuidanceModalProps = {
+  redirectOverlayCleared: boolean;
+  contentGuidance: OakPupilContentGuidance[] | null | undefined;
+  supervisionLevel: string | null | undefined;
+  ageRestriction: string | null | undefined;
+  isClassroomAssignment: boolean | null;
+  onAccept: (args: ContentGuidanceTrackingArgs) => void;
+  onDecline: (args: ContentGuidanceTrackingArgs) => void;
+};
+
+const defaultContentGuidance: OakPupilContentGuidance[] = [
+  {
+    contentguidanceLabel: "Speak to an adult before starting this lesson.",
+    contentguidanceDescription: null,
+    contentguidanceArea: null,
+  },
+];
+
+export const PupilLessonOverviewContentGuidanceModal = ({
+  redirectOverlayCleared,
+  contentGuidance,
+  supervisionLevel,
+  ageRestriction,
+  isClassroomAssignment,
+  onAccept,
+  onDecline,
+}: PupilLessonOverviewContentGuidanceModalProps) => {
+  const hasAgeRestriction = Boolean(ageRestriction);
+  const [isOpen, setIsOpen] = useState<boolean>(
+    Boolean(contentGuidance) || hasAgeRestriction,
+  );
+  const contentGuidanceWarning = contentGuidance?.find(
+    (guidance) => guidance.contentguidanceArea,
+  )?.contentguidanceArea as ContentGuidanceWarningValueType;
+  const trackingArgs = {
+    supervisionLevel: supervisionLevel || "",
+    contentGuidanceWarning,
+    ageRestriction: ageRestriction ?? "all",
+  };
+  const isModalOpen = isOpen && redirectOverlayCleared;
+  const declineIcon = isClassroomAssignment ? "cross" : undefined;
+  const declineText = isClassroomAssignment ? "Exit lesson" : undefined;
+  const handleAccept = () => {
+    setIsOpen(false);
+    onAccept(trackingArgs);
+  };
+  const ageRestrictionProps: Partial<OakPupilJourneyContentGuidanceProps> = {
+    contentGuidance: contentGuidance ?? defaultContentGuidance,
+    supervisionLevel: contentGuidance ? supervisionLevel : null,
+  };
+  const otherContentGuidanceProps: Partial<OakPupilJourneyContentGuidanceProps> =
+    {
+      contentGuidance: contentGuidance ?? null,
+      supervisionLevel: supervisionLevel,
+    };
+
+  return (
+    <OakPupilJourneyContentGuidance
+      isOpen={isModalOpen}
+      onAccept={handleAccept}
+      onDecline={() => onDecline(trackingArgs)}
+      declineIcon={declineIcon}
+      declineText={declineText}
+      title={
+        hasAgeRestriction ? getAgeRestrictionString(ageRestriction) : undefined
+      }
+      {...(hasAgeRestriction ? ageRestrictionProps : otherContentGuidanceProps)}
+    />
+  );
+};

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   OakPupilContentGuidance,
   OakPupilJourneyContentGuidance,
@@ -16,6 +15,7 @@ export type ContentGuidanceTrackingArgs = {
 
 type PupilLessonOverviewContentGuidanceModalProps = {
   redirectOverlayCleared: boolean;
+  contentGuidanceDismissed: boolean;
   contentGuidance: OakPupilContentGuidance[] | null | undefined;
   supervisionLevel: string | null | undefined;
   ageRestriction: string | null | undefined;
@@ -34,6 +34,7 @@ const defaultContentGuidance: OakPupilContentGuidance[] = [
 
 export const PupilLessonOverviewContentGuidanceModal = ({
   redirectOverlayCleared,
+  contentGuidanceDismissed,
   contentGuidance,
   supervisionLevel,
   ageRestriction,
@@ -42,9 +43,7 @@ export const PupilLessonOverviewContentGuidanceModal = ({
   onDecline,
 }: PupilLessonOverviewContentGuidanceModalProps) => {
   const hasAgeRestriction = Boolean(ageRestriction);
-  const [isOpen, setIsOpen] = useState<boolean>(
-    Boolean(contentGuidance) || hasAgeRestriction,
-  );
+  const hasContentGuidance = Boolean(contentGuidance) || hasAgeRestriction;
   const contentGuidanceWarning = contentGuidance?.find(
     (guidance) => guidance.contentguidanceArea,
   )?.contentguidanceArea as ContentGuidanceWarningValueType;
@@ -53,13 +52,10 @@ export const PupilLessonOverviewContentGuidanceModal = ({
     contentGuidanceWarning,
     ageRestriction: ageRestriction ?? "all",
   };
-  const isModalOpen = isOpen && redirectOverlayCleared;
+  const isModalOpen =
+    hasContentGuidance && !contentGuidanceDismissed && redirectOverlayCleared;
   const declineIcon = isClassroomAssignment ? "cross" : undefined;
   const declineText = isClassroomAssignment ? "Exit lesson" : undefined;
-  const handleAccept = () => {
-    setIsOpen(false);
-    onAccept(trackingArgs);
-  };
   const ageRestrictionProps: Partial<OakPupilJourneyContentGuidanceProps> = {
     contentGuidance: contentGuidance ?? defaultContentGuidance,
     supervisionLevel: contentGuidance ? supervisionLevel : null,
@@ -73,7 +69,7 @@ export const PupilLessonOverviewContentGuidanceModal = ({
   return (
     <OakPupilJourneyContentGuidance
       isOpen={isModalOpen}
-      onAccept={handleAccept}
+      onAccept={() => onAccept(trackingArgs)}
       onDecline={() => onDecline(trackingArgs)}
       declineIcon={declineIcon}
       declineText={declineText}

--- a/src/components/PupilComponents/Views/PupilLessonOverview/index.ts
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/index.ts
@@ -3,6 +3,7 @@ export * from "./PupilLessonOverviewView/PupilLessonOverview.view";
 export * from "./PupilLessonOverviewHeader/PupilLessonOverviewHeader";
 export * from "./PupilLessonOverviewOutcomes/PupilLessonOverviewOutcomes";
 export * from "./PupilLessonOverviewContentGuidance/PupilLessonOverviewContentGuidance";
+export * from "./PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal";
 export * from "./PupilLessonOverviewSectionsNav/PupilLessonOverviewSectionsNav";
 export * from "./helpers/getProceedLabel";
 export * from "./helpers/getSectionProgress";

--- a/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.test.ts
@@ -20,4 +20,34 @@ describe("pickAvailableSectionsForLesson", () => {
       } as never),
     ).toEqual(["intro", "starter-quiz", "video", "exit-quiz"]);
   });
+
+  it("restricts sections to the variant's allowed list", () => {
+    expect(
+      pickAvailableSectionsForLesson(
+        {
+          starterQuiz: [{}],
+          exitQuiz: [{}],
+          videoMuxPlaybackId: "playback-id",
+        } as never,
+        { sections: ["intro", "video"], reviewSections: [] } as never,
+      ),
+    ).toEqual(["intro", "video"]);
+  });
+
+  it("uses the variant's review sections when isReview is true", () => {
+    expect(
+      pickAvailableSectionsForLesson(
+        {
+          starterQuiz: [{}],
+          exitQuiz: [{}],
+          videoMuxPlaybackId: "playback-id",
+        } as never,
+        {
+          sections: [],
+          reviewSections: ["intro", "starter-quiz", "exit-quiz"],
+        } as never,
+        true,
+      ),
+    ).toEqual(["intro", "starter-quiz", "exit-quiz"]);
+  });
 });

--- a/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.ts
@@ -1,16 +1,32 @@
-import { allLessonReviewSections } from "@/components/PupilComponents/lessonSections";
+import {
+  allLessonReviewSections,
+  LessonReviewSection,
+} from "@/components/PupilComponents/lessonSections";
 import { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { LessonShareVariant } from "@/pages-helpers/pupil";
 
-export const pickAvailableSectionsForLesson = (lessonContent: LessonContent) =>
-  allLessonReviewSections.filter((section) => {
-    switch (section) {
-      case "starter-quiz":
-        return Boolean(lessonContent?.starterQuiz?.length);
-      case "exit-quiz":
-        return Boolean(lessonContent?.exitQuiz?.length);
-      case "video":
-        return Boolean(lessonContent?.videoMuxPlaybackId);
-      default:
-        return true;
-    }
-  });
+export const pickAvailableSectionsForLesson = (
+  lessonContent: LessonContent,
+  variant: LessonShareVariant | null,
+  isReview: boolean = false,
+) => {
+  const filterOutVariantExclusions = (section: LessonReviewSection) => {
+    if (!variant) return true;
+    const validSections = isReview ? variant.reviewSections : variant.sections;
+    return validSections.includes(section);
+  };
+  return allLessonReviewSections
+    .filter(filterOutVariantExclusions)
+    .filter((section) => {
+      switch (section) {
+        case "starter-quiz":
+          return Boolean(lessonContent?.starterQuiz?.length);
+        case "exit-quiz":
+          return Boolean(lessonContent?.exitQuiz?.length);
+        case "video":
+          return Boolean(lessonContent?.videoMuxPlaybackId);
+        default:
+          return true;
+      }
+    });
+};

--- a/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson.ts
@@ -7,7 +7,7 @@ import { LessonShareVariant } from "@/pages-helpers/pupil";
 
 export const pickAvailableSectionsForLesson = (
   lessonContent: LessonContent,
-  variant: LessonShareVariant | null,
+  variant: LessonShareVariant | null = null,
   isReview: boolean = false,
 ) => {
   const filterOutVariantExclusions = (section: LessonReviewSection) => {

--- a/src/components/PupilComponents/Views/ViewHelpers/Review/index.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Review/index.ts
@@ -1,5 +1,5 @@
 export * from "./buildReviewAttemptData";
 export * from "./buildReviewShareUrl";
 export * from "./getHasQuizSections";
-export * from "./mapLessonSummaryQuizResults";
+export * from "./mapPupilQuizResultsForAnalytics";
 export * from "./shouldShowReviewBottomNav";

--- a/src/components/PupilComponents/Views/ViewHelpers/Review/mapPupilQuizResultsForAnalytics.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Review/mapPupilQuizResultsForAnalytics.test.ts
@@ -1,9 +1,9 @@
-import { mapLessonSummaryQuizResults } from "./mapLessonSummaryQuizResults";
+import { mapPupilQuizResultsForAnalytics } from "./mapPupilQuizResultsForAnalytics";
 
-describe("mapLessonSummaryQuizResults", () => {
+describe("mapPupilQuizResultsForAnalytics", () => {
   it("returns undefined when there are no question results", () => {
     expect(
-      mapLessonSummaryQuizResults({
+      mapPupilQuizResultsForAnalytics({
         section: "starter-quiz",
         questionResults: undefined,
         questionsArray: [],
@@ -13,7 +13,7 @@ describe("mapLessonSummaryQuizResults", () => {
 
   it("maps question results into lesson summary analytics results", () => {
     expect(
-      mapLessonSummaryQuizResults({
+      mapPupilQuizResultsForAnalytics({
         section: "starter-quiz",
         questionResults: [
           { grade: 1, offerHint: false },
@@ -54,7 +54,7 @@ describe("mapLessonSummaryQuizResults", () => {
 
   it("falls back to an empty question type when question metadata is missing", () => {
     expect(
-      mapLessonSummaryQuizResults({
+      mapPupilQuizResultsForAnalytics({
         section: "exit-quiz",
         questionResults: [{ grade: 0, offerHint: false }],
         questionsArray: [],

--- a/src/components/PupilComponents/Views/ViewHelpers/Review/mapPupilQuizResultsForAnalytics.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Review/mapPupilQuizResultsForAnalytics.ts
@@ -1,13 +1,12 @@
-import { LessonSummaryReviewedProperties } from "@/browser-lib/avo/Avo";
-import { QuestionsArray } from "@/context/PupilLessonQuiz";
+import type { ActivityResultsSharedProperties } from "@/browser-lib/avo/Avo";
+import type { QuestionsArray } from "@/context/PupilLessonQuiz";
 
 type SummarySection = "starter-quiz" | "exit-quiz";
 
-export const mapLessonSummaryQuizResults = ({
-  section,
-  questionResults,
-  questionsArray,
-}: {
+type PupilQuizResultsForAnalytics =
+  ActivityResultsSharedProperties["pupilStarterQuiz"];
+
+type MapPupilQuizResultsForAnalyticsArgs = {
   section: SummarySection;
   questionResults:
     | {
@@ -16,7 +15,13 @@ export const mapLessonSummaryQuizResults = ({
       }[]
     | undefined;
   questionsArray: QuestionsArray;
-}): LessonSummaryReviewedProperties["pupilStarterQuiz"] => {
+};
+
+export const mapPupilQuizResultsForAnalytics = ({
+  section,
+  questionResults,
+  questionsArray,
+}: MapPupilQuizResultsForAnalyticsArgs): PupilQuizResultsForAnalytics => {
   if (!questionResults) return undefined;
 
   return questionResults.map((result, index) => {

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/getAgeRestrictionString.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/getAgeRestrictionString.ts
@@ -1,0 +1,12 @@
+export const getAgeRestrictionString = (
+  ageRestriction: string | undefined | null,
+) => {
+  switch (ageRestriction) {
+    case "7_and_above":
+      return "To view this lesson, you must be in year 7 and above";
+    case "10_and_above":
+      return "To view this lesson, you must be in year 10 and above";
+    default:
+      return "This lesson is age restricted.";
+  }
+};

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/index.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/index.ts
@@ -1,4 +1,5 @@
 export * from "./getAdditionalFileAssetIds";
+export * from "./getAgeRestrictionString";
 export * from "./getNewLessonSectionHref";
 export * from "./pickNextIncompleteSection";
 export * from "./pickProceedToNextSectionLabel";

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/usePupilStores.ts
@@ -8,10 +8,12 @@ import {
   LessonBrowseData,
   LessonContent,
 } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { LessonShareVariant } from "@/pages-helpers/pupil";
 
 type UsePupilStoresParams = {
   browseData: LessonBrowseData;
   lessonContent: LessonContent;
+  variant: LessonShareVariant | null;
 };
 
 /**
@@ -27,7 +29,10 @@ export const usePupilStores = (params?: UsePupilStoresParams) => {
   const browseData = params?.browseData;
   const lessonContent = params?.lessonContent;
   const availableSections = useMemo(
-    () => (lessonContent ? pickAvailableSectionsForLesson(lessonContent) : []),
+    () =>
+      lessonContent
+        ? pickAvailableSectionsForLesson(lessonContent, params.variant)
+        : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       lessonContent?.starterQuiz,

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -52,6 +52,7 @@ import {
   useGoogleClassroomContext,
 } from "@/components/GoogleClassroom/useGoogleClassroomContext";
 import { pickAvailableSectionsForLesson } from "@/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson";
+import { getAgeRestrictionString } from "@/components/PupilComponents/Views/ViewHelpers/Shared";
 import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 export { pickAvailableSectionsForLesson };
@@ -198,17 +199,6 @@ const CookieConsentStyles = createGlobalStyle`
   }
 }
 `;
-
-const getAgeRestrictionString = (ageRestriction: string | undefined | null) => {
-  switch (ageRestriction) {
-    case "7_and_above":
-      return `To view this lesson, you must be in year 7 and above`;
-    case "10_and_above":
-      return `To view this lesson, you must be in year 10 and above`;
-    default:
-      return `This lesson is age restricted.`;
-  }
-};
 
 const getLessonEngineInitialSection = ({
   initialSection,

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -55,7 +55,7 @@ import { pickAvailableSectionsForLesson } from "@/components/PupilComponents/Vie
 import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 export { pickAvailableSectionsForLesson };
-export type PupilExperienceViewProps = PupilLessonPageProps;
+export type PupilExperienceViewProps = Omit<PupilLessonPageProps, "variant">;
 
 export const PupilPageContent = ({
   browseData,
@@ -544,7 +544,7 @@ const PupilExperienceLayout = ({
     !!lessonContent.contentGuidance || hasAgeRestriction,
   );
   const router = useRouter();
-  const availableSections = pickAvailableSectionsForLesson(lessonContent);
+  const availableSections = pickAvailableSectionsForLesson(lessonContent, null);
 
   const isSensitive = lessonContent.deprecatedFields?.isSensitive === true;
 

--- a/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
+++ b/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
@@ -1,0 +1,63 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+import type {
+  PupilAnalyticsProviderClassroomContext,
+  PupilPathwayData,
+  PupilVideoData,
+} from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import type { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+
+export type AdditionalArgs = PupilPathwayData & {
+  analyticsUseCase: "Pupil";
+  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"];
+  classroomAssignmentId: string | null;
+  courseId: string | null;
+  itemId: string | null;
+  attachmentId: string | null;
+  submissionId: string | null;
+  teacherLoginHint: string | null;
+  pupilLoginHint: string | null;
+};
+
+export type TrackSectionStartedArgs = {
+  section: "intro" | "starter-quiz" | "video" | "exit-quiz" | "review";
+  sectionResults: LessonSectionResults;
+};
+
+export type TrackQuizQuestionAttemptArgs = {
+  section: "starter-quiz" | "exit-quiz";
+  questionType: string;
+  isCorrect: boolean;
+  hintAvailable: boolean;
+  hintAccessed: boolean;
+  questionNumber: number;
+};
+
+export type TrackQuizCompletedArgs = {
+  section: "starter-quiz" | "exit-quiz";
+  sectionResults: LessonSectionResults;
+  sectionStartedAt: number;
+};
+
+export type InitialisePupilLessonAnalyticsArgs = {
+  track: TrackFns;
+  pupilPathwayData: PupilPathwayData;
+  classroomAssignmentContext: PupilAnalyticsProviderClassroomContext;
+  lessonContent?: LessonContent;
+};
+
+export type PupilLessonAnalyticsState = {
+  track: TrackFns | null;
+  additionalArgs: AdditionalArgs | null;
+  videoData: PupilVideoData | null;
+  accessedLessonSlug: string | null;
+  initialisePupilLessonAnalytics: (
+    args: InitialisePupilLessonAnalyticsArgs,
+  ) => void;
+  trackSectionStarted: (args: TrackSectionStartedArgs) => void;
+  trackQuizQuestionAttempt: (args: TrackQuizQuestionAttemptArgs) => void;
+  trackQuizCompleted: (args: TrackQuizCompletedArgs) => void;
+  trackLessonAbandoned: () => void;
+};
+
+export type PupilLessonAnalyticsGet = () => PupilLessonAnalyticsState;

--- a/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
+++ b/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
@@ -39,6 +39,15 @@ export type TrackQuizCompletedArgs = {
   sectionStartedAt: number;
 };
 
+export type TrackSectionResultArgs = {
+  sectionResults: LessonSectionResults;
+};
+
+export type TrackQuizAbandonedArgs = {
+  section: "starter-quiz" | "exit-quiz";
+  sectionResults: LessonSectionResults;
+};
+
 export type InitialisePupilLessonAnalyticsArgs = {
   track: TrackFns;
   pupilPathwayData: PupilPathwayData;
@@ -57,7 +66,17 @@ export type PupilLessonAnalyticsState = {
   trackSectionStarted: (args: TrackSectionStartedArgs) => void;
   trackQuizQuestionAttempt: (args: TrackQuizQuestionAttemptArgs) => void;
   trackQuizCompleted: (args: TrackQuizCompletedArgs) => void;
+  trackQuizAbandoned: (args: TrackQuizAbandonedArgs) => void;
+  trackLessonStarted: () => void;
+  trackLessonCompleted: () => void;
   trackLessonAbandoned: () => void;
+  trackIntroCompleted: () => void;
+  trackIntroAbandoned: () => void;
+  trackWorksheetDownloaded: () => void;
+  trackVideoCompleted: (args: TrackSectionResultArgs) => void;
+  trackVideoAbandoned: (args: TrackSectionResultArgs) => void;
+  trackLessonSummaryReviewed: (args: TrackSectionResultArgs) => void;
+  trackActivityResultsShared: (args: TrackSectionResultArgs) => void;
 };
 
 export type PupilLessonAnalyticsGet = () => PupilLessonAnalyticsState;

--- a/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
+++ b/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
@@ -48,6 +48,11 @@ export type TrackQuizAbandonedArgs = {
   sectionResults: LessonSectionResults;
 };
 
+export type TrackContentGuidanceArgs = Omit<
+  Parameters<TrackFns["contentGuidanceAccepted"]>[0],
+  keyof AdditionalArgs
+>;
+
 export type InitialisePupilLessonAnalyticsArgs = {
   track: TrackFns;
   pupilPathwayData: PupilPathwayData;
@@ -77,6 +82,8 @@ export type PupilLessonAnalyticsState = {
   trackVideoAbandoned: (args: TrackSectionResultArgs) => void;
   trackLessonSummaryReviewed: (args: TrackSectionResultArgs) => void;
   trackActivityResultsShared: (args: TrackSectionResultArgs) => void;
+  trackContentGuidanceAccepted: (args: TrackContentGuidanceArgs) => void;
+  trackContentGuidanceDeclined: (args: TrackContentGuidanceArgs) => void;
 };
 
 export type PupilLessonAnalyticsGet = () => PupilLessonAnalyticsState;

--- a/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
+++ b/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
@@ -6,6 +6,7 @@ import type {
   PupilVideoData,
 } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
 import type { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import type { QuestionsArray } from "@/context/PupilLessonQuiz";
 
 export type AdditionalArgs = PupilPathwayData & {
   analyticsUseCase: "Pupil";
@@ -41,6 +42,15 @@ export type TrackQuizCompletedArgs = {
 
 export type TrackSectionResultArgs = {
   sectionResults: LessonSectionResults;
+};
+
+export type TrackSectionCompletedArgs = TrackSectionResultArgs & {
+  sectionStartedAt: number;
+};
+
+export type TrackReviewEventArgs = TrackSectionResultArgs & {
+  starterQuizQuestionsArray: QuestionsArray;
+  exitQuizQuestionsArray: QuestionsArray;
 };
 
 export type TrackQuizAbandonedArgs = {
@@ -84,13 +94,13 @@ export type PupilLessonAnalyticsState = {
   trackLessonStarted: () => void;
   trackLessonCompleted: () => void;
   trackLessonAbandoned: () => void;
-  trackIntroCompleted: () => void;
+  trackIntroCompleted: (args: TrackSectionAbandonedArgs) => void;
   trackIntroAbandoned: (args: TrackSectionAbandonedArgs) => void;
   trackWorksheetDownloaded: () => void;
-  trackVideoCompleted: (args: TrackSectionResultArgs) => void;
+  trackVideoCompleted: (args: TrackSectionCompletedArgs) => void;
   trackVideoAbandoned: (args: TrackSectionResultAbandonedArgs) => void;
-  trackLessonSummaryReviewed: (args: TrackSectionResultArgs) => void;
-  trackActivityResultsShared: (args: TrackSectionResultArgs) => void;
+  trackLessonSummaryReviewed: (args: TrackReviewEventArgs) => void;
+  trackActivityResultsShared: (args: TrackReviewEventArgs) => void;
   trackContentGuidanceAccepted: (args: TrackContentGuidanceArgs) => void;
   trackContentGuidanceDeclined: (args: TrackContentGuidanceArgs) => void;
 };

--- a/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
+++ b/src/context/PupilLessonAnalytics/pupilLessonAnalytics.types.ts
@@ -46,6 +46,15 @@ export type TrackSectionResultArgs = {
 export type TrackQuizAbandonedArgs = {
   section: "starter-quiz" | "exit-quiz";
   sectionResults: LessonSectionResults;
+  sectionStartedAt: number;
+};
+
+export type TrackSectionAbandonedArgs = {
+  sectionStartedAt: number;
+};
+
+export type TrackSectionResultAbandonedArgs = TrackSectionResultArgs & {
+  sectionStartedAt: number;
 };
 
 export type TrackContentGuidanceArgs = Omit<
@@ -76,10 +85,10 @@ export type PupilLessonAnalyticsState = {
   trackLessonCompleted: () => void;
   trackLessonAbandoned: () => void;
   trackIntroCompleted: () => void;
-  trackIntroAbandoned: () => void;
+  trackIntroAbandoned: (args: TrackSectionAbandonedArgs) => void;
   trackWorksheetDownloaded: () => void;
   trackVideoCompleted: (args: TrackSectionResultArgs) => void;
-  trackVideoAbandoned: (args: TrackSectionResultArgs) => void;
+  trackVideoAbandoned: (args: TrackSectionResultAbandonedArgs) => void;
   trackLessonSummaryReviewed: (args: TrackSectionResultArgs) => void;
   trackActivityResultsShared: (args: TrackSectionResultArgs) => void;
   trackContentGuidanceAccepted: (args: TrackContentGuidanceArgs) => void;

--- a/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.test.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.test.ts
@@ -1,0 +1,28 @@
+import { trackIntroCompleted } from "./introTracking";
+
+describe("trackIntroCompleted", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("tracks elapsed activity time from the section start timestamp", () => {
+    jest.spyOn(Date, "now").mockReturnValue(1500);
+    const lessonActivityCompletedIntroduction = jest.fn();
+
+    trackIntroCompleted(
+      () =>
+        ({
+          track: { lessonActivityCompletedIntroduction },
+          additionalArgs: {},
+        }) as never,
+      { sectionStartedAt: 1000 },
+    );
+
+    expect(lessonActivityCompletedIntroduction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pupilExperienceLessonActivity: "intro",
+        activityTimeSpent: 500,
+      }),
+    );
+  });
+});

--- a/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
@@ -1,6 +1,7 @@
 import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import type {
   PupilLessonAnalyticsGet,
+  TrackSectionAbandonedArgs,
   TrackSectionStartedArgs,
 } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
 
@@ -18,14 +19,17 @@ export const trackIntroStarted = (
   });
 };
 
-export const trackIntroCompleted = (get: PupilLessonAnalyticsGet) => {
+export const trackIntroCompleted = (
+  get: PupilLessonAnalyticsGet,
+  { sectionStartedAt }: TrackSectionAbandonedArgs,
+) => {
   const { track, additionalArgs } = get();
   if (!track || !additionalArgs) return;
 
   track.lessonActivityCompletedIntroduction({
     ...additionalArgs,
     pupilExperienceLessonActivity: "intro",
-    activityTimeSpent: 0,
+    activityTimeSpent: Date.now() - sectionStartedAt,
   });
 };
 

--- a/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
@@ -29,14 +29,17 @@ export const trackIntroCompleted = (get: PupilLessonAnalyticsGet) => {
   });
 };
 
-export const trackIntroAbandoned = (get: PupilLessonAnalyticsGet) => {
+export const trackIntroAbandoned = (
+  get: PupilLessonAnalyticsGet,
+  sectionStartedAt: number,
+) => {
   const { track, additionalArgs } = get();
   if (!track || !additionalArgs) return;
 
   track.lessonActivityAbandonedIntroduction({
     ...additionalArgs,
     pupilExperienceLessonActivity: "intro",
-    activityTimeSpent: 0,
+    activityTimeSpent: Date.now() - sectionStartedAt,
   });
 };
 

--- a/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
@@ -70,7 +70,7 @@ export const trackContentGuidanceAccepted = (
   track.contentGuidanceAccepted({
     ...additionalArgs,
     ...args,
-  } as Parameters<TrackFns["contentGuidanceAccepted"]>[0]);
+  });
 };
 
 export const trackContentGuidanceDeclined = (
@@ -86,5 +86,5 @@ export const trackContentGuidanceDeclined = (
   track.contentGuidanceDeclined({
     ...additionalArgs,
     ...args,
-  } as Parameters<TrackFns["contentGuidanceDeclined"]>[0]);
+  });
 };

--- a/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/introTracking.ts
@@ -1,0 +1,83 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type {
+  PupilLessonAnalyticsGet,
+  TrackSectionStartedArgs,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+
+export const trackIntroStarted = (
+  get: PupilLessonAnalyticsGet,
+  { section, sectionResults }: TrackSectionStartedArgs,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+  if (section !== "intro" || sectionResults.intro?.isComplete) return;
+
+  track.lessonActivityStartedIntroduction({
+    ...additionalArgs,
+    pupilExperienceLessonActivity: section,
+  });
+};
+
+export const trackIntroCompleted = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonActivityCompletedIntroduction({
+    ...additionalArgs,
+    pupilExperienceLessonActivity: "intro",
+    activityTimeSpent: 0,
+  });
+};
+
+export const trackIntroAbandoned = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonActivityAbandonedIntroduction({
+    ...additionalArgs,
+    pupilExperienceLessonActivity: "intro",
+    activityTimeSpent: 0,
+  });
+};
+
+export const trackWorksheetDownloaded = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonActivityDownloadedWorksheet({
+    ...additionalArgs,
+    pupilExperienceLessonActivity: "intro",
+  } as Parameters<TrackFns["lessonActivityDownloadedWorksheet"]>[0]);
+};
+
+export const trackContentGuidanceAccepted = (
+  get: PupilLessonAnalyticsGet,
+  args: Omit<
+    Parameters<TrackFns["contentGuidanceAccepted"]>[0],
+    keyof NonNullable<ReturnType<PupilLessonAnalyticsGet>["additionalArgs"]>
+  >,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.contentGuidanceAccepted({
+    ...additionalArgs,
+    ...args,
+  } as Parameters<TrackFns["contentGuidanceAccepted"]>[0]);
+};
+
+export const trackContentGuidanceDeclined = (
+  get: PupilLessonAnalyticsGet,
+  args: Omit<
+    Parameters<TrackFns["contentGuidanceDeclined"]>[0],
+    keyof NonNullable<ReturnType<PupilLessonAnalyticsGet>["additionalArgs"]>
+  >,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.contentGuidanceDeclined({
+    ...additionalArgs,
+    ...args,
+  } as Parameters<TrackFns["contentGuidanceDeclined"]>[0]);
+};

--- a/src/context/PupilLessonAnalytics/trackingFunctions/lessonTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/lessonTracking.ts
@@ -1,0 +1,60 @@
+import { ComponentType, Platform } from "@/browser-lib/avo/Avo";
+import type {
+  AdditionalArgs,
+  PupilLessonAnalyticsGet,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { PupilAnalyticsProviderClassroomContext } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+
+export const getCorePropertyArgs = (
+  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"],
+) =>
+  ({
+    platform:
+      clientEnvironment === "iframe" ? Platform.GOOGLE_CLASSROOM : Platform.OWA,
+    product: "pupil lesson activities",
+    engagementIntent: "use",
+    eventVersion: "2.0.0",
+  }) as const;
+
+export const trackLessonAccessed = ({
+  track,
+  additionalArgs,
+}: {
+  track: TrackFns;
+  additionalArgs: AdditionalArgs;
+}) => {
+  track.lessonAccessedPupilJourney({
+    ...additionalArgs,
+    ...getCorePropertyArgs(additionalArgs.clientEnvironment),
+    componentType: ComponentType.PAGE_VIEW,
+  });
+};
+
+export const trackLessonStarted = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonStarted({
+    ...additionalArgs,
+  });
+};
+
+export const trackLessonCompleted = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonCompleted({
+    ...additionalArgs,
+  });
+};
+
+export const trackLessonAbandoned = (get: PupilLessonAnalyticsGet) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonAbandoned({
+    ...additionalArgs,
+    ...getCorePropertyArgs(additionalArgs.clientEnvironment),
+  });
+};

--- a/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
@@ -111,6 +111,7 @@ export const trackQuizAbandoned = (
   get: PupilLessonAnalyticsGet,
   section: "starter-quiz" | "exit-quiz",
   sectionResults: LessonSectionResults,
+  sectionStartedAt: number,
 ) => {
   const { track, additionalArgs } = get();
   if (!track || !additionalArgs) return;
@@ -120,6 +121,7 @@ export const trackQuizAbandoned = (
     pupilExperienceLessonActivity: section,
     pupilQuizGrade: sectionResults[section]?.grade || 0,
     pupilQuizNumQuestions: sectionResults[section]?.numQuestions || 0,
+    activityTimeSpent: Date.now() - sectionStartedAt,
   };
 
   if (section === "starter-quiz") {

--- a/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
@@ -60,15 +60,11 @@ export const trackQuizStarted = (
   };
 
   if (section === "starter-quiz") {
-    track.lessonActivityStartedStarterQuiz(
-      payload as Parameters<TrackFns["lessonActivityStartedStarterQuiz"]>[0],
-    );
+    track.lessonActivityStartedStarterQuiz(payload);
     return;
   }
 
-  track.lessonActivityStartedExitQuiz(
-    payload as Parameters<TrackFns["lessonActivityStartedExitQuiz"]>[0],
-  );
+  track.lessonActivityStartedExitQuiz(payload);
 };
 
 export const trackQuizQuestionAttempt = (

--- a/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/quizTracking.ts
@@ -1,0 +1,135 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+import type {
+  PupilLessonAnalyticsGet,
+  TrackQuizCompletedArgs,
+  TrackQuizQuestionAttemptArgs,
+  TrackSectionStartedArgs,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+
+export const buildQuizCompletionTrackingData = ({
+  section,
+  sectionResults,
+  sectionStartedAt,
+}: TrackQuizCompletedArgs) => ({
+  pupilExperienceLessonActivity: section,
+  pupilQuizGrade: sectionResults[section]?.grade || 0,
+  pupilQuizNumQuestions: sectionResults[section]?.numQuestions || 0,
+  hintQuestion: "",
+  hintQuestionResult: "",
+  hintUsed: "",
+  activityTimeSpent: Date.now() - sectionStartedAt,
+});
+
+export const buildQuestionAttemptTrackingData = ({
+  section,
+  questionType,
+  isCorrect,
+  hintAvailable,
+  hintAccessed,
+  questionNumber,
+}: TrackQuizQuestionAttemptArgs) => ({
+  pupilExperienceLessonActivity: section,
+  questionType,
+  questionResult: isCorrect ? ("correct" as const) : ("incorrect" as const),
+  activityTimeSpent: 0,
+  hintOffered: hintAvailable,
+  hintAccessed,
+  questionNumber,
+});
+
+export const trackQuizStarted = (
+  get: PupilLessonAnalyticsGet,
+  { section, sectionResults }: TrackSectionStartedArgs,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  if (section !== "starter-quiz" && section !== "exit-quiz") {
+    return;
+  }
+
+  if (sectionResults[section]?.isComplete) return;
+
+  const payload = {
+    ...additionalArgs,
+    pupilExperienceLessonActivity: section,
+    pupilQuizGrade: sectionResults[section]?.grade || 0,
+    pupilQuizNumQuestions: sectionResults[section]?.numQuestions || 0,
+    hintAvailable: true,
+  };
+
+  if (section === "starter-quiz") {
+    track.lessonActivityStartedStarterQuiz(
+      payload as Parameters<TrackFns["lessonActivityStartedStarterQuiz"]>[0],
+    );
+    return;
+  }
+
+  track.lessonActivityStartedExitQuiz(
+    payload as Parameters<TrackFns["lessonActivityStartedExitQuiz"]>[0],
+  );
+};
+
+export const trackQuizQuestionAttempt = (
+  get: PupilLessonAnalyticsGet,
+  args: TrackQuizQuestionAttemptArgs,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.questionAttemptSubmitted({
+    ...additionalArgs,
+    ...buildQuestionAttemptTrackingData(args),
+  });
+};
+
+export const trackQuizCompleted = (
+  get: PupilLessonAnalyticsGet,
+  args: TrackQuizCompletedArgs,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  const trackData = buildQuizCompletionTrackingData(args);
+
+  if (args.section === "starter-quiz") {
+    track.lessonActivityCompletedStarterQuiz({
+      ...additionalArgs,
+      ...trackData,
+    });
+    return;
+  }
+
+  track.lessonActivityCompletedExitQuiz({
+    ...additionalArgs,
+    ...trackData,
+  });
+};
+
+export const trackQuizAbandoned = (
+  get: PupilLessonAnalyticsGet,
+  section: "starter-quiz" | "exit-quiz",
+  sectionResults: LessonSectionResults,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  const payload = {
+    ...additionalArgs,
+    pupilExperienceLessonActivity: section,
+    pupilQuizGrade: sectionResults[section]?.grade || 0,
+    pupilQuizNumQuestions: sectionResults[section]?.numQuestions || 0,
+  };
+
+  if (section === "starter-quiz") {
+    track.lessonActivityAbandonedStarterQuiz(
+      payload as Parameters<TrackFns["lessonActivityAbandonedStarterQuiz"]>[0],
+    );
+    return;
+  }
+
+  track.lessonActivityAbandonedExitQuiz(
+    payload as Parameters<TrackFns["lessonActivityAbandonedExitQuiz"]>[0],
+  );
+};

--- a/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.test.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.test.ts
@@ -1,0 +1,73 @@
+import {
+  buildActivityResultsSharedTrackingData,
+  buildLessonSummaryReviewedTrackingData,
+} from "./reviewTracking";
+
+import type { TrackReviewEventArgs } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+
+const quizQuestion = (questionType: string, hint?: string | null) =>
+  ({
+    questionType,
+    hint,
+  }) as never;
+
+describe("review tracking payload builders", () => {
+  const args: TrackReviewEventArgs = {
+    sectionResults: {
+      "starter-quiz": {
+        isComplete: true,
+        grade: 1,
+        numQuestions: 1,
+        questionResults: [{ mode: "feedback", grade: 1, offerHint: false }],
+      },
+      "exit-quiz": {
+        isComplete: true,
+        grade: 0,
+        numQuestions: 1,
+        questionResults: [{ mode: "feedback", grade: 0, offerHint: true }],
+      },
+    },
+    starterQuizQuestionsArray: [quizQuestion("multiple-choice", "hint")],
+    exitQuizQuestionsArray: [quizQuestion("short-answer", null)],
+  };
+
+  it("adds per-question quiz results to lesson summary reviewed payloads", () => {
+    expect(buildLessonSummaryReviewedTrackingData(args)).toEqual(
+      expect.objectContaining({
+        pupilStarterQuiz: [
+          expect.objectContaining({
+            pupilExperienceLessonActivity: "starter-quiz",
+            questionType: "multiple-choice",
+            questionResult: "correct",
+          }),
+        ],
+        pupilExitQuiz: [
+          expect.objectContaining({
+            pupilExperienceLessonActivity: "exit-quiz",
+            questionType: "short-answer",
+            questionResult: "incorrect",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("adds per-question quiz results to activity results shared payloads", () => {
+    expect(buildActivityResultsSharedTrackingData(args)).toEqual(
+      expect.objectContaining({
+        pupilStarterQuiz: [
+          expect.objectContaining({
+            pupilExperienceLessonActivity: "starter-quiz",
+            questionType: "multiple-choice",
+          }),
+        ],
+        pupilExitQuiz: [
+          expect.objectContaining({
+            pupilExperienceLessonActivity: "exit-quiz",
+            questionType: "short-answer",
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
@@ -1,10 +1,15 @@
 import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
-import type { LessonSectionResults } from "@/context/PupilLessonProgress";
-import type { PupilLessonAnalyticsGet } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+import type {
+  PupilLessonAnalyticsGet,
+  TrackReviewEventArgs,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+import { mapPupilQuizResultsForAnalytics } from "@/components/PupilComponents/Views/ViewHelpers/Review/mapPupilQuizResultsForAnalytics";
 
-export const buildLessonSummaryReviewedTrackingData = (
-  sectionResults: LessonSectionResults,
-) => ({
+export const buildLessonSummaryReviewedTrackingData = ({
+  sectionResults,
+  starterQuizQuestionsArray,
+  exitQuizQuestionsArray,
+}: TrackReviewEventArgs) => ({
   pupilWorksheetAvailable: sectionResults.intro?.worksheetAvailable ?? false,
   pupilWorksheetDownloaded: sectionResults.intro?.worksheetDownloaded ?? false,
   pupilExitQuizGrade: sectionResults["exit-quiz"]?.grade ?? null,
@@ -15,26 +20,44 @@ export const buildLessonSummaryReviewedTrackingData = (
   pupilVideoPlayed: sectionResults.video?.played ?? false,
   pupilVideoDurationSeconds: sectionResults.video?.duration ?? 0,
   pupilVideoTimeElapsedSeconds: sectionResults.video?.timeElapsed ?? 0,
-  pupilExitQuiz: undefined,
-  pupilStarterQuiz: undefined,
+  pupilExitQuiz: mapPupilQuizResultsForAnalytics({
+    section: "exit-quiz",
+    questionResults: sectionResults["exit-quiz"]?.questionResults,
+    questionsArray: exitQuizQuestionsArray,
+  }),
+  pupilStarterQuiz: mapPupilQuizResultsForAnalytics({
+    section: "starter-quiz",
+    questionResults: sectionResults["starter-quiz"]?.questionResults,
+    questionsArray: starterQuizQuestionsArray,
+  }),
 });
 
-export const buildActivityResultsSharedTrackingData = (
-  sectionResults: LessonSectionResults,
-) => ({
+export const buildActivityResultsSharedTrackingData = ({
+  sectionResults,
+  starterQuizQuestionsArray,
+  exitQuizQuestionsArray,
+}: TrackReviewEventArgs) => ({
   shareMedium: "copy-link" as const,
   pupilExitQuizGrade: sectionResults["exit-quiz"]?.grade ?? 0,
   pupilExitQuizNumQuestions: sectionResults["exit-quiz"]?.numQuestions ?? 0,
   pupilStarterQuizGrade: sectionResults["starter-quiz"]?.grade ?? 0,
   pupilStarterQuizNumQuesions:
     sectionResults["starter-quiz"]?.numQuestions ?? 0,
-  pupilExitQuiz: undefined,
-  pupilStarterQuiz: undefined,
+  pupilExitQuiz: mapPupilQuizResultsForAnalytics({
+    section: "exit-quiz",
+    questionResults: sectionResults["exit-quiz"]?.questionResults,
+    questionsArray: exitQuizQuestionsArray,
+  }),
+  pupilStarterQuiz: mapPupilQuizResultsForAnalytics({
+    section: "starter-quiz",
+    questionResults: sectionResults["starter-quiz"]?.questionResults,
+    questionsArray: starterQuizQuestionsArray,
+  }),
 });
 
 export const trackLessonSummaryReviewed = (
   get: PupilLessonAnalyticsGet,
-  sectionResults: LessonSectionResults,
+  args: TrackReviewEventArgs,
 ) => {
   const { track, additionalArgs, videoData } = get();
   if (!track || !additionalArgs) return;
@@ -42,19 +65,19 @@ export const trackLessonSummaryReviewed = (
   track.lessonSummaryReviewed({
     ...additionalArgs,
     ...videoData,
-    ...buildLessonSummaryReviewedTrackingData(sectionResults),
+    ...buildLessonSummaryReviewedTrackingData(args),
   } as unknown as Parameters<TrackFns["lessonSummaryReviewed"]>[0]);
 };
 
 export const trackActivityResultsShared = (
   get: PupilLessonAnalyticsGet,
-  sectionResults: LessonSectionResults,
+  args: TrackReviewEventArgs,
 ) => {
   const { track, additionalArgs } = get();
   if (!track || !additionalArgs) return;
 
   track.activityResultsShared({
     ...additionalArgs,
-    ...buildActivityResultsSharedTrackingData(sectionResults),
+    ...buildActivityResultsSharedTrackingData(args),
   } as unknown as Parameters<TrackFns["activityResultsShared"]>[0]);
 };

--- a/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
@@ -1,0 +1,60 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+import type { PupilLessonAnalyticsGet } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+
+export const buildLessonSummaryReviewedTrackingData = (
+  sectionResults: LessonSectionResults,
+) => ({
+  pupilWorksheetAvailable: sectionResults.intro?.worksheetAvailable ?? false,
+  pupilWorksheetDownloaded: sectionResults.intro?.worksheetDownloaded ?? false,
+  pupilExitQuizGrade: sectionResults["exit-quiz"]?.grade ?? null,
+  pupilExitQuizNumQuestions: sectionResults["exit-quiz"]?.numQuestions ?? null,
+  pupilStarterQuizGrade: sectionResults["starter-quiz"]?.grade ?? null,
+  pupilStarterQuizNumQuesions:
+    sectionResults["starter-quiz"]?.numQuestions ?? null,
+  pupilVideoPlayed: sectionResults.video?.played ?? false,
+  pupilVideoDurationSeconds: sectionResults.video?.duration ?? 0,
+  pupilVideoTimeElapsedSeconds: sectionResults.video?.timeElapsed ?? 0,
+  pupilExitQuiz: undefined,
+  pupilStarterQuiz: undefined,
+});
+
+export const buildActivityResultsSharedTrackingData = (
+  sectionResults: LessonSectionResults,
+) => ({
+  shareMedium: "copy-link" as const,
+  pupilExitQuizGrade: sectionResults["exit-quiz"]?.grade ?? 0,
+  pupilExitQuizNumQuestions: sectionResults["exit-quiz"]?.numQuestions ?? 0,
+  pupilStarterQuizGrade: sectionResults["starter-quiz"]?.grade ?? 0,
+  pupilStarterQuizNumQuesions:
+    sectionResults["starter-quiz"]?.numQuestions ?? 0,
+  pupilExitQuiz: undefined,
+  pupilStarterQuiz: undefined,
+});
+
+export const trackLessonSummaryReviewed = (
+  get: PupilLessonAnalyticsGet,
+  sectionResults: LessonSectionResults,
+) => {
+  const { track, additionalArgs, videoData } = get();
+  if (!track || !additionalArgs) return;
+
+  track.lessonSummaryReviewed({
+    ...additionalArgs,
+    ...videoData,
+    ...buildLessonSummaryReviewedTrackingData(sectionResults),
+  } as unknown as Parameters<TrackFns["lessonSummaryReviewed"]>[0]);
+};
+
+export const trackActivityResultsShared = (
+  get: PupilLessonAnalyticsGet,
+  sectionResults: LessonSectionResults,
+) => {
+  const { track, additionalArgs } = get();
+  if (!track || !additionalArgs) return;
+
+  track.activityResultsShared({
+    ...additionalArgs,
+    ...buildActivityResultsSharedTrackingData(sectionResults),
+  } as unknown as Parameters<TrackFns["activityResultsShared"]>[0]);
+};

--- a/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/reviewTracking.ts
@@ -1,4 +1,3 @@
-import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import type {
   PupilLessonAnalyticsGet,
   TrackReviewEventArgs,
@@ -66,7 +65,7 @@ export const trackLessonSummaryReviewed = (
     ...additionalArgs,
     ...videoData,
     ...buildLessonSummaryReviewedTrackingData(args),
-  } as unknown as Parameters<TrackFns["lessonSummaryReviewed"]>[0]);
+  });
 };
 
 export const trackActivityResultsShared = (
@@ -79,5 +78,5 @@ export const trackActivityResultsShared = (
   track.activityResultsShared({
     ...additionalArgs,
     ...buildActivityResultsSharedTrackingData(args),
-  } as unknown as Parameters<TrackFns["activityResultsShared"]>[0]);
+  });
 };

--- a/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.test.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.test.ts
@@ -1,0 +1,42 @@
+import { trackVideoCompleted } from "./videoTracking";
+
+describe("trackVideoCompleted", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("tracks elapsed activity time from the section start timestamp", () => {
+    jest.spyOn(Date, "now").mockReturnValue(2000);
+    const lessonActivityCompletedLessonVideo = jest.fn();
+
+    trackVideoCompleted(
+      () =>
+        ({
+          track: { lessonActivityCompletedLessonVideo },
+          additionalArgs: {},
+          videoData: {},
+        }) as never,
+      {
+        sectionStartedAt: 1250,
+        sectionResults: {
+          video: {
+            isComplete: true,
+            played: true,
+            duration: 120,
+            timeElapsed: 60,
+            muted: false,
+            signedOpened: false,
+            transcriptOpened: true,
+          },
+        },
+      },
+    );
+
+    expect(lessonActivityCompletedLessonVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pupilExperienceLessonActivity: "video",
+        activityTimeSpent: 750,
+      }),
+    );
+  });
+});

--- a/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
@@ -1,0 +1,71 @@
+import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
+import type {
+  PupilLessonAnalyticsGet,
+  TrackSectionStartedArgs,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+import type { LessonSectionResults } from "@/context/PupilLessonProgress";
+
+export const buildVideoTrackingData = (
+  sectionResults: LessonSectionResults,
+) => ({
+  pupilExperienceLessonActivity: "video" as const,
+  pupilVideoDurationSeconds: sectionResults.video?.duration || 0,
+  pupilVideoPlayed: sectionResults.video?.played || false,
+});
+
+export const trackVideoStarted = (
+  get: PupilLessonAnalyticsGet,
+  { section, sectionResults }: TrackSectionStartedArgs,
+) => {
+  const { track, additionalArgs, videoData } = get();
+  if (!track || !additionalArgs || !videoData) return;
+  if (section !== "video" || sectionResults.video?.isComplete) return;
+
+  track.lessonActivityStartedLessonVideo({
+    ...additionalArgs,
+    ...videoData,
+    ...buildVideoTrackingData(sectionResults),
+  });
+};
+
+export const trackVideoCompleted = (
+  get: PupilLessonAnalyticsGet,
+  sectionResults: LessonSectionResults,
+) => {
+  const { track, additionalArgs, videoData } = get();
+  if (!track || !additionalArgs || !videoData) return;
+
+  track.lessonActivityCompletedLessonVideo({
+    ...additionalArgs,
+    ...videoData,
+    ...buildVideoTrackingData(sectionResults),
+    pupilVideoTimeElapsedSeconds: sectionResults.video?.timeElapsed || 0,
+    isMuted: sectionResults.video?.muted || false,
+    signedOpened: sectionResults.video?.signedOpened || false,
+    transcriptOpened: sectionResults.video?.transcriptOpened || false,
+    activityTimeSpent: 0,
+  } as unknown as Parameters<
+    TrackFns["lessonActivityCompletedLessonVideo"]
+  >[0]);
+};
+
+export const trackVideoAbandoned = (
+  get: PupilLessonAnalyticsGet,
+  sectionResults: LessonSectionResults,
+) => {
+  const { track, additionalArgs, videoData } = get();
+  if (!track || !additionalArgs || !videoData) return;
+
+  track.lessonActivityAbandonedLessonVideo({
+    ...additionalArgs,
+    ...videoData,
+    ...buildVideoTrackingData(sectionResults),
+    pupilVideoTimeElapsedSeconds: sectionResults.video?.timeElapsed || 0,
+    isMuted: sectionResults.video?.muted || false,
+    signedOpened: sectionResults.video?.signedOpened || false,
+    transcriptOpened: sectionResults.video?.transcriptOpened || false,
+    activityTimeSpent: 0,
+  } as unknown as Parameters<
+    TrackFns["lessonActivityAbandonedLessonVideo"]
+  >[0]);
+};

--- a/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
@@ -52,6 +52,7 @@ export const trackVideoCompleted = (
 export const trackVideoAbandoned = (
   get: PupilLessonAnalyticsGet,
   sectionResults: LessonSectionResults,
+  sectionStartedAt: number,
 ) => {
   const { track, additionalArgs, videoData } = get();
   if (!track || !additionalArgs || !videoData) return;
@@ -64,7 +65,7 @@ export const trackVideoAbandoned = (
     isMuted: sectionResults.video?.muted || false,
     signedOpened: sectionResults.video?.signedOpened || false,
     transcriptOpened: sectionResults.video?.transcriptOpened || false,
-    activityTimeSpent: 0,
+    activityTimeSpent: Date.now() - sectionStartedAt,
   } as unknown as Parameters<
     TrackFns["lessonActivityAbandonedLessonVideo"]
   >[0]);

--- a/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
@@ -1,4 +1,3 @@
-import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import type {
   PupilLessonAnalyticsGet,
   TrackSectionCompletedArgs,
@@ -45,9 +44,7 @@ export const trackVideoCompleted = (
     signedOpened: sectionResults.video?.signedOpened || false,
     transcriptOpened: sectionResults.video?.transcriptOpened || false,
     activityTimeSpent: Date.now() - sectionStartedAt,
-  } as unknown as Parameters<
-    TrackFns["lessonActivityCompletedLessonVideo"]
-  >[0]);
+  });
 };
 
 export const trackVideoAbandoned = (
@@ -67,7 +64,5 @@ export const trackVideoAbandoned = (
     signedOpened: sectionResults.video?.signedOpened || false,
     transcriptOpened: sectionResults.video?.transcriptOpened || false,
     activityTimeSpent: Date.now() - sectionStartedAt,
-  } as unknown as Parameters<
-    TrackFns["lessonActivityAbandonedLessonVideo"]
-  >[0]);
+  });
 };

--- a/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
+++ b/src/context/PupilLessonAnalytics/trackingFunctions/videoTracking.ts
@@ -1,6 +1,7 @@
 import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
 import type {
   PupilLessonAnalyticsGet,
+  TrackSectionCompletedArgs,
   TrackSectionStartedArgs,
 } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
 import type { LessonSectionResults } from "@/context/PupilLessonProgress";
@@ -30,7 +31,7 @@ export const trackVideoStarted = (
 
 export const trackVideoCompleted = (
   get: PupilLessonAnalyticsGet,
-  sectionResults: LessonSectionResults,
+  { sectionResults, sectionStartedAt }: TrackSectionCompletedArgs,
 ) => {
   const { track, additionalArgs, videoData } = get();
   if (!track || !additionalArgs || !videoData) return;
@@ -43,7 +44,7 @@ export const trackVideoCompleted = (
     isMuted: sectionResults.video?.muted || false,
     signedOpened: sectionResults.video?.signedOpened || false,
     transcriptOpened: sectionResults.video?.transcriptOpened || false,
-    activityTimeSpent: 0,
+    activityTimeSpent: Date.now() - sectionStartedAt,
   } as unknown as Parameters<
     TrackFns["lessonActivityCompletedLessonVideo"]
   >[0]);

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
@@ -59,6 +59,12 @@ export const usePupilLessonAnalytics = () => {
   const trackActivityResultsShared = usePupilLessonAnalyticsStore(
     (state) => state.trackActivityResultsShared,
   );
+  const trackContentGuidanceAccepted = usePupilLessonAnalyticsStore(
+    (state) => state.trackContentGuidanceAccepted,
+  );
+  const trackContentGuidanceDeclined = usePupilLessonAnalyticsStore(
+    (state) => state.trackContentGuidanceDeclined,
+  );
 
   const initialisePupilLessonAnalytics = useCallback(
     (args: InitialisePupilLessonAnalyticsArgs) => {
@@ -83,5 +89,7 @@ export const usePupilLessonAnalytics = () => {
     trackVideoAbandoned,
     trackLessonSummaryReviewed,
     trackActivityResultsShared,
+    trackContentGuidanceAccepted,
+    trackContentGuidanceDeclined,
   };
 };

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalytics.ts
@@ -26,8 +26,38 @@ export const usePupilLessonAnalytics = () => {
   const trackQuizCompleted = usePupilLessonAnalyticsStore(
     (state) => state.trackQuizCompleted,
   );
+  const trackQuizAbandoned = usePupilLessonAnalyticsStore(
+    (state) => state.trackQuizAbandoned,
+  );
+  const trackLessonStarted = usePupilLessonAnalyticsStore(
+    (state) => state.trackLessonStarted,
+  );
+  const trackLessonCompleted = usePupilLessonAnalyticsStore(
+    (state) => state.trackLessonCompleted,
+  );
   const trackLessonAbandoned = usePupilLessonAnalyticsStore(
     (state) => state.trackLessonAbandoned,
+  );
+  const trackIntroCompleted = usePupilLessonAnalyticsStore(
+    (state) => state.trackIntroCompleted,
+  );
+  const trackIntroAbandoned = usePupilLessonAnalyticsStore(
+    (state) => state.trackIntroAbandoned,
+  );
+  const trackWorksheetDownloaded = usePupilLessonAnalyticsStore(
+    (state) => state.trackWorksheetDownloaded,
+  );
+  const trackVideoCompleted = usePupilLessonAnalyticsStore(
+    (state) => state.trackVideoCompleted,
+  );
+  const trackVideoAbandoned = usePupilLessonAnalyticsStore(
+    (state) => state.trackVideoAbandoned,
+  );
+  const trackLessonSummaryReviewed = usePupilLessonAnalyticsStore(
+    (state) => state.trackLessonSummaryReviewed,
+  );
+  const trackActivityResultsShared = usePupilLessonAnalyticsStore(
+    (state) => state.trackActivityResultsShared,
   );
 
   const initialisePupilLessonAnalytics = useCallback(
@@ -42,6 +72,16 @@ export const usePupilLessonAnalytics = () => {
     trackSectionStarted,
     trackQuizQuestionAttempt,
     trackQuizCompleted,
+    trackQuizAbandoned,
+    trackLessonStarted,
+    trackLessonCompleted,
     trackLessonAbandoned,
+    trackIntroCompleted,
+    trackIntroAbandoned,
+    trackWorksheetDownloaded,
+    trackVideoCompleted,
+    trackVideoAbandoned,
+    trackLessonSummaryReviewed,
+    trackActivityResultsShared,
   };
 };

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
@@ -38,12 +38,28 @@ const expectedVideoData = getPupilVideoData(lessonContent);
 
 const createTrack = () =>
   ({
-    lessonActivityStartedIntroduction: jest.fn(),
-    lessonActivityStartedStarterQuiz: jest.fn(),
-    lessonActivityStartedLessonVideo: jest.fn(),
-    lessonActivityStartedExitQuiz: jest.fn(),
-    lessonAbandoned: jest.fn(),
     lessonAccessedPupilJourney: jest.fn(),
+    lessonStarted: jest.fn(),
+    lessonCompleted: jest.fn(),
+    lessonAbandoned: jest.fn(),
+    lessonActivityStartedIntroduction: jest.fn(),
+    lessonActivityCompletedIntroduction: jest.fn(),
+    lessonActivityAbandonedIntroduction: jest.fn(),
+    lessonActivityDownloadedWorksheet: jest.fn(),
+    lessonActivityStartedStarterQuiz: jest.fn(),
+    lessonActivityCompletedStarterQuiz: jest.fn(),
+    lessonActivityAbandonedStarterQuiz: jest.fn(),
+    lessonActivityStartedExitQuiz: jest.fn(),
+    lessonActivityCompletedExitQuiz: jest.fn(),
+    lessonActivityAbandonedExitQuiz: jest.fn(),
+    lessonActivityStartedLessonVideo: jest.fn(),
+    lessonActivityCompletedLessonVideo: jest.fn(),
+    lessonActivityAbandonedLessonVideo: jest.fn(),
+    questionAttemptSubmitted: jest.fn(),
+    lessonSummaryReviewed: jest.fn(),
+    activityResultsShared: jest.fn(),
+    contentGuidanceAccepted: jest.fn(),
+    contentGuidanceDeclined: jest.fn(),
   }) as unknown as jest.Mocked<TrackFns>;
 
 const initialiseStore = ({
@@ -71,6 +87,7 @@ describe("usePupilLessonAnalyticsStore", () => {
       track: null,
       additionalArgs: null,
       videoData: null,
+      accessedLessonSlug: null,
     });
   });
 
@@ -296,4 +313,329 @@ describe("usePupilLessonAnalyticsStore", () => {
       });
     },
   );
+
+  it("skips tracking lesson access when re-initialised for the same lesson slug", () => {
+    const trackOne = initialiseStore();
+    expect(trackOne.lessonAccessedPupilJourney).toHaveBeenCalledTimes(1);
+
+    const trackTwo = createTrack();
+    usePupilLessonAnalyticsStore.getState().initialisePupilLessonAnalytics({
+      track: trackTwo,
+      pupilPathwayData,
+      classroomAssignmentContext,
+      lessonContent,
+    });
+
+    expect(trackTwo.lessonAccessedPupilJourney).not.toHaveBeenCalled();
+  });
+
+  it("tracks lesson started", () => {
+    const track = initialiseStore();
+    usePupilLessonAnalyticsStore.getState().trackLessonStarted();
+    expect(track.lessonStarted).toHaveBeenCalledWith(expectedAdditionalArgs);
+  });
+
+  it("tracks lesson completed", () => {
+    const track = initialiseStore();
+    usePupilLessonAnalyticsStore.getState().trackLessonCompleted();
+    expect(track.lessonCompleted).toHaveBeenCalledWith(expectedAdditionalArgs);
+  });
+
+  it("tracks intro completed with elapsed time", () => {
+    jest.spyOn(Date, "now").mockReturnValue(2500);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackIntroCompleted({ sectionStartedAt: 1000 });
+
+    expect(track.lessonActivityCompletedIntroduction).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      pupilExperienceLessonActivity: "intro",
+      activityTimeSpent: 1500,
+    });
+  });
+
+  it("tracks intro abandoned with elapsed time", () => {
+    jest.spyOn(Date, "now").mockReturnValue(3000);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackIntroAbandoned({ sectionStartedAt: 1000 });
+
+    expect(track.lessonActivityAbandonedIntroduction).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      pupilExperienceLessonActivity: "intro",
+      activityTimeSpent: 2000,
+    });
+  });
+
+  it("tracks worksheet downloaded", () => {
+    const track = initialiseStore();
+    usePupilLessonAnalyticsStore.getState().trackWorksheetDownloaded();
+    expect(track.lessonActivityDownloadedWorksheet).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      pupilExperienceLessonActivity: "intro",
+    });
+  });
+
+  it.each([
+    {
+      section: "starter-quiz" as const,
+      eventName: "lessonActivityCompletedStarterQuiz" as const,
+    },
+    {
+      section: "exit-quiz" as const,
+      eventName: "lessonActivityCompletedExitQuiz" as const,
+    },
+  ])("tracks $section quiz completed", ({ section, eventName }) => {
+    jest.spyOn(Date, "now").mockReturnValue(4000);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackQuizCompleted({
+      section,
+      sectionResults: {
+        [section]: {
+          ...sectionResultsFixture[section],
+          grade: 5,
+          numQuestions: 7,
+        },
+      } as LessonSectionResults,
+      sectionStartedAt: 1000,
+    });
+
+    expect(track[eventName]).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      pupilExperienceLessonActivity: section,
+      pupilQuizGrade: 5,
+      pupilQuizNumQuestions: 7,
+      hintQuestion: "",
+      hintQuestionResult: "",
+      hintUsed: "",
+      activityTimeSpent: 3000,
+    });
+  });
+
+  it.each([
+    {
+      section: "starter-quiz" as const,
+      eventName: "lessonActivityAbandonedStarterQuiz" as const,
+    },
+    {
+      section: "exit-quiz" as const,
+      eventName: "lessonActivityAbandonedExitQuiz" as const,
+    },
+  ])("tracks $section quiz abandoned", ({ section, eventName }) => {
+    jest.spyOn(Date, "now").mockReturnValue(5000);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackQuizAbandoned({
+      section,
+      sectionResults: {
+        [section]: {
+          ...sectionResultsFixture[section],
+          grade: 2,
+          numQuestions: 4,
+        },
+      } as LessonSectionResults,
+      sectionStartedAt: 1000,
+    });
+
+    expect(track[eventName]).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...expectedAdditionalArgs,
+        pupilExperienceLessonActivity: section,
+        pupilQuizGrade: 2,
+        pupilQuizNumQuestions: 4,
+        activityTimeSpent: 4000,
+      }),
+    );
+  });
+
+  it("tracks quiz question attempts", () => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackQuizQuestionAttempt({
+      section: "starter-quiz",
+      questionType: "multiple-choice",
+      isCorrect: true,
+      hintAvailable: true,
+      hintAccessed: false,
+      questionNumber: 1,
+    });
+
+    expect(track.questionAttemptSubmitted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...expectedAdditionalArgs,
+        pupilExperienceLessonActivity: "starter-quiz",
+        questionType: "multiple-choice",
+        questionResult: "correct",
+        hintOffered: true,
+        hintAccessed: false,
+        questionNumber: 1,
+      }),
+    );
+  });
+
+  it("marks incorrect quiz attempts in the tracking payload", () => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackQuizQuestionAttempt({
+      section: "exit-quiz",
+      questionType: "short-answer",
+      isCorrect: false,
+      hintAvailable: false,
+      hintAccessed: false,
+      questionNumber: 2,
+    });
+
+    expect(track.questionAttemptSubmitted).toHaveBeenCalledWith(
+      expect.objectContaining({ questionResult: "incorrect" }),
+    );
+  });
+
+  it("tracks video completed with elapsed time and video state", () => {
+    jest.spyOn(Date, "now").mockReturnValue(6000);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackVideoCompleted({
+      sectionResults: {
+        video: {
+          ...sectionResultsFixture.video,
+          duration: 200,
+          timeElapsed: 180,
+          muted: true,
+          signedOpened: true,
+          transcriptOpened: true,
+        },
+      } as LessonSectionResults,
+      sectionStartedAt: 1000,
+    });
+
+    expect(track.lessonActivityCompletedLessonVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pupilExperienceLessonActivity: "video",
+        pupilVideoDurationSeconds: 200,
+        pupilVideoTimeElapsedSeconds: 180,
+        isMuted: true,
+        signedOpened: true,
+        transcriptOpened: true,
+        activityTimeSpent: 5000,
+      }),
+    );
+  });
+
+  it("tracks video abandoned with elapsed time and video state", () => {
+    jest.spyOn(Date, "now").mockReturnValue(7000);
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore.getState().trackVideoAbandoned({
+      sectionResults: {
+        video: {
+          ...sectionResultsFixture.video,
+          duration: 90,
+          timeElapsed: 30,
+          muted: false,
+        },
+      } as LessonSectionResults,
+      sectionStartedAt: 2000,
+    });
+
+    expect(track.lessonActivityAbandonedLessonVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pupilExperienceLessonActivity: "video",
+        pupilVideoDurationSeconds: 90,
+        pupilVideoTimeElapsedSeconds: 30,
+        isMuted: false,
+        activityTimeSpent: 5000,
+      }),
+    );
+  });
+
+  it("does not track video completed when no video data has been initialised", () => {
+    const track = initialiseStore({ includeLessonContent: false });
+
+    usePupilLessonAnalyticsStore.getState().trackVideoCompleted({
+      sectionResults: {},
+      sectionStartedAt: 1000,
+    });
+
+    expect(track.lessonActivityCompletedLessonVideo).not.toHaveBeenCalled();
+  });
+
+  it("does not track video abandoned when no video data has been initialised", () => {
+    const track = initialiseStore({ includeLessonContent: false });
+
+    usePupilLessonAnalyticsStore.getState().trackVideoAbandoned({
+      sectionResults: {},
+      sectionStartedAt: 1000,
+    });
+
+    expect(track.lessonActivityAbandonedLessonVideo).not.toHaveBeenCalled();
+  });
+
+  const reviewArgs = {
+    sectionResults: sectionResultsFixture,
+    starterQuizQuestionsArray: [],
+    exitQuizQuestionsArray: [],
+  };
+
+  it("tracks lesson summary reviewed", () => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackLessonSummaryReviewed(reviewArgs);
+
+    expect(track.lessonSummaryReviewed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...expectedAdditionalArgs,
+        pupilWorksheetAvailable: true,
+        pupilWorksheetDownloaded: false,
+      }),
+    );
+  });
+
+  it("tracks activity results shared", () => {
+    const track = initialiseStore();
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackActivityResultsShared(reviewArgs);
+
+    expect(track.activityResultsShared).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...expectedAdditionalArgs,
+      }),
+    );
+  });
+
+  it("tracks content guidance accepted", () => {
+    const track = initialiseStore();
+    const guidanceArgs = { contentGuidanceLabel: "violence" } as never;
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackContentGuidanceAccepted(guidanceArgs);
+
+    expect(track.contentGuidanceAccepted).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      contentGuidanceLabel: "violence",
+    });
+  });
+
+  it("tracks content guidance declined", () => {
+    const track = initialiseStore();
+    const guidanceArgs = { contentGuidanceLabel: "language" } as never;
+
+    usePupilLessonAnalyticsStore
+      .getState()
+      .trackContentGuidanceDeclined(guidanceArgs);
+
+    expect(track.contentGuidanceDeclined).toHaveBeenCalledWith({
+      ...expectedAdditionalArgs,
+      contentGuidanceLabel: "language",
+    });
+  });
 });

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.test.ts
@@ -43,6 +43,7 @@ const createTrack = () =>
     lessonActivityStartedLessonVideo: jest.fn(),
     lessonActivityStartedExitQuiz: jest.fn(),
     lessonAbandoned: jest.fn(),
+    lessonAccessedPupilJourney: jest.fn(),
   }) as unknown as jest.Mocked<TrackFns>;
 
 const initialiseStore = ({

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -85,18 +85,19 @@ export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
     },
     trackQuizQuestionAttempt: (args) => trackQuizQuestionAttempt(get, args),
     trackQuizCompleted: (args) => trackQuizCompleted(get, args),
-    trackQuizAbandoned: ({ section, sectionResults }) =>
-      trackQuizAbandoned(get, section, sectionResults),
+    trackQuizAbandoned: ({ section, sectionResults, sectionStartedAt }) =>
+      trackQuizAbandoned(get, section, sectionResults, sectionStartedAt),
     trackLessonStarted: () => trackLessonStarted(get),
     trackLessonCompleted: () => trackLessonCompleted(get),
     trackLessonAbandoned: () => trackLessonAbandoned(get),
     trackIntroCompleted: () => trackIntroCompleted(get),
-    trackIntroAbandoned: () => trackIntroAbandoned(get),
+    trackIntroAbandoned: ({ sectionStartedAt }) =>
+      trackIntroAbandoned(get, sectionStartedAt),
     trackWorksheetDownloaded: () => trackWorksheetDownloaded(get),
     trackVideoCompleted: ({ sectionResults }) =>
       trackVideoCompleted(get, sectionResults),
-    trackVideoAbandoned: ({ sectionResults }) =>
-      trackVideoAbandoned(get, sectionResults),
+    trackVideoAbandoned: ({ sectionResults, sectionStartedAt }) =>
+      trackVideoAbandoned(get, sectionResults, sectionStartedAt),
     trackLessonSummaryReviewed: ({ sectionResults }) =>
       trackLessonSummaryReviewed(get, sectionResults),
     trackActivityResultsShared: ({ sectionResults }) =>

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -6,16 +6,32 @@ import type {
   PupilLessonAnalyticsState,
 } from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
 import {
+  trackLessonCompleted,
   trackLessonAbandoned,
   trackLessonAccessed,
+  trackLessonStarted,
 } from "@/context/PupilLessonAnalytics/trackingFunctions/lessonTracking";
-import { trackIntroStarted } from "@/context/PupilLessonAnalytics/trackingFunctions/introTracking";
 import {
+  trackIntroAbandoned,
+  trackIntroCompleted,
+  trackIntroStarted,
+  trackWorksheetDownloaded,
+} from "@/context/PupilLessonAnalytics/trackingFunctions/introTracking";
+import {
+  trackQuizAbandoned,
   trackQuizCompleted,
   trackQuizQuestionAttempt,
   trackQuizStarted,
 } from "@/context/PupilLessonAnalytics/trackingFunctions/quizTracking";
-import { trackVideoStarted } from "@/context/PupilLessonAnalytics/trackingFunctions/videoTracking";
+import {
+  trackVideoAbandoned,
+  trackVideoCompleted,
+  trackVideoStarted,
+} from "@/context/PupilLessonAnalytics/trackingFunctions/videoTracking";
+import {
+  trackActivityResultsShared,
+  trackLessonSummaryReviewed,
+} from "@/context/PupilLessonAnalytics/trackingFunctions/reviewTracking";
 
 export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
   (set, get) => ({
@@ -67,6 +83,21 @@ export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
     },
     trackQuizQuestionAttempt: (args) => trackQuizQuestionAttempt(get, args),
     trackQuizCompleted: (args) => trackQuizCompleted(get, args),
+    trackQuizAbandoned: ({ section, sectionResults }) =>
+      trackQuizAbandoned(get, section, sectionResults),
+    trackLessonStarted: () => trackLessonStarted(get),
+    trackLessonCompleted: () => trackLessonCompleted(get),
     trackLessonAbandoned: () => trackLessonAbandoned(get),
+    trackIntroCompleted: () => trackIntroCompleted(get),
+    trackIntroAbandoned: () => trackIntroAbandoned(get),
+    trackWorksheetDownloaded: () => trackWorksheetDownloaded(get),
+    trackVideoCompleted: ({ sectionResults }) =>
+      trackVideoCompleted(get, sectionResults),
+    trackVideoAbandoned: ({ sectionResults }) =>
+      trackVideoAbandoned(get, sectionResults),
+    trackLessonSummaryReviewed: ({ sectionResults }) =>
+      trackLessonSummaryReviewed(get, sectionResults),
+    trackActivityResultsShared: ({ sectionResults }) =>
+      trackActivityResultsShared(get, sectionResults),
   }),
 );

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -1,92 +1,28 @@
 import { create } from "zustand";
 
-import { Platform } from "@/browser-lib/avo/Avo";
-import type { TrackFns } from "@/context/Analytics/AnalyticsProvider";
-import type { LessonSectionResults } from "@/context/PupilLessonProgress";
-import type {
-  PupilAnalyticsProviderClassroomContext,
-  PupilPathwayData,
-  PupilVideoData,
-} from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
 import { getPupilVideoData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
-import type { LessonContent } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
-
-type AdditionalArgs = PupilPathwayData & {
-  analyticsUseCase: "Pupil";
-  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"];
-  classroomAssignmentId: string | null;
-  courseId: string | null;
-  itemId: string | null;
-  attachmentId: string | null;
-  submissionId: string | null;
-  teacherLoginHint: string | null;
-  pupilLoginHint: string | null;
-};
-
-type PupilLessonAnalyticsState = {
-  track: TrackFns | null;
-  additionalArgs: AdditionalArgs | null;
-  videoData: PupilVideoData | null;
-  initialisePupilLessonAnalytics: (args: {
-    track: TrackFns;
-    pupilPathwayData: PupilPathwayData;
-    classroomAssignmentContext: PupilAnalyticsProviderClassroomContext;
-    lessonContent?: LessonContent;
-  }) => void;
-  trackSectionStarted: (args: {
-    section: "intro" | "starter-quiz" | "video" | "exit-quiz" | "review";
-    sectionResults: LessonSectionResults;
-  }) => void;
-  trackQuizQuestionAttempt: (args: {
-    section: "starter-quiz" | "exit-quiz";
-    questionType: string;
-    isCorrect: boolean;
-    hintAvailable: boolean;
-    hintAccessed: boolean;
-    questionNumber: number;
-  }) => void;
-  trackQuizCompleted: (args: {
-    section: "starter-quiz" | "exit-quiz";
-    sectionResults: LessonSectionResults;
-    sectionStartedAt: number;
-  }) => void;
-  trackLessonAbandoned: () => void;
-};
-
-const getCorePropertyArgs = (
-  clientEnvironment: PupilAnalyticsProviderClassroomContext["clientEnvironment"],
-) =>
-  ({
-    platform:
-      clientEnvironment === "iframe" ? Platform.GOOGLE_CLASSROOM : Platform.OWA,
-    product: "pupil lesson activities",
-    engagementIntent: "use",
-    eventVersion: "2.0.0",
-  }) as const;
-
-const buildQuizCompletionTrackingData = ({
-  section,
-  sectionResults,
-  sectionStartedAt,
-}: {
-  section: "starter-quiz" | "exit-quiz";
-  sectionResults: LessonSectionResults;
-  sectionStartedAt: number;
-}) => ({
-  pupilExperienceLessonActivity: section,
-  pupilQuizGrade: sectionResults[section]?.grade || 0,
-  pupilQuizNumQuestions: sectionResults[section]?.numQuestions || 0,
-  hintQuestion: "",
-  hintQuestionResult: "",
-  hintUsed: "",
-  activityTimeSpent: Date.now() - sectionStartedAt,
-});
+import type {
+  AdditionalArgs,
+  PupilLessonAnalyticsState,
+} from "@/context/PupilLessonAnalytics/pupilLessonAnalytics.types";
+import {
+  trackLessonAbandoned,
+  trackLessonAccessed,
+} from "@/context/PupilLessonAnalytics/trackingFunctions/lessonTracking";
+import { trackIntroStarted } from "@/context/PupilLessonAnalytics/trackingFunctions/introTracking";
+import {
+  trackQuizCompleted,
+  trackQuizQuestionAttempt,
+  trackQuizStarted,
+} from "@/context/PupilLessonAnalytics/trackingFunctions/quizTracking";
+import { trackVideoStarted } from "@/context/PupilLessonAnalytics/trackingFunctions/videoTracking";
 
 export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
   (set, get) => ({
     track: null,
     additionalArgs: null,
     videoData: null,
+    accessedLessonSlug: null,
     initialisePupilLessonAnalytics: ({
       track,
       pupilPathwayData,
@@ -100,138 +36,37 @@ export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
         clientEnvironment,
         classroomAssignmentId,
       } = classroomAssignmentContext;
+      const additionalArgs: AdditionalArgs = {
+        ...pupilPathwayData,
+        analyticsUseCase: "Pupil",
+        clientEnvironment,
+        classroomAssignmentId,
+        courseId,
+        itemId,
+        attachmentId,
+        submissionId: null,
+        teacherLoginHint: null,
+        pupilLoginHint: null,
+      };
+
+      if (get().accessedLessonSlug !== pupilPathwayData.lessonSlug) {
+        trackLessonAccessed({ track, additionalArgs });
+      }
 
       set({
         track,
         videoData: lessonContent ? getPupilVideoData(lessonContent) : null,
-        additionalArgs: {
-          ...pupilPathwayData,
-          analyticsUseCase: "Pupil",
-          clientEnvironment,
-          classroomAssignmentId,
-          courseId,
-          itemId,
-          attachmentId,
-          submissionId: null,
-          teacherLoginHint: null,
-          pupilLoginHint: null,
-        },
+        additionalArgs,
+        accessedLessonSlug: pupilPathwayData.lessonSlug,
       });
     },
-    trackSectionStarted: ({ section, sectionResults }) => {
-      const { track, additionalArgs, videoData } = get();
-      if (!track || !additionalArgs) return;
-
-      if (section === "intro" && !sectionResults.intro?.isComplete) {
-        const payload: Parameters<
-          TrackFns["lessonActivityStartedIntroduction"]
-        >[0] = {
-          ...additionalArgs,
-          pupilExperienceLessonActivity: section,
-        };
-        track.lessonActivityStartedIntroduction(payload);
-        return;
-      }
-
-      if (
-        section === "starter-quiz" &&
-        !sectionResults["starter-quiz"]?.isComplete
-      ) {
-        const payload: Parameters<
-          TrackFns["lessonActivityStartedStarterQuiz"]
-        >[0] = {
-          ...additionalArgs,
-          pupilExperienceLessonActivity: section,
-          pupilQuizGrade: sectionResults["starter-quiz"]?.grade || 0,
-          pupilQuizNumQuestions:
-            sectionResults["starter-quiz"]?.numQuestions || 0,
-          hintAvailable: true,
-        };
-        track.lessonActivityStartedStarterQuiz(payload);
-        return;
-      }
-
-      if (section === "exit-quiz" && !sectionResults["exit-quiz"]?.isComplete) {
-        const payload: Parameters<
-          TrackFns["lessonActivityStartedExitQuiz"]
-        >[0] = {
-          ...additionalArgs,
-          pupilExperienceLessonActivity: section,
-          pupilQuizGrade: sectionResults["exit-quiz"]?.grade || 0,
-          pupilQuizNumQuestions: sectionResults["exit-quiz"]?.numQuestions || 0,
-          hintAvailable: true,
-        };
-        track.lessonActivityStartedExitQuiz(payload);
-        return;
-      }
-
-      if (section === "video" && !sectionResults.video?.isComplete) {
-        if (!videoData) return;
-        const payload: Parameters<
-          TrackFns["lessonActivityStartedLessonVideo"]
-        >[0] = {
-          ...additionalArgs,
-          ...videoData,
-          pupilExperienceLessonActivity: section,
-          pupilVideoDurationSeconds: sectionResults.video?.duration || 0,
-          pupilVideoPlayed: sectionResults.video?.played || false,
-        };
-        track.lessonActivityStartedLessonVideo(payload);
-      }
+    trackSectionStarted: (args) => {
+      trackIntroStarted(get, args);
+      trackQuizStarted(get, args);
+      trackVideoStarted(get, args);
     },
-    trackQuizQuestionAttempt: ({
-      section,
-      questionType,
-      isCorrect,
-      hintAvailable,
-      hintAccessed,
-      questionNumber,
-    }) => {
-      const { track, additionalArgs } = get();
-      if (!track || !additionalArgs) return;
-
-      track.questionAttemptSubmitted({
-        ...additionalArgs,
-        pupilExperienceLessonActivity: section,
-        questionType,
-        questionResult: isCorrect ? "correct" : "incorrect",
-        activityTimeSpent: 0,
-        hintOffered: hintAvailable,
-        hintAccessed,
-        questionNumber,
-      });
-    },
-    trackQuizCompleted: ({ section, sectionResults, sectionStartedAt }) => {
-      const { track, additionalArgs } = get();
-      if (!track || !additionalArgs) return;
-      const trackData = buildQuizCompletionTrackingData({
-        section,
-        sectionResults,
-        sectionStartedAt,
-      });
-
-      if (section === "starter-quiz") {
-        track.lessonActivityCompletedStarterQuiz({
-          ...additionalArgs,
-          ...trackData,
-        });
-        return;
-      }
-
-      track.lessonActivityCompletedExitQuiz({
-        ...additionalArgs,
-        ...trackData,
-      });
-    },
-    trackLessonAbandoned: () => {
-      const { track, additionalArgs } = get();
-      if (!track || !additionalArgs) return;
-
-      const payload: Parameters<TrackFns["lessonAbandoned"]>[0] = {
-        ...additionalArgs,
-        ...getCorePropertyArgs(additionalArgs.clientEnvironment),
-      };
-      track.lessonAbandoned(payload);
-    },
+    trackQuizQuestionAttempt: (args) => trackQuizQuestionAttempt(get, args),
+    trackQuizCompleted: (args) => trackQuizCompleted(get, args),
+    trackLessonAbandoned: () => trackLessonAbandoned(get),
   }),
 );

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -13,6 +13,8 @@ import {
 } from "@/context/PupilLessonAnalytics/trackingFunctions/lessonTracking";
 import {
   trackIntroAbandoned,
+  trackContentGuidanceAccepted,
+  trackContentGuidanceDeclined,
   trackIntroCompleted,
   trackIntroStarted,
   trackWorksheetDownloaded,
@@ -99,5 +101,9 @@ export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
       trackLessonSummaryReviewed(get, sectionResults),
     trackActivityResultsShared: ({ sectionResults }) =>
       trackActivityResultsShared(get, sectionResults),
+    trackContentGuidanceAccepted: (args) =>
+      trackContentGuidanceAccepted(get, args),
+    trackContentGuidanceDeclined: (args) =>
+      trackContentGuidanceDeclined(get, args),
   }),
 );

--- a/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
+++ b/src/context/PupilLessonAnalytics/usePupilLessonAnalyticsStore.ts
@@ -90,18 +90,15 @@ export const usePupilLessonAnalyticsStore = create<PupilLessonAnalyticsState>()(
     trackLessonStarted: () => trackLessonStarted(get),
     trackLessonCompleted: () => trackLessonCompleted(get),
     trackLessonAbandoned: () => trackLessonAbandoned(get),
-    trackIntroCompleted: () => trackIntroCompleted(get),
+    trackIntroCompleted: (args) => trackIntroCompleted(get, args),
     trackIntroAbandoned: ({ sectionStartedAt }) =>
       trackIntroAbandoned(get, sectionStartedAt),
     trackWorksheetDownloaded: () => trackWorksheetDownloaded(get),
-    trackVideoCompleted: ({ sectionResults }) =>
-      trackVideoCompleted(get, sectionResults),
+    trackVideoCompleted: (args) => trackVideoCompleted(get, args),
     trackVideoAbandoned: ({ sectionResults, sectionStartedAt }) =>
       trackVideoAbandoned(get, sectionResults, sectionStartedAt),
-    trackLessonSummaryReviewed: ({ sectionResults }) =>
-      trackLessonSummaryReviewed(get, sectionResults),
-    trackActivityResultsShared: ({ sectionResults }) =>
-      trackActivityResultsShared(get, sectionResults),
+    trackLessonSummaryReviewed: (args) => trackLessonSummaryReviewed(get, args),
+    trackActivityResultsShared: (args) => trackActivityResultsShared(get, args),
     trackContentGuidanceAccepted: (args) =>
       trackContentGuidanceAccepted(get, args),
     trackContentGuidanceDeclined: (args) =>

--- a/src/context/PupilLessonProgress/PupilLessonProgressStore.test.ts
+++ b/src/context/PupilLessonProgress/PupilLessonProgressStore.test.ts
@@ -112,4 +112,69 @@ describe("PupilLessonProgressStore", () => {
 
     expect(store.getState().sectionResults.video?.isComplete).toBe(true);
   });
+
+  it("marks the lesson started via markLessonStarted", () => {
+    const store = createPupilLessonProgressStore();
+    expect(store.getState().lessonStarted).toBe(false);
+    store.getState().markLessonStarted();
+    expect(store.getState().lessonStarted).toBe(true);
+  });
+
+  it("records worksheet downloads through updateWorksheetDownloaded", () => {
+    const store = createPupilLessonProgressStore();
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["intro"],
+    });
+    store.getState().updateWorksheetDownloaded({
+      worksheetDownloaded: true,
+      worksheetAvailable: true,
+    });
+    expect(store.getState().sectionResults.intro?.worksheetDownloaded).toBe(
+      true,
+    );
+  });
+
+  it("records additional file downloads through updateAdditionalFilesDownloaded", () => {
+    const store = createPupilLessonProgressStore();
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["intro"],
+    });
+    store.getState().updateAdditionalFilesDownloaded({
+      filesDownloaded: true,
+      additionalFilesAvailable: true,
+    });
+    expect(store.getState().sectionResults.intro?.filesDownloaded).toBe(true);
+  });
+
+  it("dismisses content guidance", () => {
+    const store = createPupilLessonProgressStore();
+    expect(store.getState().contentGuidanceDismissed).toBe(false);
+    store.getState().dismissContentGuidance();
+    expect(store.getState().contentGuidanceDismissed).toBe(true);
+  });
+
+  it("toggles the initial-progress hydration flag", () => {
+    const store = createPupilLessonProgressStore();
+    store.getState().setHydratingInitialProgress(true);
+    expect(store.getState().isHydratingInitialProgress).toBe(true);
+    store.getState().setHydratingInitialProgress(false);
+    expect(store.getState().isHydratingInitialProgress).toBe(false);
+  });
+
+  it("resets the lesson progress back to the default state", () => {
+    const store = createPupilLessonProgressStore();
+    store.getState().initialiseLessonProgress({
+      lessonSlug: "lesson-one",
+      lessonReviewSections: ["intro"],
+    });
+    store.getState().completeSection("intro");
+    expect(store.getState().lessonSlug).toBe("lesson-one");
+
+    store.getState().resetLessonProgress();
+    expect(store.getState().lessonSlug).toBe(null);
+    expect(store.getState().sectionResults).toEqual({});
+    expect(store.getState().lessonStarted).toBe(false);
+  });
 });

--- a/src/context/PupilLessonProgress/pupilLessonProgressHelpers.ts
+++ b/src/context/PupilLessonProgress/pupilLessonProgressHelpers.ts
@@ -22,6 +22,7 @@ export const getDefaultLessonProgressState =
     isLessonComplete: false,
     isReadOnly: false,
     isHydratingInitialProgress: false,
+    contentGuidanceDismissed: false,
   });
 
 /**

--- a/src/context/PupilLessonProgress/pupilLessonProgressTypes.ts
+++ b/src/context/PupilLessonProgress/pupilLessonProgressTypes.ts
@@ -54,6 +54,7 @@ export type PupilLessonProgressState = {
   isLessonComplete: boolean;
   isReadOnly: boolean;
   isHydratingInitialProgress: boolean;
+  contentGuidanceDismissed: boolean;
   initialiseLessonProgress: (args: LessonProgressInitArgs) => void;
   markLessonStarted: () => void;
   completeSection: (section: LessonReviewSection) => void;
@@ -63,6 +64,7 @@ export type PupilLessonProgressState = {
   ) => void;
   updateWorksheetDownloaded: (result: IntroResult) => void;
   updateAdditionalFilesDownloaded: (result: IntroResult) => void;
+  dismissContentGuidance: () => void;
   setHydratingInitialProgress: (isHydrating: boolean) => void;
   resetLessonProgress: () => void;
 };
@@ -75,6 +77,7 @@ export type PupilLessonProgressDataState = Omit<
   | "updateSectionInProgressResult"
   | "updateWorksheetDownloaded"
   | "updateAdditionalFilesDownloaded"
+  | "dismissContentGuidance"
   | "setHydratingInitialProgress"
   | "resetLessonProgress"
 >;

--- a/src/context/PupilLessonProgress/usePupilLessonProgress.ts
+++ b/src/context/PupilLessonProgress/usePupilLessonProgress.ts
@@ -41,6 +41,10 @@ export const createPupilLessonProgressState: StateCreator<
     set((state) => updateSectionInProgressResultAction(state, "intro", result)),
   updateAdditionalFilesDownloaded: (result) =>
     set((state) => updateSectionInProgressResultAction(state, "intro", result)),
+  dismissContentGuidance: () =>
+    set(() => ({
+      contentGuidanceDismissed: true,
+    })),
   setHydratingInitialProgress: (isHydratingInitialProgress) =>
     set(() => ({
       isHydratingInitialProgress,

--- a/src/pages-helpers/pupil/lessons-pages/getProps.ts
+++ b/src/pages-helpers/pupil/lessons-pages/getProps.ts
@@ -15,12 +15,14 @@ import {
   PupilLessonPageType,
 } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 import { invariant } from "@/utils/invariant";
+import { getLessonShareVariant } from "@/pages-helpers/pupil";
 
 export type PupilLessonPageURLParams = {
   lessonSlug: string;
   unitSlug?: string;
   programmeSlug?: string;
   section: string;
+  variant?: string;
 };
 
 export const getProps = ({
@@ -34,7 +36,8 @@ export const getProps = ({
     if (!context.params) {
       throw new Error("context.params is undefined");
     }
-    const { lessonSlug, unitSlug, programmeSlug, section } = context.params;
+    const { lessonSlug, unitSlug, programmeSlug, section, variant } =
+      context.params;
 
     if (page === "browse") {
       invariant(unitSlug, "unitSlug is required for browse page");
@@ -103,7 +106,13 @@ export const getProps = ({
     const { browseData, content } = res;
 
     // 404 if the lesson does not contain the given section
-    if (!isAvailablePupilLessonSection(section, content)) {
+    if (
+      !isAvailablePupilLessonSection(
+        section,
+        content,
+        variant ? getLessonShareVariant(variant) : null,
+      )
+    ) {
       return {
         notFound: true,
       };
@@ -125,6 +134,7 @@ export const getProps = ({
       initialSection: section,
       pageType: page,
       suppressResourceErrors: page === "preview",
+      variant: variant ? getLessonShareVariant(variant) : null,
     });
 
     const results: GetStaticPropsResult<PupilLessonPageProps> = {

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -385,19 +385,4 @@ describe("QuizPageContent", () => {
     const { getByText } = renderPage();
     expect(getByText("Well done!")).toBeInTheDocument();
   });
-
-  it("focuses the first answer when a tab key is pressed before any interaction", () => {
-    quizState = buildQuizState();
-    quizHookMock.mockImplementation((selector) => selector(quizState));
-
-    renderPage();
-    const event = new KeyboardEvent("keydown", { key: "Tab" });
-    Object.defineProperty(event, "preventDefault", {
-      value: jest.fn(),
-      writable: false,
-    });
-    globalThis.dispatchEvent(event);
-    // No assertion needed — exercise the handler path including default cases.
-    expect(quizState.initialiseQuiz).toHaveBeenCalled();
-  });
 });

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -20,6 +20,7 @@ jest.mock("next/router", () => ({
 type ProgressState = {
   sectionResults: LessonSectionResults;
   lessonReviewSections: readonly ("starter-quiz" | "exit-quiz")[];
+  lessonStarted: boolean;
   isReadOnly: boolean;
   completeSection: jest.Mock;
   updateSectionInProgressResult: jest.Mock;
@@ -62,12 +63,18 @@ jest.mock("@/context/PupilLessonQuiz", () => ({
 const trackSectionStarted = jest.fn();
 const trackQuizQuestionAttempt = jest.fn();
 const trackQuizCompleted = jest.fn();
+const trackQuizAbandoned = jest.fn();
+const trackLessonStarted = jest.fn();
+const trackLessonCompleted = jest.fn();
 
 jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
   usePupilLessonAnalytics: () => ({
     trackSectionStarted,
     trackQuizQuestionAttempt,
     trackQuizCompleted,
+    trackQuizAbandoned,
+    trackLessonStarted,
+    trackLessonCompleted,
   }),
 }));
 
@@ -85,6 +92,7 @@ const buildProgressState = (
 ): ProgressState => ({
   sectionResults: {},
   lessonReviewSections: ["starter-quiz", "exit-quiz"],
+  lessonStarted: false,
   isReadOnly: false,
   completeSection: jest.fn(),
   updateSectionInProgressResult: jest.fn(),
@@ -110,6 +118,9 @@ beforeEach(() => {
   trackSectionStarted.mockReset();
   trackQuizQuestionAttempt.mockReset();
   trackQuizCompleted.mockReset();
+  trackQuizAbandoned.mockReset();
+  trackLessonStarted.mockReset();
+  trackLessonCompleted.mockReset();
   progressState = buildProgressState();
   quizState = buildQuizState();
   progressHookMock.mockImplementation((selector) => selector(progressState));
@@ -215,5 +226,178 @@ describe("QuizPageContent", () => {
     expect(quizState.updateQuestionMode).toHaveBeenCalledWith("grading");
     expect(quizState.applyCurrentQuestionResult).toHaveBeenCalledTimes(1);
     expect(trackQuizQuestionAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores form submissions while the question is in incomplete mode", () => {
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "incomplete" }],
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { container } = renderPage();
+    const form = container.querySelector("#quiz-form") as HTMLFormElement;
+    act(() => {
+      fireEvent.submit(form);
+    });
+    expect(quizState.updateQuestionMode).not.toHaveBeenCalled();
+    expect(quizState.applyCurrentQuestionResult).not.toHaveBeenCalled();
+  });
+
+  it("advances to the next question when the next button is pressed mid-quiz", () => {
+    quizState = buildQuizState({
+      questionState: [
+        { ...baseQuestionState, mode: "feedback", grade: 1 },
+        baseQuestionState,
+      ],
+      currentQuestionIndex: 0,
+      numQuestions: 2,
+      numInteractiveQuestions: 2,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByRole } = renderPage();
+    fireEvent.click(getByRole("button", { name: "Next question" }));
+    expect(quizState.handleNextQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes the quiz and navigates to the overview when finishing the starter quiz", () => {
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
+      currentQuestionIndex: 0,
+      numQuestions: 1,
+      numInteractiveQuestions: 1,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByRole } = renderPage();
+    fireEvent.click(getByRole("button", { name: "Continue lesson" }));
+    expect(progressState.completeSection).toHaveBeenCalledWith("starter-quiz");
+    expect(trackQuizCompleted).toHaveBeenCalledTimes(1);
+    expect(trackLessonStarted).toHaveBeenCalledTimes(1);
+    expect(routerPush.mock.calls[0]?.[0]).toContain("overview");
+  });
+
+  it("tracks the lesson as completed when the exit quiz finishes the lesson", () => {
+    progressState = buildProgressState({
+      sectionResults: {
+        intro: { isComplete: true, worksheetAvailable: false },
+        "starter-quiz": {
+          isComplete: true,
+          grade: 1,
+          numQuestions: 1,
+          questionResults: [],
+        },
+      },
+    });
+    progressHookMock.mockImplementation((selector) => selector(progressState));
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
+      currentQuestionIndex: 0,
+      numQuestions: 1,
+      numInteractiveQuestions: 1,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByRole } = renderWithTheme(
+      <QuizPageContent
+        section="exit-quiz"
+        questionsArray={[mcqQuestion]}
+        lessonSlug="test-lesson"
+        phase="primary"
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: "Lesson review" }));
+    expect(progressState.completeSection).toHaveBeenCalledWith("exit-quiz");
+    expect(trackLessonCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips tracking lesson started on completion when the lesson is already in progress", () => {
+    progressState = buildProgressState({ lessonStarted: true });
+    progressHookMock.mockImplementation((selector) => selector(progressState));
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
+      currentQuestionIndex: 0,
+      numQuestions: 1,
+      numInteractiveQuestions: 1,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByRole } = renderPage();
+    fireEvent.click(getByRole("button", { name: "Continue lesson" }));
+    expect(trackLessonStarted).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the overview without tracking when the back button is pressed on an already complete quiz", () => {
+    progressState = buildProgressState({
+      sectionResults: {
+        "starter-quiz": {
+          isComplete: true,
+          grade: 1,
+          numQuestions: 1,
+          questionResults: [],
+        },
+      },
+    });
+    progressHookMock.mockImplementation((selector) => selector(progressState));
+
+    const { getByLabelText } = renderPage();
+    fireEvent.click(getByLabelText(/Back/));
+    expect(trackQuizAbandoned).not.toHaveBeenCalled();
+    expect(trackQuizCompleted).not.toHaveBeenCalled();
+    expect(routerPush.mock.calls[0]?.[0]).toContain("overview");
+  });
+
+  it("tracks the quiz as abandoned when the back button is pressed mid-quiz", () => {
+    quizState = buildQuizState({
+      questionState: [baseQuestionState],
+      currentQuestionIndex: 0,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByLabelText } = renderPage();
+    fireEvent.click(getByLabelText(/Back/));
+    expect(trackQuizAbandoned).toHaveBeenCalledTimes(1);
+    expect(trackLessonStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes the quiz on back when the quiz is effectively complete but not yet committed", () => {
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
+      currentQuestionIndex: 0,
+      numQuestions: 1,
+      numInteractiveQuestions: 1,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByLabelText } = renderPage();
+    fireEvent.click(getByLabelText(/Back/));
+    expect(progressState.completeSection).toHaveBeenCalledWith("starter-quiz");
+    expect(trackQuizCompleted).toHaveBeenCalledTimes(1);
+    expect(trackQuizAbandoned).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Well done!' for a correct answer in feedback mode", () => {
+    quizState = buildQuizState({
+      questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    const { getByText } = renderPage();
+    expect(getByText("Well done!")).toBeInTheDocument();
+  });
+
+  it("focuses the first answer when a tab key is pressed before any interaction", () => {
+    quizState = buildQuizState();
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+
+    renderPage();
+    const event = new KeyboardEvent("keydown", { key: "Tab" });
+    Object.defineProperty(event, "preventDefault", {
+      value: jest.fn(),
+      writable: false,
+    });
+    globalThis.dispatchEvent(event);
+    // No assertion needed — exercise the handler path including default cases.
+    expect(quizState.initialiseQuiz).toHaveBeenCalled();
   });
 });

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -67,6 +67,7 @@ export const QuizPageContent = ({
   const {
     sectionResults,
     lessonReviewSections,
+    lessonStarted,
     isReadOnly,
     completeSection,
     updateSectionInProgressResult,
@@ -74,6 +75,7 @@ export const QuizPageContent = ({
     useShallow((state) => ({
       sectionResults: state.sectionResults,
       lessonReviewSections: state.lessonReviewSections,
+      lessonStarted: state.lessonStarted,
       isReadOnly: state.isReadOnly,
       completeSection: state.completeSection,
       updateSectionInProgressResult: state.updateSectionInProgressResult,
@@ -104,8 +106,14 @@ export const QuizPageContent = ({
       handleNextQuestion: state.handleNextQuestion,
     })),
   );
-  const { trackSectionStarted, trackQuizQuestionAttempt, trackQuizCompleted } =
-    usePupilLessonAnalytics();
+  const {
+    trackSectionStarted,
+    trackQuizQuestionAttempt,
+    trackQuizCompleted,
+    trackQuizAbandoned,
+    trackLessonStarted,
+    trackLessonCompleted,
+  } = usePupilLessonAnalytics();
   const currentQuestionData = questionsArray[currentQuestionIndex];
   const currentQuestionState = questionState[currentQuestionIndex];
   const currentQuestionDisplayIndex = getCurrentQuestionDisplayIndex({
@@ -254,12 +262,22 @@ export const QuizPageContent = ({
       section,
       sectionResults,
     });
+    if (!lessonStarted) {
+      trackLessonStarted();
+    }
 
     trackQuizCompleted({
       section,
       sectionResults: nextSectionResults,
       sectionStartedAt: sectionStartedAtRef.current,
     });
+    if (
+      lessonReviewSections.every(
+        (reviewSection) => nextSectionResults[reviewSection]?.isComplete,
+      )
+    ) {
+      trackLessonCompleted();
+    }
 
     navigateToSection(
       getQuizCompletionDestination({
@@ -305,6 +323,12 @@ export const QuizPageContent = ({
                 label="Back"
                 onClick={(event) => {
                   event.preventDefault();
+                  if (!sectionResults[section]?.isComplete) {
+                    if (!lessonStarted) {
+                      trackLessonStarted();
+                    }
+                    trackQuizAbandoned({ section, sectionResults });
+                  }
                   navigateToSection("overview");
                 }}
               />

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -313,7 +313,11 @@ export const QuizPageContent = ({
       if (!lessonStarted) {
         trackLessonStarted();
       }
-      trackQuizAbandoned({ section, sectionResults });
+      trackQuizAbandoned({
+        section,
+        sectionResults,
+        sectionStartedAt: sectionStartedAtRef.current,
+      });
     }
 
     navigateToSection("overview");

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -239,24 +239,19 @@ export const QuizPageContent = ({
     handleQuestionResult(result);
   };
 
-  const onNext = () => {
+  const isQuizEffectivelyComplete = () => {
     const nextStep = getQuizNextStep({
       currentQuestionIndex,
       numQuestions,
       isReadOnly,
     });
+    return (
+      nextStep.action === "complete-quiz" &&
+      currentQuestionState?.mode === "feedback"
+    );
+  };
 
-    if (nextStep.action === "next-question") {
-      handleNextQuestion();
-      return;
-    }
-
-    if (nextStep.action === "go-review") {
-      trackSectionStarted({ section: "review", sectionResults });
-      navigateToSection("review");
-      return;
-    }
-
+  const completeQuizAndTrack = () => {
     completeSection(section);
     const nextSectionResults = getCompletedQuizSectionResults({
       section,
@@ -279,12 +274,49 @@ export const QuizPageContent = ({
       trackLessonCompleted();
     }
 
+    return nextSectionResults;
+  };
+
+  const onNext = () => {
+    const nextStep = getQuizNextStep({
+      currentQuestionIndex,
+      numQuestions,
+      isReadOnly,
+    });
+
+    if (nextStep.action === "next-question") {
+      handleNextQuestion();
+      return;
+    }
+
+    if (nextStep.action === "go-review") {
+      trackSectionStarted({ section: "review", sectionResults });
+      navigateToSection("review");
+      return;
+    }
+
+    const nextSectionResults = completeQuizAndTrack();
     navigateToSection(
       getQuizCompletionDestination({
         sectionResults: nextSectionResults,
         lessonReviewSections,
       }),
     );
+  };
+
+  const onBack = () => {
+    const alreadyComplete = sectionResults[section]?.isComplete;
+
+    if (!alreadyComplete && isQuizEffectivelyComplete()) {
+      completeQuizAndTrack();
+    } else if (!alreadyComplete) {
+      if (!lessonStarted) {
+        trackLessonStarted();
+      }
+      trackQuizAbandoned({ section, sectionResults });
+    }
+
+    navigateToSection("overview");
   };
 
   const isFeedbackMode = currentQuestionState?.mode === "feedback";
@@ -323,13 +355,7 @@ export const QuizPageContent = ({
                 label="Back"
                 onClick={(event) => {
                   event.preventDefault();
-                  if (!sectionResults[section]?.isComplete) {
-                    if (!lessonStarted) {
-                      trackLessonStarted();
-                    }
-                    trackQuizAbandoned({ section, sectionResults });
-                  }
-                  navigateToSection("overview");
+                  onBack();
                 }}
               />
             ),

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -43,6 +43,7 @@ import {
   QuestionsArray,
   usePupilLessonQuiz,
 } from "@/context/PupilLessonQuiz";
+import { isMatchAnswer } from "@/components/PupilComponents/QuizUtils/answerTypeDiscriminators";
 
 type QuizPageContentProps = {
   section: QuizSection;
@@ -329,6 +330,25 @@ export const QuizPageContent = ({
   const isCorrect = currentQuestionState?.grade === 1;
   const isPartiallyCorrect = currentQuestionState?.isPartiallyCorrect;
 
+  const renderAnswerFeedback = () => {
+    if (isCorrect) {
+      return <OakSpan $font="body-2">Well done!</OakSpan>;
+    }
+
+    if (
+      !currentQuestionData?.answers ||
+      isMatchAnswer(currentQuestionData.answers)
+    ) {
+      return null;
+    }
+
+    return (
+      <MathJaxWrap>
+        <QuizCorrectAnswers questionState={currentQuestionState} />
+      </MathJaxWrap>
+    );
+  };
+
   return (
     <OakCloudinaryConfigProvider
       value={{
@@ -384,11 +404,7 @@ export const QuizPageContent = ({
             feedback: isFeedbackMode
               ? pickQuizFeedbackState(isCorrect, isPartiallyCorrect)
               : null,
-            answerFeedback: isCorrect ? (
-              <OakSpan $font="body-2">Well done!</OakSpan>
-            ) : (
-              <QuizCorrectAnswers questionState={currentQuestionState} />
-            ),
+            answerFeedback: renderAnswerFeedback(),
             actionSlot:
               currentQuestionData?.answers &&
               !isFeedbackMode &&

--- a/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.test.ts
+++ b/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.test.ts
@@ -31,23 +31,23 @@ describe("pupilLessonPage.helpers", () => {
   describe("isAvailablePupilLessonSection", () => {
     it("returns true for non-review sections regardless of content", () => {
       const lessonContent = lessonContentFixture({});
-      expect(isAvailablePupilLessonSection("overview", lessonContent)).toBe(
-        true,
-      );
+      expect(
+        isAvailablePupilLessonSection("overview", lessonContent, null),
+      ).toBe(true);
     });
 
     it("returns true for a review section available in the lesson content", () => {
       const lessonContent = lessonContentFixture({});
-      expect(isAvailablePupilLessonSection("starter-quiz", lessonContent)).toBe(
-        true,
-      );
+      expect(
+        isAvailablePupilLessonSection("starter-quiz", lessonContent, null),
+      ).toBe(true);
     });
 
     it("returns false for a review section not available in the lesson content", () => {
       const lessonContent = lessonContentFixture({ starterQuiz: [] });
-      expect(isAvailablePupilLessonSection("starter-quiz", lessonContent)).toBe(
-        false,
-      );
+      expect(
+        isAvailablePupilLessonSection("starter-quiz", lessonContent, null),
+      ).toBe(false);
     });
   });
 
@@ -112,6 +112,7 @@ describe("pupilLessonPage.helpers", () => {
         backUrl: "/back",
         initialSection: "overview",
         pageType: "canonical",
+        variant: null,
       });
 
       expect(mockGetWorksheetInfo).toHaveBeenCalledWith(browseData.lessonSlug);

--- a/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.ts
+++ b/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.ts
@@ -14,16 +14,20 @@ import {
   LessonBrowseData,
   LessonContent,
 } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { LessonShareVariant } from "@/pages-helpers/pupil";
 
 export const isAvailablePupilLessonSection = (
   section: LessonSection,
   lessonContent: LessonContent,
+  variant: LessonShareVariant | null,
 ) => {
   if (!isLessonReviewSection(section)) {
     return true;
   }
 
-  return pickAvailableSectionsForLesson(lessonContent).includes(section);
+  return pickAvailableSectionsForLesson(lessonContent, variant).includes(
+    section,
+  );
 };
 
 export const hydrateLessonContentResources = async ({
@@ -61,6 +65,7 @@ export const buildPupilLessonPageProps = async ({
   initialSection,
   pageType,
   suppressResourceErrors = false,
+  variant,
 }: {
   browseData: LessonBrowseData;
   lessonContent: LessonContent;
@@ -68,6 +73,7 @@ export const buildPupilLessonPageProps = async ({
   initialSection: LessonSection;
   pageType: PupilLessonPageType;
   suppressResourceErrors?: boolean;
+  variant: LessonShareVariant | null;
 }): Promise<PupilLessonPageProps> => {
   const hydratedLessonContent = await hydrateLessonContentResources({
     lessonContent,
@@ -88,5 +94,6 @@ export const buildPupilLessonPageProps = async ({
     initialSection,
     backUrl,
     pageType,
+    variant,
   };
 };

--- a/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.types.ts
+++ b/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.types.ts
@@ -4,6 +4,7 @@ import {
   LessonBrowseData,
   LessonContent,
 } from "@/node-lib/curriculum-api-2023/queries/pupilLesson/pupilLesson.schema";
+import { LessonShareVariant } from "@/pages-helpers/pupil";
 
 export type WorksheetInfo = {
   item: string;
@@ -24,4 +25,5 @@ export type PupilLessonPageProps = {
   hasAdditionalFiles: boolean;
   additionalFiles: AdditionalFile[] | null;
   worksheetInfo: WorksheetInfo | null;
+  variant: LessonShareVariant | null;
 };

--- a/src/pages-helpers/pupil/lessons-pages/validateSharedVariant.test.ts
+++ b/src/pages-helpers/pupil/lessons-pages/validateSharedVariant.test.ts
@@ -1,0 +1,31 @@
+import { hasValidSharedVariant } from "./validateSharedVariant";
+
+describe("hasValidSharedVariant", () => {
+  it("returns true when the shared variant slug exists", () => {
+    expect(
+      hasValidSharedVariant({
+        params: {
+          variant: "exit-quiz-only",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when the shared variant slug does not exist", () => {
+    expect(
+      hasValidSharedVariant({
+        params: {
+          variant: "blah",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when there is no shared variant route param", () => {
+    expect(
+      hasValidSharedVariant({
+        params: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/pages-helpers/pupil/lessons-pages/validateSharedVariant.ts
+++ b/src/pages-helpers/pupil/lessons-pages/validateSharedVariant.ts
@@ -1,0 +1,11 @@
+import type { GetStaticPropsContext } from "next";
+
+import { getLessonShareVariant } from "@/pages-helpers/pupil";
+
+export const hasValidSharedVariant = (
+  context: Pick<GetStaticPropsContext, "params">,
+) => {
+  const variant = context.params?.variant;
+
+  return typeof variant === "string" && Boolean(getLessonShareVariant(variant));
+};

--- a/src/pages/pupils/l/[redirectFrom]/lessons/[lessonSlug]/[section].tsx
+++ b/src/pages/pupils/l/[redirectFrom]/lessons/[lessonSlug]/[section].tsx
@@ -94,7 +94,7 @@ export const getStaticProps: GetStaticProps<
 
       const { browseData, content } = res;
       // 404 if the lesson does not contain the given section
-      if (!isAvailablePupilLessonSection(section, content)) {
+      if (!isAvailablePupilLessonSection(section, content, null)) {
         return {
           notFound: true,
         };
@@ -110,6 +110,7 @@ export const getStaticProps: GetStaticProps<
         backUrl,
         initialSection: section,
         pageType: "canonical",
+        variant: null,
       });
 
       const results: GetStaticPropsResult<PupilLessonPageProps> = { props };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
@@ -8,6 +8,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
@@ -49,6 +50,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   ExitQuizPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
@@ -9,15 +9,15 @@ import {
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
 import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type ExitQuizPageURLParams = {
   lessonSlug: string;
 };
 
-const PupilLessonExitQuizNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonExitQuizNewPage = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, variant } = props;
 
   return (
@@ -46,7 +46,7 @@ export default PupilLessonExitQuizNewPage;
 export const getStaticPaths = getStaticPathsTemplate<ExitQuizPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   ExitQuizPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 
 import getPageProps from "@/node-lib/getPageProps";
@@ -66,7 +64,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-exit-quiz::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/exit-quiz.tsx
@@ -1,0 +1,67 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+
+type ExitQuizPageURLParams = {
+  lessonSlug: string;
+};
+
+const PupilLessonExitQuizNewPage = (props: PupilExperienceViewProps) => {
+  const { browseData, lessonContent, variant } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <QuizPageContent
+        section="exit-quiz"
+        questionsArray={lessonContent.exitQuiz}
+        lessonSlug={browseData.lessonSlug}
+        phase={browseData.programmeFields.phase as "primary" | "secondary"}
+      />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonExitQuizNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<ExitQuizPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  ExitQuizPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "exit-quiz",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-exit-quiz::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.tsx
@@ -1,0 +1,22 @@
+import { GetServerSideProps, NextPage } from "next";
+
+const SharedLessonVariantIndexPage: NextPage = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({
+  resolvedUrl,
+}) => {
+  const queryIndex = resolvedUrl.indexOf("?");
+  const hasQuery = queryIndex !== -1;
+  const pathname = !hasQuery ? resolvedUrl : resolvedUrl.slice(0, queryIndex);
+  const queryParams = !hasQuery ? "" : resolvedUrl.slice(queryIndex);
+  const destination = `${pathname}/overview${queryParams}`;
+
+  return {
+    redirect: {
+      destination,
+      permanent: false,
+    },
+  };
+};
+
+export default SharedLessonVariantIndexPage;

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/index.tsx
@@ -7,8 +7,8 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   const queryIndex = resolvedUrl.indexOf("?");
   const hasQuery = queryIndex !== -1;
-  const pathname = !hasQuery ? resolvedUrl : resolvedUrl.slice(0, queryIndex);
-  const queryParams = !hasQuery ? "" : resolvedUrl.slice(queryIndex);
+  const pathname = hasQuery ? resolvedUrl.slice(0, queryIndex) : resolvedUrl;
+  const queryParams = hasQuery ? resolvedUrl.slice(queryIndex) : "";
   const destination = `${pathname}/overview${queryParams}`;
 
   return {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -1,6 +1,6 @@
 import { ParsedUrlQuery } from "querystring";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
 import {
@@ -101,6 +101,7 @@ const IntroPageContent = ({
     browseData.lessonSlug,
     lessonContent.isLegacy ?? false,
   );
+  const sectionStartedAtRef = useRef(Date.now());
   const [isCompletingAndRedirecting, setIsCompletingAndRedirecting] =
     useState(false);
 
@@ -215,7 +216,9 @@ const IntroPageContent = ({
                   if (!lessonStarted) {
                     trackLessonStarted();
                   }
-                  trackIntroAbandoned();
+                  trackIntroAbandoned({
+                    sectionStartedAt: sectionStartedAtRef.current,
+                  });
                 }
                 void router.push(overviewHref);
               }}

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -19,7 +19,6 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import {
@@ -42,6 +41,7 @@ import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupil
 import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 import { useAdditionalFilesDownload } from "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload";
 import { useWorksheetDownload } from "@/components/PupilViews/PupilIntro/useWorksheetDownload";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type IntroPageURLParams = {
   lessonSlug: string;
@@ -55,7 +55,7 @@ const IntroPageContent = ({
   hasAdditionalFiles,
   additionalFiles,
 }: Pick<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   | "browseData"
   | "lessonContent"
   | "hasWorksheet"
@@ -321,7 +321,7 @@ const IntroPageContent = ({
   );
 };
 
-const PupilLessonIntroNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonIntroNewPage = (props: PupilLessonPageProps) => {
   const {
     browseData,
     lessonContent,
@@ -360,7 +360,7 @@ export default PupilLessonIntroNewPage;
 export const getStaticPaths = getStaticPathsTemplate<IntroPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   IntroPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -67,6 +67,7 @@ const IntroPageContent = ({
   const {
     sectionResults,
     lessonReviewSections,
+    lessonStarted,
     isReadOnly,
     completeSection,
     updateSectionInProgressResult,
@@ -74,12 +75,20 @@ const IntroPageContent = ({
     useShallow((state) => ({
       sectionResults: state.sectionResults,
       lessonReviewSections: state.lessonReviewSections,
+      lessonStarted: state.lessonStarted,
       isReadOnly: state.isReadOnly,
       completeSection: state.completeSection,
       updateSectionInProgressResult: state.updateSectionInProgressResult,
     })),
   );
-  const { trackSectionStarted } = usePupilLessonAnalytics();
+  const {
+    trackSectionStarted,
+    trackLessonStarted,
+    trackLessonCompleted,
+    trackIntroCompleted,
+    trackIntroAbandoned,
+    trackWorksheetDownloaded,
+  } = usePupilLessonAnalytics();
 
   const additionalFilesAssetIds = useMemo(
     () => getAdditionalFileAssetIds(additionalFiles),
@@ -142,11 +151,18 @@ const IntroPageContent = ({
   const handleProceed = () => {
     if (!sectionResults.intro?.isComplete) {
       setIsCompletingAndRedirecting(true);
+      if (!lessonStarted) {
+        trackLessonStarted();
+      }
+      trackIntroCompleted();
       completeSection("intro");
       const nextSectionResults = getSectionResultsAfterComplete();
       const allComplete = lessonReviewSections.every(
         (section) => nextSectionResults[section]?.isComplete,
       );
+      if (allComplete) {
+        trackLessonCompleted();
+      }
       void router.push(
         getNewLessonSectionHref({
           currentRoute: router.asPath,
@@ -195,6 +211,12 @@ const IntroPageContent = ({
               label="Back"
               onClick={(event) => {
                 event.preventDefault();
+                if (!sectionResults.intro?.isComplete) {
+                  if (!lessonStarted) {
+                    trackLessonStarted();
+                  }
+                  trackIntroAbandoned();
+                }
                 void router.push(overviewHref);
               }}
             />
@@ -290,6 +312,10 @@ const IntroPageContent = ({
                       worksheetDownloaded: true,
                       worksheetAvailable: true,
                     });
+                    if (!lessonStarted) {
+                      trackLessonStarted();
+                    }
+                    trackWorksheetDownloaded();
                     void startDownload();
                   }}
                   isLoading={isDownloading}

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -19,6 +19,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import {
@@ -394,6 +395,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   IntroPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -156,7 +156,7 @@ const IntroPageContent = ({
       if (!lessonStarted) {
         trackLessonStarted();
       }
-      trackIntroCompleted();
+      trackIntroCompleted({ sectionStartedAt: sectionStartedAtRef.current });
       completeSection("intro");
       const nextSectionResults = getSectionResultsAfterComplete();
       const allComplete = lessonReviewSections.every(

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -298,10 +298,12 @@ const IntroPageContent = ({
                   $font="heading-7"
                 >
                   Download worksheet{" "}
-                  <OakSpan>
-                    ({worksheetInfo?.[0]?.ext?.toUpperCase()}{" "}
-                    {worksheetInfo?.[0]?.fileSize})
-                  </OakSpan>
+                  {worksheetInfo?.[0]?.ext && worksheetInfo?.[0]?.fileSize && (
+                    <OakSpan>
+                      ({worksheetInfo[0].ext.toUpperCase()}{" "}
+                      {worksheetInfo[0].fileSize})
+                    </OakSpan>
+                  )}
                 </OakPrimaryInvertedButton>
               </OakFlex>
             </PupilLessonIntroInfoCard>

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -1,0 +1,381 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { useEffect, useMemo, useState } from "react";
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+import { useRouter } from "next/router";
+import {
+  OakBackLink,
+  OakFlex,
+  OakP,
+  OakPrimaryInvertedButton,
+  OakSpan,
+  OakLessonTopNav,
+} from "@oaknational/oak-components";
+import { useShallow } from "zustand/react/shallow";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import {
+  PupilLessonIntroAdditionalFileItem,
+  PupilLessonIntroInfoCard,
+  PupilLessonIntroLicence,
+  PupilLessonIntroReadyCard,
+  PupilLessonIntroView,
+} from "@/components/PupilComponents/Views/PupilLessonIntro";
+import {
+  getAdditionalFileAssetIds,
+  getDedupedContentGuidanceLabels,
+  getIntroBottomNavLabel,
+  getIntroWorksheetInitResult,
+  getNewLessonSectionHref,
+  pickNextIncompleteSection,
+  shouldInitIntroWorksheetResult,
+} from "@/components/PupilComponents/Views/ViewHelpers";
+import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { useAdditionalFilesDownload } from "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload";
+import { useWorksheetDownload } from "@/components/PupilViews/PupilIntro/useWorksheetDownload";
+
+type IntroPageURLParams = {
+  lessonSlug: string;
+};
+
+const IntroPageContent = ({
+  browseData,
+  lessonContent,
+  hasWorksheet,
+  worksheetInfo,
+  hasAdditionalFiles,
+  additionalFiles,
+}: Pick<
+  PupilExperienceViewProps,
+  | "browseData"
+  | "lessonContent"
+  | "hasWorksheet"
+  | "worksheetInfo"
+  | "hasAdditionalFiles"
+  | "additionalFiles"
+>) => {
+  const router = useRouter();
+  const {
+    sectionResults,
+    lessonReviewSections,
+    isReadOnly,
+    completeSection,
+    updateSectionInProgressResult,
+  } = usePupilLessonProgress(
+    useShallow((state) => ({
+      sectionResults: state.sectionResults,
+      lessonReviewSections: state.lessonReviewSections,
+      isReadOnly: state.isReadOnly,
+      completeSection: state.completeSection,
+      updateSectionInProgressResult: state.updateSectionInProgressResult,
+    })),
+  );
+  const { trackSectionStarted } = usePupilLessonAnalytics();
+
+  const additionalFilesAssetIds = useMemo(
+    () => getAdditionalFileAssetIds(additionalFiles),
+    [additionalFiles],
+  );
+
+  const { startAdditionalFilesDownload, isAdditionalFilesDownloading } =
+    useAdditionalFilesDownload(browseData.lessonSlug, additionalFilesAssetIds);
+  const { startDownload, isDownloading } = useWorksheetDownload(
+    browseData.lessonSlug,
+    lessonContent.isLegacy ?? false,
+  );
+  const [isCompletingAndRedirecting, setIsCompletingAndRedirecting] =
+    useState(false);
+
+  const currentSearchParams = useMemo(
+    () => new URLSearchParams(router.asPath.split("?")[1]),
+    [router.asPath],
+  );
+  const overviewHref = getNewLessonSectionHref({
+    currentRoute: router.asPath,
+    section: "overview",
+    searchParams: currentSearchParams,
+  });
+
+  const getSectionResultsAfterComplete = () => ({
+    ...sectionResults,
+    intro: {
+      ...sectionResults.intro,
+      isComplete: true,
+    },
+  });
+
+  useEffect(() => {
+    if (
+      shouldInitIntroWorksheetResult({
+        worksheetAvailable: sectionResults.intro?.worksheetAvailable,
+        currentSection: "intro",
+      })
+    ) {
+      updateSectionInProgressResult(
+        "intro",
+        getIntroWorksheetInitResult({
+          worksheetDownloaded: sectionResults.intro?.worksheetDownloaded,
+          hasWorksheet,
+        }),
+      );
+    }
+  }, [
+    hasWorksheet,
+    sectionResults.intro?.worksheetAvailable,
+    sectionResults.intro?.worksheetDownloaded,
+    updateSectionInProgressResult,
+  ]);
+
+  const removedGuidanceDuplicates = getDedupedContentGuidanceLabels(
+    lessonContent.contentGuidance,
+  );
+
+  const handleProceed = () => {
+    if (!sectionResults.intro?.isComplete) {
+      setIsCompletingAndRedirecting(true);
+      completeSection("intro");
+      const nextSectionResults = getSectionResultsAfterComplete();
+      const allComplete = lessonReviewSections.every(
+        (section) => nextSectionResults[section]?.isComplete,
+      );
+      void router.push(
+        getNewLessonSectionHref({
+          currentRoute: router.asPath,
+          section: allComplete ? "review" : "overview",
+          searchParams: currentSearchParams,
+        }),
+      );
+      return;
+    }
+
+    const nextSection = pickNextIncompleteSection({
+      lessonReviewSections,
+      sectionResults,
+    });
+
+    if (isReadOnly) {
+      trackSectionStarted({ section: "review", sectionResults });
+      void router.push(
+        getNewLessonSectionHref({
+          currentRoute: router.asPath,
+          section: "review",
+          searchParams: currentSearchParams,
+        }),
+      );
+      return;
+    }
+
+    trackSectionStarted({ section: nextSection, sectionResults });
+    void router.push(
+      getNewLessonSectionHref({
+        currentRoute: router.asPath,
+        section: nextSection,
+        searchParams: currentSearchParams,
+      }),
+    );
+  };
+
+  return (
+    <PupilLessonIntroView
+      phase={browseData.programmeFields.phase as "primary" | "secondary"}
+      topNavSlot={
+        <OakLessonTopNav
+          backLinkSlot={
+            <OakBackLink
+              href={overviewHref}
+              label="Back"
+              onClick={(event) => {
+                event.preventDefault();
+                void router.push(overviewHref);
+              }}
+            />
+          }
+          heading="Introduction"
+          lessonSectionName="intro"
+          mobileSummary={<OakSpan $font="body-3">In progress...</OakSpan>}
+        />
+      }
+      readyToLearnSlot={<PupilLessonIntroReadyCard />}
+      lessonInfoSlot={
+        <>
+          {hasAdditionalFiles && !!additionalFiles?.length && (
+            <PupilLessonIntroInfoCard
+              title={`File${additionalFiles.length > 1 ? "s" : ""} you will need for this lesson`}
+              iconName="additional-material"
+            >
+              <OakFlex $flexDirection="column" $gap="spacing-16">
+                {additionalFiles.map((file) => (
+                  <PupilLessonIntroAdditionalFileItem
+                    key={file.assetId}
+                    displayName={file.mediaObject.displayName}
+                    bytes={file.mediaObject.bytes}
+                    url={file.mediaObject.url}
+                  />
+                ))}
+                <OakFlex $justifyContent="flex-end">
+                  <OakPrimaryInvertedButton
+                    onClick={() => {
+                      updateSectionInProgressResult("intro", {
+                        filesDownloaded: true,
+                        additionalFilesAvailable: true,
+                      });
+                      void startAdditionalFilesDownload();
+                    }}
+                    isLoading={isAdditionalFilesDownloading}
+                    iconName="download"
+                    isTrailingIcon
+                    $font="heading-7"
+                  >
+                    {additionalFiles.length === 1
+                      ? "Download file"
+                      : "Download files"}
+                  </OakPrimaryInvertedButton>
+                </OakFlex>
+              </OakFlex>
+            </PupilLessonIntroInfoCard>
+          )}
+
+          {lessonContent.equipmentAndResources?.[0]?.equipment && (
+            <PupilLessonIntroInfoCard
+              title="Equipment"
+              iconName="equipment-required"
+            >
+              <OakP>{lessonContent.equipmentAndResources[0].equipment}</OakP>
+            </PupilLessonIntroInfoCard>
+          )}
+
+          {(removedGuidanceDuplicates.length > 0 ||
+            browseData.features?.ageRestriction) && (
+            <PupilLessonIntroInfoCard
+              title="Content guidance"
+              iconName="content-guidance"
+            >
+              <OakFlex $flexDirection="column" $gap="spacing-8">
+                {removedGuidanceDuplicates.length > 0 ? (
+                  removedGuidanceDuplicates.map((guidance) => (
+                    <OakP key={guidance}>{guidance}</OakP>
+                  ))
+                ) : (
+                  <OakP>Speak to an adult before starting this lesson.</OakP>
+                )}
+              </OakFlex>
+            </PupilLessonIntroInfoCard>
+          )}
+
+          {lessonContent.supervisionLevel && (
+            <PupilLessonIntroInfoCard
+              title="Supervision"
+              iconName="supervision-level"
+            >
+              <OakP>{lessonContent.supervisionLevel}</OakP>
+            </PupilLessonIntroInfoCard>
+          )}
+
+          {hasWorksheet && (
+            <PupilLessonIntroInfoCard title="Worksheet" iconName="worksheet-3">
+              <OakP>Optional</OakP>
+              <OakFlex $justifyContent="flex-end">
+                <OakPrimaryInvertedButton
+                  onClick={() => {
+                    updateSectionInProgressResult("intro", {
+                      worksheetDownloaded: true,
+                      worksheetAvailable: true,
+                    });
+                    void startDownload();
+                  }}
+                  isLoading={isDownloading}
+                  iconName="download"
+                  isTrailingIcon
+                  $font="heading-7"
+                >
+                  Download worksheet{" "}
+                  <OakSpan>
+                    ({worksheetInfo?.[0]?.ext?.toUpperCase()}{" "}
+                    {worksheetInfo?.[0]?.fileSize})
+                  </OakSpan>
+                </OakPrimaryInvertedButton>
+              </OakFlex>
+            </PupilLessonIntroInfoCard>
+          )}
+        </>
+      }
+      licenceSlot={
+        <PupilLessonIntroLicence isLegacyLicense={!!lessonContent.isLegacy} />
+      }
+      bottomNav={{
+        proceedLabel: isCompletingAndRedirecting
+          ? "I'm ready"
+          : getIntroBottomNavLabel(sectionResults.intro?.isComplete),
+        onProceed: handleProceed,
+      }}
+    />
+  );
+};
+
+const PupilLessonIntroNewPage = (props: PupilExperienceViewProps) => {
+  const {
+    browseData,
+    lessonContent,
+    hasWorksheet,
+    worksheetInfo,
+    hasAdditionalFiles,
+    additionalFiles,
+    variant,
+  } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <IntroPageContent
+        browseData={browseData}
+        lessonContent={lessonContent}
+        hasWorksheet={hasWorksheet}
+        worksheetInfo={worksheetInfo}
+        hasAdditionalFiles={hasAdditionalFiles}
+        additionalFiles={additionalFiles}
+      />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonIntroNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<IntroPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  IntroPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "intro",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-intro::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { useEffect, useMemo, useRef, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
@@ -411,7 +409,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-intro::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -69,7 +69,7 @@ const OverviewPageContent = ({
       markLessonStarted: state.markLessonStarted,
     })),
   );
-  const { trackSectionStarted, trackLessonAbandoned } =
+  const { trackSectionStarted, trackLessonStarted, trackLessonAbandoned } =
     usePupilLessonAnalytics();
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
@@ -105,6 +105,9 @@ const OverviewPageContent = ({
       lessonReviewSections,
       sectionResults,
     });
+    if (!lessonStarted) {
+      trackLessonStarted();
+    }
     markLessonStarted();
     trackSectionStarted({ section: nextSection, sectionResults });
     void router.push(
@@ -131,6 +134,9 @@ const OverviewPageContent = ({
     starterQuizNumQuestions,
     exitQuizNumQuestions,
     onSectionClick: (section) => {
+      if (!lessonStarted) {
+        trackLessonStarted();
+      }
       markLessonStarted();
       trackSectionStarted({ section, sectionResults });
     },

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -1,0 +1,265 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { useEffect, useState } from "react";
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+import { useRouter } from "next/router";
+import { OakPupilContentGuidance } from "@oaknational/oak-components";
+import { useShallow } from "zustand/react/shallow";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
+import { ViewAllLessonsButton } from "@/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton";
+import {
+  PupilLessonOverviewContentGuidance,
+  PupilLessonOverviewOutcomes,
+  PupilLessonOverviewView,
+} from "@/components/PupilComponents/Views/PupilLessonOverview";
+import {
+  buildOverviewSectionItems,
+  getIsLessonExpiring,
+  getNewLessonSectionHref,
+  getInteractiveQuestions,
+  getUnitListingHref,
+  pickNextIncompleteSection,
+  pickProceedToNextSectionLabel,
+} from "@/components/PupilComponents/Views/ViewHelpers";
+import {
+  getDoesSubjectHaveNewUnits,
+  TakedownBanner,
+} from "@/components/SharedComponents/TakedownBanner/TakedownBanner";
+import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
+
+type OverviewPageURLParams = {
+  lessonSlug: string;
+};
+
+const OverviewPageContent = ({
+  browseData,
+  lessonContent,
+  backUrl,
+}: Pick<
+  PupilExperienceViewProps,
+  "browseData" | "lessonContent" | "backUrl"
+>) => {
+  const { isClassroomAssignment, classroomAssignmentChecked } =
+    useAssignmentSearchParams();
+  const {
+    sectionResults,
+    lessonReviewSections,
+    isLessonComplete,
+    lessonStarted,
+    isReadOnly,
+    isHydratingInitialProgress,
+    markLessonStarted,
+  } = usePupilLessonProgress(
+    useShallow((state) => ({
+      sectionResults: state.sectionResults,
+      lessonReviewSections: state.lessonReviewSections,
+      isLessonComplete: state.isLessonComplete,
+      lessonStarted: state.lessonStarted,
+      isReadOnly: state.isReadOnly,
+      isHydratingInitialProgress: state.isHydratingInitialProgress,
+      markLessonStarted: state.markLessonStarted,
+    })),
+  );
+  const { trackSectionStarted, trackLessonAbandoned } =
+    usePupilLessonAnalytics();
+  const router = useRouter();
+  const [isMounted, setIsMounted] = useState(false);
+
+  const {
+    programmeFields: {
+      phase = "primary",
+      subjectSlug,
+      yearDescription,
+      subject,
+    },
+    lessonData: { expirationDate },
+    programmeSlug,
+    actions,
+  } = browseData;
+
+  const {
+    lessonTitle,
+    pupilLessonOutcome,
+    phonicsOutcome,
+    contentGuidance,
+    supervisionLevel,
+  } = lessonContent;
+
+  const unitListingHref = getUnitListingHref({
+    subjectSlug: browseData.programmeFields.subjectSlug,
+    phaseSlug: browseData.programmeFields.phaseSlug,
+    yearSlug: browseData.programmeFields.yearSlug,
+  });
+
+  const handleProceedToNextSectionClick = () => {
+    const nextSection = pickNextIncompleteSection({
+      lessonReviewSections,
+      sectionResults,
+    });
+    markLessonStarted();
+    trackSectionStarted({ section: nextSection, sectionResults });
+    void router.push(
+      getNewLessonSectionHref({
+        currentRoute: router.asPath,
+        section: nextSection,
+        searchParams: new URLSearchParams(router.asPath.split("?")[1]),
+      }),
+    );
+  };
+
+  const starterQuizNumQuestions = getInteractiveQuestions(
+    lessonContent.starterQuiz,
+  ).length;
+  const exitQuizNumQuestions = getInteractiveQuestions(
+    lessonContent.exitQuiz,
+  ).length;
+
+  const sectionItems = buildOverviewSectionItems({
+    lessonReviewSections,
+    sectionResults,
+    isReadOnly,
+    isHydratingInitialProgress,
+    starterQuizNumQuestions,
+    exitQuizNumQuestions,
+    onSectionClick: (section) => {
+      markLessonStarted();
+      trackSectionStarted({ section, sectionResults });
+    },
+    getSectionHref: (section) =>
+      getNewLessonSectionHref({
+        currentRoute: router.asPath,
+        section,
+        searchParams: new URLSearchParams(router.asPath.split("?")[1]),
+      }),
+  });
+
+  const lessonOutcomes = [pupilLessonOutcome, phonicsOutcome].filter(
+    Boolean,
+  ) as string[];
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return (
+    <PupilLessonOverviewView
+      phase={phase as "primary" | "secondary"}
+      backButtonSlot={
+        classroomAssignmentChecked && !isClassroomAssignment ? (
+          <ViewAllLessonsButton
+            href={backUrl}
+            onClick={() => {
+              if (isLessonComplete === false) {
+                trackLessonAbandoned();
+              }
+            }}
+          />
+        ) : undefined
+      }
+      bannerSlot={
+        <TakedownBanner
+          isExpiring={getIsLessonExpiring({
+            expirationDate,
+            displayExpiringBanner: actions?.displayExpiringBanner,
+          })}
+          isLegacy={isSlugLegacy(programmeSlug)}
+          hasNewUnits={getDoesSubjectHaveNewUnits(subjectSlug)}
+          subjectSlug={subjectSlug}
+          userType="pupil"
+          onwardHref={unitListingHref}
+          isSingle
+        />
+      }
+      header={{
+        lessonTitle: lessonTitle ?? "",
+        yearDescription,
+        subject,
+        subjectSlug,
+        phase: phase as "primary" | "secondary",
+      }}
+      outcomesSlot={
+        lessonOutcomes.length > 0 ? (
+          <PupilLessonOverviewOutcomes outcomes={lessonOutcomes} />
+        ) : undefined
+      }
+      contentGuidanceSlot={
+        contentGuidance && contentGuidance.length > 0 ? (
+          <PupilLessonOverviewContentGuidance
+            contentGuidance={contentGuidance as OakPupilContentGuidance[]}
+            supervisionLevel={supervisionLevel}
+          />
+        ) : undefined
+      }
+      sectionsNav={{ items: sectionItems }}
+      bottomNav={{
+        proceedLabel: pickProceedToNextSectionLabel({
+          lessonStarted,
+          isLessonComplete,
+          sectionResults,
+        }),
+        onProceed: handleProceedToNextSectionClick,
+        disabled: !isMounted,
+      }}
+    />
+  );
+};
+
+const PupilLessonOverviewNewPage = (props: PupilExperienceViewProps) => {
+  const { browseData, lessonContent, backUrl, variant } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <OverviewPageContent
+        browseData={browseData}
+        lessonContent={lessonContent}
+        backUrl={backUrl}
+      />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonOverviewNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<OverviewPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  OverviewPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "overview",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-overview::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -17,7 +17,9 @@ import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
 import { ViewAllLessonsButton } from "@/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton";
 import {
+  ContentGuidanceTrackingArgs,
   PupilLessonOverviewContentGuidance,
+  PupilLessonOverviewContentGuidanceModal,
   PupilLessonOverviewOutcomes,
   PupilLessonOverviewView,
 } from "@/components/PupilComponents/Views/PupilLessonOverview";
@@ -38,6 +40,7 @@ import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupil
 import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
 import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
+import { PupilRedirectedOverlay } from "@/components/PupilComponents/PupilRedirectedOverlay/PupilRedirectedOverlay";
 
 type OverviewPageURLParams = {
   lessonSlug: string;
@@ -69,8 +72,13 @@ const OverviewPageContent = ({
       markLessonStarted: state.markLessonStarted,
     })),
   );
-  const { trackSectionStarted, trackLessonStarted, trackLessonAbandoned } =
-    usePupilLessonAnalytics();
+  const {
+    trackSectionStarted,
+    trackLessonStarted,
+    trackLessonAbandoned,
+    trackContentGuidanceAccepted,
+    trackContentGuidanceDeclined,
+  } = usePupilLessonAnalytics();
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
 
@@ -93,6 +101,7 @@ const OverviewPageContent = ({
     contentGuidance,
     supervisionLevel,
   } = lessonContent;
+  const [redirectOverlayCleared, setRedirectOverlayCleared] = useState(false);
 
   const unitListingHref = getUnitListingHref({
     subjectSlug: browseData.programmeFields.subjectSlug,
@@ -152,70 +161,108 @@ const OverviewPageContent = ({
     Boolean,
   ) as string[];
 
+  const handleContentGuidanceAccept = (args: ContentGuidanceTrackingArgs) => {
+    trackContentGuidanceAccepted(args);
+  };
+
+  const handleContentGuidanceDecline = (args: ContentGuidanceTrackingArgs) => {
+    trackContentGuidanceDeclined(args);
+
+    if (isClassroomAssignment) {
+      globalThis.window?.parent?.postMessage(
+        {
+          type: "Classroom",
+          action: "closeIframe",
+        },
+        "https://classroom.google.com",
+      );
+    } else if (backUrl) {
+      void router.replace(backUrl);
+    } else {
+      router.back();
+    }
+  };
+
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
   return (
-    <PupilLessonOverviewView
-      phase={phase as "primary" | "secondary"}
-      backButtonSlot={
-        classroomAssignmentChecked && !isClassroomAssignment ? (
-          <ViewAllLessonsButton
-            href={backUrl}
-            onClick={() => {
-              if (isLessonComplete === false) {
-                trackLessonAbandoned();
-              }
-            }}
+    <>
+      <PupilLessonOverviewContentGuidanceModal
+        redirectOverlayCleared={redirectOverlayCleared}
+        contentGuidance={contentGuidance as OakPupilContentGuidance[] | null}
+        supervisionLevel={supervisionLevel}
+        ageRestriction={browseData.features?.ageRestriction}
+        isClassroomAssignment={isClassroomAssignment}
+        onAccept={handleContentGuidanceAccept}
+        onDecline={handleContentGuidanceDecline}
+      />
+      <PupilLessonOverviewView
+        phase={phase as "primary" | "secondary"}
+        backButtonSlot={
+          classroomAssignmentChecked && !isClassroomAssignment ? (
+            <ViewAllLessonsButton
+              href={backUrl}
+              onClick={() => {
+                if (isLessonComplete === false) {
+                  trackLessonAbandoned();
+                }
+              }}
+            />
+          ) : undefined
+        }
+        bannerSlot={
+          <TakedownBanner
+            isExpiring={getIsLessonExpiring({
+              expirationDate,
+              displayExpiringBanner: actions?.displayExpiringBanner,
+            })}
+            isLegacy={isSlugLegacy(programmeSlug)}
+            hasNewUnits={getDoesSubjectHaveNewUnits(subjectSlug)}
+            subjectSlug={subjectSlug}
+            userType="pupil"
+            onwardHref={unitListingHref}
+            isSingle
           />
-        ) : undefined
-      }
-      bannerSlot={
-        <TakedownBanner
-          isExpiring={getIsLessonExpiring({
-            expirationDate,
-            displayExpiringBanner: actions?.displayExpiringBanner,
-          })}
-          isLegacy={isSlugLegacy(programmeSlug)}
-          hasNewUnits={getDoesSubjectHaveNewUnits(subjectSlug)}
-          subjectSlug={subjectSlug}
-          userType="pupil"
-          onwardHref={unitListingHref}
-          isSingle
-        />
-      }
-      header={{
-        lessonTitle: lessonTitle ?? "",
-        yearDescription,
-        subject,
-        subjectSlug,
-        phase: phase as "primary" | "secondary",
-      }}
-      outcomesSlot={
-        lessonOutcomes.length > 0 ? (
-          <PupilLessonOverviewOutcomes outcomes={lessonOutcomes} />
-        ) : undefined
-      }
-      contentGuidanceSlot={
-        contentGuidance && contentGuidance.length > 0 ? (
-          <PupilLessonOverviewContentGuidance
-            contentGuidance={contentGuidance as OakPupilContentGuidance[]}
-            supervisionLevel={supervisionLevel}
-          />
-        ) : undefined
-      }
-      sectionsNav={{ items: sectionItems }}
-      bottomNav={{
-        proceedLabel: pickProceedToNextSectionLabel({
-          lessonStarted,
-          isLessonComplete,
-          sectionResults,
-        }),
-        onProceed: handleProceedToNextSectionClick,
-        disabled: !isMounted,
-      }}
-    />
+        }
+        header={{
+          lessonTitle: lessonTitle ?? "",
+          yearDescription,
+          subject,
+          subjectSlug,
+          phase: phase as "primary" | "secondary",
+        }}
+        outcomesSlot={
+          lessonOutcomes.length > 0 ? (
+            <PupilLessonOverviewOutcomes outcomes={lessonOutcomes} />
+          ) : undefined
+        }
+        contentGuidanceSlot={
+          contentGuidance && contentGuidance.length > 0 ? (
+            <PupilLessonOverviewContentGuidance
+              contentGuidance={contentGuidance as OakPupilContentGuidance[]}
+              supervisionLevel={supervisionLevel}
+            />
+          ) : undefined
+        }
+        sectionsNav={{ items: sectionItems }}
+        bottomNav={{
+          proceedLabel: pickProceedToNextSectionLabel({
+            lessonStarted,
+            isLessonComplete,
+            sectionResults,
+          }),
+          onProceed: handleProceedToNextSectionClick,
+          disabled: !isMounted,
+        }}
+      />
+      <PupilRedirectedOverlay
+        isLessonPage={true}
+        onLoaded={(isShowing) => setRedirectOverlayCleared(!isShowing)}
+        onClose={() => setRedirectOverlayCleared(true)}
+      />
+    </>
   );
 };
 

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -12,6 +12,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
@@ -303,6 +304,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   OverviewPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -60,7 +60,9 @@ const OverviewPageContent = ({
     lessonStarted,
     isReadOnly,
     isHydratingInitialProgress,
+    contentGuidanceDismissed,
     markLessonStarted,
+    dismissContentGuidance,
   } = usePupilLessonProgress(
     useShallow((state) => ({
       sectionResults: state.sectionResults,
@@ -69,7 +71,9 @@ const OverviewPageContent = ({
       lessonStarted: state.lessonStarted,
       isReadOnly: state.isReadOnly,
       isHydratingInitialProgress: state.isHydratingInitialProgress,
+      contentGuidanceDismissed: state.contentGuidanceDismissed,
       markLessonStarted: state.markLessonStarted,
+      dismissContentGuidance: state.dismissContentGuidance,
     })),
   );
   const {
@@ -162,6 +166,7 @@ const OverviewPageContent = ({
   ) as string[];
 
   const handleContentGuidanceAccept = (args: ContentGuidanceTrackingArgs) => {
+    dismissContentGuidance();
     trackContentGuidanceAccepted(args);
   };
 
@@ -191,6 +196,7 @@ const OverviewPageContent = ({
     <>
       <PupilLessonOverviewContentGuidanceModal
         redirectOverlayCleared={redirectOverlayCleared}
+        contentGuidanceDismissed={contentGuidanceDismissed}
         contentGuidance={contentGuidance as OakPupilContentGuidance[] | null}
         supervisionLevel={supervisionLevel}
         ageRestriction={browseData.features?.ageRestriction}

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -1,9 +1,6 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { useEffect, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
-import { OakPupilContentGuidance } from "@oaknational/oak-components";
 import { useShallow } from "zustand/react/shallow";
 
 import getPageProps from "@/node-lib/getPageProps";
@@ -198,7 +195,7 @@ const OverviewPageContent = ({
       <PupilLessonOverviewContentGuidanceModal
         redirectOverlayCleared={redirectOverlayCleared}
         contentGuidanceDismissed={contentGuidanceDismissed}
-        contentGuidance={contentGuidance as OakPupilContentGuidance[] | null}
+        contentGuidance={contentGuidance}
         supervisionLevel={supervisionLevel}
         ageRestriction={browseData.features?.ageRestriction}
         isClassroomAssignment={isClassroomAssignment}
@@ -248,7 +245,7 @@ const OverviewPageContent = ({
         contentGuidanceSlot={
           contentGuidance && contentGuidance.length > 0 ? (
             <PupilLessonOverviewContentGuidance
-              contentGuidance={contentGuidance as OakPupilContentGuidance[]}
+              contentGuidance={contentGuidance}
               supervisionLevel={supervisionLevel}
             />
           ) : undefined
@@ -320,7 +317,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-overview::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -12,7 +12,6 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
@@ -38,6 +37,7 @@ import {
 import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
 import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 import isSlugLegacy from "@/utils/slugModifiers/isSlugLegacy";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type OverviewPageURLParams = {
   lessonSlug: string;
@@ -47,10 +47,7 @@ const OverviewPageContent = ({
   browseData,
   lessonContent,
   backUrl,
-}: Pick<
-  PupilExperienceViewProps,
-  "browseData" | "lessonContent" | "backUrl"
->) => {
+}: Pick<PupilLessonPageProps, "browseData" | "lessonContent" | "backUrl">) => {
   const { isClassroomAssignment, classroomAssignmentChecked } =
     useAssignmentSearchParams();
   const {
@@ -216,7 +213,7 @@ const OverviewPageContent = ({
   );
 };
 
-const PupilLessonOverviewNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonOverviewNewPage = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, backUrl, variant } = props;
 
   return (
@@ -244,7 +241,7 @@ export default PupilLessonOverviewNewPage;
 export const getStaticPaths = getStaticPathsTemplate<OverviewPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   OverviewPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -114,10 +114,16 @@ const ReviewPageContent = ({
 
   useEffect(() => {
     if (trackingSent || !isLessonComplete) return;
-    trackLessonSummaryReviewed({ sectionResults });
+    trackLessonSummaryReviewed({
+      sectionResults,
+      starterQuizQuestionsArray: lessonContent.starterQuiz,
+      exitQuizQuestionsArray: lessonContent.exitQuiz,
+    });
     setTrackingSent(true);
   }, [
     isLessonComplete,
+    lessonContent.exitQuiz,
+    lessonContent.starterQuiz,
     sectionResults,
     trackLessonSummaryReviewed,
     trackingSent,
@@ -207,7 +213,11 @@ const ReviewPageContent = ({
                     attemptId: res,
                   }),
                 );
-                trackActivityResultsShared({ sectionResults });
+                trackActivityResultsShared({
+                  sectionResults,
+                  starterQuizQuestionsArray: lessonContent.starterQuiz,
+                  exitQuizQuestionsArray: lessonContent.exitQuiz,
+                });
                 setIsAttemptingShare("shared");
                 return;
               }
@@ -218,7 +228,11 @@ const ReviewPageContent = ({
                   attemptId: res.attemptId,
                 }),
               );
-              trackActivityResultsShared({ sectionResults });
+              trackActivityResultsShared({
+                sectionResults,
+                starterQuizQuestionsArray: lessonContent.starterQuiz,
+                exitQuizQuestionsArray: lessonContent.exitQuiz,
+              });
               setIsAttemptingShare("shared");
               res.promise.catch(() => {
                 setIsAttemptingShare("failed");

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -1,0 +1,282 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { useEffect, useMemo, useState } from "react";
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+import { useRouter } from "next/router";
+import { OakImage, OakTertiaryButton } from "@oaknational/oak-components";
+import { useShallow } from "zustand/react/shallow";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import {
+  PupilLessonReviewBottomNav,
+  PupilLessonReviewFeedbackCard,
+  PupilLessonReviewSections,
+  PupilLessonReviewShareOptions,
+  PupilLessonReviewView,
+} from "@/components/PupilComponents/Views/PupilLessonReview";
+import {
+  buildReviewAttemptData,
+  buildReviewShareUrl,
+  getHasQuizSections,
+  getNewLessonSectionHref,
+  shouldShowReviewBottomNav,
+} from "@/components/PupilComponents/Views/ViewHelpers";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { resolveOakHref } from "@/common-lib/urls";
+import { useOakPupil } from "@/hooks/useOakPupil";
+import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
+import { getReviewSections } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewSections";
+import { getReviewFinalFeedback } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewFinalFeedback";
+
+type ReviewPageURLParams = {
+  lessonSlug: string;
+};
+
+const ReviewPageContent = ({
+  browseData,
+  lessonContent,
+  backUrl,
+}: Pick<
+  PupilExperienceViewProps,
+  "browseData" | "lessonContent" | "backUrl"
+>) => {
+  const router = useRouter();
+  const { sectionResults, lessonReviewSections, isLessonComplete, isReadOnly } =
+    usePupilLessonProgress(
+      useShallow((state) => ({
+        sectionResults: state.sectionResults,
+        lessonReviewSections: state.lessonReviewSections,
+        isLessonComplete: state.isLessonComplete,
+        isReadOnly: state.isReadOnly,
+      })),
+    );
+  const { isClassroomAssignment, classroomAssignmentChecked } =
+    useAssignmentSearchParams();
+  const [trackingSent, setTrackingSent] = useState(false);
+  const [isAttemptingShare, setIsAttemptingShare] = useState<
+    "failed" | "shared" | "initial"
+  >("initial");
+  const [storedAttemptLocally, setStoredAttemptLocally] = useState<{
+    stored: boolean;
+    attemptId: string;
+  }>({ stored: false, attemptId: "" });
+  const pupilClient = useOakPupil();
+
+  const hasQuizSections = getHasQuizSections(lessonReviewSections);
+  const showBottomNav = shouldShowReviewBottomNav({
+    classroomAssignmentChecked,
+    isClassroomAssignment,
+  });
+  const currentSearchParams = useMemo(
+    () => new URLSearchParams(router.asPath.split("?")[1]),
+    [router.asPath],
+  );
+
+  const finalFeedback = useMemo(
+    () => getReviewFinalFeedback(isLessonComplete, sectionResults),
+    [isLessonComplete, sectionResults],
+  );
+
+  useEffect(() => {
+    if (storedAttemptLocally.stored || !isLessonComplete) return;
+
+    const attemptData = buildReviewAttemptData({
+      lessonSlug: browseData.lessonSlug,
+      lessonTitle: lessonContent.lessonTitle ?? "",
+      subject: browseData.programmeFields.subject,
+      yearDescription: browseData.programmeFields.yearDescription,
+      sectionResults,
+    });
+    const attemptId = pupilClient.logAttempt(attemptData, true);
+
+    if (typeof attemptId === "string") {
+      setStoredAttemptLocally({ stored: true, attemptId });
+    }
+  }, [
+    browseData.lessonSlug,
+    browseData.programmeFields.subject,
+    browseData.programmeFields.yearDescription,
+    isLessonComplete,
+    lessonContent.lessonTitle,
+    pupilClient,
+    sectionResults,
+    storedAttemptLocally.stored,
+  ]);
+
+  useEffect(() => {
+    if (trackingSent) return;
+    // Placeholder to keep parity path open for lesson-summary analytics.
+    setTrackingSent(true);
+  }, [trackingSent]);
+
+  useEffect(() => {
+    if (!isLessonComplete) {
+      void router.push(
+        getNewLessonSectionHref({
+          currentRoute: router.asPath,
+          section: "overview",
+          searchParams: currentSearchParams,
+        }),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLessonComplete]);
+
+  const reviewSections = getReviewSections(
+    lessonContent,
+    lessonReviewSections,
+    sectionResults,
+  );
+
+  const printableHref = storedAttemptLocally.stored
+    ? resolveOakHref({
+        page: "pupil-lesson-results-canonical-printable",
+        lessonSlug: browseData.lessonSlug,
+        attemptId: storedAttemptLocally.attemptId,
+      })
+    : undefined;
+
+  return (
+    <PupilLessonReviewView
+      phase={browseData.programmeFields.phase as "primary" | "secondary"}
+      lessonTitle={lessonContent.lessonTitle ?? ""}
+      bottomNavSlot={
+        showBottomNav ? (
+          <PupilLessonReviewBottomNav href={backUrl ?? undefined} />
+        ) : undefined
+      }
+      overviewButtonSlot={
+        !isReadOnly ? (
+          <OakTertiaryButton
+            iconName="arrow-left"
+            element="a"
+            href={getNewLessonSectionHref({
+              currentRoute: router.asPath,
+              section: "overview",
+              searchParams: currentSearchParams,
+            })}
+            onClick={(event) => {
+              event.preventDefault();
+              void router.push(
+                getNewLessonSectionHref({
+                  currentRoute: router.asPath,
+                  section: "overview",
+                  searchParams: currentSearchParams,
+                }),
+              );
+            }}
+          >
+            Lesson overview
+          </OakTertiaryButton>
+        ) : undefined
+      }
+      shareOptionsSlot={
+        hasQuizSections && showBottomNav ? (
+          <PupilLessonReviewShareOptions
+            showPrintable={storedAttemptLocally.stored}
+            printableHref={printableHref}
+            shareState={isAttemptingShare}
+            onCopyLink={() => {
+              const attemptData = buildReviewAttemptData({
+                lessonSlug: browseData.lessonSlug,
+                lessonTitle: lessonContent.lessonTitle ?? "",
+                subject: browseData.programmeFields.subject,
+                yearDescription: browseData.programmeFields.yearDescription,
+                sectionResults,
+              });
+              const res = pupilClient.logAttempt(attemptData, false);
+
+              if (typeof res === "string") {
+                void navigator.clipboard.writeText(
+                  buildReviewShareUrl({
+                    lessonSlug: browseData.lessonSlug,
+                    attemptId: res,
+                  }),
+                );
+                setIsAttemptingShare("shared");
+                return;
+              }
+
+              void navigator.clipboard.writeText(
+                buildReviewShareUrl({
+                  lessonSlug: browseData.lessonSlug,
+                  attemptId: res.attemptId,
+                }),
+              );
+              setIsAttemptingShare("shared");
+              res.promise.catch(() => {
+                setIsAttemptingShare("failed");
+              });
+            }}
+          />
+        ) : undefined
+      }
+      illustrationSlot={
+        <OakImage
+          $display={["none", "none", "block"]}
+          $height="spacing-240"
+          alt="Review illustration"
+          src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1699887218/svg-illustrations/xrazqgtjmbdf1clz8wic`}
+        />
+      }
+      sectionSummarySlot={<PupilLessonReviewSections items={reviewSections} />}
+      feedbackSlot={<PupilLessonReviewFeedbackCard feedback={finalFeedback} />}
+    />
+  );
+};
+
+const PupilLessonReviewNewPage = (props: PupilExperienceViewProps) => {
+  const { browseData, lessonContent, backUrl, variant } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <ReviewPageContent
+        browseData={browseData}
+        lessonContent={lessonContent}
+        backUrl={backUrl}
+      />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonReviewNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<ReviewPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  ReviewPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "review",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-review::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -35,6 +35,7 @@ import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
 import { getReviewSections } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewSections";
 import { getReviewFinalFeedback } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewFinalFeedback";
 import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
+import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
 
 type ReviewPageURLParams = {
   lessonSlug: string;
@@ -57,6 +58,8 @@ const ReviewPageContent = ({
     );
   const { isClassroomAssignment, classroomAssignmentChecked } =
     useAssignmentSearchParams();
+  const { trackLessonSummaryReviewed, trackActivityResultsShared } =
+    usePupilLessonAnalytics();
   const [trackingSent, setTrackingSent] = useState(false);
   const [isAttemptingShare, setIsAttemptingShare] = useState<
     "failed" | "shared" | "initial"
@@ -109,10 +112,15 @@ const ReviewPageContent = ({
   ]);
 
   useEffect(() => {
-    if (trackingSent) return;
-    // Placeholder to keep parity path open for lesson-summary analytics.
+    if (trackingSent || !isLessonComplete) return;
+    trackLessonSummaryReviewed({ sectionResults });
     setTrackingSent(true);
-  }, [trackingSent]);
+  }, [
+    isLessonComplete,
+    sectionResults,
+    trackLessonSummaryReviewed,
+    trackingSent,
+  ]);
 
   useEffect(() => {
     if (!isLessonComplete) {
@@ -198,6 +206,7 @@ const ReviewPageContent = ({
                     attemptId: res,
                   }),
                 );
+                trackActivityResultsShared({ sectionResults });
                 setIsAttemptingShare("shared");
                 return;
               }
@@ -208,6 +217,7 @@ const ReviewPageContent = ({
                   attemptId: res.attemptId,
                 }),
               );
+              trackActivityResultsShared({ sectionResults });
               setIsAttemptingShare("shared");
               res.promise.catch(() => {
                 setIsAttemptingShare("failed");

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { useEffect, useMemo, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
@@ -166,7 +164,7 @@ const ReviewPageContent = ({
         ) : undefined
       }
       overviewButtonSlot={
-        !isReadOnly ? (
+        isReadOnly ? undefined : (
           <OakTertiaryButton
             iconName="arrow-left"
             element="a"
@@ -188,7 +186,7 @@ const ReviewPageContent = ({
           >
             Lesson overview
           </OakTertiaryButton>
-        ) : undefined
+        )
       }
       shareOptionsSlot={
         hasQuizSections && showBottomNav ? (
@@ -302,7 +300,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-review::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -12,7 +12,6 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import {
@@ -35,6 +34,7 @@ import { useOakPupil } from "@/hooks/useOakPupil";
 import { useAssignmentSearchParams } from "@/hooks/useAssignmentSearchParams";
 import { getReviewSections } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewSections";
 import { getReviewFinalFeedback } from "@/components/PupilComponents/Views/ViewHelpers/Review/getReviewFinalFeedback";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type ReviewPageURLParams = {
   lessonSlug: string;
@@ -44,10 +44,7 @@ const ReviewPageContent = ({
   browseData,
   lessonContent,
   backUrl,
-}: Pick<
-  PupilExperienceViewProps,
-  "browseData" | "lessonContent" | "backUrl"
->) => {
+}: Pick<PupilLessonPageProps, "browseData" | "lessonContent" | "backUrl">) => {
   const router = useRouter();
   const { sectionResults, lessonReviewSections, isLessonComplete, isReadOnly } =
     usePupilLessonProgress(
@@ -233,7 +230,7 @@ const ReviewPageContent = ({
   );
 };
 
-const PupilLessonReviewNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonReviewNewPage = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, backUrl, variant } = props;
 
   return (
@@ -261,7 +258,7 @@ export default PupilLessonReviewNewPage;
 export const getStaticPaths = getStaticPathsTemplate<ReviewPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   ReviewPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/review.tsx
@@ -12,6 +12,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import {
@@ -271,6 +272,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   ReviewPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
@@ -9,15 +9,15 @@ import {
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
 import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type StarterQuizPageURLParams = {
   lessonSlug: string;
 };
 
-const PupilLessonStarterQuizNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonStarterQuizNewPage = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, variant } = props;
 
   return (
@@ -46,7 +46,7 @@ export default PupilLessonStarterQuizNewPage;
 export const getStaticPaths = getStaticPathsTemplate<StarterQuizPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   StarterQuizPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
@@ -8,6 +8,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
@@ -49,6 +50,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   StarterQuizPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 
 import getPageProps from "@/node-lib/getPageProps";
@@ -66,7 +64,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-starter-quiz::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/starter-quiz.tsx
@@ -1,0 +1,67 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { QuizPageContent } from "@/pages-helpers/pupil/lessons-pages/new/QuizPageContent";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+
+type StarterQuizPageURLParams = {
+  lessonSlug: string;
+};
+
+const PupilLessonStarterQuizNewPage = (props: PupilExperienceViewProps) => {
+  const { browseData, lessonContent, variant } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <QuizPageContent
+        section="starter-quiz"
+        questionsArray={lessonContent.starterQuiz}
+        lessonSlug={browseData.lessonSlug}
+        phase={browseData.programmeFields.phase as "primary" | "secondary"}
+      />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonStarterQuizNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<StarterQuizPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  StarterQuizPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "starter-quiz",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-starter-quiz::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from "querystring";
-
 import { useMemo, useRef, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
@@ -236,6 +234,12 @@ const VideoPageContent = ({
     );
   };
 
+  const isVideoComplete = sectionResults.video?.isComplete ?? false;
+  const proceedLabel =
+    !isCompletingAndRedirecting && isVideoComplete
+      ? "Continue lesson"
+      : "I've finished the video";
+
   return (
     <PupilLessonVideoView
       phase={browseData.programmeFields.phase as "primary" | "secondary"}
@@ -252,11 +256,7 @@ const VideoPageContent = ({
         ),
       }}
       bottomNav={{
-        proceedLabel: isCompletingAndRedirecting
-          ? "I've finished the video"
-          : sectionResults.video?.isComplete
-            ? "Continue lesson"
-            : "I've finished the video",
+        proceedLabel,
         onProceed: handleProceed,
       }}
       videoSlot={
@@ -366,7 +366,7 @@ export const getStaticProps: GetStaticProps<
 
   return getPageProps({
     page: "pupils-lesson-new-video::getStaticProps",
-    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    context,
     getProps: getProps({ context: contextWithSection, page: "canonical" }),
   });
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -12,6 +12,7 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { hasValidSharedVariant } from "@/pages-helpers/pupil/lessons-pages/validateSharedVariant";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { getPupilPathwayData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
@@ -346,6 +347,10 @@ export const getStaticProps: GetStaticProps<
   PupilLessonPageProps,
   VideoPageURLParams
 > = async (context) => {
+  if (!hasValidSharedVariant(context)) {
+    return { notFound: true };
+  }
+
   const contextWithSection = {
     ...context,
     params: context.params

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -12,7 +12,6 @@ import {
   getProps,
   PupilLessonPageURLParams,
 } from "@/pages-helpers/pupil/lessons-pages/getProps";
-import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { getPupilPathwayData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
@@ -36,6 +35,7 @@ import { useAdditionalFilesDownload } from "@/components/PupilViews/PupilIntro/u
 import VideoPlayer, {
   VideoEventCallbackArgs,
 } from "@/components/SharedComponents/VideoPlayer/VideoPlayer";
+import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type VideoPageURLParams = {
   lessonSlug: string;
@@ -47,7 +47,7 @@ const VideoPageContent = ({
   hasAdditionalFiles,
   additionalFiles,
 }: Pick<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   "browseData" | "lessonContent" | "hasAdditionalFiles" | "additionalFiles"
 >) => {
   const router = useRouter();
@@ -282,7 +282,7 @@ const VideoPageContent = ({
   );
 };
 
-const PupilLessonVideoNewPage = (props: PupilExperienceViewProps) => {
+const PupilLessonVideoNewPage = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, variant } = props;
 
   return (
@@ -306,7 +306,7 @@ export default PupilLessonVideoNewPage;
 export const getStaticPaths = getStaticPathsTemplate<VideoPageURLParams>;
 
 export const getStaticProps: GetStaticProps<
-  PupilExperienceViewProps,
+  PupilLessonPageProps,
   VideoPageURLParams
 > = async (context) => {
   const contextWithSection = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -189,7 +189,10 @@ const VideoPageContent = ({
       }
       completeSection("video");
       const nextSectionResults = getSectionResultsAfterComplete();
-      trackVideoCompleted({ sectionResults: nextSectionResults });
+      trackVideoCompleted({
+        sectionResults: nextSectionResults,
+        sectionStartedAt: sectionStartedAtRef.current,
+      });
       const allComplete = lessonReviewSections.every(
         (section) => nextSectionResults[section]?.isComplete,
       );

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -1,0 +1,327 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { useMemo, useRef, useState } from "react";
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
+import { useRouter } from "next/router";
+import { OakBackLink, OakP } from "@oaknational/oak-components";
+import { useShallow } from "zustand/react/shallow";
+
+import getPageProps from "@/node-lib/getPageProps";
+import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
+import {
+  getProps,
+  PupilLessonPageURLParams,
+} from "@/pages-helpers/pupil/lessons-pages/getProps";
+import { PupilExperienceViewProps } from "@/components/PupilViews/PupilExperience";
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import { getPupilPathwayData } from "@/components/PupilComponents/PupilAnalyticsProvider/PupilAnalyticsProvider";
+import { PupilLessonIntroAdditionalFileItem } from "@/components/PupilComponents/Views/PupilLessonIntro";
+import {
+  PupilLessonVideoAdditionalFilesCard,
+  PupilLessonVideoTranscript,
+  PupilLessonVideoView,
+} from "@/components/PupilComponents/Views/PupilLessonVideo";
+import {
+  getAdditionalFileAssetIds,
+  getNewLessonSectionHref,
+  getNarrowTranscriptSentences,
+  getVideoPlaybackId,
+  pickNextIncompleteSection,
+  shouldPersistVideoTimeElapsed,
+} from "@/components/PupilComponents/Views/ViewHelpers";
+import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupilLessonAnalytics";
+import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
+import { useAdditionalFilesDownload } from "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload";
+import VideoPlayer, {
+  VideoEventCallbackArgs,
+} from "@/components/SharedComponents/VideoPlayer/VideoPlayer";
+
+type VideoPageURLParams = {
+  lessonSlug: string;
+};
+
+const VideoPageContent = ({
+  browseData,
+  lessonContent,
+  hasAdditionalFiles,
+  additionalFiles,
+}: Pick<
+  PupilExperienceViewProps,
+  "browseData" | "lessonContent" | "hasAdditionalFiles" | "additionalFiles"
+>) => {
+  const router = useRouter();
+  const [signLanguageOn, setSignLanguageOn] = useState(false);
+  const {
+    sectionResults,
+    lessonReviewSections,
+    isReadOnly,
+    completeSection,
+    updateSectionInProgressResult,
+    markLessonStarted,
+  } = usePupilLessonProgress(
+    useShallow((state) => ({
+      sectionResults: state.sectionResults,
+      lessonReviewSections: state.lessonReviewSections,
+      isReadOnly: state.isReadOnly,
+      completeSection: state.completeSection,
+      updateSectionInProgressResult: state.updateSectionInProgressResult,
+      markLessonStarted: state.markLessonStarted,
+    })),
+  );
+  const { trackSectionStarted } = usePupilLessonAnalytics();
+
+  const additionalFilesAssetIds = useMemo(
+    () => getAdditionalFileAssetIds(additionalFiles),
+    [additionalFiles],
+  );
+  const { startAdditionalFilesDownload, isAdditionalFilesDownloading } =
+    useAdditionalFilesDownload(browseData.lessonSlug, additionalFilesAssetIds);
+  const [isCompletingAndRedirecting, setIsCompletingAndRedirecting] =
+    useState(false);
+
+  const transcriptSentences = getNarrowTranscriptSentences(
+    lessonContent.transcriptSentences,
+  );
+  const currentSearchParams = useMemo(
+    () => new URLSearchParams(router.asPath.split("?")[1]),
+    [router.asPath],
+  );
+  const overviewHref = getNewLessonSectionHref({
+    currentRoute: router.asPath,
+    section: "overview",
+    searchParams: currentSearchParams,
+  });
+  const playbackId = getVideoPlaybackId({
+    signLanguageOn,
+    videoMuxPlaybackId: lessonContent.videoMuxPlaybackId ?? undefined,
+    videoWithSignLanguageMuxPlaybackId:
+      lessonContent.videoWithSignLanguageMuxPlaybackId ?? undefined,
+  });
+
+  const videoResultRef = useRef({
+    played: sectionResults.video?.played || false,
+    duration: sectionResults.video?.duration || 0,
+    timeElapsed: sectionResults.video?.timeElapsed || 0,
+    muted: sectionResults.video?.muted || false,
+    signedOpened: sectionResults.video?.signedOpened || false,
+    transcriptOpened: sectionResults.video?.transcriptOpened || false,
+  });
+
+  const handleVideoEvent = ({
+    event,
+    timeElapsed,
+    duration,
+    muted,
+  }: VideoEventCallbackArgs) => {
+    videoResultRef.current.played = true;
+    videoResultRef.current.duration = duration || 0;
+    videoResultRef.current.muted = muted || false;
+
+    const nextTimeElapsed = timeElapsed || 0;
+    if (
+      shouldPersistVideoTimeElapsed({
+        event,
+        nextTimeElapsed,
+        currentTimeElapsed: videoResultRef.current.timeElapsed,
+        currentSection: "video",
+      })
+    ) {
+      videoResultRef.current.timeElapsed = nextTimeElapsed;
+      updateSectionInProgressResult("video", videoResultRef.current);
+    }
+  };
+
+  const handleBackToOverview = () => {
+    markLessonStarted();
+    void router.push(overviewHref);
+  };
+
+  const getSectionResultsAfterComplete = () => ({
+    ...sectionResults,
+    video: {
+      ...sectionResults.video,
+      isComplete: true,
+    },
+  });
+
+  const getPostCompleteSection = () => {
+    const nextSectionResults = getSectionResultsAfterComplete();
+    return lessonReviewSections.every(
+      (section) => nextSectionResults[section]?.isComplete,
+    )
+      ? "review"
+      : "overview";
+  };
+
+  const handleProceed = () => {
+    if (!sectionResults.video?.isComplete) {
+      setIsCompletingAndRedirecting(true);
+      completeSection("video");
+      void router.push(
+        getNewLessonSectionHref({
+          currentRoute: router.asPath,
+          section: getPostCompleteSection(),
+          searchParams: currentSearchParams,
+        }),
+      );
+      return;
+    }
+
+    const nextSection = pickNextIncompleteSection({
+      lessonReviewSections,
+      sectionResults,
+    });
+
+    if (isReadOnly) {
+      trackSectionStarted({ section: "review", sectionResults });
+      void router.push(
+        getNewLessonSectionHref({
+          currentRoute: router.asPath,
+          section: "review",
+          searchParams: currentSearchParams,
+        }),
+      );
+      return;
+    }
+
+    trackSectionStarted({ section: nextSection, sectionResults });
+    void router.push(
+      getNewLessonSectionHref({
+        currentRoute: router.asPath,
+        section: nextSection,
+        searchParams: currentSearchParams,
+      }),
+    );
+  };
+
+  return (
+    <PupilLessonVideoView
+      phase={browseData.programmeFields.phase as "primary" | "secondary"}
+      topNav={{
+        backLinkSlot: (
+          <OakBackLink
+            href={overviewHref}
+            label="Back to overview"
+            onClick={(event) => {
+              event.preventDefault();
+              handleBackToOverview();
+            }}
+          />
+        ),
+      }}
+      bottomNav={{
+        proceedLabel: isCompletingAndRedirecting
+          ? "I've finished the video"
+          : sectionResults.video?.isComplete
+            ? "Continue lesson"
+            : "I've finished the video",
+        onProceed: handleProceed,
+      }}
+      videoSlot={
+        playbackId ? (
+          <VideoPlayer
+            playbackId={playbackId}
+            playbackPolicy="signed"
+            initialStartTime={sectionResults.video?.timeElapsed ?? 0}
+            title={lessonContent.lessonTitle ?? ""}
+            location="pupil"
+            isLegacy={lessonContent.isLegacy ?? false}
+            userEventCallback={handleVideoEvent}
+            pathwayData={getPupilPathwayData(browseData)}
+          />
+        ) : (
+          <OakP $font="body-1">This lesson does not contain a video</OakP>
+        )
+      }
+      transcriptSlot={
+        <PupilLessonVideoTranscript
+          transcriptSentences={transcriptSentences}
+          onTranscriptToggled={({ isOpen }) => {
+            if (!isOpen) return;
+            videoResultRef.current.transcriptOpened = true;
+            updateSectionInProgressResult("video", videoResultRef.current);
+          }}
+          showSignLanguageToggle={Boolean(
+            lessonContent.videoWithSignLanguageMuxPlaybackId,
+          )}
+          signLanguageOn={signLanguageOn}
+          onSignLanguageToggle={() => {
+            const isTurningOn = !signLanguageOn;
+            setSignLanguageOn(isTurningOn);
+            if (!isTurningOn) return;
+
+            videoResultRef.current.signedOpened = true;
+            updateSectionInProgressResult("video", videoResultRef.current);
+          }}
+        />
+      }
+      additionalFilesSlot={
+        <PupilLessonVideoAdditionalFilesCard
+          hasAdditionalFiles={hasAdditionalFiles}
+          filesCount={additionalFiles?.length ?? 0}
+          isDownloading={isAdditionalFilesDownloading}
+          onDownload={() => {
+            updateSectionInProgressResult("intro", {
+              filesDownloaded: true,
+              additionalFilesAvailable: true,
+            });
+            void startAdditionalFilesDownload();
+          }}
+          filesListSlot={additionalFiles?.map((file) => (
+            <PupilLessonIntroAdditionalFileItem
+              key={file.assetId}
+              displayName={file.mediaObject.displayName}
+              bytes={file.mediaObject.bytes}
+              url={file.mediaObject.url}
+            />
+          ))}
+        />
+      }
+    />
+  );
+};
+
+const PupilLessonVideoNewPage = (props: PupilExperienceViewProps) => {
+  const { browseData, lessonContent, variant } = props;
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({
+          title: browseData.lessonData.title,
+          description: browseData.lessonData.pupilLessonOutcome,
+        }),
+        noIndex: true,
+      }}
+      pupilStores={{ browseData, lessonContent, variant }}
+    >
+      <VideoPageContent {...props} />
+    </PupilLayout>
+  );
+};
+
+export default PupilLessonVideoNewPage;
+
+export const getStaticPaths = getStaticPathsTemplate<VideoPageURLParams>;
+
+export const getStaticProps: GetStaticProps<
+  PupilExperienceViewProps,
+  VideoPageURLParams
+> = async (context) => {
+  const contextWithSection = {
+    ...context,
+    params: context.params
+      ? {
+          ...context.params,
+          section: "video",
+        }
+      : undefined,
+  } as GetStaticPropsContext<PupilLessonPageURLParams, PreviewData>;
+
+  return getPageProps({
+    page: "pupils-lesson-new-video::getStaticProps",
+    context: context as GetStaticPropsContext<ParsedUrlQuery, PreviewData>,
+    getProps: getProps({ context: contextWithSection, page: "canonical" }),
+  });
+};

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -55,6 +55,7 @@ const VideoPageContent = ({
   const {
     sectionResults,
     lessonReviewSections,
+    lessonStarted,
     isReadOnly,
     completeSection,
     updateSectionInProgressResult,
@@ -63,13 +64,20 @@ const VideoPageContent = ({
     useShallow((state) => ({
       sectionResults: state.sectionResults,
       lessonReviewSections: state.lessonReviewSections,
+      lessonStarted: state.lessonStarted,
       isReadOnly: state.isReadOnly,
       completeSection: state.completeSection,
       updateSectionInProgressResult: state.updateSectionInProgressResult,
       markLessonStarted: state.markLessonStarted,
     })),
   );
-  const { trackSectionStarted } = usePupilLessonAnalytics();
+  const {
+    trackSectionStarted,
+    trackLessonStarted,
+    trackLessonCompleted,
+    trackVideoCompleted,
+    trackVideoAbandoned,
+  } = usePupilLessonAnalytics();
 
   const additionalFilesAssetIds = useMemo(
     () => getAdditionalFileAssetIds(additionalFiles),
@@ -133,6 +141,21 @@ const VideoPageContent = ({
   };
 
   const handleBackToOverview = () => {
+    if (!sectionResults.video?.isComplete) {
+      if (!lessonStarted) {
+        trackLessonStarted();
+      }
+      trackVideoAbandoned({
+        sectionResults: {
+          ...sectionResults,
+          video: {
+            ...sectionResults.video,
+            ...videoResultRef.current,
+            isComplete: false,
+          },
+        },
+      });
+    }
     markLessonStarted();
     void router.push(overviewHref);
   };
@@ -141,6 +164,7 @@ const VideoPageContent = ({
     ...sectionResults,
     video: {
       ...sectionResults.video,
+      ...videoResultRef.current,
       isComplete: true,
     },
   });
@@ -157,7 +181,18 @@ const VideoPageContent = ({
   const handleProceed = () => {
     if (!sectionResults.video?.isComplete) {
       setIsCompletingAndRedirecting(true);
+      if (!lessonStarted) {
+        trackLessonStarted();
+      }
       completeSection("video");
+      const nextSectionResults = getSectionResultsAfterComplete();
+      trackVideoCompleted({ sectionResults: nextSectionResults });
+      const allComplete = lessonReviewSections.every(
+        (section) => nextSectionResults[section]?.isComplete,
+      );
+      if (allComplete) {
+        trackLessonCompleted();
+      }
       void router.push(
         getNewLessonSectionHref({
           currentRoute: router.asPath,

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -85,6 +85,7 @@ const VideoPageContent = ({
   );
   const { startAdditionalFilesDownload, isAdditionalFilesDownloading } =
     useAdditionalFilesDownload(browseData.lessonSlug, additionalFilesAssetIds);
+  const sectionStartedAtRef = useRef(Date.now());
   const [isCompletingAndRedirecting, setIsCompletingAndRedirecting] =
     useState(false);
 
@@ -154,6 +155,7 @@ const VideoPageContent = ({
             isComplete: false,
           },
         },
+        sectionStartedAt: sectionStartedAtRef.current,
       });
     }
     markLessonStarted();


### PR DESCRIPTION
## Description

- Adds the new pages under the shared variant route
- Redirects / to overview page
- Breaks out pupil analytics tracking into smaller files with semantic grouping
- Fixes bug with correct answers not rendering correctly in quiz questions
- Adds content guidance and redirect modal support
- Fix bug where bullet point was showing for intro additional files
- Fix bug where certain analytics events were missing fields (time based and starter/exit quiz)
- Fix bug where invalid variant url would show full lesson and not 404
- Fix bug where multi choice selections would carry over to the next question

## Issue(s)
[Notion Ticket](https://www.notion.so/oaknationalacademy/Render-correct-lesson-sections-for-active-variant-33b26cc4e1b1805abc78ec7c2741f728?source=copy_link)

## How to test
Code review only. Functional testing will be conducted on feature branch.

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
