### PR TITLE
fix(pupil): stop server-side worksheet check during ISR

### DIFF
--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.test.tsx
@@ -10,6 +10,19 @@ import { lessonContentFixture } from "@/node-lib/curriculum-api-2023/fixtures/le
 import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 import { getDefaultLessonProgressState } from "@/context/PupilLessonProgress/pupilLessonProgressHelpers";
 
+const useWorksheetInfoState = jest.fn(
+  (_hasWorksheetAssetObject: boolean | null, _lessonSlug: string) => ({
+    worksheetInfo: null,
+  }),
+);
+jest.mock(
+  "@/components/PupilComponents/pupilUtils/useWorksheetInfoState",
+  () => ({
+    useWorksheetInfoState: (...args: [boolean | null, string]) =>
+      useWorksheetInfoState(...args),
+  }),
+);
+
 const routerPush = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: () => ({ asPath: "/intro", push: routerPush }),
@@ -91,6 +104,21 @@ beforeEach(() => {
 });
 
 describe("intro page", () => {
+  it("renders worksheet metadata from client worksheetInfo when props worksheetInfo is null", () => {
+    useWorksheetInfoState.mockReturnValueOnce({
+      worksheetInfo: [{ ext: "pdf", fileSize: "1MB" }] as never,
+    });
+
+    const { getByText } = renderPage({
+      hasWorksheet: true,
+      worksheetInfo: null,
+    });
+
+    expect(getByText(/Download worksheet/i)).toBeInTheDocument();
+    expect(getByText(/\(PDF 1MB\)/)).toBeInTheDocument();
+    expect(useWorksheetInfoState).toHaveBeenCalled();
+  });
+
   it("completes the section and navigates on proceed", () => {
     const { getByTestId } = renderPage();
     fireEvent.click(getByTestId("proceed-to-next-section"));

--- a/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
+++ b/src/components/PupilViews/PupilExperience/PupilExperience.view.tsx
@@ -729,10 +729,11 @@ export const PupilExperienceView = (props: PupilExperienceViewProps) => {
     setAssignmentToken(searchParams.get("assignmentToken"));
   }, []);
 
-  const { worksheetInfo } = useWorksheetInfoState(
-    lessonContent.hasWorksheetAssetObject,
+  const { worksheetInfo: clientWorksheetInfo } = useWorksheetInfoState(
+    props.hasWorksheet ? lessonContent.hasWorksheetAssetObject : false,
     lessonContent.lessonSlug,
   );
+  const worksheetInfo = props.worksheetInfo ?? clientWorksheetInfo;
 
   return (
     <PupilAnalyticsProvider

--- a/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.tsx
+++ b/src/components/SharedComponents/helpers/downloadAndShareHelpers/getDownloadResourcesExistence.tsx
@@ -9,6 +9,12 @@ import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 const DOWNLOADS_API_URL = getBrowserConfig("downloadApiUrl");
 
 /**
+ * PUPIL-1750: Keep downloads API "check-files" calls client-side only.
+ * Calling these during SSR / ISR (including revalidate) has repeatedly been rolled back
+ * due to high-volume failures/noise and unreliable upstream behaviour under revalidation load.
+ */
+
+/**
  * Expected response schema
  */
 export const lessonDataSchema = z.object({

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useLessonDownloadExistenceCheck.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useLessonDownloadExistenceCheck.tsx
@@ -28,7 +28,7 @@ const useLessonDownloadExistenceCheck = (
   } = props;
 
   useEffect(() => {
-    // check if lesson download resources exist and if not update the state
+    // PUPIL-1750: Keep "check-files" existence checks client-side only (SSR/ISR attempts were rolled back).
     const resourceTypesAsString = resourcesToCheck.join(",");
     const additionalFilesIdsAsString = additionalFilesIdsToCheck?.join(",");
 

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useUnitDownloadExistenceCheck.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useUnitDownloadExistenceCheck.tsx
@@ -12,6 +12,7 @@ const useUnitDownloadExistenceCheck = (unitProgrammeSlug: string) => {
   const [fileSize, setFileSize] = useState<string | undefined>(undefined);
 
   useEffect(() => {
+    // PUPIL-1750: Keep "check-files" existence checks client-side only (SSR/ISR attempts were rolled back).
     (async () => {
       if (hasCheckedFiles) {
         return;

--- a/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.test.ts
+++ b/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.test.ts
@@ -93,12 +93,8 @@ describe("pupilLessonPage.helpers", () => {
   });
 
   describe("buildPupilLessonPageProps", () => {
-    it("fetches worksheet info when hasWorksheetAssetObject is true", async () => {
+    it("does not fetch worksheet info on the server when hasWorksheetAssetObject is true", async () => {
       mockRequestLessonResources.mockResolvedValueOnce([]);
-      const worksheetInfo = [
-        { item: "worksheet-pdf", exists: true, fileSize: "1kb", ext: "pdf" },
-      ];
-      mockGetWorksheetInfo.mockResolvedValueOnce(worksheetInfo);
 
       const browseData = lessonBrowseDataFixture({});
       const lessonContent = lessonContentFixture({
@@ -115,9 +111,9 @@ describe("pupilLessonPage.helpers", () => {
         variant: null,
       });
 
-      expect(mockGetWorksheetInfo).toHaveBeenCalledWith(browseData.lessonSlug);
+      expect(mockGetWorksheetInfo).not.toHaveBeenCalled();
       expect(props.hasWorksheet).toBe(true);
-      expect(props.worksheetInfo).toEqual(worksheetInfo);
+      expect(props.worksheetInfo).toBeNull();
       expect(props.hasAdditionalFiles).toBe(false);
       expect(props.additionalFiles).toBeNull();
     });

--- a/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.ts
+++ b/src/pages-helpers/pupil/lessons-pages/pupilLessonPage.helpers.ts
@@ -7,7 +7,6 @@ import {
   isLessonReviewSection,
   LessonSection,
 } from "@/components/PupilComponents/lessonSections";
-import { getWorksheetInfo } from "@/components/PupilComponents/pupilUtils/getWorksheetInfo";
 import { requestLessonResources } from "@/components/PupilComponents/pupilUtils/requestLessonResources";
 import { pickAvailableSectionsForLesson } from "@/components/PupilComponents/Views/ViewHelpers/Experience/pickAvailableSectionsForLesson";
 import {
@@ -80,15 +79,12 @@ export const buildPupilLessonPageProps = async ({
     suppressErrors: suppressResourceErrors,
   });
   const hasWorksheet = !!lessonContent.hasWorksheetAssetObject;
-  const worksheetInfo = hasWorksheet
-    ? ((await getWorksheetInfo(browseData.lessonSlug)) ?? null)
-    : null;
 
   return {
     lessonContent: hydratedLessonContent,
     browseData,
     hasWorksheet,
-    worksheetInfo,
+    worksheetInfo: null,
     hasAdditionalFiles: !!lessonContent.downloadableFiles?.length,
     additionalFiles: lessonContent.downloadableFiles || null,
     initialSection,

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/intro.tsx
@@ -40,6 +40,7 @@ import { usePupilLessonAnalytics } from "@/context/PupilLessonAnalytics/usePupil
 import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 import { useAdditionalFilesDownload } from "@/components/PupilViews/PupilIntro/useAdditionalFilesDownload";
 import { useWorksheetDownload } from "@/components/PupilViews/PupilIntro/useWorksheetDownload";
+import { useWorksheetInfoState } from "@/components/PupilComponents/pupilUtils/useWorksheetInfoState";
 import { PupilLessonPageProps } from "@/pages-helpers/pupil/lessons-pages/pupilLessonPage.types";
 
 type IntroPageURLParams = {
@@ -368,6 +369,12 @@ const PupilLessonIntroNewPage = (props: PupilLessonPageProps) => {
     variant,
   } = props;
 
+  const { worksheetInfo: clientWorksheetInfo } = useWorksheetInfoState(
+    hasWorksheet && worksheetInfo === null,
+    browseData.lessonSlug,
+  );
+  const resolvedWorksheetInfo = worksheetInfo ?? clientWorksheetInfo;
+
   return (
     <PupilLayout
       seoProps={{
@@ -383,7 +390,7 @@ const PupilLessonIntroNewPage = (props: PupilLessonPageProps) => {
         browseData={browseData}
         lessonContent={lessonContent}
         hasWorksheet={hasWorksheet}
-        worksheetInfo={worksheetInfo}
+        worksheetInfo={resolvedWorksheetInfo}
         hasAdditionalFiles={hasAdditionalFiles}
         additionalFiles={additionalFiles}
       />


### PR DESCRIPTION
[Bugsnag Error](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/6a0d93d28c3285d1a5154eba?event_id=6a16a5b60174a1626ab30000&i=sk&m=ef)
`Error getWorksheetInfo` `Failed to fetch downloads`

We’re seeing many “Failed to fetch downloads” warnings in production. This started after a change that makes pupil lesson pages check for worksheet download info in the background. When the downloads service has a wobble, we log thousands of warnings.

Remove getWorksheetInfo from buildPupilLessonPageProps so ISR and revalidate no longer call the downloads API. Worksheet availability is fetched on the client via useWorksheetInfoState instead.


## Description
- Stop server-side worksheet “check-files” calls during ISR/revalidate by setting worksheetInfo: null in buildPupilLessonPageProps
- Keep worksheet existence checks client-side via useWorksheetInfoState
- Add inline documentation (PUPIL-1750) near shared check-files helper + teacher download existence hooks to prevent reintroducing SSR/ISR usage
- Update unit tests to reflect the server-side behaviour change

Music year: 2019

## Issue(s)
[Fixes PUPIL-1750](https://www.notion.so/oaknationalacademy/Server-Error-Failed-to-fetch-downloads-Pupil-lesson-pages-are-checking-worksheet-downloads-too-of-36d26cc4e1b180668a00ce910c54d27f?source=copy_link)
[BugSnag](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/6a0d93d28c3285d1a5154eba?event_id=6a16a5b60174a1626ab30000&i=sk&m=ef)

## How to test

1. Go to https://oak-web-application-website-git-fix-pupil-1750stop-serve-b4c256.vercel.thenational.academy/pupils/programmes/cooking-nutrition-primary-year-3/units/cooking-around-the-world/lessons/making-veggie-kebabs/intro (or any pupil lesson section URL)
2. Confirm the worksheet/download UI still appears with the Metadata about the size of the download
3. Confirm the page loads and you can navigate between lesson sections as normal

## Screenshots
<img width="1293" height="590" alt="Screenshot 2026-05-27 at 16 53 13" src="https://github.com/user-attachments/assets/078543a6-d11d-471d-a918-a5a43763745b" />



## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
