### PR TITLE
Scope year filters to the active keystage LESQ-2018

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/Filters/ProgrammeFilters.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/Filters/ProgrammeFilters.test.tsx
@@ -81,7 +81,7 @@ describe("Programme filters...", () => {
 
     const filterLegendNames = [
       "Year group",
-      "Category",
+      "Category (KS3)",
       "Exam subject (KS4)",
       "Learning tier (KS4)",
       "Highlight a thread",

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersChildSubjects.tsx
@@ -9,6 +9,7 @@ import { useId } from "react";
 import { CurriculumFilters, Unit } from "@/utils/curriculum/types";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 import { getFilterData } from "@/utils/curriculum/filtering";
+import { scopeYearsToKeystageFilter } from "@/utils/curriculum/filtersUrl";
 import {
   byKeyStageSlug,
   presentAtKeyStageSlugs,
@@ -36,13 +37,15 @@ export function CurricFiltersChildSubjects({
   const id = useId();
   const { yearData } = data;
 
-  const { childSubjects } = getFilterData(data.yearData, filters.years);
+  const effectiveYears = scopeYearsToKeystageFilter(filters);
+
+  const { childSubjects } = getFilterData(data.yearData, effectiveYears);
 
   const keyStageSlugData = byKeyStageSlug(yearData);
   const childSubjectsAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "childSubjects",
-    filters.years,
+    effectiveYears,
   );
 
   function setSingleInFilter(key: keyof CurriculumFilters, newValue: string) {

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersSubjectCategories.tsx
@@ -9,6 +9,7 @@ import { useMemo, useId } from "react";
 import { getValidSubjectCategoryIconById } from "@/utils/getValidSubjectCategoryIconById";
 import { CurriculumFilters } from "@/utils/curriculum/types";
 import { getFilterData } from "@/utils/curriculum/filtering";
+import { scopeYearsToKeystageFilter } from "@/utils/curriculum/filtersUrl";
 import {
   byKeyStageSlug,
   presentAtKeyStageSlugs,
@@ -39,18 +40,20 @@ export function CurricFiltersSubjectCategories({
   const id = useId();
   const { yearData } = data;
 
-  const { subjectCategories } = getFilterData(data.yearData, filters.years);
+  const effectiveYears = scopeYearsToKeystageFilter(filters);
+
+  const { subjectCategories } = getFilterData(data.yearData, effectiveYears);
 
   const keyStageSlugData = byKeyStageSlug(yearData);
   const childSubjectsAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "childSubjects",
-    filters.years,
+    effectiveYears,
   );
   const subjectCategoriesAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "subjectCategories",
-    filters.years,
+    effectiveYears,
   ).filter((ks) => !childSubjectsAt.includes(ks));
 
   function setSingleInFilter(key: keyof CurriculumFilters, newValue: string) {
@@ -91,8 +94,7 @@ export function CurricFiltersSubjectCategories({
               $mb={["spacing-24", "spacing-16"]}
             >
               Category
-              {subjectCategoriesAt.length === 1 &&
-              context === "curriculum-visualiser"
+              {subjectCategoriesAt.length === 1
                 ? ` (${subjectCategoriesAt[0]?.toUpperCase()})`
                 : ""}
             </OakP>

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersTiers.test.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersTiers.test.tsx
@@ -40,7 +40,7 @@ describe("CurricFiltersTiers", () => {
           childSubjects: [],
           subjectCategories: [],
           tiers: [],
-          years: ["10", "11"],
+          years: ["7", "8", "9", "10", "11"],
           threads: [],
           pathways: [],
           keystages: [],
@@ -106,28 +106,16 @@ describe("CurricFiltersTiers", () => {
 
     act(() => elements[0]!.click());
     expect(onChangeFilters).toHaveBeenCalledWith(
-      {
-        subjectCategories: [],
-        childSubjects: [],
-        threads: [],
+      expect.objectContaining({
         tiers: ["foundation"],
-        years: ["10", "11"],
-        pathways: [],
-        keystages: [],
-      },
+      }),
       "learning_tier_button",
     );
     act(() => elements[1]!.click());
     expect(onChangeFilters).toHaveBeenCalledWith(
-      {
-        subjectCategories: [],
-        childSubjects: [],
-        threads: [],
+      expect.objectContaining({
         tiers: ["higher"],
-        years: ["10", "11"],
-        pathways: [],
-        keystages: [],
-      },
+      }),
       "learning_tier_button",
     );
   });

--- a/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersTiers.tsx
+++ b/src/components/CurriculumComponents/CurricVisualiserFilters/CurricFiltersTiers.tsx
@@ -8,6 +8,7 @@ import { useId } from "react";
 
 import { CurriculumFilters } from "@/utils/curriculum/types";
 import { getFilterData } from "@/utils/curriculum/filtering";
+import { scopeYearsToKeystageFilter } from "@/utils/curriculum/filtersUrl";
 import {
   byKeyStageSlug,
   presentAtKeyStageSlugs,
@@ -35,10 +36,16 @@ export function CurricFiltersTiers({
   const id = useId();
   const { yearData } = data;
 
-  const { tiers } = getFilterData(data.yearData, filters.years);
+  const effectiveYears = scopeYearsToKeystageFilter(filters);
+
+  const { tiers } = getFilterData(data.yearData, effectiveYears);
 
   const keyStageSlugData = byKeyStageSlug(yearData);
-  const tiersAt = presentAtKeyStageSlugs(keyStageSlugData, "tiers");
+  const tiersAt = presentAtKeyStageSlugs(
+    keyStageSlugData,
+    "tiers",
+    effectiveYears,
+  );
 
   function setSingleInFilter(key: keyof CurriculumFilters, newValue: string) {
     onChangeFilters({ ...filters, [key]: [newValue] }, "learning_tier_button");

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -761,12 +761,20 @@ describe("shouldDisplayFilter", () => {
             createChildSubject({ subject_slug: "physics" }),
             createChildSubject({ subject_slug: "biology" }),
           ],
+          tiers: [
+            createTier({ tier_slug: "foundation" }),
+            createTier({ tier_slug: "higher" }),
+          ],
         }),
         "11": createYearData({
           units: [createUnit({ slug: "y11" })],
           childSubjects: [
             createChildSubject({ subject_slug: "physics" }),
             createChildSubject({ subject_slug: "biology" }),
+          ],
+          tiers: [
+            createTier({ tier_slug: "foundation" }),
+            createTier({ tier_slug: "higher" }),
           ],
         }),
       },
@@ -775,7 +783,7 @@ describe("shouldDisplayFilter", () => {
       keystages: [],
     };
 
-    it("Science KS3 view: shows subject categories, hides child subjects", () => {
+    it("Science KS3 view: shows subject categories, hides child subjects and tiers", () => {
       const filters = createFilter({
         years: ["7", "8", "9", "10", "11"],
         keystages: ["ks3"],
@@ -786,9 +794,12 @@ describe("shouldDisplayFilter", () => {
       expect(
         shouldDisplayFilter(scienceSecondaryData, filters, "childSubjects"),
       ).toEqual(false);
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "tiers"),
+      ).toEqual(false);
     });
 
-    it("Science KS4 view: shows child subjects, hides subject categories", () => {
+    it("Science KS4 view: shows child subjects and tiers, hides subject categories", () => {
       const filters = createFilter({
         years: ["7", "8", "9", "10", "11"],
         keystages: ["ks4"],
@@ -798,6 +809,9 @@ describe("shouldDisplayFilter", () => {
       ).toEqual(false);
       expect(
         shouldDisplayFilter(scienceSecondaryData, filters, "childSubjects"),
+      ).toEqual(true);
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "tiers"),
       ).toEqual(true);
     });
 

--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -23,6 +23,7 @@ import {
   tierForFilter,
   useFilters,
 } from "./filtering";
+import { scopeYearsToKeystageFilter } from "./filtersUrl";
 import { CurriculumFilters, YearData, Unit } from "./types";
 
 import { createUnit } from "@/fixtures/curriculum/unit";
@@ -463,6 +464,38 @@ describe("diffFilters", () => {
   });
 });
 
+describe("scopeYearsToKeystageFilter", () => {
+  it("returns all years when no keystage filter is active", () => {
+    const filters = createFilter({
+      years: ["7", "8", "9", "10", "11"],
+      keystages: [],
+    });
+    expect(scopeYearsToKeystageFilter(filters)).toEqual([
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+    ]);
+  });
+
+  it("narrows to KS4 years when keystage filter is ks4 and all years selected", () => {
+    const filters = createFilter({
+      years: ["7", "8", "9", "10", "11"],
+      keystages: ["ks4"],
+    });
+    expect(scopeYearsToKeystageFilter(filters)).toEqual(["10", "11"]);
+  });
+
+  it("returns selected year only when a single year is selected", () => {
+    const filters = createFilter({
+      years: ["10"],
+      keystages: ["ks4"],
+    });
+    expect(scopeYearsToKeystageFilter(filters)).toEqual(["10"]);
+  });
+});
+
 describe("shouldDisplayFilter", () => {
   describe("years", () => {
     it("with data", () => {
@@ -698,6 +731,105 @@ describe("shouldDisplayFilter", () => {
         "threads",
       );
       expect(result).toEqual(false);
+    });
+  });
+
+  // Science secondary: KS3 has subject categories, KS4 has child subjects (exam
+  // subjects). When a keystage filter is active the sidebar should only show
+  // filters relevant to that keystage.
+  describe("keystage scoping", () => {
+    const scienceSecondaryData: CurriculumUnitsFormattedData = {
+      yearData: {
+        // KS3 years: subject categories, no child subjects
+        "7": createYearData({
+          units: [createUnit({ slug: "y7" })],
+          subjectCategories: [createSubjectCategory({ id: 1 })],
+        }),
+        "8": createYearData({
+          units: [createUnit({ slug: "y8" })],
+          subjectCategories: [createSubjectCategory({ id: 1 })],
+        }),
+        "9": createYearData({
+          units: [createUnit({ slug: "y9" })],
+          subjectCategories: [createSubjectCategory({ id: 1 })],
+        }),
+        // KS4 years: child subjects (>1 required for byKeyStageSlug to expose
+        // them), no meaningful categories (stripped by byKeyStageSlug)
+        "10": createYearData({
+          units: [createUnit({ slug: "y10" })],
+          childSubjects: [
+            createChildSubject({ subject_slug: "physics" }),
+            createChildSubject({ subject_slug: "biology" }),
+          ],
+        }),
+        "11": createYearData({
+          units: [createUnit({ slug: "y11" })],
+          childSubjects: [
+            createChildSubject({ subject_slug: "physics" }),
+            createChildSubject({ subject_slug: "biology" }),
+          ],
+        }),
+      },
+      threadOptions: [],
+      yearOptions: ["7", "8", "9", "10", "11"],
+      keystages: [],
+    };
+
+    it("Science KS3 view: shows subject categories, hides child subjects", () => {
+      const filters = createFilter({
+        years: ["7", "8", "9", "10", "11"],
+        keystages: ["ks3"],
+      });
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "subjectCategories"),
+      ).toEqual(true);
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "childSubjects"),
+      ).toEqual(false);
+    });
+
+    it("Science KS4 view: shows child subjects, hides subject categories", () => {
+      const filters = createFilter({
+        years: ["7", "8", "9", "10", "11"],
+        keystages: ["ks4"],
+      });
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "subjectCategories"),
+      ).toEqual(false);
+      expect(
+        shouldDisplayFilter(scienceSecondaryData, filters, "childSubjects"),
+      ).toEqual(true);
+    });
+
+    // English secondary: KS3 units have no categories; KS4 has categories.
+    // Without keystage scoping, the KS4 categories would bleed into a KS3 view.
+    it("English KS3 view: hides subject categories when KS3 has none (no bleed from KS4)", () => {
+      const englishSecondaryData: CurriculumUnitsFormattedData = {
+        yearData: {
+          "7": createYearData({ units: [createUnit({ slug: "y7" })] }),
+          "8": createYearData({ units: [createUnit({ slug: "y8" })] }),
+          "9": createYearData({ units: [createUnit({ slug: "y9" })] }),
+          "10": createYearData({
+            units: [createUnit({ slug: "y10" })],
+            subjectCategories: [createSubjectCategory({ id: 2 })],
+          }),
+          "11": createYearData({
+            units: [createUnit({ slug: "y11" })],
+            subjectCategories: [createSubjectCategory({ id: 2 })],
+          }),
+        },
+        threadOptions: [],
+        yearOptions: ["7", "8", "9", "10", "11"],
+        keystages: [],
+      };
+
+      const filters = createFilter({
+        years: ["7", "8", "9", "10", "11"],
+        keystages: ["ks3"],
+      });
+      expect(
+        shouldDisplayFilter(englishSecondaryData, filters, "subjectCategories"),
+      ).toEqual(false);
     });
   });
 });

--- a/src/utils/curriculum/filtersUrl.ts
+++ b/src/utils/curriculum/filtersUrl.ts
@@ -291,7 +291,11 @@ export function shouldDisplayFilter(
     return childSubjectsAt.length > 0;
   }
   if (key === "tiers") {
-    const tiersAt = presentAtKeyStageSlugs(keyStageSlugData, "tiers");
+    const tiersAt = presentAtKeyStageSlugs(
+      keyStageSlugData,
+      "tiers",
+      effectiveYears,
+    );
     return tiersAt.length > 0;
   }
   if (key === "threads") {

--- a/src/utils/curriculum/filtersUrl.ts
+++ b/src/utils/curriculum/filtersUrl.ts
@@ -9,6 +9,7 @@ import {
 } from "./sorting";
 import {
   CurriculumFilters,
+  KeyStageSlug,
   Subject,
   SubjectCategory,
   Thread,
@@ -17,7 +18,11 @@ import {
   YearData,
 } from "./types";
 import { isVisibleUnit } from "./isVisibleUnit";
-import { byKeyStageSlug, presentAtKeyStageSlugs } from "./keystage";
+import {
+  byKeyStageSlug,
+  keystageYearMappings,
+  presentAtKeyStageSlugs,
+} from "./keystage";
 
 import {
   CurriculumUnitsFormattedData,
@@ -235,22 +240,43 @@ export function highlightedUnitCount(
   return count;
 }
 
+/**
+ * When a keystage filter is active and years is at its default (all years),
+ * returns only the years belonging to the active keystage(s). Mirrors the
+ * applyFiltering logic in by-pathway.ts so filter visibility matches the unit list.
+ */
+export function scopeYearsToKeystageFilter(
+  filters: CurriculumFilters,
+): string[] {
+  const selectingAllYears = filters.years.length > 1;
+  if (!selectingAllYears || filters.keystages.length === 0) {
+    return filters.years;
+  }
+
+  return filters.years.filter((year) =>
+    filters.keystages.some((ks) =>
+      keystageYearMappings[ks as KeyStageSlug]?.includes(year),
+    ),
+  );
+}
+
 export function shouldDisplayFilter(
   data: CurriculumUnitsFormattedData,
   filters: CurriculumFilters,
   key: "years" | "subjectCategories" | "childSubjects" | "tiers" | "threads",
 ) {
+  const effectiveYears = scopeYearsToKeystageFilter(filters);
   const keyStageSlugData = byKeyStageSlug(data.yearData);
   const childSubjectsAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "childSubjects",
-    filters.years,
+    effectiveYears,
   );
 
   const subjectCategoriesAt = presentAtKeyStageSlugs(
     keyStageSlugData,
     "subjectCategories",
-    filters.years,
+    effectiveYears,
   ).filter((ks) => !childSubjectsAt.includes(ks));
 
   if (key === "years") {

--- a/src/utils/curriculum/keystage.ts
+++ b/src/utils/curriculum/keystage.ts
@@ -11,7 +11,7 @@ export type YearDataPartialYearDataArray = {
   subjectCategories: SubjectCategory[];
 };
 
-const keystageYearMappings: Record<KeyStageSlug, string[]> = {
+export const keystageYearMappings: Record<KeyStageSlug, string[]> = {
   ks1: ["1", "2"],
   ks2: ["3", "4", "5", "6"],
   ks3: ["7", "8", "9"],


### PR DESCRIPTION
## Description

Music year: 1994

When a keystage filter is active and years is at its default (all years), filter the years down to those belonging to the active keystage

This effectively hides filters when they're not applicable to content displayed for the KS

## How to test

1. Go to
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/english-secondary-aqa/units?keystages=ks3
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/english-secondary-aqa/units?keystages=ks4
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/science-secondary-aqa/units?keystages=ks4
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/religious-education-secondary-aqa/units?keystages=ks4
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/religious-education-secondary-aqa/units?keystages=ks3
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/religious-education-secondary-core/units?keystages=ks4
  - https://oak-web-application-website-git-feat-lesq-2018scope-year-c37eb5.vercel.thenational.academy/programmes/religious-education-secondary-core/units?keystages=ks3
2. You should see filters appropriate for the active keystage


## Screenshots

### English KS3
**before**
<img width="500"  alt="Screenshot 2026-05-22 at 14 27 59" src="https://github.com/user-attachments/assets/bfcbe142-de3f-4bb2-97e9-653decd18e21" />

**after**
<img width="500" alt="Screenshot 2026-05-22 at 14 28 01" src="https://github.com/user-attachments/assets/23066be4-794c-4379-910f-f8471865121d" />

### Science KS4
**before**
<img width="500" alt="Screenshot 2026-05-22 at 14 37 31" src="https://github.com/user-attachments/assets/6af1cc7b-ca13-420b-a049-872f68ae3baa" />

**after**
<img width="500" alt="Screenshot 2026-05-22 at 14 37 12" src="https://github.com/user-attachments/assets/e7ae7352-e902-4bec-8e2c-4b9073684aaf" />

### Science KS3
**before**
<img width="500" alt="Screenshot 2026-05-22 at 14 37 45" src="https://github.com/user-attachments/assets/63037ac2-4676-4add-b87a-f34e20a6b30c" />

**after**
<img width="500" alt="Screenshot 2026-05-22 at 14 37 53" src="https://github.com/user-attachments/assets/89bd12ed-4c34-47db-8d4f-89d6888c194f" />

### RE KS4
**before**
<img width="500" alt="Screenshot 2026-05-22 at 14 43 51" src="https://github.com/user-attachments/assets/ddf46e6c-7a16-4923-aa3a-30a5481ddd7d" />

**after**
<img width="500" alt="Screenshot 2026-05-22 at 14 43 46" src="https://github.com/user-attachments/assets/969a7a82-598e-4ead-a474-886d3decf716" />

### RE KS3
**before**
<img width="500" alt="Screenshot 2026-05-22 at 14 44 17" src="https://github.com/user-attachments/assets/8e8d2da5-aef5-4238-a1c7-6765ecbf0df7" />

**after**
<img width="500" alt="Screenshot 2026-05-22 at 14 44 10" src="https://github.com/user-attachments/assets/7d711078-e2ea-4360-a8cb-a80092aa3b1d" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
