### PR TITLE
Feat/pupil 1724/skeleton share page rebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@mux/mux-node": "^9.0.1",
         "@mux/mux-player-react": "3.10.2",
         "@oaknational/google-classroom-addon": "^1.33.0",
-        "@oaknational/oak-components": "^2.28.0",
+        "@oaknational/oak-components": "^2.29.0",
         "@oaknational/oak-consent-client": "2.4.0",
         "@oaknational/oak-curriculum-schema": "2.4.0-beta.2",
         "@ooxml-tools/units": "^0.3.0",
@@ -8685,9 +8685,9 @@
       }
     },
     "node_modules/@oaknational/oak-components": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-2.28.0.tgz",
-      "integrity": "sha512-tt5eUogzLDCt1lISsS4ciLB3r2O56uR9Bw5fT5rQlYgK4yBIOvDY5dhBCo/1q7ZrNd7VVIyB0COQYYMZg8DqaA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@oaknational/oak-components/-/oak-components-2.29.0.tgz",
+      "integrity": "sha512-KZYK6AuH4WlAY2Ap86Fg6D6msB9Av1x8MNrLgVU6YaX6VGW0laz7UaFTHE52bYU/pZ71YzS5BGqKDcUvN5ZpzA==",
       "peerDependencies": {
         "next": ">=14.2.12",
         "next-cloudinary": ">=6.16.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@mux/mux-node": "^9.0.1",
     "@mux/mux-player-react": "3.10.2",
     "@oaknational/google-classroom-addon": "^1.33.0",
-    "@oaknational/oak-components": "^2.28.0",
+    "@oaknational/oak-components": "^2.29.0",
     "@oaknational/oak-consent-client": "2.4.0",
     "@oaknational/oak-curriculum-schema": "2.4.0-beta.2",
     "@ooxml-tools/units": "^0.3.0",

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -1892,10 +1892,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   margin: 0rem;
   padding: 0rem;
   list-style: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   gap: 0.5rem;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3447,6 +3447,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             >
               <ul
                 class="c74"
+                style="display: flex;"
               >
                 <li
                   class="c75"

--- a/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
+++ b/src/__tests__/pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[lessonSlug]/share.test.tsx
@@ -136,9 +136,33 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
       });
     });
 
-    render(<LessonSharePage {...props} />);
+    render(
+      <LessonSharePage
+        {...{
+          ...props,
+          // curriculumData: {
+          // ...props.curriculumData,
+          // shareableResources: [
+          //   {
+          //     exists: true,
+          //     type: "exit-quiz",
+          //     label: "Exit quiz",
+          //     metadata: null,
+          //   },
+          //   { exists: true, type: "video", label: "Video", metadata: null },
+          //   {
+          //     exists: true,
+          //     type: "starter-quiz",
+          //     label: "Starter quiz",
+          //     metadata: null,
+          //   },
+          // ],
+          // },
+        }}
+      />,
+    );
     const shareButtonCopy = await screen.findByRole("link", {
-      name: "Share to Email",
+      name: "Copy link",
     });
     expect(shareButtonCopy).not.toBeDisabled();
     const user = userEvent.setup();
@@ -172,7 +196,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
       render(<LessonSharePage {...props} />);
 
       expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent(
-        "Your details",
+        "1Select activities",
       );
 
       expect(
@@ -205,7 +229,7 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
       // Lesson resources to share
       const lessonResourcesToShare = screen.getAllByTestId("resourceCard");
       expect(lessonResourcesToShare.length).toEqual(
-        props.curriculumData.shareableResources.length,
+        props.curriculumData.shareableResources.length + 1,
       );
 
       const exitQuizQuestions = screen.getByText("Exit quiz");
@@ -234,10 +258,6 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
         name: "Share to Microsoft Teams",
       });
       expect(shareButtonMicrosoft).toBeInTheDocument();
-      const shareButtonEmail = screen.getByRole("link", {
-        name: "Share to Email",
-      });
-      expect(shareButtonEmail).toBeInTheDocument();
     });
 
     it("should display error hint on blur email if not formatted correctly", async () => {
@@ -383,24 +403,6 @@ describe("pages/teachers/programmes/[programmeSlug]/units/[unitSlug]/lessons/[le
 
       expect(schoolId).toBe("222-Primary-School");
       expect(schoolName).toBe("Primary School");
-    });
-  });
-
-  describe("Copyright notice", () => {
-    it("renders pre-ALB copyright notice on legacy lessons", async () => {
-      render(
-        <LessonSharePage
-          curriculumData={lessonShareFixtures({ isLegacy: true })}
-          topNav={topNavFixture}
-        />,
-      );
-
-      const copyrightNotice = await screen.findByText(
-        "This content is made available by Oak National Academy Limited and its partners",
-        { exact: false },
-      );
-
-      expect(copyrightNotice).toBeInTheDocument();
     });
   });
 

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -347,9 +347,9 @@ export const ProgrammeDownloads = ({
                               data-testid="resourceCard"
                               value={download.id}
                               name="curriculum-download"
-                              titleSlot={download.label}
+                              title={download.label}
                               checked={fieldValue.includes(download.id)}
-                              formatSlot={
+                              format={
                                 <OakFlex
                                   $alignItems={"center"}
                                   $gap={"spacing-8"}

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -389,6 +389,12 @@ type PupilLessonCanonical = {
   lessonSlug: string;
 };
 
+type PupilLessonCanonicalShared = {
+  page: "pupil-lesson-canonical-shared";
+  lessonSlug: string;
+  shareVariant: string;
+};
+
 type MyLibraryProps = {
   page: "my-library";
 };
@@ -502,6 +508,7 @@ export type OakLinkProps =
   | OnboardingRoleSelectionLinkProps
   | OnboardingUseOfOak
   | PupilLessonCanonical
+  | PupilLessonCanonicalShared
   | MyLibraryProps
   | ProgrammePageProps
   | ClassroomSignInLinkProps
@@ -926,6 +933,12 @@ export const OAK_PAGES: {
     analyticsPageName: "Lesson",
     configType: "internal",
     pageType: "pupil-lesson-canonical",
+  }),
+  "pupil-lesson-canonical-shared": createOakPageConfig({
+    pathPattern: "/pupils/lessons/:lessonSlug/shared/:shareVariant/overview",
+    analyticsPageName: "Lesson",
+    configType: "internal",
+    pageType: "pupil-lesson-canonical-shared",
   }),
   "pupil-lesson-index": createOakPageConfig({
     pathPattern: "/pupils/programmes/:programmeSlug/units/:unitSlug/lessons",

--- a/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadSelection.tsx
+++ b/src/components/CurriculumComponents/CurriculumDownloadView/CurriculumDownloadSelection.tsx
@@ -41,7 +41,7 @@ export function CurriculumDownloadSelection({
               data-testid="resourceCard"
               value={download.id}
               name="curriculum-download"
-              titleSlot={download.label}
+              title={download.label}
               checked={isChecked}
               onChange={(e) => {
                 const downloadType = assertValidDownloadType(e.target.value);
@@ -55,7 +55,7 @@ export function CurriculumDownloadSelection({
                 }
                 onChange(newDownloadTypes);
               }}
-              formatSlot={download.subTitle}
+              format={download.subTitle}
               iconName={download.icon}
             />
           );

--- a/src/components/PupilComponents/Views/ViewHelpers/ViewHelpers.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/ViewHelpers.test.ts
@@ -1,0 +1,413 @@
+import {
+  OakQuizMatchItemId,
+  OakQuizOrderitemId,
+} from "@oaknational/oak-components";
+
+import { pickQuizTabId } from "../../QuizQuestions/helpers";
+
+import {
+  getAdditionalFileAssetIds,
+  getDedupedContentGuidanceLabels,
+  getHasQuizSections,
+  getIntroBottomNavLabel,
+  getIntroWorksheetInitResult,
+  getIsLessonExpiring,
+  getNarrowTranscriptSentences,
+  getQuizNextStep,
+  getUnitListingHref,
+  getVideoPlaybackId,
+  isQuizSection,
+  pickAvailableSectionsForLesson,
+  mapLessonSummaryQuizResults,
+  buildReviewAttemptData,
+  buildReviewShareUrl,
+  pickNextIncompleteSection,
+  pickProceedToNextSectionLabel,
+  pickQuizFeedbackState,
+  pickQuizNavigationButtonLabel,
+  // pickQuizTabId,
+  pickQuizTooltip,
+  pickSectionProgress,
+  shouldPersistVideoTimeElapsed,
+  shouldShowReviewBottomNav,
+  shouldInitIntroWorksheetResult,
+} from ".";
+
+import { multipleChoiceAnswerId } from "@/components/PupilComponents/LegacyQuiz/QuizMCQMultiAnswer";
+import { shortAnswerInputId } from "@/components/PupilComponents/LegacyQuiz/QuizShortAnswer";
+import {
+  matchAnswers,
+  mcqTextAnswers,
+  orderAnswers,
+  shortAnswers,
+} from "@/node-lib/curriculum-api-2023/fixtures/quizElements.new.fixture";
+
+describe("ViewHelpers", () => {
+  describe("pickNextIncompleteSection", () => {
+    it("returns the first incomplete section", () => {
+      expect(
+        pickNextIncompleteSection({
+          lessonReviewSections: ["intro", "starter-quiz", "video", "exit-quiz"],
+          sectionResults: {
+            intro: { isComplete: true },
+            "starter-quiz": { isComplete: false },
+          },
+        }),
+      ).toBe("starter-quiz");
+    });
+
+    it("returns review when all sections are complete", () => {
+      expect(
+        pickNextIncompleteSection({
+          lessonReviewSections: ["intro", "starter-quiz"],
+          sectionResults: {
+            intro: { isComplete: true },
+            "starter-quiz": { isComplete: true },
+          },
+        }),
+      ).toBe("review");
+    });
+  });
+
+  describe("pickProceedToNextSectionLabel", () => {
+    it("returns Lesson review when lesson is complete", () => {
+      expect(
+        pickProceedToNextSectionLabel({
+          lessonStarted: true,
+          isLessonComplete: true,
+          sectionResults: {},
+        }),
+      ).toBe("Lesson review");
+    });
+
+    it("returns Start lesson when intro is complete but lesson not started", () => {
+      expect(
+        pickProceedToNextSectionLabel({
+          lessonStarted: false,
+          isLessonComplete: false,
+          sectionResults: { intro: { isComplete: true } },
+        }),
+      ).toBe("Start lesson");
+    });
+  });
+
+  describe("pickSectionProgress", () => {
+    it("returns complete, in-progress and not-started as expected", () => {
+      expect(
+        pickSectionProgress({
+          section: "intro",
+          sectionResults: { intro: { isComplete: true } },
+        }),
+      ).toBe("complete");
+      expect(
+        pickSectionProgress({
+          section: "video",
+          sectionResults: { video: { isComplete: false } },
+        }),
+      ).toBe("in-progress");
+      expect(
+        pickSectionProgress({
+          section: "exit-quiz",
+          sectionResults: {},
+        }),
+      ).toBe("not-started");
+    });
+  });
+
+  describe("file and guidance helpers", () => {
+    it("gets additional file asset ids", () => {
+      expect(
+        getAdditionalFileAssetIds([{ assetId: 1 }, { assetId: 2 }, null]),
+      ).toEqual([1, 2]);
+    });
+
+    it("dedupes guidance labels", () => {
+      expect(
+        getDedupedContentGuidanceLabels([
+          {
+            contentguidanceLabel: "Contains conflict.",
+            contentguidanceArea: null,
+            contentguidanceDescription: null,
+          },
+          {
+            contentguidanceLabel: "Contains conflict.",
+            contentguidanceArea: null,
+            contentguidanceDescription: null,
+          },
+          {
+            contentguidanceLabel: "Mentions loss.",
+            contentguidanceArea: null,
+            contentguidanceDescription: null,
+          },
+        ]),
+      ).toEqual(["Contains conflict.", "Mentions loss."]);
+    });
+  });
+
+  describe("overview/experience helpers", () => {
+    it("picks available lesson sections", () => {
+      expect(
+        pickAvailableSectionsForLesson(
+          {
+            starterQuiz: [],
+            exitQuiz: [],
+            videoMuxPlaybackId: null,
+          } as never,
+          null,
+        ),
+      ).toEqual(["intro"]);
+    });
+
+    it("builds unit listing href", () => {
+      expect(
+        getUnitListingHref({
+          subjectSlug: "english",
+          phaseSlug: "primary",
+          yearSlug: "year-1",
+        }),
+      ).toBe("/pupils/programmes/english-primary-year-1/options");
+    });
+
+    it("detects expiring lesson", () => {
+      expect(
+        getIsLessonExpiring({
+          expirationDate: "2026-01-01",
+          displayExpiringBanner: false,
+        }),
+      ).toBe(true);
+      expect(
+        getIsLessonExpiring({
+          expirationDate: null,
+          displayExpiringBanner: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("narrows transcript sentences into array", () => {
+      expect(getNarrowTranscriptSentences("Sentence")).toEqual(["Sentence"]);
+      expect(getNarrowTranscriptSentences(undefined)).toEqual([""]);
+    });
+  });
+
+  describe("intro helpers", () => {
+    it("returns intro bottom nav label", () => {
+      expect(getIntroBottomNavLabel(true)).toBe("Continue lesson");
+      expect(getIntroBottomNavLabel(false)).toBe("I'm ready");
+    });
+
+    it("initialises worksheet result", () => {
+      expect(
+        getIntroWorksheetInitResult({
+          worksheetDownloaded: undefined,
+          hasWorksheet: true,
+        }),
+      ).toEqual({
+        worksheetDownloaded: false,
+        worksheetAvailable: true,
+      });
+      expect(
+        shouldInitIntroWorksheetResult({
+          worksheetAvailable: undefined,
+          currentSection: "intro",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("video helpers", () => {
+    it("picks sign-language playback id when enabled", () => {
+      expect(
+        getVideoPlaybackId({
+          signLanguageOn: true,
+          videoMuxPlaybackId: "standard",
+          videoWithSignLanguageMuxPlaybackId: "signed",
+        }),
+      ).toBe("signed");
+    });
+
+    it("persists on non-playing events or when elapsed threshold met", () => {
+      expect(
+        shouldPersistVideoTimeElapsed({
+          event: "pause",
+          nextTimeElapsed: 5,
+          currentTimeElapsed: 4,
+          currentSection: "video",
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldPersistVideoTimeElapsed({
+          event: "playing",
+          nextTimeElapsed: 21,
+          currentTimeElapsed: 10,
+          currentSection: "video",
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldPersistVideoTimeElapsed({
+          event: "playing",
+          nextTimeElapsed: 15,
+          currentTimeElapsed: 10,
+          currentSection: "video",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("quiz helpers", () => {
+    it("identifies quiz sections", () => {
+      expect(isQuizSection("starter-quiz")).toBe(true);
+      expect(isQuizSection("overview")).toBe(false);
+    });
+
+    it("determines quiz next step", () => {
+      expect(
+        getQuizNextStep({
+          currentQuestionIndex: 0,
+          numQuestions: 3,
+          // currentSection: "starter-quiz",
+          isReadOnly: false,
+        }),
+      ).toEqual({ action: "next-question" });
+      expect(
+        getQuizNextStep({
+          currentQuestionIndex: 2,
+          numQuestions: 3,
+          // currentSection: "starter-quiz",
+          isReadOnly: false,
+        }),
+      ).toEqual({ action: "complete-quiz" });
+      expect(
+        getQuizNextStep({
+          currentQuestionIndex: 0,
+          numQuestions: 3,
+          // currentSection: "exit-quiz",
+          isReadOnly: true,
+        }),
+      ).toEqual({ action: "go-review" });
+    });
+
+    it("picks feedback state", () => {
+      expect(pickQuizFeedbackState(true)).toBe("correct");
+      expect(pickQuizFeedbackState(false, true)).toBe("partially-correct");
+      expect(pickQuizFeedbackState(false, false)).toBe("incorrect");
+    });
+
+    it("picks navigation button label", () => {
+      expect(
+        pickQuizNavigationButtonLabel({
+          currentQuestionIndex: 0,
+          numQuestions: 3,
+          currentSection: "starter-quiz",
+        }),
+      ).toBe("Next question");
+
+      expect(
+        pickQuizNavigationButtonLabel({
+          currentQuestionIndex: 2,
+          numQuestions: 3,
+          currentSection: "exit-quiz",
+        }),
+      ).toBe("Lesson review");
+    });
+
+    it("picks quiz tooltip by answer type", () => {
+      expect(pickQuizTooltip({ order: orderAnswers })).toBe(
+        "You need to order to move on!",
+      );
+      expect(pickQuizTooltip({ match: matchAnswers })).toBe(
+        "You need to match to move on!",
+      );
+      expect(pickQuizTooltip({ "short-answer": shortAnswers })).toBe(
+        "You need to type an answer to move on!",
+      );
+      expect(pickQuizTooltip({ "multiple-choice": mcqTextAnswers })).toBe(
+        "You need to select an answer to move on!",
+      );
+    });
+
+    it("picks quiz tab id by answer type", () => {
+      expect(pickQuizTabId({ order: orderAnswers }, "Q1")).toBe(
+        OakQuizOrderitemId("1"),
+      );
+      expect(pickQuizTabId({ match: matchAnswers }, "Q1")).toBe(
+        OakQuizMatchItemId("0"),
+      );
+      expect(pickQuizTabId({ "short-answer": shortAnswers }, "Q1")).toBe(
+        shortAnswerInputId("Q1"),
+      );
+      expect(pickQuizTabId({ "multiple-choice": mcqTextAnswers }, "Q1")).toBe(
+        multipleChoiceAnswerId("Q1", 0),
+      );
+    });
+  });
+
+  describe("review helpers", () => {
+    it("builds review attempt data and share url", () => {
+      expect(
+        buildReviewAttemptData({
+          lessonSlug: "slug",
+          lessonTitle: "title",
+          subject: "Maths",
+          yearDescription: "Year 7",
+          sectionResults: {},
+        }),
+      ).toEqual({
+        lessonData: { slug: "slug", title: "title" },
+        browseData: { subject: "Maths", yearDescription: "Year 7" },
+        sectionResults: {},
+      });
+
+      process.env.NEXT_PUBLIC_CLIENT_APP_BASE_URL = "https://example.com";
+      expect(
+        buildReviewShareUrl({ lessonSlug: "lesson", attemptId: "attempt" }),
+      ).toContain("/pupils/lessons/lesson/results/attempt/share");
+    });
+
+    it("maps summary quiz results", () => {
+      expect(
+        mapLessonSummaryQuizResults({
+          section: "starter-quiz",
+          questionResults: [{ grade: 1, offerHint: false }],
+          questionsArray: [
+            {
+              questionType: "multiple-choice",
+              hint: "Hint",
+            } as never,
+          ],
+        }),
+      ).toEqual([
+        {
+          pupilExperienceLessonActivity: "starter-quiz",
+          questionNumber: 1,
+          questionType: "multiple-choice",
+          questionResult: "correct",
+          hintOffered: true,
+          hintAccessed: false,
+          activityTimeSpent: 0,
+        },
+      ]);
+    });
+
+    it("detects presence of quiz sections", () => {
+      expect(getHasQuizSections(["intro", "video"])).toBe(false);
+      expect(getHasQuizSections(["intro", "starter-quiz"])).toBe(true);
+    });
+
+    it("decides review bottom nav visibility", () => {
+      expect(
+        shouldShowReviewBottomNav({
+          classroomAssignmentChecked: true,
+          isClassroomAssignment: false,
+        }),
+      ).toBe(true);
+      expect(
+        shouldShowReviewBottomNav({
+          classroomAssignmentChecked: true,
+          isClassroomAssignment: true,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/components/PupilComponents/Views/ViewHelpers/ViewHelpers.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/ViewHelpers.test.ts
@@ -18,7 +18,6 @@ import {
   getVideoPlaybackId,
   isQuizSection,
   pickAvailableSectionsForLesson,
-  mapLessonSummaryQuizResults,
   buildReviewAttemptData,
   buildReviewShareUrl,
   pickNextIncompleteSection,
@@ -363,31 +362,6 @@ describe("ViewHelpers", () => {
       expect(
         buildReviewShareUrl({ lessonSlug: "lesson", attemptId: "attempt" }),
       ).toContain("/pupils/lessons/lesson/results/attempt/share");
-    });
-
-    it("maps summary quiz results", () => {
-      expect(
-        mapLessonSummaryQuizResults({
-          section: "starter-quiz",
-          questionResults: [{ grade: 1, offerHint: false }],
-          questionsArray: [
-            {
-              questionType: "multiple-choice",
-              hint: "Hint",
-            } as never,
-          ],
-        }),
-      ).toEqual([
-        {
-          pupilExperienceLessonActivity: "starter-quiz",
-          questionNumber: 1,
-          questionType: "multiple-choice",
-          questionResult: "correct",
-          hintOffered: true,
-          hintAccessed: false,
-          activityTimeSpent: 0,
-        },
-      ]);
     });
 
     it("detects presence of quiz sections", () => {

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -83,23 +83,4 @@ describe("lesson share card group", () => {
     await user.click(checkboxLabel);
     expect(checkbox).not.toBeChecked();
   });
-  it("should render pdf label in uppercase", () => {
-    const shareableResources = [
-      {
-        exists: true,
-        type: "worksheet-pdf" as const,
-        metadata: "pdf",
-        label: "Worksheet",
-      },
-    ];
-    renderWithTheme(
-      <ComponentWrapper
-        shareableResources={shareableResources}
-        shareLink="www.fake.com"
-      />,
-    );
-
-    const resourceCardLabel = screen.getByText("PDF");
-    expect(resourceCardLabel).toBeInTheDocument();
-  });
 });

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -1,15 +1,12 @@
 import { ChangeEvent, FC } from "react";
 import { Control, Controller } from "react-hook-form";
-import { OakFlex } from "@oaknational/oak-components";
+import { OakDownloadCard, OakFlex, OakGrid } from "@oaknational/oak-components";
 
-import ResourceCard from "@/components/TeacherComponents/ResourceCard";
+import ResourceCard from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
 import { sortShareResources } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
-import ButtonAsLink from "@/components/SharedComponents/Button/ButtonAsLink";
-import {
-  LessonShareData,
-  LessonShareResourceData,
-} from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+import { SharePageNumberedHeading } from "@/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading";
+import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 
 export type LessonShareCardGroupProps = {
   shareableResources: LessonShareData["shareableResources"];
@@ -25,87 +22,128 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
     (r) => r.exists && r.metadata !== null,
   );
 
-  const removeFieldValue = (fieldValue: string[], resourceType: string) =>
-    fieldValue.filter(
-      (val: LessonShareResourceData["type"] | string) => val !== resourceType,
-    );
+  // const removeFieldValue = (fieldValue: string[], resourceType: string) =>
+  //   fieldValue.filter(
+  //     (val: LessonShareResourceData["type"] | string) => val !== resourceType,
+  //   );
 
   const checkboxOnChangeHandler = (
     e: ChangeEvent<HTMLInputElement>,
     onChange: (val: string[]) => void,
     fieldValue: string[],
-    resourceType: string,
+    resourceType: string | string[],
   ) => {
     if (e.target.checked) {
-      onChange([...fieldValue, resourceType]);
+      onChange([
+        ...fieldValue,
+        ...(Array.isArray(resourceType) ? resourceType : [resourceType]),
+      ]);
     } else {
-      onChange(removeFieldValue(fieldValue, resourceType));
+      onChange(
+        fieldValue.filter(
+          (val) =>
+            !(Array.isArray(resourceType)
+              ? resourceType.includes(val)
+              : val === resourceType),
+        ),
+      );
     }
     // Trigger the form to reevaluate errors
     props.triggerForm();
   };
 
   return (
-    <OakFlex
-      $flexDirection="column"
-      $gap={["spacing-16", "spacing-24"]}
-      $alignItems="flex-start"
-    >
-      <OakFlex
-        $gap={"spacing-16"}
-        $flexDirection={["column", "row"]}
-        $flexWrap={["nowrap", "wrap"]}
+    <OakFlex $flexDirection={"column"} $gap={"spacing-40"}>
+      <SharePageNumberedHeading
+        number={1}
+        title={"Select activities"}
+        paragraph={
+          "Select the activities you want to share. You must select at least one activity."
+        }
+      />
+      <OakGrid
+        $display="grid"
+        $gridTemplateColumns={["1fr", "1fr 1fr"]}
+        $cg="spacing-16"
+        $rg="spacing-32"
+        $maxWidth={"spacing-960"}
       >
-        {sortedResources.map((resource, i) => (
+        <OakFlex
+          $flexDirection={"row"}
+          $gap={"spacing-16"}
+          $justifyContent={"stretch"}
+        >
           <Controller
             data-testid="lessonResourcesToShare"
             control={props.control}
             name="resources"
             defaultValue={[]}
-            key={`${resource.type}-${i}`}
+            key={`${"all"}`}
             render={({
               field: { value: fieldValue, onChange, name, onBlur },
             }) => {
               return (
-                <ResourceCard
-                  id={resource.type}
+                <OakDownloadCard
+                  format="Best for homework, revision, or when pupils are learning independently"
+                  id={"download-card-wrapping-long"}
+                  data-testid="resourceCard"
+                  value={"all"}
                   name={name}
-                  label={resource.label}
-                  subtitle={
-                    resource.metadata?.toLowerCase() === "pdf"
-                      ? "PDF"
-                      : resource.metadata! // this cannot be null here
-                  }
-                  resourceType={resource.type}
+                  title="Full online lesson"
+                  checked={["exit-quiz", "starter-quiz", "video"].every(
+                    (section) => fieldValue.includes(section),
+                  )}
                   onChange={(e) => {
-                    checkboxOnChangeHandler(
-                      e,
-                      onChange,
-                      fieldValue,
-                      resource.type,
-                    );
+                    checkboxOnChangeHandler(e, onChange, fieldValue, [
+                      "exit-quiz",
+                      "starter-quiz",
+                      "video",
+                    ]);
                   }}
-                  disabled={true}
-                  checked={fieldValue.includes(resource.type)}
                   onBlur={onBlur}
-                  hasError={props.hasError}
-                  useDownloadPageLayout={false}
+                  iconName={["quiz", "video", "worksheet", "quiz"]}
                 />
               );
             }}
           />
-        ))}
-      </OakFlex>
-      <ButtonAsLink
-        label="Preview as a pupil"
-        icon="external"
-        $iconPosition="trailing"
-        variant="minimal"
-        href={props.shareLink}
-        page={null}
-        iconBackground="black"
-        disabled={props.hasError}
-      />
+        </OakFlex>
+        <OakFlex $flexDirection={"column"} $gap={"spacing-32"}>
+          {sortedResources.map((resource, i) => (
+            <Controller
+              data-testid="lessonResourcesToShare"
+              control={props.control}
+              name="resources"
+              defaultValue={[]}
+              key={`${resource.type}-${i}`}
+              render={({
+                field: { value: fieldValue, onChange, name, onBlur },
+              }) => {
+                return (
+                  <ResourceCard
+                    id={resource.type}
+                    name={name}
+                    label={resource.label}
+                    subtitle={resource.metadata!}
+                    resourceType={resource.type}
+                    onChange={(e) => {
+                      checkboxOnChangeHandler(
+                        e,
+                        onChange,
+                        fieldValue,
+                        resource.type,
+                      );
+                    }}
+                    checked={fieldValue.includes(resource.type)}
+                    onBlur={onBlur}
+                    hasError={props.hasError}
+                    useDownloadPageLayout={false}
+                  />
+                );
+              }}
+            />
+          ))}
+        </OakFlex>
+      </OakGrid>
     </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
@@ -12,6 +12,8 @@ jest.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: jest.fn(),
 }));
 
+const onSubmitMock = jest.fn(() => true);
+
 describe("LessonShareLinks", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,8 +23,9 @@ describe("LessonShareLinks", () => {
       <LessonShareLinks
         disabled={false}
         lessonSlug="test-slug"
-        selectedActivities={["exit-quiz-questions"]}
-        onSubmit={jest.fn}
+        selectedActivities={["exit-quiz"]}
+        onSubmit={onSubmitMock}
+        shareLink=""
       />,
     );
     const shareHeader = screen.getByRole("heading");
@@ -35,7 +38,8 @@ describe("LessonShareLinks", () => {
         disabled={false}
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
-        onSubmit={jest.fn}
+        onSubmit={onSubmitMock}
+        shareLink=""
       />,
     );
     const copyLinkButton = screen.getByRole("button", {
@@ -52,7 +56,8 @@ describe("LessonShareLinks", () => {
         disabled={false}
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
-        onSubmit={jest.fn}
+        onSubmit={onSubmitMock}
+        shareLink=""
       />,
     );
     const copyLinkButton = screen.getByRole("button", {
@@ -71,6 +76,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={onSubmit}
+        shareLink=""
       />,
     );
     const copyLinkButton = screen.getByRole("button", {
@@ -90,6 +96,7 @@ describe("LessonShareLinks", () => {
         lessonSlug="test-slug"
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={onSubmit}
+        shareLink=""
       />,
     );
 
@@ -115,6 +122,7 @@ describe("LessonShareLinks", () => {
         selectedActivities={["exit-quiz-questions"]}
         onSubmit={onSubmit}
         onGoogleClassroomClick={onGoogleClassroomClick}
+        shareLink=""
       />,
     );
 

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
@@ -1,32 +1,51 @@
 import { FC, useEffect, useState } from "react";
-import { OakHeading, OakFlex } from "@oaknational/oak-components";
+import { OakFlex, OakSecondaryButton } from "@oaknational/oak-components";
 import { useFeatureFlagEnabled } from "posthog-js/react";
+
+import { SharePageNumberedHeading } from "../SharePageNumberedHeading/SharePageNumberedHeading";
 
 import { shareLinkConfig } from "./linkConfig";
 import { getHrefForSocialSharing } from "./getHrefForSocialSharing";
 
 import { ResourceType } from "@/components/TeacherComponents/types/downloadAndShare.types";
-import LoadingButton from "@/components/SharedComponents/Button/LoadingButton";
 import { ShareMediumValueType } from "@/browser-lib/avo/Avo";
 import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
+import { getLessonShareVariantSlug } from "@/pages-helpers/pupil";
 
-const copyToClipboard = (textToCopy: string, callback: () => void) => {
-  if (navigator.clipboard) {
-    navigator.clipboard.writeText(textToCopy);
-    callback();
+const copyToClipboard = (textToCopy: string, callback: () => boolean) => {
+  const isValid = callback();
+  if (isValid) {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(textToCopy);
+    } else {
+      alert("Please update your browser to support this feature");
+    }
   } else {
-    alert("Please update your browser to support this feature");
+    return;
   }
 };
 
 const LessonShareLinks: FC<{
+  hasError?: boolean;
+  shareLink: string;
   disabled: boolean;
   lessonSlug: string;
   selectedActivities?: Array<ResourceType>;
   schoolUrn?: string;
-  onSubmit: (shareMedium: ShareMediumValueType) => void;
+  onSubmit: (shareMedium: ShareMediumValueType) => boolean;
   onGoogleClassroomClick?: () => void;
 }> = (props) => {
+  const lessonShareVariantSlug =
+    getLessonShareVariantSlug(
+      props.selectedActivities as (
+        | "video"
+        | "intro"
+        | "overview"
+        | "starter-quiz"
+        | "exit-quiz"
+        | "review"
+      )[],
+    ) || "";
   const [isShareSuccessful, setIsShareSuccessful] = useState(false);
   const { setCurrentToastProps } = useOakNotificationsContext();
   const useGoogleClassroomAddon = useFeatureFlagEnabled(
@@ -39,99 +58,103 @@ const LessonShareLinks: FC<{
 
   const linkShareOptions = [
     shareLinkConfig.microsoftTeams,
-    shareLinkConfig.email,
+    // shareLinkConfig.email,
     ...(props.onGoogleClassroomClick && useGoogleClassroomAddon
       ? []
       : [shareLinkConfig.googleClassroom]),
   ];
 
   return (
-    <>
-      <OakHeading
-        $mt="spacing-24"
-        $mb="spacing-4"
-        tag={"h4"}
-        $font={"heading-7"}
-      >
-        Share options:
-      </OakHeading>
+    <OakFlex
+      $background={"bg-decorative5-main"}
+      $width={"100%"}
+      $borderRadius={"border-radius-l"}
+      $pa={"spacing-24"}
+      $flexDirection={"column"}
+      $gap={"spacing-20"}
+    >
+      <SharePageNumberedHeading
+        number={2}
+        title={"Share with pupils"}
+        paragraph={
+          "Use one of the links below to share the selected activities with your pupils."
+        }
+      />
       <OakFlex $flexWrap={"wrap"} $width={"100%"} $gap={"spacing-12"}>
-        <LoadingButton
-          text={
-            isShareSuccessful
-              ? "Link copied to clipboard"
-              : shareLinkConfig.copy.name
-          }
-          success={isShareSuccessful}
-          type="button"
-          ariaLabel="Copy link to clipboard"
-          ariaLive={"polite"}
-          onClick={() =>
+        <OakSecondaryButton
+          element="button"
+          iconName={shareLinkConfig.copy.icon}
+          isTrailingIcon={true}
+          onClick={() => {
             copyToClipboard(
               getHrefForSocialSharing({
                 lessonSlug: props.lessonSlug,
                 selectedActivities: props.selectedActivities,
                 schoolUrn: props.schoolUrn,
                 linkConfig: shareLinkConfig.copy,
+                shareVariant: lessonShareVariantSlug,
               }),
               () => {
-                setIsShareSuccessful(true);
-                setCurrentToastProps({
-                  message: "Link copied to clipboard",
-                  variant: "green",
-                  autoDismiss: true,
-                  showIcon: true,
-                });
-                props.onSubmit("copy-link");
+                const isValid = props.onSubmit("copy-link");
+                if (isValid) {
+                  setIsShareSuccessful(true);
+                  setCurrentToastProps({
+                    message: "Link copied to clipboard",
+                    variant: "green",
+                    autoDismiss: true,
+                    showIcon: true,
+                  });
+                }
+                return isValid;
               },
-            )
-          }
-          isLoading={false}
-          loadingText="Copying..."
-          icon={shareLinkConfig.copy.icon}
-          disabled={props.disabled}
-        />
+            );
+          }}
+          aria-label="Copy link to clipboard"
+        >
+          {isShareSuccessful
+            ? "Link copied to clipboard"
+            : shareLinkConfig.copy.name}
+        </OakSecondaryButton>
 
         {props.onGoogleClassroomClick && useGoogleClassroomAddon && (
-          <LoadingButton
-            text={shareLinkConfig.googleClassroom.name}
-            icon={shareLinkConfig.googleClassroom.icon}
-            isLoading={false}
-            disabled={props.disabled}
-            type="button"
-            key={shareLinkConfig.googleClassroom.name}
+          <OakSecondaryButton
+            iconName={shareLinkConfig.googleClassroom.icon}
+            isTrailingIcon={true}
             onClick={() => {
               props.onSubmit(shareLinkConfig.googleClassroom.avoMedium);
               props.onGoogleClassroomClick!();
             }}
-            ariaLabel="Assign to Google Classroom"
-            ariaLive={"polite"}
-          />
+            disabled={props.disabled}
+            aria-label="Assign to Google Classroom"
+          >
+            {shareLinkConfig.googleClassroom.name}
+          </OakSecondaryButton>
         )}
 
-        {linkShareOptions.map((link) => (
-          <LoadingButton
-            text={link.name}
-            icon={link.icon}
-            isLoading={false}
-            disabled={props.disabled}
-            type="link"
-            external={true}
-            key={link.name}
-            href={getHrefForSocialSharing({
-              lessonSlug: props.lessonSlug,
-              selectedActivities: props.selectedActivities,
-              linkConfig: link,
-            })}
+        {linkShareOptions.map((link, index) => (
+          <OakSecondaryButton
+            element="a"
+            iconName={link.icon}
+            isTrailingIcon={true}
             onClick={() => {
               props.onSubmit(link.avoMedium);
             }}
-            ariaLabel={`Share to ${link.name}`}
-            ariaLive={"polite"}
-          />
+            aria-label={`Share to ${link.name}`}
+            href={getHrefForSocialSharing({
+              lessonSlug: props.lessonSlug,
+              selectedActivities: props.selectedActivities,
+              schoolUrn: props.schoolUrn,
+              linkConfig: link,
+              shareVariant: lessonShareVariantSlug,
+            })}
+            target="_blank"
+            key={index}
+          >
+            {link.name}
+          </OakSecondaryButton>
         ))}
       </OakFlex>
-    </>
+    </OakFlex>
   );
 };
 

--- a/src/components/TeacherComponents/LessonShareLinks/getHrefForSocialSharing.test.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getHrefForSocialSharing.test.ts
@@ -6,6 +6,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.copy,
+      shareVariant: "copy",
     });
 
     expect(href).toBe(
@@ -16,6 +17,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.googleClassroom,
+      shareVariant: "googleClassroom",
     });
     expect(href).toBe(
       "https://classroom.google.com/u/0/share?url=https%3A%2F%2Fthenational.academy%2Fpupils%2Flessons%2Flesson-slug%3Fshare%3Dtrue",
@@ -25,6 +27,7 @@ describe("getHrefForSocialSharing", () => {
     const href = getHrefForSocialSharing({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.microsoftTeams,
+      shareVariant: "microsoftTeams",
     });
     expect(href).toBe(
       "https://teams.microsoft.com/share?href=https%3A%2F%2Fthenational.academy%2Fpupils%2Flessons%2Flesson-slug%3Fshare%3Dtrue&text=",

--- a/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.test.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.test.ts
@@ -4,9 +4,10 @@ import { shareLinkConfig } from "./linkConfig";
 describe("getSharingMetadata", () => {
   it("generates sharing metadata for copy", () => {
     const result = getSharingMetadata({
-      selectedActivities: ["exit-quiz-questions", "video"],
+      selectedActivities: ["exit-quiz", "video"],
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.copy,
+      shareVariant: "copy",
     });
 
     expect(result.link).toBe(
@@ -17,6 +18,7 @@ describe("getSharingMetadata", () => {
     const result = getSharingMetadata({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.microsoftTeams,
+      shareVariant: "microsoftTeams",
     });
 
     expect(result.link).toBe(
@@ -30,6 +32,7 @@ describe("getSharingMetadata", () => {
     const result = getSharingMetadata({
       lessonSlug: "lesson-slug",
       linkConfig: shareLinkConfig.copy,
+      shareVariant: "copy",
     });
     expect(result.link).toBe(
       "https://thenational.academy/pupils/lessons/lesson-slug?share=true",

--- a/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/getSharingMetadata.ts
@@ -1,6 +1,8 @@
 import { ShareLinkConfig } from "./linkConfig";
 
 import { ResourceType } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { resolveOakHref } from "@/common-lib/urls";
+import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 
 export type SharingMetadata = {
   link: string;
@@ -10,21 +12,33 @@ export type SharingMetadata = {
   shareStr: string;
   urlEncodedShareStr: string;
 };
+const baseUrl = getBrowserConfig("clientAppBaseUrl");
 
-const pupilsPath = (lessonSlug: string) =>
-  `https://thenational.academy/pupils/lessons/${lessonSlug}?share=true`;
+const pupilsPath = (lessonSlug: string, shareVariant: string) =>
+  shareVariant
+    ? `${baseUrl}${resolveOakHref({
+        page: "pupil-lesson-canonical-shared",
+        lessonSlug,
+        shareVariant,
+      })}`
+    : `${baseUrl}${resolveOakHref({
+        page: "pupil-lesson-canonical",
+        lessonSlug,
+      })}?share=true`;
 
 export type GetSharingMetadataParams = {
   lessonSlug: string;
   selectedActivities?: Array<ResourceType>;
   schoolUrn?: string;
   linkConfig: ShareLinkConfig;
+  shareVariant: string;
 };
 
 export const getSharingMetadata = ({
   lessonSlug,
+  shareVariant,
 }: GetSharingMetadataParams): SharingMetadata => {
-  const link = pupilsPath(lessonSlug);
+  const link = pupilsPath(lessonSlug, shareVariant);
 
   const urlEncodedLink = encodeURIComponent(link);
   const pageTitle =

--- a/src/components/TeacherComponents/LessonShareLinks/linkConfig.ts
+++ b/src/components/TeacherComponents/LessonShareLinks/linkConfig.ts
@@ -3,7 +3,11 @@ import { OakIconName } from "@oaknational/oak-components";
 import { SharingMetadata } from "./getSharingMetadata";
 
 export type ShareLinkConfig = {
-  name: "Email" | "Google Classroom" | "Microsoft Teams" | "Copy link";
+  name:
+    | "Email"
+    | "Share via Google Classroom"
+    | "Share via Microsoft Teams"
+    | "Copy link";
   network?: "email" | "google-classroom" | "microsoft-teams";
   medium: "social" | "email" | "lms" | "copy-link";
   avoMedium: "microsoft-teams" | "google-classroom" | "email" | "copy-link";
@@ -35,7 +39,7 @@ export const shareLinkConfig: Record<
     avoMedium: "email",
   },
   googleClassroom: {
-    name: "Google Classroom",
+    name: "Share via Google Classroom",
     network: "google-classroom",
     icon: "google-classroom",
     url: ({ urlEncodedLink }) => {
@@ -45,7 +49,7 @@ export const shareLinkConfig: Record<
     avoMedium: "google-classroom",
   },
   microsoftTeams: {
-    name: "Microsoft Teams",
+    name: "Share via Microsoft Teams",
     network: "microsoft-teams",
     icon: "microsoft-teams",
     url: ({ urlEncodedLink, urlEncodedPageTitle }) => {

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -14,6 +14,7 @@ import {
   OakBox,
   OakLoadingSpinner,
   OakIcon,
+  OakHandDrawnHR,
 } from "@oaknational/oak-components";
 import styled from "styled-components";
 
@@ -50,13 +51,13 @@ export type SharePageLayoutProps = ResourcePageDetailsCompletedProps &
 const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
   const hasFormErrors = Object.keys(props.errors).length > 0;
   return (
-    <OakBox $width="100%">
+    <OakBox $maxWidth={"spacing-960"} $mb={"spacing-48"}>
       <OakFlex
         $alignItems={"flex-start"}
         $flexDirection={"column"}
         $gap={["spacing-24", "spacing-32"]}
       >
-        <OakHeading tag="h1" $font={["heading-5", "heading-4"]}>
+        <OakHeading tag="h1" $font={["heading-4", "heading-2"]}>
           {props.header}
         </OakHeading>
         {props.isLoading ? (
@@ -67,7 +68,7 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
           <OakFlex
             $justifyContent="space-between"
             $width="100%"
-            $flexDirection={["column", "column", "row"]}
+            $flexDirection={"column"}
             $gap="spacing-48"
             $alignItems={"flex-start"}
             $position={"relative"}
@@ -88,9 +89,9 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
             <OakFlex
               $flexDirection="column"
               $gap="spacing-16"
-              $maxWidth="spacing-480"
               $position={"sticky"}
               $top={"spacing-56"}
+              $width={"100%"}
             >
               {props.showNoResources ? (
                 <NoResourcesToShare />
@@ -155,8 +156,22 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
                       />
                     </OakBox>
                   )}
+                  <OakHandDrawnHR
+                    $height={"spacing-2"}
+                    $width={"100%"}
+                    $mb={"spacing-16"}
+                    $mt={"spacing-16"}
+                    hrColor={"border-neutral-lighter"}
+                  />
 
                   {props.cta}
+
+                  <CopyrightNotice
+                    fullWidth
+                    showPostAlbCopyright={true}
+                    openLinksExternally={true}
+                    copyrightYear={props.updatedAt}
+                  />
 
                   {props.apiError && !hasFormErrors && (
                     <FieldError

--- a/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.tsx
+++ b/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.tsx
@@ -1,0 +1,40 @@
+import {
+  OakFlex,
+  OakHeading,
+  OakP,
+  OakSpan,
+} from "@oaknational/oak-components";
+
+export const SharePageNumberedHeading = ({
+  number,
+  title,
+  paragraph,
+}: {
+  number: number;
+  title: string;
+  paragraph: string;
+}) => {
+  return (
+    <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
+      <OakHeading tag="h2" $font={["heading-5", "heading-4"]}>
+        <OakFlex $alignItems={"center"}>
+          <OakFlex
+            $background={"bg-btn-secondary"}
+            $borderRadius={"border-radius-circle"}
+            $width={"spacing-48"}
+            $height={"spacing-48"}
+            $pa={"spacing-8"}
+            $borderColor={"icon-primary"}
+            $borderStyle={"solid"}
+            $alignItems={"center"}
+            $justifyContent={"center"}
+          >
+            <OakSpan $font={"body-1-bold"}>{number}</OakSpan>
+          </OakFlex>
+          <OakSpan $ml={"spacing-16"}>{title}</OakSpan>
+        </OakFlex>
+      </OakHeading>
+      <OakP $font={"body-1"}>{paragraph}</OakP>
+    </OakFlex>
+  );
+};

--- a/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
+++ b/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
@@ -6,28 +6,22 @@ import {
 } from "@oaknational/oak-components";
 import styled from "styled-components";
 
-import type { DownloadResourceType } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { CheckboxProps } from "@/components/SharedComponents/Checkbox/Checkbox";
+import { LessonShareResourceData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 
-const CustomSizing = styled("div")<{
+export const CustomSizing = styled("div")<{
   checked?: boolean;
   useDownloadPageLayout?: boolean;
 }>`
-  display: grid;
-  width: ${(props) => (props.useDownloadPageLayout ? "100%" : "320px")};
   input {
     border: ${(props) => (props.checked ? "0" : "default")};
-  }
-
-  @media (min-width: 1280px) {
-    width: ${(props) => (props.useDownloadPageLayout ? "300px" : "320px")};
   }
 `;
 
 export type ResourceCardProps = Omit<CheckboxProps, "checked"> & {
   label: string;
-  resourceType: DownloadResourceType;
+  resourceType: LessonShareResourceData["type"];
   subtitle: string;
   subjectIcon?: string;
   isEditable?: boolean;
@@ -36,19 +30,13 @@ export type ResourceCardProps = Omit<CheckboxProps, "checked"> & {
   checked?: boolean;
 };
 
-const RESOURCE_TYPE_ICON_MAP: Record<DownloadResourceType, OakIconName> = {
-  presentation: "slide-deck",
-  "intro-quiz-questions": "quiz",
-  "intro-quiz-answers": "quiz",
-  "exit-quiz-questions": "quiz",
-  "exit-quiz-answers": "quiz",
-  "worksheet-pdf": "worksheet",
-  "worksheet-pptx": "worksheet",
-  "supplementary-pdf": "additional-material",
-  "supplementary-docx": "additional-material",
-  "curriculum-pdf": "additional-material",
-  "lesson-guide-pdf": "additional-material",
-  "additional-files": "additional-material",
+const RESOURCE_TYPE_ICON_MAP: Record<
+  LessonShareResourceData["type"],
+  OakIconName
+> = {
+  "starter-quiz": "quiz",
+  "exit-quiz": "quiz",
+  video: "video",
 };
 
 const ResourceCard: FC<ResourceCardProps> = (props) => {
@@ -68,11 +56,9 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
     useDownloadPageLayout = false,
   } = props;
 
-  const isCurriculumIcon = resourceType === "curriculum-pdf";
-  const iconName =
-    isCurriculumIcon && subjectIcon
-      ? getValidSubjectIconName(subjectIcon)
-      : RESOURCE_TYPE_ICON_MAP[resourceType];
+  const iconName = subjectIcon
+    ? getValidSubjectIconName(subjectIcon)
+    : RESOURCE_TYPE_ICON_MAP[resourceType];
 
   return (
     <CustomSizing

--- a/src/components/TeacherComponents/ShareResourceCard/index.ts
+++ b/src/components/TeacherComponents/ShareResourceCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./ShareResourceCard";

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -15,13 +15,13 @@ import {
   OakTextInput,
   OakJauntyAngleLabel,
   OakFieldError,
+  OakRoundIcon,
 } from "@oaknational/oak-components";
 
 import FieldError from "@/components/SharedComponents/FieldError";
 import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
 import ResourcePageSchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
 import ResourcePageTermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
-import CopyrightNotice from "@/components/TeacherComponents/OglCopyrightNotice";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { resolveOakHref } from "@/common-lib/urls";
 
@@ -53,8 +53,6 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
   setSchool = () => {},
   showSavedDetails = false,
   handleEditDetailsCompletedClick = () => {},
-  showPostAlbCopyright = true,
-  oglCopyrightYear,
   useDownloadPageLayout = false,
 }) => {
   const [emailHasFocus, setEmailHasFocus] = useState(false);
@@ -68,7 +66,15 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
           $font={["heading-6", "heading-5"]}
           $mb={["spacing-24", "spacing-32"]}
         >
-          Your details
+          <OakFlex $alignItems={"center"} $gap={"spacing-12"}>
+            {!useDownloadPageLayout && (
+              <OakRoundIcon
+                iconName={"tick"}
+                $background={"bg-btn-secondary"}
+              />
+            )}
+            Your details
+          </OakFlex>
         </OakHeading>
       )}
       {form?.errors.school && (
@@ -211,15 +217,6 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                     />
                   );
                 }}
-              />
-            </OakBox>
-          )}
-          {!useDownloadPageLayout && (
-            <OakBox $maxWidth="spacing-480">
-              <CopyrightNotice
-                showPostAlbCopyright={showPostAlbCopyright}
-                openLinksExternally={true}
-                copyrightYear={oglCopyrightYear}
               />
             </OakBox>
           )}

--- a/src/components/TeacherComponents/downloadAndShare.schema.ts
+++ b/src/components/TeacherComponents/downloadAndShare.schema.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const preselectedResourceBaseType = z.union([
   z.literal("exit quiz"),
   z.literal("starter quiz"),
-  z.literal("worksheet"),
   z.literal("all"),
 ]);
 

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/combinedPreselectedTypeMap.tsx
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/combinedPreselectedTypeMap.tsx
@@ -4,15 +4,14 @@ export const combinedPreselectedTypeMap: CombinedPreselectedTypeMap = {
   "slide deck": { downloadType: ["presentation"] },
   "starter quiz": {
     downloadType: ["intro-quiz-questions", "intro-quiz-answers"],
-    shareType: ["intro-quiz-questions"],
+    shareType: ["starter-quiz"],
   },
   "exit quiz": {
     downloadType: ["exit-quiz-questions", "exit-quiz-answers"],
-    shareType: ["exit-quiz-questions"],
+    shareType: ["exit-quiz"],
   },
   worksheet: {
     downloadType: ["worksheet-pdf", "worksheet-pptx"],
-    shareType: ["worksheet-pdf"],
   },
   "additional material": {
     downloadType: ["supplementary-pdf", "supplementary-docx"],

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/containerTitleToPreselectMap.tsx
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/containerTitleToPreselectMap.tsx
@@ -20,7 +20,7 @@ export const containerTitleToPreselectMap: Omit<
     downloadType: "additional material",
     shareType: null,
   },
-  Worksheet: { downloadType: "worksheet", shareType: "worksheet" },
+  Worksheet: { downloadType: "worksheet", shareType: null },
   Transcript: { downloadType: null, shareType: null },
   "Lesson video": { downloadType: null, shareType: "video" },
 };

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources.test.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources.test.ts
@@ -5,6 +5,6 @@ import * as shareResources from "@/node-lib/curriculum-api-2023/fixtures/shareab
 describe("sortResources", () => {
   it("sorts share resources", () => {
     const sorted = sortShareResources(shareResources.allResources);
-    expect(sorted[0]?.type).toBe("intro-quiz-questions");
+    expect(sorted[0]?.type).toBe("video");
   });
 });

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources.ts
@@ -9,6 +9,8 @@ export const sortShareResources = (
     "worksheet-pdf": 3,
     "intro-quiz-answers": 4,
     "exit-quiz-questions": 5,
+    "starter-quiz": 6,
+    "exit-quiz": 7,
     presentation: 100,
     "worksheet-pptx": 100,
     "exit-quiz-answers": 100,

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
@@ -50,6 +50,7 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
     setValue,
     trigger,
     watch,
+    getValues,
     handleSubmit,
   } = useForm({
     resolver: zodResolver(resourceFormValuesSchema),
@@ -308,7 +309,6 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
 
     const preselectedQuery = () => {
       const res = searchParams?.get("preselected");
-
       const result =
         props.type === "download"
           ? preselectedDownloadType.safeParse(res)
@@ -327,10 +327,10 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
       (getInitialAdditionalFilesState() || []) as ResourceType[],
     );
 
-    if (isPreselectedShareType(queryResults)) {
+    if (isPreselectedShareType(queryResults) && props.type === "share") {
       preselected = getPreselectedShareResourceTypes(queryResults);
     }
-    if (isPreselectedDownloadType(queryResults)) {
+    if (isPreselectedDownloadType(queryResults) && props.type === "download") {
       const preselectedResources = additionalResources
         ? resources?.concat(additionalResources)
         : resources;
@@ -417,6 +417,7 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
       trigger,
       setValue,
       watch,
+      getValues,
       formState,
       getInitialResourcesState,
       errors,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -39,6 +39,7 @@ import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonSh
 import { SpecialistLessonShareData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema";
 import { useOnboardingStatus } from "@/components/TeacherComponents/hooks/useOnboardingStatus";
 import { AssignToClassroomModal } from "@/components/TeacherComponents/AssignToClassroomModal/AssignToClassroomModal";
+import { getLessonShareVariantSlug } from "@/pages-helpers/pupil";
 
 export type LessonShareProps =
   | {
@@ -60,9 +61,8 @@ export type LessonShareProps =
 const classroomActivityMap: Partial<
   Record<ResourceType, ResourceTypesValueType>
 > = {
-  "intro-quiz-questions": "starter-quiz",
-  "exit-quiz-questions": "exit-quiz",
-  "worksheet-pdf": "worksheet",
+  "starter-quiz": "starter-quiz",
+  "exit-quiz": "exit-quiz",
   video: "video",
 };
 
@@ -82,7 +82,7 @@ export function LessonShare(props: LessonShareProps) {
 
   const exitQuizNumQuestions = (() => {
     const exitQuizResource = shareableResources.find(
-      (r) => r.type === "exit-quiz-questions",
+      (r) => r.type === "exit-quiz",
     );
     const parsed = exitQuizResource
       ? Number.parseInt(exitQuizResource.metadata ?? "", 10)
@@ -114,6 +114,45 @@ export function LessonShare(props: LessonShareProps) {
   } = useResourceFormState({
     shareResources: shareableResources,
     type: "share",
+  });
+
+  const onValidateAndSubmit = (shareMedium: ShareMediumValueType) => {
+    const isValid =
+      !hasFormErrors &&
+      !expired &&
+      (form.formState.isValid || localStorageDetails);
+    const resources = form.getValues("resources");
+
+    void form.handleSubmit((data) => {
+      onFormSubmit(
+        {
+          ...data,
+          resources,
+        },
+        shareMedium,
+      );
+    })(); // https://github.com/orgs/react-hook-form/discussions/8622
+    return isValid;
+  };
+
+  const lessonShareVariantSlug =
+    getLessonShareVariantSlug(
+      selectedResources as (
+        | "video"
+        | "intro"
+        | "overview"
+        | "starter-quiz"
+        | "exit-quiz"
+        | "review"
+      )[],
+    ) || "";
+
+  const shareLink = getHrefForSocialSharing({
+    lessonSlug: lessonSlug,
+    selectedActivities: selectedResources,
+    schoolUrn: schoolUrn,
+    linkConfig: shareLinkConfig.copy,
+    shareVariant: lessonShareVariantSlug,
   });
   const onboardingStatus = useOnboardingStatus();
 
@@ -232,6 +271,7 @@ export function LessonShare(props: LessonShareProps) {
                 selectedActivities: selectedResources,
                 schoolUrn: schoolUrn,
                 linkConfig: shareLinkConfig.copy,
+                shareVariant: lessonShareVariantSlug,
               })}
             />
           }
@@ -246,13 +286,10 @@ export function LessonShare(props: LessonShareProps) {
                 lessonSlug={lessonSlug}
                 selectedActivities={selectedResources}
                 schoolUrn={schoolUrn}
-                onSubmit={
-                  (shareMedium: ShareMediumValueType) =>
-                    void form.handleSubmit((data) => {
-                      onFormSubmit(data, shareMedium);
-                    })() // https://github.com/orgs/react-hook-form/discussions/8622
-                }
+                onSubmit={onValidateAndSubmit}
                 onGoogleClassroomClick={() => setIsClassroomModalOpen(true)}
+                hasError={form.errors?.resources !== undefined}
+                shareLink={shareLink}
               />
               {!isSpecialist && programmeSlug && unitSlug && (
                 <AssignToClassroomModal

--- a/src/node-lib/curriculum-api-2023/fixtures/lessonShare.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/lessonShare.fixture.ts
@@ -22,13 +22,13 @@ const lessonShareFixtures = (
     examBoardTitle: null,
     shareableResources: [
       {
-        type: "exit-quiz-questions",
+        type: "exit-quiz",
         exists: true,
         label: "Exit quiz",
         metadata: "6 questions",
       },
       {
-        type: "intro-quiz-questions",
+        type: "starter-quiz",
         exists: true,
         label: "Starter quiz",
         metadata: "6 questions",

--- a/src/node-lib/curriculum-api-2023/fixtures/shareableResources.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/shareableResources.fixture.ts
@@ -1,11 +1,11 @@
 const exitQuiz = {
-  type: "exit-quiz-questions" as const,
+  type: "exit-quiz" as const,
   exists: true,
   label: "Exit quiz",
   metadata: "6 questions",
 };
 const starterQuiz = {
-  type: "intro-quiz-questions" as const,
+  type: "starter-quiz" as const,
   exists: true,
   label: "Starter quiz",
   metadata: "6 questions",
@@ -16,17 +16,7 @@ const video = {
   label: "Video",
   metadata: "57:23",
 };
-const worksheet = {
-  type: "worksheet-pdf" as const,
-  exists: true,
-  label: "Worksheet",
-  metadata: "PDF",
-};
 
-export const allResources = [video, worksheet, exitQuiz, starterQuiz];
-export const noVideo = [worksheet, exitQuiz, starterQuiz];
-export const noVideoNoExitQuiz = [
-  worksheet,
-  starterQuiz,
-  { ...exitQuiz, exists: false },
-];
+export const allResources = [video, exitQuiz, starterQuiz];
+export const noVideo = [exitQuiz, starterQuiz];
+export const noVideoNoExitQuiz = [starterQuiz, { ...exitQuiz, exists: false }];

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/constructShareableResources.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/constructShareableResources.ts
@@ -6,32 +6,26 @@ export const constructShareableResources = (lesson: RawLessonShareSchema) => {
 
   const introQuiz = {
     exists: lesson.starter_quiz !== null,
-    type: "intro-quiz-questions" as const,
-    label: "Starter quiz",
+    type: "starter-quiz" as const,
+    label: "Prior knowledge starter quiz",
     metadata: lesson.starter_quiz
-      ? `${starterQuizLength} question${starterQuizLength === 1 ? "" : "s"}`
+      ? `Check prior knowledge (${starterQuizLength} question${starterQuizLength === 1 ? "" : "s"})`
       : "",
   };
   const exitQuiz = {
     exists: lesson.exit_quiz !== null,
-    type: "exit-quiz-questions" as const,
-    label: "Exit quiz",
+    type: "exit-quiz" as const,
+    label: "Assessment exit quiz",
     metadata: lesson.exit_quiz
-      ? `${exitQuizLength} question${exitQuizLength === 1 ? "" : "s"}`
+      ? `Check understanding (${exitQuizLength} question${exitQuizLength === 1 ? "" : "s"})`
       : "",
   };
   const video = {
     exists: lesson.video_mux_playback_id !== null,
     type: "video" as const,
-    label: "Video",
-    metadata: lesson.video_duration,
-  };
-  const worksheet = {
-    exists: lesson.worksheet_asset_object_url !== null,
-    type: "worksheet-pdf" as const,
-    label: "Worksheet",
-    metadata: "pdf",
+    label: "Lesson video",
+    metadata: `Support independent learning (${lesson.video_duration})`,
   };
 
-  return [video, introQuiz, exitQuiz, worksheet];
+  return [video, introQuiz, exitQuiz];
 };

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.test.ts
@@ -72,7 +72,7 @@ describe("lessonShare()", () => {
     expect(result).toHaveLength(4);
     expect(result.every((r) => r.exists === false)).toBe(true);
 
-    const starterQuiz = result.find((r) => r.type === "intro-quiz-questions");
+    const starterQuiz = result.find((r) => r.type === "starter-quiz");
     expect(starterQuiz?.metadata).toBe("");
   });
 
@@ -84,10 +84,10 @@ describe("lessonShare()", () => {
 
     expect(result).toHaveLength(4);
 
-    const starterQuiz = result.find((r) => r.type === "intro-quiz-questions");
+    const starterQuiz = result.find((r) => r.type === "starter-quiz");
     expect(starterQuiz?.metadata).toBe("4 questions");
 
-    const exitQuiz = result.find((r) => r.type === "exit-quiz-questions");
+    const exitQuiz = result.find((r) => r.type === "exit-quiz");
     expect(exitQuiz?.metadata).toBe("");
 
     const video = result.find((r) => r.type === "video");
@@ -107,7 +107,26 @@ describe("lessonShare()", () => {
     expect(parsed).toEqual(res);
     expect(parsed.shareableResources).toHaveLength(4);
     const starterQuiz = parsed.shareableResources.find(
-      (r) => r.type === "intro-quiz-questions",
+      (r) => r.type === "starter-quiz",
+    );
+    expect(starterQuiz?.metadata).toBe("1 question");
+  });
+
+  test("returns the correct response for canonical lesson", async () => {
+    const res = await lessonShare({
+      ...sdk,
+      lessonShare: jest.fn(() => Promise.resolve(mockLessonShareResponse)),
+    })({
+      lessonSlug: "lesson-slug",
+    });
+
+    const parsed = canonicalLessonShareSchema.parse(res);
+
+    expect(parsed).toEqual(res);
+    expect(parsed.pathways).toHaveLength(1);
+    expect(parsed.shareableResources).toHaveLength(4);
+    const starterQuiz = parsed.shareableResources.find(
+      (r) => r.type === "starter-quiz",
     );
     expect(starterQuiz?.metadata).toBe("1 question");
   });

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.test.ts
@@ -111,23 +111,4 @@ describe("lessonShare()", () => {
     );
     expect(starterQuiz?.metadata).toBe("1 question");
   });
-
-  test("returns the correct response for canonical lesson", async () => {
-    const res = await lessonShare({
-      ...sdk,
-      lessonShare: jest.fn(() => Promise.resolve(mockLessonShareResponse)),
-    })({
-      lessonSlug: "lesson-slug",
-    });
-
-    const parsed = canonicalLessonShareSchema.parse(res);
-
-    expect(parsed).toEqual(res);
-    expect(parsed.pathways).toHaveLength(1);
-    expect(parsed.shareableResources).toHaveLength(4);
-    const starterQuiz = parsed.shareableResources.find(
-      (r) => r.type === "starter-quiz",
-    );
-    expect(starterQuiz?.metadata).toBe("1 question");
-  });
 });

--- a/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.query.ts
@@ -12,13 +12,13 @@ export const constructShareableResources = (
 ) => {
   const introQuiz = {
     exists: lesson.starter_quiz !== null,
-    type: "intro-quiz-questions" as const,
+    type: "starter-quiz" as const,
     label: "Starter Quiz",
     metadata: "", // TODO: get quiz questions
   };
   const exitQuiz = {
     exists: lesson.exit_quiz !== null,
-    type: "exit-quiz-questions" as const,
+    type: "exit-quiz" as const,
     label: "Exit Quiz",
     metadata: "", // TODO: get quiz questions
   };
@@ -28,14 +28,8 @@ export const constructShareableResources = (
     label: "Video",
     metadata: "mp4", // TODO: get video duration
   };
-  const worksheet = {
-    exists: lesson.worksheet_url !== null,
-    type: "worksheet-pdf" as const,
-    label: "Worksheet",
-    metadata: "pdf",
-  };
 
-  return [video, introQuiz, exitQuiz, worksheet];
+  return [video, introQuiz, exitQuiz];
 };
 
 export const specialistLessonShareQuery =

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -369,12 +369,7 @@ export const legacyAssetObjectSchema = z
 
 export const lessonShareResourceSchema = z.object({
   exists: z.boolean().nullable(),
-  type: z.enum([
-    "intro-quiz-questions",
-    "exit-quiz-questions",
-    "worksheet-pdf",
-    "video",
-  ]),
+  type: z.enum(["starter-quiz", "exit-quiz", "video"]),
   label: z.string(),
   metadata: z.string().nullable(),
 });


### PR DESCRIPTION
## Description

Music year: 1959

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to  [preview](https://oak-web-application-website-git-feat-pupil-1724skeleton-fb947d.vercel.thenational.academy/)
2. Click through to a lesson
3. select share with pupil
4. You should see new share page, diffferent share options, links to correct pupil lesson

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
