### PR TITLE
Feat/pupil 1747/share page app router

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,10 +6,11 @@ import {
 } from "@oaknational/oak-components";
 
 import { resolveOakHref } from "@/common-lib/urls";
-import { LessonDownloadsPageData } from "@/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.schema";
-import { LessonMediaClipsData } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
-import { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
-import { TeachersUnitOverviewData } from "@/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.schema";
+import type { LessonDownloadsPageData } from "@/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.schema";
+import type { LessonMediaClipsData } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
+import type { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+import type { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
+import type { TeachersUnitOverviewData } from "@/node-lib/curriculum-api-2023/queries/teachersUnitOverview/teachersUnitOverview.schema";
 
 type BreadcrumbsProps =
   | {
@@ -25,6 +26,11 @@ type BreadcrumbsProps =
   | {
       mode: "downloads";
       data: LessonDownloadsPageData;
+      subjectPhaseSlug: string;
+    }
+  | {
+      mode: "share";
+      data: LessonShareData;
       subjectPhaseSlug: string;
     }
   | {
@@ -68,7 +74,7 @@ export const Breadcrumbs = ({
   };
 
   let breadcrumbs: OakBreadcrumbsProps["breadcrumbs"];
-  if (mode === "downloads") {
+  if (mode === "downloads" || mode === "share") {
     breadcrumbs = [
       firstBreadcrumb,
       {
@@ -89,7 +95,7 @@ export const Breadcrumbs = ({
         }),
       },
       {
-        text: "Downloads",
+        text: mode === "downloads" ? "Downloads" : "Share",
       },
     ];
   } else if (mode === "media") {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.test.tsx
@@ -22,7 +22,7 @@ describe("LessonShareBar", () => {
     expect(pupilShareLink).toHaveAttribute(
       "href",
       resolveOakHref({
-        page: "lesson-share",
+        page: "integrated-lesson-share",
         lessonSlug: defaultProps.lessonSlug,
         unitSlug: defaultProps.unitSlug,
         programmeSlug: defaultProps.programmeSlug,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.tsx
@@ -40,7 +40,7 @@ export default function LessonActionsBar({
     return null;
   }
   const shareHref = resolveOakHref({
-    page: "lesson-share",
+    page: "integrated-lesson-share",
     lessonSlug,
     unitSlug,
     programmeSlug,

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ */
+import LessonSharePage, { generateMetadata } from "./page";
+
+import lessonShareFixtures from "@/node-lib/curriculum-api-2023/fixtures/lessonShare.fixture";
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  notFound: () => {
+    throw new Error("NEXT_HTTP_ERROR_FALLBACK;404");
+  },
+}));
+
+// Jest is not setup to test RSCs, so it does not load the server build
+// so we mock the cache function.
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  return {
+    ...actualReact,
+    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  };
+});
+
+const mockLessonShare = jest.fn();
+jest.mock("@/node-lib/curriculum-api-2023", () => ({
+  __esModule: true,
+  default: {
+    lessonShare: (...args: unknown[]) => mockLessonShare(...args),
+  },
+}));
+
+const mockErrorReporter = jest.fn();
+jest.mock("@/common-lib/error-reporter", () => ({
+  __esModule: true,
+  initialiseBugsnag: jest.fn(),
+  initialiseSentry: jest.fn(),
+  default:
+    () =>
+    (...args: []) =>
+      mockErrorReporter(...args),
+}));
+
+const lessonShareFixture = lessonShareFixtures({
+  programmeSlug: "maths-primary",
+  unitSlug: "geometry-abc123",
+  unitTitle: "Geometry",
+  lessonSlug: "intro-to-geometry-abc123",
+  lessonTitle: "Introduction to Geometry",
+  subjectSlug: "maths",
+  subjectTitle: "Maths",
+  subjectParent: null,
+  phaseSlug: "primary",
+  phaseTitle: "Primary",
+  pathwaySlug: null,
+  keyStageSlug: "ks2",
+  keyStageTitle: "Key Stage 2",
+  examBoardSlug: null,
+  examBoardTitle: null,
+  tierTitle: null,
+  yearGroupTitle: "Year 4",
+  pathwayTitle: null,
+  expired: false,
+  isLegacy: false,
+  lessonReleaseDate: null,
+  loginRequired: false,
+  georestricted: false,
+});
+
+const defaultParams = {
+  subjectPhaseSlug: "maths-primary",
+  unitSlug: "geometry-abc123",
+  lessonSlug: "intro-to-geometry-abc123",
+};
+
+describe("LessonSharePage", () => {
+  beforeEach(() => {
+    mockLessonShare.mockResolvedValue(lessonShareFixture);
+  });
+
+  it("renders share view data", async () => {
+    const result = await LessonSharePage({
+      params: Promise.resolve(defaultParams),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(result).toBeDefined();
+    expect(mockLessonShare).toHaveBeenCalledWith({
+      programmeSlug: defaultParams.subjectPhaseSlug,
+      unitSlug: defaultParams.unitSlug,
+      lessonSlug: defaultParams.lessonSlug,
+    });
+    expect(result).toMatchObject({
+      props: {
+        lesson: lessonShareFixture,
+        breadcrumbsSlot: expect.anything(),
+      },
+    });
+  });
+
+  it("returns 404 for restricted lessons", async () => {
+    mockLessonShare.mockResolvedValue({
+      ...lessonShareFixture,
+      georestricted: true,
+    });
+
+    await expect(
+      LessonSharePage({
+        params: Promise.resolve(defaultParams),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toEqual(new Error("NEXT_HTTP_ERROR_FALLBACK;404"));
+  });
+});
+
+describe("generateMetadata", () => {
+  it("returns empty object when fetch fails", async () => {
+    mockLessonShare.mockRejectedValue(new Error("Not found"));
+
+    const result = await generateMetadata({
+      params: Promise.resolve(defaultParams),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("returns metadata with noindex and nofollow when fetch succeeds", async () => {
+    mockLessonShare.mockResolvedValue(lessonShareFixture);
+
+    const result = await generateMetadata({
+      params: Promise.resolve(defaultParams),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(result).toMatchObject({
+      title: "Lesson Share: Introduction to Geometry | KS2 Maths",
+      description:
+        "Share online lesson activities with your students, such as videos, worksheets and quizzes.",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    });
+  });
+});

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.test.tsx
@@ -12,6 +12,11 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
+const featureFlagMock = jest.fn().mockResolvedValue(true);
+jest.mock("@/utils/featureFlags", () => ({
+  getFeatureFlagValue: () => featureFlagMock(),
+}));
+
 // Jest is not setup to test RSCs, so it does not load the server build
 // so we mock the cache function.
 jest.mock("react", () => {
@@ -76,7 +81,19 @@ const defaultParams = {
 
 describe("LessonSharePage", () => {
   beforeEach(() => {
+    featureFlagMock.mockResolvedValue(true);
     mockLessonShare.mockResolvedValue(lessonShareFixture);
+  });
+
+  it("renders 404 if feature flag is disabled", async () => {
+    featureFlagMock.mockResolvedValue(false);
+
+    await expect(
+      LessonSharePage({
+        params: Promise.resolve(defaultParams),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toEqual(new Error("NEXT_HTTP_ERROR_FALLBACK;404"));
   });
 
   it("renders share view data", async () => {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/share/page.tsx
@@ -1,0 +1,123 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+
+import { Breadcrumbs } from "../../Components/Breadcrumbs/Breadcrumbs";
+
+import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
+import { LessonShare } from "@/components/TeacherViews/LessonShare/LessonShare.view";
+import withPageErrorHandling, {
+  AppPageProps,
+} from "@/hocs/withPageErrorHandling";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import type { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { getFeatureFlagValue } from "@/utils/featureFlags";
+
+type LessonSharePageParams = {
+  subjectPhaseSlug: string;
+  unitSlug: string;
+  lessonSlug: string;
+};
+
+const getCachedLessonShareData = cache(
+  async (
+    programmeSlug: string,
+    unitSlug: string,
+    lessonSlug: string,
+  ): Promise<LessonShareData> => {
+    return curriculumApi2023.lessonShare({
+      programmeSlug,
+      unitSlug,
+      lessonSlug,
+    });
+  },
+);
+
+export async function generateMetadata(
+  props: AppPageProps<LessonSharePageParams>,
+): Promise<Metadata> {
+  const { subjectPhaseSlug, unitSlug, lessonSlug } = await props.params;
+
+  try {
+    const data = await getCachedLessonShareData(
+      subjectPhaseSlug,
+      unitSlug,
+      lessonSlug,
+    );
+    const title = `Lesson Share: ${data.lessonTitle} | ${data.keyStageSlug.toUpperCase()} ${data.subjectTitle}`;
+    const description =
+      "Share online lesson activities with your students, such as videos, worksheets and quizzes.";
+
+    return {
+      title,
+      description,
+      robots: {
+        index: false,
+        follow: false,
+      },
+      openGraph: getOpenGraphMetadata({ title, description }),
+      twitter: getTwitterMetadata({ title, description }),
+    };
+  } catch {
+    return {};
+  }
+}
+
+const InnerLessonSharePage = async (
+  props: AppPageProps<LessonSharePageParams>,
+) => {
+  const isEnabled = await getFeatureFlagValue(
+    "teachers-integrated-journey",
+    "boolean",
+  );
+
+  if (!isEnabled) {
+    return notFound();
+  }
+
+  const {
+    subjectPhaseSlug: programmeSlug,
+    unitSlug,
+    lessonSlug,
+  } = await props.params;
+
+  const data = await getCachedLessonShareData(
+    programmeSlug,
+    unitSlug,
+    lessonSlug,
+  );
+
+  if (data.georestricted || data.loginRequired) {
+    return notFound();
+  }
+
+  const breadcrumbsSubjectPhaseSlug = getTeacherSubjectPhaseSlug({
+    subjectSlug: data.subjectSlug,
+    phaseSlug: data.phaseSlug,
+    subjectParentTitle: data.subjectParent,
+    examboardSlug: data.examBoardSlug,
+    pathwaySlug: data.pathwaySlug,
+  });
+
+  return (
+    <LessonShare
+      lesson={data}
+      breadcrumbsSlot={
+        <Breadcrumbs
+          key="lesson-share-breadcrumbs"
+          data={data}
+          subjectPhaseSlug={breadcrumbsSubjectPhaseSlug}
+          mode="share"
+        />
+      }
+    />
+  );
+};
+
+const LessonSharePage = withPageErrorHandling(
+  InnerLessonSharePage,
+  "lesson-share-page::app",
+);
+
+export default LessonSharePage;

--- a/src/common-lib/urls/urls.test.ts
+++ b/src/common-lib/urls/urls.test.ts
@@ -175,6 +175,18 @@ describe("urls.ts", () => {
         "/programmes/maths-secondary-year-10-aqa/units/algebra-123/lessons/solving-equations-456/downloads/success",
       );
     });
+    it("Integrated lesson share", () => {
+      expect(
+        resolveOakHref({
+          page: "integrated-lesson-share",
+          programmeSlug: "maths-secondary-year-10-aqa",
+          unitSlug: "algebra-123",
+          lessonSlug: "solving-equations-456",
+        }),
+      ).toBe(
+        "/programmes/maths-secondary-year-10-aqa/units/algebra-123/lessons/solving-equations-456/share",
+      );
+    });
     it("Integrated lesson media", () => {
       expect(
         resolveOakHref({

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -147,6 +147,15 @@ export type IntegratedLessonDownloadsSuccessLinkProps = {
   unitSlug: string;
   lessonSlug: string;
 };
+export type IntegratedLessonShareLinkProps = {
+  page: "integrated-lesson-share";
+  programmeSlug: string;
+  unitSlug: string;
+  lessonSlug: string;
+  query?: {
+    preselected: PreselectedShareType | null;
+  };
+};
 export type IntegratedLessonMediaLinkProps = {
   page: "integrated-lesson-media";
   programmeSlug: string;
@@ -481,6 +490,7 @@ export type OakLinkProps =
   | IntegratedLessonOverviewLinkProps
   | IntegratedLessonDownloadsLinkProps
   | IntegratedLessonDownloadsSuccessLinkProps
+  | IntegratedLessonShareLinkProps
   | IntegratedLessonMediaLinkProps
   | SpecialistLessonListingLinkProps
   | UnitListingLinkProps
@@ -897,6 +907,13 @@ export const OAK_PAGES: {
     analyticsPageName: "Lesson Download",
     configType: "internal",
     pageType: "integrated-lesson-downloads-success",
+  }),
+  "integrated-lesson-share": createOakPageConfig({
+    pathPattern:
+      "/programmes/:programmeSlug/units/:unitSlug/lessons/:lessonSlug/share",
+    analyticsPageName: "Lesson Share",
+    configType: "internal",
+    pageType: "integrated-lesson-share",
   }),
   "integrated-lesson-media": createOakPageConfig({
     pathPattern:

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+"use client";
+
+import { type ReactNode, useState } from "react";
 import {
   OakBox,
   OakHandDrawnHR,
@@ -33,8 +35,8 @@ import {
   getSchoolOption,
 } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getFormattedDetailsForTracking";
 import { useHubspotSubmit } from "@/components/TeacherComponents/hooks/downloadAndShareHooks/useHubspotSubmit";
-import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
-import { SpecialistLessonShareData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema";
+import type { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+import type { SpecialistLessonShareData } from "@/node-lib/curriculum-api-2023/queries/specialistLessonShare/specialistLessonShare.schema";
 import { useOnboardingStatus } from "@/components/TeacherComponents/hooks/useOnboardingStatus";
 import { AssignToClassroomModal } from "@/components/TeacherComponents/AssignToClassroomModal/AssignToClassroomModal";
 import {
@@ -42,7 +44,9 @@ import {
   LessonSection,
 } from "@/components/PupilComponents/lessonSections";
 
-export type LessonShareProps =
+export type LessonShareProps = {
+  breadcrumbsSlot?: ReactNode;
+} & (
   | {
       lesson: LessonPathway & {
         isSpecialist: false;
@@ -57,7 +61,8 @@ export type LessonShareProps =
     }
   | {
       lesson: SpecialistLessonShareData;
-    };
+    }
+);
 
 const classroomActivityMap: Partial<
   Record<ResourceType, ResourceTypesValueType>
@@ -196,36 +201,40 @@ export function LessonShare(props: LessonShareProps) {
     <OakBox $ph={["spacing-16", null]} $background={"bg-neutral"}>
       <OakMaxWidth $maxWidth={["spacing-480", "spacing-960", "spacing-1280"]}>
         <OakBox $mb={"spacing-32"} $mt={"spacing-24"}>
-          <Breadcrumbs
-            breadcrumbs={
-              !isSpecialist
-                ? [
-                    ...getBreadcrumbsForLessonPathway(lesson),
-                    getLessonOverviewBreadCrumb({
-                      lessonTitle,
-                      lessonSlug,
-                      programmeSlug,
-                      unitSlug,
-                      isCanonical: false,
-                    }),
-                    getLessonShareBreadCrumb({
-                      lessonSlug,
-                      programmeSlug,
-                      unitSlug,
-                      disabled: true,
-                    }),
-                  ]
-                : [
-                    ...getBreadcrumbsForSpecialistLessonPathway(lesson),
-                    ...getBreadCrumbForSpecialistShare({
-                      lessonSlug,
-                      programmeSlug,
-                      unitSlug,
-                      disabled: true,
-                    }),
-                  ]
-            }
-          />
+          {props.breadcrumbsSlot ? (
+            props.breadcrumbsSlot
+          ) : (
+            <Breadcrumbs
+              breadcrumbs={
+                !isSpecialist
+                  ? [
+                      ...getBreadcrumbsForLessonPathway(lesson),
+                      getLessonOverviewBreadCrumb({
+                        lessonTitle,
+                        lessonSlug,
+                        programmeSlug,
+                        unitSlug,
+                        isCanonical: false,
+                      }),
+                      getLessonShareBreadCrumb({
+                        lessonSlug,
+                        programmeSlug,
+                        unitSlug,
+                        disabled: true,
+                      }),
+                    ]
+                  : [
+                      ...getBreadcrumbsForSpecialistLessonPathway(lesson),
+                      ...getBreadCrumbForSpecialistShare({
+                        lessonSlug,
+                        programmeSlug,
+                        unitSlug,
+                        disabled: true,
+                      }),
+                    ]
+              }
+            />
+          )}
           <OakHandDrawnHR
             hrColor={"text-subdued"}
             $height={"spacing-4"}

--- a/src/node-lib/curriculum-api-2023/fixtures/lessonShare.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/lessonShare.fixture.ts
@@ -14,12 +14,17 @@ const lessonShareFixtures = (
     keyStageTitle: "Key stage 4",
     subjectSlug: "maths",
     subjectTitle: "Maths",
+    subjectParent: null,
+    phaseSlug: "secondary",
+    phaseTitle: "Secondary",
     unitSlug: "geometry",
     unitTitle: "Geometry",
     tierSlug: null,
     tierTitle: null,
     examBoardSlug: null,
     examBoardTitle: null,
+    pathwaySlug: null,
+    yearGroupTitle: "Year 10",
     shareableResources: [
       {
         type: "exit-quiz",

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.query.ts
@@ -68,6 +68,14 @@ const lessonShareQuery =
 
     const lesson = lessonShareSchema.parse({
       ...constructPathwayLesson(parsedModifiedBrowseData),
+      subjectParent:
+        parsedModifiedBrowseData.programme_fields.subject_parent ?? null,
+      phaseSlug: parsedModifiedBrowseData.programme_fields.phase_slug,
+      phaseTitle: parsedModifiedBrowseData.programme_fields.phase_description,
+      pathwaySlug:
+        parsedModifiedBrowseData.programme_fields.pathway_slug ?? null,
+      yearGroupTitle:
+        parsedModifiedBrowseData.programme_fields.year_description,
       isSpecialist: false,
       lessonSlug: lessonSlug,
       lessonTitle: parsedRawLesson.lesson_title,

--- a/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema.ts
@@ -40,10 +40,16 @@ export const baseLessonBrowseSchema = z.object({
   unitTitle: z.string(),
   subjectSlug: z.string(),
   subjectTitle: z.string(),
+  subjectParent: z.string().nullable(),
+  phaseSlug: z.string(),
+  phaseTitle: z.string().nullish(),
   examBoardSlug: z.string().nullish(),
   examBoardTitle: z.string().nullish(),
   tierSlug: z.string().nullish(),
   tierTitle: z.string().nullish(),
+  pathwaySlug: z.string().nullable(),
+  pathwayTitle: z.string().nullish(),
+  yearGroupTitle: z.string().nullish(),
 });
 
 export const lessonShareSchema = baseLessonShareSchema.extend({


### PR DESCRIPTION
## Description

Music year: {owa_music_year}

- List of changes
Added a share page to app router for use after migration to integrated journey.

It is currently behind a feature flag, so the page should 404 with the feature turned off.

the current share page should be working as before

## Issue(s)

Fixes #

## How to test

First of all the the current share page experience needs to have no regressions before the integrated journey is released.

in order to test the new share page 
1. Go to [preview](https://oak-web-application-website-git-feat-pupil-1747share-pag-3e476b.vercel.thenational.academy/programmes/biology-secondary-ks4-higher-aqa/units/eukaryotic-and-prokaryotic-cells/lessons/cells/share?preselected=all)
2. if it 404s youwill need to add your distinct id to posthog
3. go to [posthog](https://eu.posthog.com/project/124/feature_flags/118700)
<img width="1002" height="553" alt="Screenshot 2026-05-29 at 10 33 14" src="https://github.com/user-attachments/assets/3c61c0cc-5d5c-44de-8d25-3f5fafef11f7" />
5. On 1. Go to preview page above
6. open dev tools and look for distinct posthog id 
8. 
<img width="1233" height="679" alt="Screenshot 2026-05-29 at 10 36 56" src="https://github.com/user-attachments/assets/7428b7bc-06d2-4969-8002-ef7d5b09b493" />
9. Add the distinct id to the list of enabled ids, this should enable the page link

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
