### PR TITLE
Lesson resource download all button tracking not firing LESQ-2050

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/dom";
+import { act } from "@testing-library/react";
 
 import LessonHeader, { LessonHeaderProps } from "./LessonHeader";
 
@@ -10,14 +11,37 @@ import {
   mockLoggedIn,
 } from "@/__tests__/__helpers__/mockUser";
 
+const lessonResourceDownloadStarted = jest.fn();
+jest.mock("@/context/Analytics/useAnalytics", () => ({
+  __esModule: true,
+  default: () => ({
+    track: {
+      lessonResourceDownloadStarted: (...args: unknown[]) =>
+        lessonResourceDownloadStarted(...args),
+    },
+  }),
+}));
+
 const render = renderWithTheme;
 
 const defaultProps: LessonHeaderProps = {
   heading: "Lesson title",
+  lessonTitle: "Lesson title",
   heroImage: "imageSrc",
   currentLessonSlug: "lesson-2",
   programmeSlug: "programme-1",
   unitSlug: "unit-1",
+  unitTitle: "Unit 1",
+  keyStageSlug: "ks4",
+  keyStageTitle: "KS4",
+  subjectSlug: "english",
+  subjectTitle: "English",
+  year: "10",
+  yearGroupTitle: "Year 10",
+  examBoardTitle: null,
+  tierTitle: null,
+  pathwayTitle: null,
+  lessonReleaseDate: "2024-01-01",
   prevLesson: {
     lessonIndex: 1,
     lessonSlug: "lesson-1",
@@ -33,6 +57,10 @@ const defaultProps: LessonHeaderProps = {
 };
 
 describe("LessonHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders prev and next lesson buttons", () => {
     render(<LessonHeader {...defaultProps} />);
 
@@ -77,6 +105,21 @@ describe("LessonHeader", () => {
         programmeSlug: defaultProps.programmeSlug,
         unitSlug: defaultProps.unitSlug,
         query: { preselected: "all" },
+      }),
+    );
+  });
+  it("fires lesson resource download started when download link is clicked", () => {
+    render(<LessonHeader {...defaultProps} />);
+
+    const downloadLink = screen.getByTestId("download-all-button");
+
+    act(() => {
+      downloadLink.click();
+    });
+
+    expect(lessonResourceDownloadStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downloadResourceButtonName: "all",
       }),
     );
   });

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
@@ -8,9 +8,30 @@ import {
 } from "@/components/TeacherComponents/Header/Header";
 import HeaderNavFooter from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
 import { resolveOakHref } from "@/common-lib/urls";
-import { TeachersLessonOverviewAdjacentLesson } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
+import {
+  TeachersLessonOverviewAdjacentLesson,
+  TeachersLessonOverviewPageData,
+} from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
 import { getBreakpoint } from "@/styles/utils/responsive";
 import LoginRequiredButton from "@/components/TeacherComponents/LoginRequiredButton/LoginRequiredButton";
+import useAnalytics from "@/context/Analytics/useAnalytics";
+import { getAnalyticsBrowseData } from "@/components/TeacherComponents/helpers/getAnalyticsBrowseData";
+
+type LessonHeaderBrowseProps = Pick<
+  TeachersLessonOverviewPageData,
+  | "lessonTitle"
+  | "unitTitle"
+  | "keyStageSlug"
+  | "keyStageTitle"
+  | "subjectSlug"
+  | "subjectTitle"
+  | "year"
+  | "yearGroupTitle"
+  | "examBoardTitle"
+  | "tierTitle"
+  | "pathwayTitle"
+  | "lessonReleaseDate"
+>;
 
 export type LessonHeaderProps = Omit<LargeHeaderProps, "layoutVariant"> & {
   currentLessonSlug: string;
@@ -20,7 +41,7 @@ export type LessonHeaderProps = Omit<LargeHeaderProps, "layoutVariant"> & {
   unitSlug: string;
   loginRequired: boolean;
   georestricted: boolean;
-};
+} & LessonHeaderBrowseProps;
 
 const LessonHeader = (props: LessonHeaderProps) => {
   const {
@@ -29,9 +50,39 @@ const LessonHeader = (props: LessonHeaderProps) => {
     unitSlug,
     programmeSlug,
     currentLessonSlug,
+    lessonTitle,
+    unitTitle,
+    keyStageSlug,
+    keyStageTitle,
+    subjectSlug,
+    subjectTitle,
+    year,
+    yearGroupTitle,
+    examBoardTitle,
+    tierTitle,
+    pathwayTitle,
+    lessonReleaseDate,
     loginRequired,
     georestricted,
   } = props;
+  const { track } = useAnalytics();
+  const browsePathwayData = getAnalyticsBrowseData({
+    keyStageSlug,
+    keyStageTitle,
+    subjectSlug,
+    subjectTitle,
+    unitSlug,
+    unitTitle,
+    year,
+    yearTitle: yearGroupTitle,
+    examBoardTitle,
+    tierTitle,
+    pathwayTitle,
+    lessonSlug: currentLessonSlug,
+    lessonName: lessonTitle,
+    lessonReleaseDate,
+    isLegacy: false,
+  });
 
   return (
     <>
@@ -82,6 +133,18 @@ const LessonHeader = (props: LessonHeaderProps) => {
                   Download <DesktopButtonText>all resources</DesktopButtonText>
                 </OakSpan>
               ),
+              onClick: () => {
+                track.lessonResourceDownloadStarted({
+                  platform: "owa",
+                  product: "teacher lesson resources",
+                  engagementIntent: "use",
+                  componentType: "lesson_download_button",
+                  eventVersion: "2.0.0",
+                  analyticsUseCase: "Teacher",
+                  downloadResourceButtonName: "all",
+                  ...browsePathwayData,
+                });
+              },
               isActionGeorestricted: true,
               shouldHidewhenGeoRestricted: true,
               href: resolveOakHref({

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
@@ -82,11 +82,23 @@ const InnerLessonPage = async (props: AppPageProps<LessonPageParams>) => {
       <LessonHeader
         heroImage={getSubjectHeroImageUrl(data.subjectSlug as SubjectName)}
         heading={data.lessonTitle}
+        lessonTitle={data.lessonTitle}
         currentLessonSlug={data.lessonSlug}
         nextLesson={data.nextLesson}
         prevLesson={data.previousLesson}
         programmeSlug={data.programmeSlug}
         unitSlug={data.unitSlug}
+        unitTitle={data.unitTitle}
+        keyStageSlug={data.keyStageSlug}
+        keyStageTitle={data.keyStageTitle}
+        subjectSlug={data.subjectSlug}
+        subjectTitle={data.subjectTitle}
+        year={data.year}
+        yearGroupTitle={data.yearGroupTitle}
+        examBoardTitle={data.examBoardTitle}
+        tierTitle={data.tierTitle}
+        pathwayTitle={data.pathwayTitle}
+        lessonReleaseDate={data.lessonReleaseDate}
         headerSlot={
           <Breadcrumbs
             data={data}


### PR DESCRIPTION
## Description

Music year: 1950

- Fixes the tracking on the download all button under the IJ.
- Wires tracking props through and fires the tracking handler in the onClick

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2050lesson-reso-6a35e2.vercel.thenational.academy/teachers/programmes/citizenship-secondary-ks3/units/citizenship-whats-it-all-about/lessons/what-is-citizenship
2. Be sure to consent to analytics if needed
3. Click on "Download all resources" in the header
4. You should see a tracking event "Lesson Resource Download Started" sent to Posthog


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
