### PR TITLE
Remove curriculum from the top nav LESQ-2026

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -428,7 +428,20 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
         },
       ];
 
-      return [...pupilsRedirects, ...aboutUsRedirects, ...eyfsRedirects];
+      const integratedJourneyRedirects = [
+        {
+          source: "/teachers/curriculum",
+          destination: "/about-us/oaks-curricula",
+          permanent: true,
+        },
+      ];
+
+      return [
+        ...pupilsRedirects,
+        ...aboutUsRedirects,
+        ...eyfsRedirects,
+        ...integratedJourneyRedirects,
+      ];
     },
     async rewrites() {
       // Reverse proxy posthog in development to avoid localhost CORS issues in Chrome https://posthog.com/docs/advanced/proxy/nextjs

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -4431,10 +4431,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <div
                       class="c8 yellow-shadow"
                     />
-                    <a
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c35 c36 internal-button"
-                      href="/teachers/curriculum"
-                      id="teachers-curriculum-landing-page"
+                      data-testid="teachers-guidance"
+                      id="teachers-guidance"
                     >
                       <div
                         class="c11 c37"
@@ -4442,10 +4444,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         <span
                           class="c38"
                         >
-                          Curriculum
+                          Guidance
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
                 <li
@@ -4474,37 +4476,6 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c38"
                         >
                           About us
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                </li>
-                <li
-                  class="c34"
-                >
-                  <div
-                    class="c6 c19"
-                  >
-                    <div
-                      class="c8 grey-shadow"
-                    />
-                    <div
-                      class="c8 yellow-shadow"
-                    />
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="c35 c36 internal-button"
-                      data-testid="teachers-guidance"
-                      id="teachers-guidance"
-                    >
-                      <div
-                        class="c11 c37"
-                      >
-                        <span
-                          class="c38"
-                        >
-                          Guidance
                         </span>
                       </div>
                     </button>

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -4265,10 +4265,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <div
                       class="c8 yellow-shadow"
                     />
-                    <a
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c35 c36 internal-button"
-                      href="/teachers/curriculum"
-                      id="teachers-curriculum-landing-page"
+                      data-testid="teachers-guidance"
+                      id="teachers-guidance"
                     >
                       <div
                         class="c11 c37"
@@ -4276,10 +4278,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         <span
                           class="c38"
                         >
-                          Curriculum
+                          Guidance
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
                 <li
@@ -4308,37 +4310,6 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c38"
                         >
                           About us
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                </li>
-                <li
-                  class="c34"
-                >
-                  <div
-                    class="c6 c19"
-                  >
-                    <div
-                      class="c8 grey-shadow"
-                    />
-                    <div
-                      class="c8 yellow-shadow"
-                    />
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="c35 c36 internal-button"
-                      data-testid="teachers-guidance"
-                      id="teachers-guidance"
-                    >
-                      <div
-                        class="c11 c37"
-                      >
-                        <span
-                          class="c38"
-                        >
-                          Guidance
                         </span>
                       </div>
                     </button>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -4624,10 +4624,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <div
                       class="c8 yellow-shadow"
                     />
-                    <a
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c35 c36 internal-button"
-                      href="/teachers/curriculum"
-                      id="teachers-curriculum-landing-page"
+                      data-testid="teachers-guidance"
+                      id="teachers-guidance"
                     >
                       <div
                         class="c11 c37"
@@ -4635,10 +4637,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         <span
                           class="c38"
                         >
-                          Curriculum
+                          Guidance
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
                 <li
@@ -4667,37 +4669,6 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c38"
                         >
                           About us
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                </li>
-                <li
-                  class="c34"
-                >
-                  <div
-                    class="c6 c19"
-                  >
-                    <div
-                      class="c8 grey-shadow"
-                    />
-                    <div
-                      class="c8 yellow-shadow"
-                    />
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="c35 c36 internal-button"
-                      data-testid="teachers-guidance"
-                      id="teachers-guidance"
-                    >
-                      <div
-                        class="c11 c37"
-                      >
-                        <span
-                          class="c38"
-                        >
-                          Guidance
                         </span>
                       </div>
                     </button>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -4450,10 +4450,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <div
                       class="c8 yellow-shadow"
                     />
-                    <a
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c35 c36 internal-button"
-                      href="/teachers/curriculum"
-                      id="teachers-curriculum-landing-page"
+                      data-testid="teachers-guidance"
+                      id="teachers-guidance"
                     >
                       <div
                         class="c11 c37"
@@ -4461,10 +4463,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         <span
                           class="c38"
                         >
-                          Curriculum
+                          Guidance
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
                 <li
@@ -4493,37 +4495,6 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c38"
                         >
                           About us
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                </li>
-                <li
-                  class="c34"
-                >
-                  <div
-                    class="c6 c19"
-                  >
-                    <div
-                      class="c8 grey-shadow"
-                    />
-                    <div
-                      class="c8 yellow-shadow"
-                    />
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="c35 c36 internal-button"
-                      data-testid="teachers-guidance"
-                      id="teachers-guidance"
-                    >
-                      <div
-                        class="c11 c37"
-                      >
-                        <span
-                          class="c38"
-                        >
-                          Guidance
                         </span>
                       </div>
                     </button>

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -3100,10 +3100,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <div
                       class="c8 yellow-shadow"
                     />
-                    <a
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c35 c36 internal-button"
-                      href="/teachers/curriculum"
-                      id="teachers-curriculum-landing-page"
+                      data-testid="teachers-guidance"
+                      id="teachers-guidance"
                     >
                       <div
                         class="c11 c37"
@@ -3111,10 +3113,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         <span
                           class="c38"
                         >
-                          Curriculum
+                          Guidance
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
                 <li
@@ -3143,37 +3145,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c38"
                         >
                           About us
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                </li>
-                <li
-                  class="c34"
-                >
-                  <div
-                    class="c6 c19"
-                  >
-                    <div
-                      class="c8 grey-shadow"
-                    />
-                    <div
-                      class="c8 yellow-shadow"
-                    />
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="c35 c36 internal-button"
-                      data-testid="teachers-guidance"
-                      id="teachers-guidance"
-                    >
-                      <div
-                        class="c11 c37"
-                      >
-                        <span
-                          class="c38"
-                        >
-                          Guidance
                         </span>
                       </div>
                     </button>

--- a/src/app/(core)/__snapshots__/layout.test.tsx.snap
+++ b/src/app/(core)/__snapshots__/layout.test.tsx.snap
@@ -108,11 +108,6 @@ exports[`core layout renders correctly 1`] = `
           "slug": "labs",
           "title": "Ai experiments",
         },
-        "curriculum": {
-          "href": "/teachers/curriculum",
-          "slug": "curriculum-landing-page",
-          "title": "Curriculum",
-        },
         "guidance": {
           "children": [
             {

--- a/src/components/AppComponents/TopNav/DropdownFocusManager/DropdownFocusManager.test.ts
+++ b/src/components/AppComponents/TopNav/DropdownFocusManager/DropdownFocusManager.test.ts
@@ -17,7 +17,6 @@ describe("DropdownFocusManager", () => {
     // Top-level keys
     expect(focusMap.has("teachers-primary")).toBe(true);
     expect(focusMap.has("teachers-secondary")).toBe(true);
-    expect(focusMap.has("teachers-curriculum-landing-page")).toBe(true);
     expect(focusMap.has("teachers-aboutUs")).toBe(true);
     expect(focusMap.has("teachers-guidance")).toBe(true);
   });

--- a/src/components/AppComponents/TopNav/SubNav/SubNav.test.tsx
+++ b/src/components/AppComponents/TopNav/SubNav/SubNav.test.tsx
@@ -34,13 +34,19 @@ describe("SubNav (Teachers)", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the Curriculum link as a link element with correct href", () => {
+  it("renders Ai experiments link as a link element with external icon", () => {
     render(<SubNav {...defaultProps} />);
 
-    const curriculumLink = screen.getByRole("link", { name: "Curriculum" });
+    const aiExperimentsLink = screen.getByRole("link", {
+      name: "Ai experiments (this will open in a new tab)",
+    });
 
-    expect(curriculumLink).toBeInTheDocument();
-    expect(curriculumLink).toHaveAttribute("href", "/teachers/curriculum");
+    expect(aiExperimentsLink).toBeInTheDocument();
+    expect(aiExperimentsLink).toHaveAttribute(
+      "href",
+      "https://labs.thenational.academy",
+    );
+    expect(aiExperimentsLink).toHaveAttribute("target", "_blank");
   });
 
   it("renders Primary as a button", () => {

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
@@ -48,13 +48,6 @@ export function MainMenuContent(
       <SubjectsSection {...navData.primary} hamburgerMenu={hamburgerMenu} />
       <SubjectsSection {...navData.secondary} hamburgerMenu={hamburgerMenu} />
       <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
-        <MainMenuLink
-          hamburgerMenu={hamburgerMenu}
-          href={resolveOakHref({
-            page: "curriculum-landing-page",
-          })}
-          title="Curriculum"
-        />
         <MainMenuButton title={"About us"} hamburgerMenu={hamburgerMenu} />
         <MainMenuButton title={"Guidance"} hamburgerMenu={hamburgerMenu} />
         <MainMenuLink

--- a/src/components/AppComponents/TopNav/TopNav.test.tsx
+++ b/src/components/AppComponents/TopNav/TopNav.test.tsx
@@ -207,9 +207,8 @@ describe("TopNav", () => {
 const subnavLabels = [
   { label: "Primary", element: "button" },
   { label: "Secondary", element: "button" },
-  { label: "Curriculum", element: "link" },
-  { label: "About us", element: "button" },
   { label: "Guidance", element: "button" },
+  { label: "About us", element: "button" },
   { label: "Ai experiments (this will open in a new tab)", element: "link" },
 ];
 
@@ -283,8 +282,8 @@ describe("TopNav accessibility", () => {
     const secondaryButton = await screen.findByRole("button", {
       name: "Secondary",
     });
-    const curriculumButton = await screen.findByRole("link", {
-      name: "Curriculum",
+    const guidanceButton = await screen.findByRole("button", {
+      name: "Guidance",
     });
 
     // tab to secondary button and open the submenu, should not focus primary dropdown items as they are not open
@@ -309,7 +308,7 @@ describe("TopNav accessibility", () => {
 
     // return to the next nav item after tabbing from the last dropdown item
     await user.tab();
-    expect(curriculumButton).toHaveFocus();
+    expect(guidanceButton).toHaveFocus();
   });
 
   it("ArrowRight and ArrowLeft navigate Teachers subnav buttons", async () => {
@@ -324,7 +323,6 @@ describe("TopNav accessibility", () => {
     const [
       primaryButton,
       secondaryButton,
-      curriculumButton,
       guidanceButton,
       aboutUsButton,
       aiExperimentsButton,
@@ -336,8 +334,6 @@ describe("TopNav accessibility", () => {
 
     await user.keyboard("{ArrowRight}");
     expect(secondaryButton).toHaveFocus();
-    await user.keyboard("{ArrowRight}");
-    expect(curriculumButton).toHaveFocus();
     await user.keyboard("{ArrowRight}");
     expect(guidanceButton).toHaveFocus();
     await user.keyboard("{ArrowRight}");

--- a/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
@@ -97,10 +97,27 @@ export const topNavFixture: TopNavProps = {
         },
       ],
     },
-    curriculum: {
-      slug: "curriculum-landing-page",
-      title: "Curriculum",
-      href: "/teachers/curriculum",
+    guidance: {
+      slug: "guidance",
+      title: "Guidance",
+      children: [
+        {
+          slug: "lesson-planning",
+          title: "Plan a lesson",
+          href: "/teachers/lesson-planning",
+        },
+        {
+          slug: "blog-index",
+          title: "Blogs",
+          href: "/blog",
+        },
+        {
+          slug: "help",
+          title: "Help",
+          href: "https://support.thenational.academy",
+          external: true,
+        },
+      ],
     },
     aboutUs: {
       slug: "aboutUs",
@@ -130,28 +147,6 @@ export const topNavFixture: TopNavProps = {
           slug: "contact",
           title: "Contact us",
           href: "/contact-us",
-        },
-      ],
-    },
-    guidance: {
-      slug: "guidance",
-      title: "Guidance",
-      children: [
-        {
-          slug: "lesson-planning",
-          title: "Plan a lesson",
-          href: "/teachers/lesson-planning",
-        },
-        {
-          slug: "blog-index",
-          title: "Blogs",
-          href: "/blog",
-        },
-        {
-          slug: "help",
-          title: "Help",
-          href: "https://support.thenational.academy",
-          external: true,
         },
       ],
     },

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
@@ -36,12 +36,6 @@ const topNavQuery = (sdk: Sdk) => async (): Promise<TopNavProps> => {
   const teachersNavData: TeachersSubNavData = {
     primary: getTeachersNavData(parsed.data, "primary"),
     secondary: getTeachersNavData(parsed.data, "secondary"),
-    curriculum: {
-      title: "Curriculum",
-      slug: "curriculum-landing-page",
-      href: resolveOakHref({ page: "curriculum-landing-page" }),
-    },
-
     guidance: {
       title: "Guidance",
       slug: "guidance",

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.schema.ts
@@ -38,7 +38,6 @@ export type NavDropDownButton = {
 export type TeachersSubNavData = {
   primary: TeachersBrowse;
   secondary: TeachersBrowse;
-  curriculum: NavLink;
   guidance: NavDropDownButton;
   aboutUs: NavDropDownButton;
   aiExperiments: NavLink;


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

Removes "Curriculum" from the top nav and hamburger menu

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-2026remove-cur-13fb94.vercel.thenational.academy/
2. You should not see "Curriculum" in the top nav or mobile hamburger menu

--

1. Go to https://oak-web-application-website-git-feat-lesq-2026remove-cur-13fb94.vercel.thenational.academy/teachers/curriculum
2. You should find yourself at https://oak-web-application-website-git-feat-lesq-2026remove-cur-13fb94.vercel.thenational.academy/about-us/oaks-curricula

## Screenshots
<img width="1077" height="1487" alt="Screenshot 2026-05-19 at 15 05 19" src="https://github.com/user-attachments/assets/b96dd33c-57a7-4ea6-9da1-627bae70fda6" />

<img width="1642" height="1106" alt="Screenshot 2026-05-19 at 15 06 02" src="https://github.com/user-attachments/assets/77e389e8-d2dd-49ad-ac13-524f69149262" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
