### PR TITLE
feat: update footer links [LESQ-2006]

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -6161,68 +6161,54 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       >
                         <a
                           class="c182 "
-                          href="/teachers/key-stages/ks1/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 1
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c181"
-                      >
-                        <a
-                          class="c182 "
-                          href="/teachers/key-stages/ks2/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 2
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c181"
-                      >
-                        <a
-                          class="c182 "
-                          href="/teachers/key-stages/ks3/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 3
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c181"
-                      >
-                        <a
-                          class="c182 "
-                          href="/teachers/key-stages/ks4/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 4
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c181"
-                      >
-                        <a
-                          class="c182 "
                           href="/lesson-planning"
                         >
                           <span
                             class="c29"
                           >
                             Plan a lesson
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c181"
+                      >
+                        <a
+                          class="c182 "
+                          href="https://labs.thenational.academy"
+                          target="_blank"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Aila, Oak’s AI lesson assistant
+                          </span>
+                          <span
+                            class="c24 "
+                          >
+                            <img
+                              alt=""
+                              class="c25"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c181"
+                      >
+                        <a
+                          class="c182 "
+                          href="/blog"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Blog
                           </span>
                         </a>
                       </li>
@@ -6386,20 +6372,6 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
                               style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                             />
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c181"
-                      >
-                        <a
-                          class="c182 "
-                          href="/blog"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Blog
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -5929,68 +5929,54 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       >
                         <a
                           class="c181 "
-                          href="/teachers/key-stages/ks1/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 1
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c180"
-                      >
-                        <a
-                          class="c181 "
-                          href="/teachers/key-stages/ks2/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 2
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c180"
-                      >
-                        <a
-                          class="c181 "
-                          href="/teachers/key-stages/ks3/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 3
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c180"
-                      >
-                        <a
-                          class="c181 "
-                          href="/teachers/key-stages/ks4/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 4
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c180"
-                      >
-                        <a
-                          class="c181 "
                           href="/lesson-planning"
                         >
                           <span
                             class="c29"
                           >
                             Plan a lesson
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c180"
+                      >
+                        <a
+                          class="c181 "
+                          href="https://labs.thenational.academy"
+                          target="_blank"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Aila, Oak’s AI lesson assistant
+                          </span>
+                          <span
+                            class="c24 "
+                          >
+                            <img
+                              alt=""
+                              class="c25"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c180"
+                      >
+                        <a
+                          class="c181 "
+                          href="/blog"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Blog
                           </span>
                         </a>
                       </li>
@@ -6154,20 +6140,6 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
                               style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                             />
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c180"
-                      >
-                        <a
-                          class="c181 "
-                          href="/blog"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Blog
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -6486,68 +6486,54 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       >
                         <a
                           class="c213 "
-                          href="/teachers/key-stages/ks1/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 1
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c212"
-                      >
-                        <a
-                          class="c213 "
-                          href="/teachers/key-stages/ks2/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 2
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c212"
-                      >
-                        <a
-                          class="c213 "
-                          href="/teachers/key-stages/ks3/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 3
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c212"
-                      >
-                        <a
-                          class="c213 "
-                          href="/teachers/key-stages/ks4/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 4
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c212"
-                      >
-                        <a
-                          class="c213 "
                           href="/lesson-planning"
                         >
                           <span
                             class="c29"
                           >
                             Plan a lesson
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c212"
+                      >
+                        <a
+                          class="c213 "
+                          href="https://labs.thenational.academy"
+                          target="_blank"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Aila, Oak’s AI lesson assistant
+                          </span>
+                          <span
+                            class="c24 "
+                          >
+                            <img
+                              alt=""
+                              class="c25"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c212"
+                      >
+                        <a
+                          class="c213 "
+                          href="/blog"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Blog
                           </span>
                         </a>
                       </li>
@@ -6711,20 +6697,6 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
                               style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                             />
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c212"
-                      >
-                        <a
-                          class="c213 "
-                          href="/blog"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Blog
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -5988,68 +5988,54 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       >
                         <a
                           class="c189 "
-                          href="/teachers/key-stages/ks1/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 1
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c188"
-                      >
-                        <a
-                          class="c189 "
-                          href="/teachers/key-stages/ks2/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 2
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c188"
-                      >
-                        <a
-                          class="c189 "
-                          href="/teachers/key-stages/ks3/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 3
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c188"
-                      >
-                        <a
-                          class="c189 "
-                          href="/teachers/key-stages/ks4/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 4
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c188"
-                      >
-                        <a
-                          class="c189 "
                           href="/lesson-planning"
                         >
                           <span
                             class="c29"
                           >
                             Plan a lesson
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c188"
+                      >
+                        <a
+                          class="c189 "
+                          href="https://labs.thenational.academy"
+                          target="_blank"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Aila, Oak’s AI lesson assistant
+                          </span>
+                          <span
+                            class="c24 "
+                          >
+                            <img
+                              alt=""
+                              class="c25"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c188"
+                      >
+                        <a
+                          class="c189 "
+                          href="/blog"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Blog
                           </span>
                         </a>
                       </li>
@@ -6213,20 +6199,6 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
                               style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                             />
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c188"
-                      >
-                        <a
-                          class="c189 "
-                          href="/blog"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Blog
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -3763,68 +3763,54 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       >
                         <a
                           class="c76 "
-                          href="/teachers/key-stages/ks1/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 1
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
-                          href="/teachers/key-stages/ks2/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 2
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
-                          href="/teachers/key-stages/ks3/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 3
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
-                          href="/teachers/key-stages/ks4/subjects"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Key stage 4
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
                           href="/lesson-planning"
                         >
                           <span
                             class="c29"
                           >
                             Plan a lesson
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c112"
+                      >
+                        <a
+                          class="c76 "
+                          href="https://labs.thenational.academy"
+                          target="_blank"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Aila, Oak’s AI lesson assistant
+                          </span>
+                          <span
+                            class="c24 "
+                          >
+                            <img
+                              alt=""
+                              class="c25"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c112"
+                      >
+                        <a
+                          class="c76 "
+                          href="/blog"
+                        >
+                          <span
+                            class="c29"
+                          >
+                            Blog
                           </span>
                         </a>
                       </li>
@@ -3988,20 +3974,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                               src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
                               style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                             />
-                          </span>
-                        </a>
-                      </li>
-                      <li
-                        class="c112"
-                      >
-                        <a
-                          class="c76 "
-                          href="/blog"
-                        >
-                          <span
-                            class="c29"
-                          >
-                            Blog
                           </span>
                         </a>
                       </li>

--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
@@ -56,29 +56,20 @@ const footerSections: FooterSections = {
         }),
       },
       {
-        text: "Key stage 1",
-        type: "link",
-        href: resolveOakHref({ page: "subject-index", keyStageSlug: "ks1" }),
-      },
-      {
-        text: "Key stage 2",
-        type: "link",
-        href: resolveOakHref({ page: "subject-index", keyStageSlug: "ks2" }),
-      },
-      {
-        text: "Key stage 3",
-        type: "link",
-        href: resolveOakHref({ page: "subject-index", keyStageSlug: "ks3" }),
-      },
-      {
-        text: "Key stage 4",
-        type: "link",
-        href: resolveOakHref({ page: "subject-index", keyStageSlug: "ks4" }),
-      },
-      {
         text: "Plan a lesson",
         type: "link",
         href: resolveOakHref({ page: "lesson-planning" }),
+      },
+      {
+        text: "Aila, Oak’s AI lesson assistant",
+        type: "link",
+        icon: "external",
+        href: resolveOakHref({ page: "labs" }),
+      },
+      {
+        text: "Blog",
+        type: "link",
+        href: resolveOakHref({ page: "blog-index" }),
       },
     ],
   },
@@ -128,11 +119,6 @@ const footerSections: FooterSections = {
         href: resolveOakHref({ page: "help" }),
         icon: "external",
         ariaLabel: "Help (opens in a new tab)",
-      },
-      {
-        text: "Blog",
-        type: "link",
-        href: resolveOakHref({ page: "blog-index" }),
       },
       {
         text: "Webinars",


### PR DESCRIPTION
## Description

Music year: 2003

- Remove keystage page links from teachers section of footer
- Add a link to Aila
- Move the link to blogs into the teachers sections
- Update snapshot tests


## How to test

1. Go to [OWA Preview URL from Vercel bot comment]
2. You should see the footer has updated to match designs

## Screenshots

How it should now look:

<img width="800" alt="Screenshot 2026-05-15 at 07 50 33" src="https://github.com/user-attachments/assets/46ff2b8e-0b6a-493b-9d60-6701cb8b1a72" />

<img width="348" height="635" alt="Screenshot 2026-05-15 at 07 50 45" src="https://github.com/user-attachments/assets/7dd909c9-ca0c-4263-b176-d5ba67270eb9" />
