### PR TITLE
fix: reject requests to the curriculum page with too many segments

### DIFF
--- a/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
+++ b/src/__tests__/pages/teachers/curriculum/[subjectPhaseSlug]/[tab].test.tsx
@@ -745,6 +745,24 @@ describe("pages/teachers/curriculum/[subjectPhaseSlug]/[tab]", () => {
         },
       });
     });
+
+    it.each([
+      ["overview", ["extra"]],
+      ["downloads", ["extra"]],
+      ["units", ["extra", "extra2"]],
+    ] as const)(
+      "returns notFound for %s tab with trailing path segments",
+      async (tab, trailingSegments) => {
+        const result = await getStaticProps({
+          params: {
+            slugs: [tab, ...trailingSegments],
+            subjectPhaseSlug: "english-secondary-aqa",
+          },
+        });
+
+        expect(result).toEqual({ notFound: true });
+      },
+    );
   });
 
   describe("getStaticPaths", () => {

--- a/src/pages/teachers/curriculum/[subjectPhaseSlug]/[...slugs].tsx
+++ b/src/pages/teachers/curriculum/[subjectPhaseSlug]/[...slugs].tsx
@@ -235,6 +235,18 @@ export type URLParams = {
   subjectPhaseSlug: string;
 };
 
+/** Rejects catch all paths with too many segments */
+function hasAllowedCurriculumPathShape(
+  tab: string,
+  pathSegmentsAfterTab: string[],
+): boolean {
+  if (tab === "units") {
+    return pathSegmentsAfterTab.length <= 1;
+  }
+
+  return pathSegmentsAfterTab.length === 0;
+}
+
 export const getStaticPaths = async () => {
   if (shouldSkipInitialBuild) {
     return getFallbackBlockingConfig();
@@ -258,9 +270,14 @@ export const getStaticProps: GetStaticProps<
       if (!context.params) {
         throw new Error("Missing params");
       }
-      const [tab] = context.params.slugs;
+      const [tab, ...restSegments] = context.params.slugs;
       const isPreviewMode = context.preview === true;
       if (!tab || !VALID_TABS.includes(tab as CurriculumTab)) {
+        throw new OakError({
+          code: "curriculum-api/not-found",
+        });
+      }
+      if (!hasAllowedCurriculumPathShape(tab, restSegments)) {
         throw new OakError({
           code: "curriculum-api/not-found",
         });


### PR DESCRIPTION
## Description

Music year: 1982

the catch all route meant that a request with too many segments would still be served with a 200 which would be cached through ISR creating a lot of entries in the cache.

E.g. `/teachers/curriculum/science-secondary-edexcel/units/iamevil/HTTP/1.0%25252525252525250D%25252525252525250Ax:/`

would be served a 200 with only a cosmetic 404 in the unit modal


## How to test

1. Go to https://oak-web-application-website-git-fix-isrpocalypse.vercel.thenational.academy/teachers/curriculum/computing-secondary-aqa/units/iamevil/this/is/an/injection/attack
2. You should see a 404
3. Go to https://oak-web-application-website-git-fix-isrpocalypse.vercel.thenational.academy/teachers/curriculum/computing-secondary-aqa/units
4. All proper links should work as before


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
