### PR TITLE
Fix/pupil 1694 worksheet download analytics on success

### DIFF
--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 
 import PupilLessonIntroNewPage, {
   getStaticProps,
@@ -123,8 +123,13 @@ describe("intro page", () => {
     fireEvent.click(getByText("Download file"));
     expect(startWorksheet).toHaveBeenCalledTimes(1);
     expect(startFiles).toHaveBeenCalledTimes(1);
-    await Promise.resolve();
-    expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
+      expect(
+        usePupilLessonProgress.getState().sectionResults.intro
+          ?.worksheetDownloaded,
+      ).toBe(true);
+    });
   });
 
   it("does not track worksheet download when the download fails", async () => {
@@ -134,9 +139,14 @@ describe("intro page", () => {
       worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
     });
     fireEvent.click(getByText(/Download worksheet/));
-    await Promise.resolve();
-    expect(startWorksheet).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(startWorksheet).toHaveBeenCalledTimes(1);
+    });
     expect(track.trackWorksheetDownloaded).not.toHaveBeenCalled();
+    expect(
+      usePupilLessonProgress.getState().sectionResults.intro
+        ?.worksheetDownloaded,
+    ).not.toBe(true);
   });
 
   it("returns notFound from getStaticProps when the variant is invalid", async () => {

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 
 import PupilLessonIntroNewPage, {
   getStaticProps,
@@ -123,13 +123,8 @@ describe("intro page", () => {
     fireEvent.click(getByText("Download file"));
     expect(startWorksheet).toHaveBeenCalledTimes(1);
     expect(startFiles).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
-      expect(
-        usePupilLessonProgress.getState().sectionResults.intro
-          ?.worksheetDownloaded,
-      ).toBe(true);
-    });
+    await Promise.resolve();
+    expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
   });
 
   it("does not track worksheet download when the download fails", async () => {
@@ -139,14 +134,9 @@ describe("intro page", () => {
       worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
     });
     fireEvent.click(getByText(/Download worksheet/));
-    await waitFor(() => {
-      expect(startWorksheet).toHaveBeenCalledTimes(1);
-    });
+    await Promise.resolve();
+    expect(startWorksheet).toHaveBeenCalledTimes(1);
     expect(track.trackWorksheetDownloaded).not.toHaveBeenCalled();
-    expect(
-      usePupilLessonProgress.getState().sectionResults.intro
-        ?.worksheetDownloaded,
-    ).not.toBe(true);
   });
 
   it("returns notFound from getStaticProps when the variant is invalid", async () => {

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
@@ -27,7 +27,7 @@ jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
   usePupilLessonAnalytics: () => track,
 }));
 
-const startWorksheet = jest.fn();
+const startWorksheet = jest.fn(() => Promise.resolve(true));
 jest.mock("@/components/PupilViews/PupilIntro/useWorksheetDownload", () => ({
   useWorksheetDownload: () => ({
     startDownload: startWorksheet,
@@ -107,7 +107,7 @@ describe("intro page", () => {
     expect(track.trackIntroAbandoned).toHaveBeenCalledTimes(1);
   });
 
-  it("triggers worksheet and additional file downloads", () => {
+  it("triggers worksheet and additional file downloads", async () => {
     const { getByText } = renderPage({
       hasWorksheet: true,
       worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
@@ -123,7 +123,20 @@ describe("intro page", () => {
     fireEvent.click(getByText("Download file"));
     expect(startWorksheet).toHaveBeenCalledTimes(1);
     expect(startFiles).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
     expect(track.trackWorksheetDownloaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not track worksheet download when the download fails", async () => {
+    startWorksheet.mockResolvedValueOnce(false);
+    const { getByText } = renderPage({
+      hasWorksheet: true,
+      worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
+    });
+    fireEvent.click(getByText(/Download worksheet/));
+    await Promise.resolve();
+    expect(startWorksheet).toHaveBeenCalledTimes(1);
+    expect(track.trackWorksheetDownloaded).not.toHaveBeenCalled();
   });
 
   it("returns notFound from getStaticProps when the variant is invalid", async () => {

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
@@ -45,6 +45,8 @@ jest.mock(
   "@/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources",
 );
 
+window.alert = jest.fn();
+
 const curriculumData = lessonContentFixture({});
 const equipmentAndResources = [{ equipment: "equipment" }];
 const contentGuidance: LessonContent["contentGuidance"] = [
@@ -63,6 +65,11 @@ describe("PupilIntro", () => {
     downloadSpy = jest
       .spyOn(downloadLessonResources, "default")
       .mockResolvedValue();
+    Object.values(usePupilAnalyticsMock.track).forEach((trackFn) => {
+      if (jest.isMockFunction(trackFn)) {
+        trackFn.mockClear();
+      }
+    });
   });
 
   afterEach(() => {
@@ -405,6 +412,33 @@ describe("PupilIntro", () => {
       worksheetDownloaded: true,
       worksheetAvailable: true,
     });
+    expect(
+      usePupilAnalyticsMock.track.lessonActivityDownloadedWorksheet,
+    ).toHaveBeenCalledWith({});
+  });
+
+  it("does not update section results or track worksheet download when the download fails", async () => {
+    downloadSpy.mockRejectedValueOnce(new Error("download failed"));
+    const context = createLessonEngineContext();
+    const { getByRole } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider value={context}>
+          <PupilViewsIntro
+            hasWorksheet={true}
+            worksheetInfo={null}
+            hasAdditionalFiles={false}
+            additionalFiles={null}
+            {...curriculumData}
+          />
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    await userEvent.click(getByRole("button", { name: /Download worksheet/i }));
+    expect(context.updateWorksheetDownloaded).not.toHaveBeenCalled();
+    expect(
+      usePupilAnalyticsMock.track.lessonActivityDownloadedWorksheet,
+    ).not.toHaveBeenCalled();
   });
 
   it("updates the section results when the worksheet is available", async () => {

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.test.tsx
@@ -45,8 +45,6 @@ jest.mock(
   "@/components/SharedComponents/helpers/downloadAndShareHelpers/downloadLessonResources",
 );
 
-window.alert = jest.fn();
-
 const curriculumData = lessonContentFixture({});
 const equipmentAndResources = [{ equipment: "equipment" }];
 const contentGuidance: LessonContent["contentGuidance"] = [
@@ -65,11 +63,6 @@ describe("PupilIntro", () => {
     downloadSpy = jest
       .spyOn(downloadLessonResources, "default")
       .mockResolvedValue();
-    Object.values(usePupilAnalyticsMock.track).forEach((trackFn) => {
-      if (jest.isMockFunction(trackFn)) {
-        trackFn.mockClear();
-      }
-    });
   });
 
   afterEach(() => {
@@ -412,33 +405,6 @@ describe("PupilIntro", () => {
       worksheetDownloaded: true,
       worksheetAvailable: true,
     });
-    expect(
-      usePupilAnalyticsMock.track.lessonActivityDownloadedWorksheet,
-    ).toHaveBeenCalledWith({});
-  });
-
-  it("does not update section results or track worksheet download when the download fails", async () => {
-    downloadSpy.mockRejectedValueOnce(new Error("download failed"));
-    const context = createLessonEngineContext();
-    const { getByRole } = renderWithTheme(
-      <OakThemeProvider theme={oakDefaultTheme}>
-        <LessonEngineContext.Provider value={context}>
-          <PupilViewsIntro
-            hasWorksheet={true}
-            worksheetInfo={null}
-            hasAdditionalFiles={false}
-            additionalFiles={null}
-            {...curriculumData}
-          />
-        </LessonEngineContext.Provider>
-      </OakThemeProvider>,
-    );
-
-    await userEvent.click(getByRole("button", { name: /Download worksheet/i }));
-    expect(context.updateWorksheetDownloaded).not.toHaveBeenCalled();
-    expect(
-      usePupilAnalyticsMock.track.lessonActivityDownloadedWorksheet,
-    ).not.toHaveBeenCalled();
   });
 
   it("updates the section results when the worksheet is available", async () => {

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
@@ -111,15 +111,13 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
   }, [hasWorksheet, sectionResults.intro, updateSectionResult, currentSection]);
 
   const handleDownloadClicked = async () => {
-    const isSuccess = await startDownload();
-    if (isSuccess) {
-      updateWorksheetDownloaded({
-        worksheetDownloaded: true,
-        worksheetAvailable: true,
-      });
-      if (track.lessonActivityDownloadedWorksheet) {
-        track.lessonActivityDownloadedWorksheet({});
-      }
+    updateWorksheetDownloaded({
+      worksheetDownloaded: true,
+      worksheetAvailable: true,
+    });
+    const succeeded = await startDownload();
+    if (succeeded && track.lessonActivityDownloadedWorksheet) {
+      track.lessonActivityDownloadedWorksheet({});
     }
   };
 

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
@@ -115,8 +115,8 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
       worksheetDownloaded: true,
       worksheetAvailable: true,
     });
-    const succeeded = await startDownload();
-    if (succeeded && track.lessonActivityDownloadedWorksheet) {
+    const isSuccess = await startDownload();
+    if (isSuccess && track.lessonActivityDownloadedWorksheet) {
       track.lessonActivityDownloadedWorksheet({});
     }
   };

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
@@ -111,13 +111,15 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
   }, [hasWorksheet, sectionResults.intro, updateSectionResult, currentSection]);
 
   const handleDownloadClicked = async () => {
-    updateWorksheetDownloaded({
-      worksheetDownloaded: true,
-      worksheetAvailable: true,
-    });
-    const succeeded = await startDownload();
-    if (succeeded && track.lessonActivityDownloadedWorksheet) {
-      track.lessonActivityDownloadedWorksheet({});
+    const isSuccess = await startDownload();
+    if (isSuccess) {
+      updateWorksheetDownloaded({
+        worksheetDownloaded: true,
+        worksheetAvailable: true,
+      });
+      if (track.lessonActivityDownloadedWorksheet) {
+        track.lessonActivityDownloadedWorksheet({});
+      }
     }
   };
 

--- a/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
+++ b/src/components/PupilViews/PupilIntro/PupilIntro.view.tsx
@@ -110,16 +110,15 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
     }
   }, [hasWorksheet, sectionResults.intro, updateSectionResult, currentSection]);
 
-  const handleDownloadClicked = () => {
+  const handleDownloadClicked = async () => {
     updateWorksheetDownloaded({
       worksheetDownloaded: true,
       worksheetAvailable: true,
     });
-    startDownload().then(() => {
-      if (track.lessonActivityDownloadedWorksheet) {
-        track.lessonActivityDownloadedWorksheet({});
-      }
-    });
+    const succeeded = await startDownload();
+    if (succeeded && track.lessonActivityDownloadedWorksheet) {
+      track.lessonActivityDownloadedWorksheet({});
+    }
   };
 
   const handleAdditionalFilesDownloadClicked = () => {
@@ -328,7 +327,9 @@ export const PupilViewsIntro = (props: PupilViewsIntroProps) => {
                 <OakP $font={"body-1"}>Optional</OakP>
                 <OakFlex $justifyContent={"flex-end"}>
                   <OakPrimaryInvertedButton
-                    onClick={handleDownloadClicked}
+                    onClick={() => {
+                      void handleDownloadClicked();
+                    }}
                     isLoading={isDownloading}
                     iconName="download"
                     isTrailingIcon

--- a/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
+++ b/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
@@ -28,12 +28,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
-    let isSuccess = false;
+    let succeeded = false;
     await act(async () => {
-      isSuccess = await result.current.startDownload();
+      succeeded = await result.current.startDownload();
     });
 
-    expect(isSuccess).toBe(true);
+    expect(succeeded).toBe(true);
     expect(downloadSpy).toHaveBeenCalledWith({
       lessonSlug: "lesson-slug",
       selectedResourceTypes: ["worksheet-pdf-questions"],
@@ -85,12 +85,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
-    let isSuccess = true;
+    let succeeded = true;
     await act(async () => {
-      isSuccess = await result.current.startDownload();
+      succeeded = await result.current.startDownload();
     });
 
-    expect(isSuccess).toBe(false);
+    expect(succeeded).toBe(false);
     expect(alertSpy).toHaveBeenCalledWith(
       "Whoops, the download failed. You could try again.",
     );

--- a/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
+++ b/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
@@ -28,12 +28,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
-    let succeeded = false;
+    let isSuccess = false;
     await act(async () => {
-      succeeded = await result.current.startDownload();
+      isSuccess = await result.current.startDownload();
     });
 
-    expect(succeeded).toBe(true);
+    expect(isSuccess).toBe(true);
     expect(downloadSpy).toHaveBeenCalledWith({
       lessonSlug: "lesson-slug",
       selectedResourceTypes: ["worksheet-pdf-questions"],
@@ -85,12 +85,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
-    let succeeded = true;
+    let isSuccess = true;
     await act(async () => {
-      succeeded = await result.current.startDownload();
+      isSuccess = await result.current.startDownload();
     });
 
-    expect(succeeded).toBe(false);
+    expect(isSuccess).toBe(false);
     expect(alertSpy).toHaveBeenCalledWith(
       "Whoops, the download failed. You could try again.",
     );

--- a/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
+++ b/src/components/PupilViews/PupilIntro/useWorksheetDownload.test.ts
@@ -28,10 +28,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
+    let succeeded = false;
     await act(async () => {
-      await result.current.startDownload();
+      succeeded = await result.current.startDownload();
     });
 
+    expect(succeeded).toBe(true);
     expect(downloadSpy).toHaveBeenCalledWith({
       lessonSlug: "lesson-slug",
       selectedResourceTypes: ["worksheet-pdf-questions"],
@@ -83,14 +85,12 @@ describe(useWorksheetDownload, () => {
       useWorksheetDownload("lesson-slug", false),
     );
 
-    act(() => {
-      result.current.startDownload();
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.startDownload();
     });
 
-    await waitFor(async () => {
-      expect(result.current.isDownloading).toBe(false);
-    });
-
+    expect(succeeded).toBe(false);
     expect(alertSpy).toHaveBeenCalledWith(
       "Whoops, the download failed. You could try again.",
     );

--- a/src/components/PupilViews/PupilIntro/useWorksheetDownload.ts
+++ b/src/components/PupilViews/PupilIntro/useWorksheetDownload.ts
@@ -4,7 +4,7 @@ import downloadLessonResources from "@/components/SharedComponents/helpers/downl
 import errorReporter from "@/common-lib/error-reporter";
 
 type WorksheetDownload = {
-  startDownload: () => Promise<void>;
+  startDownload: () => Promise<boolean>;
   isDownloading: boolean;
 };
 
@@ -18,9 +18,9 @@ export function useWorksheetDownload(
   isLegacyDownload: boolean,
 ): WorksheetDownload {
   const [isDownloading, setIsDownloading] = useState(false);
-  const startDownload = async () => {
+  const startDownload = async (): Promise<boolean> => {
     if (isDownloading) {
-      return;
+      return false;
     }
     setIsDownloading(true);
 
@@ -30,12 +30,14 @@ export function useWorksheetDownload(
         selectedResourceTypes: ["worksheet-pdf-questions"],
         isLegacyDownload,
       });
+      return true;
     } catch (error) {
       window.alert("Whoops, the download failed. You could try again.");
       reportError(error);
+      return false;
+    } finally {
+      setIsDownloading(false);
     }
-
-    setIsDownloading(false);
   };
 
   return { startDownload, isDownloading };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -208,8 +208,8 @@ const IntroPageContent = ({
     if (!lessonStarted) {
       trackLessonStarted();
     }
-    const succeeded = await startDownload();
-    if (succeeded) {
+    const isSuccess = await startDownload();
+    if (isSuccess) {
       trackWorksheetDownloaded();
     }
   };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -200,6 +200,20 @@ const IntroPageContent = ({
     );
   };
 
+  const handleWorksheetDownload = async () => {
+    updateSectionInProgressResult("intro", {
+      worksheetDownloaded: true,
+      worksheetAvailable: true,
+    });
+    if (!lessonStarted) {
+      trackLessonStarted();
+    }
+    const succeeded = await startDownload();
+    if (succeeded) {
+      trackWorksheetDownloaded();
+    }
+  };
+
   return (
     <PupilLessonIntroView
       phase={browseData.programmeFields.phase as "primary" | "secondary"}
@@ -310,15 +324,7 @@ const IntroPageContent = ({
               <OakFlex $justifyContent="flex-end">
                 <OakPrimaryInvertedButton
                   onClick={() => {
-                    updateSectionInProgressResult("intro", {
-                      worksheetDownloaded: true,
-                      worksheetAvailable: true,
-                    });
-                    if (!lessonStarted) {
-                      trackLessonStarted();
-                    }
-                    trackWorksheetDownloaded();
-                    void startDownload();
+                    void handleWorksheetDownload();
                   }}
                   isLoading={isDownloading}
                   iconName="download"

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -201,15 +201,15 @@ const IntroPageContent = ({
   };
 
   const handleWorksheetDownload = async () => {
+    updateSectionInProgressResult("intro", {
+      worksheetDownloaded: true,
+      worksheetAvailable: true,
+    });
     if (!lessonStarted) {
       trackLessonStarted();
     }
-    const isSuccess = await startDownload();
-    if (isSuccess) {
-      updateSectionInProgressResult("intro", {
-        worksheetDownloaded: true,
-        worksheetAvailable: true,
-      });
+    const succeeded = await startDownload();
+    if (succeeded) {
       trackWorksheetDownloaded();
     }
   };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -201,15 +201,15 @@ const IntroPageContent = ({
   };
 
   const handleWorksheetDownload = async () => {
-    updateSectionInProgressResult("intro", {
-      worksheetDownloaded: true,
-      worksheetAvailable: true,
-    });
     if (!lessonStarted) {
       trackLessonStarted();
     }
-    const succeeded = await startDownload();
-    if (succeeded) {
+    const isSuccess = await startDownload();
+    if (isSuccess) {
+      updateSectionInProgressResult("intro", {
+        worksheetDownloaded: true,
+        worksheetAvailable: true,
+      });
       trackWorksheetDownloaded();
     }
   };


### PR DESCRIPTION
## Description
Return success from useWorksheetDownload and call trackWorksheetDownloaded / lessonActivityDownloadedWorksheet only when the download completes. Aligns shared intro and legacy PupilIntro with the old startDownload().then() intent
and avoids Lesson Activity Downloaded on failed downloads.


Music year: {owa_music_year}


## Issue(s)

Fixes issue-17 on [PUPIL-1694](https://www.notion.so/oaknationalacademy/Lesson-Refactor-Lessons-can-support-individual-lesson-components-33b26cc4e1b18012a5a2cc907634d290?source=copy_link) Event Lesson Activity Downloaded should not fire until after successful download

**Expected Behaviour:** lessonActivityDownloadedWorksheet runs in startDownload().then(...) — if the download fails, the event may not fire.

**Actual Behaviour**:trackWorksheetDownloaded() runs on click (with void startDownload() after) — event can fire even if the download fails

## How to test

1. Go to [[OWA Preview URL from Vercel bot comment]/pupils/lessons/transverse-waves/shared/quizzes-only/intro]
2. Use chrome dev-tools to throttle the connection to a slow speed
3. Click on Download PDF
4. You should see the Lesson Activity Downloaded fire after the download has started, not on click. 

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
