### PR TITLE
feat: add API catalog and Link header for agent discovery

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -122,6 +122,18 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
   const nextConfig: NextConfig = {
     headers: async () => [
       {
+        // Advertise the RFC 9727 API catalog from the homepage so discovery
+        // agents can find it without guessing (RFC 8288 Link header,
+        // RFC 9727 section 3).
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: '</.well-known/api-catalog>; rel="api-catalog"',
+          },
+        ],
+      },
+      {
         source: "/api/pupil/:path*",
         headers: [
           {
@@ -431,23 +443,33 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
       return [...pupilsRedirects, ...aboutUsRedirects, ...eyfsRedirects];
     },
     async rewrites() {
+      // Serve the RFC 9727 API catalog from /.well-known/ — the App Router does
+      // not route folders that start with a dot, so the handler lives under /api.
+      const wellKnownRewrites = [
+        {
+          source: "/.well-known/api-catalog",
+          destination: "/api/well-known/api-catalog",
+        },
+      ];
       // Reverse proxy posthog in development to avoid localhost CORS issues in Chrome https://posthog.com/docs/advanced/proxy/nextjs
-      return releaseStage === "development"
-        ? [
-            {
-              source: "/ingest/static/:path*",
-              destination: "https://eu-assets.i.posthog.com/static/:path*",
-            },
-            {
-              source: "/ingest/:path*",
-              destination: "https://eu.i.posthog.com/:path*",
-            },
-            {
-              source: "/ingest/decide",
-              destination: "https://eu.i.posthog.com/decide",
-            },
-          ]
-        : [];
+      const developmentRewrites =
+        releaseStage === "development"
+          ? [
+              {
+                source: "/ingest/static/:path*",
+                destination: "https://eu-assets.i.posthog.com/static/:path*",
+              },
+              {
+                source: "/ingest/:path*",
+                destination: "https://eu.i.posthog.com/:path*",
+              },
+              {
+                source: "/ingest/decide",
+                destination: "https://eu.i.posthog.com/decide",
+              },
+            ]
+          : [];
+      return [...wellKnownRewrites, ...developmentRewrites];
     },
     // Required for the posthog reverse proxy, but interferes with static URL redirections so we don't want this applied on production
     skipTrailingSlashRedirect: releaseStage === "development",

--- a/src/app/api/well-known/api-catalog/route.test.ts
+++ b/src/app/api/well-known/api-catalog/route.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/well-known/api-catalog/route";
+
+describe("/.well-known/api-catalog", () => {
+  it("responds 200 with the RFC 9727 linkset+json content type", async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+    );
+  });
+
+  it("returns a linkset array whose entries carry an anchor and link relations", async () => {
+    const response = GET();
+    const body = await response.json();
+
+    expect(Array.isArray(body.linkset)).toBe(true);
+    expect(body.linkset.length).toBeGreaterThan(0);
+
+    for (const entry of body.linkset) {
+      expect(typeof entry.anchor).toBe("string");
+      expect(entry.anchor).toMatch(/^https:\/\//);
+
+      // Each documented relation is an array of { href, ... } link objects.
+      for (const relation of ["service-desc", "service-doc", "status"]) {
+        expect(Array.isArray(entry[relation])).toBe(true);
+        for (const link of entry[relation]) {
+          expect(link.href).toMatch(/^https:\/\//);
+        }
+      }
+    }
+  });
+
+  it("advertises the Oak Curriculum Open API with its docs and health endpoints", async () => {
+    const response = GET();
+    const body = await response.json();
+
+    const openApi = body.linkset.find(
+      (entry: { anchor: string }) =>
+        entry.anchor === "https://open-api.thenational.academy",
+    );
+
+    expect(openApi).toBeDefined();
+    expect(openApi["service-desc"][0].href).toBe(
+      "https://open-api.thenational.academy/api/v0/swagger.json",
+    );
+    expect(openApi["service-doc"][0].href).toBe(
+      "https://open-api.thenational.academy/docs",
+    );
+    expect(openApi.status[0].href).toBe(
+      "https://open-api.thenational.academy/api/health",
+    );
+  });
+});

--- a/src/app/api/well-known/api-catalog/route.ts
+++ b/src/app/api/well-known/api-catalog/route.ts
@@ -1,0 +1,83 @@
+/**
+ * API catalog for automated API discovery.
+ *
+ * Served at `/.well-known/api-catalog` via a rewrite in `next.config.ts`
+ * (App Router does not route folders that start with a dot).
+ *
+ * - RFC 9727: Well-Known URI for API discovery
+ *   https://www.rfc-editor.org/rfc/rfc9727
+ * - RFC 9264: `application/linkset+json` document format
+ *   https://www.rfc-editor.org/rfc/rfc9264
+ */
+
+/**
+ * The `profile` parameter advertises that the linkset is an RFC 9727 API
+ * catalog, per the media type registration in that RFC.
+ */
+const LINKSET_CONTENT_TYPE =
+  'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"';
+
+/**
+ * One linkset member per advertised API. `anchor` is the API's base URL; the
+ * link relations point a consumer at the machine-readable description
+ * (`service-desc`), human-readable documentation (`service-doc`) and health
+ * endpoint (`status`).
+ */
+const apiCatalog = {
+  linkset: [
+    {
+      anchor: "https://open-api.thenational.academy",
+      "service-desc": [
+        {
+          href: "https://open-api.thenational.academy/api/v0/swagger.json",
+          type: "application/json",
+          title: "Oak National Academy Curriculum Open API OpenAPI document",
+        },
+      ],
+      "service-doc": [
+        {
+          href: "https://open-api.thenational.academy/docs",
+          type: "text/html",
+          title: "Oak National Academy Curriculum Open API documentation",
+        },
+        {
+          href: "https://open-api.thenational.academy/playground",
+          type: "text/html",
+          title: "Oak National Academy Curriculum Open API playground",
+        },
+      ],
+      status: [
+        {
+          href: "https://open-api.thenational.academy/api/health",
+          type: "application/json",
+          title: "Oak National Academy Curriculum Open API health check",
+        },
+      ],
+    },
+    // Oak Curriculum MCP server. Held back from the public catalog while it is
+    // alpha and invitation-only (OAuth 2.1, internal/invited access only) —
+    // listing it here would point discovery agents at an endpoint that rejects
+    // them. Uncomment to advertise it once it reaches general availability.
+    // {
+    //   anchor: "https://curriculum-mcp-alpha.oaknational.dev/mcp",
+    //   "service-doc": [
+    //     {
+    //       href: "https://curriculum-mcp-alpha.oaknational.dev/",
+    //       type: "text/html",
+    //       title: "Oak National Academy Curriculum MCP server",
+    //     },
+    //   ],
+    // },
+  ],
+} as const;
+
+export function GET() {
+  return new Response(JSON.stringify(apiCatalog, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": LINKSET_CONTENT_TYPE,
+      // The catalog changes rarely; allow shared caches to hold it for an hour.
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}


### PR DESCRIPTION
## Description

Adds two complementary, standards-based **API discovery** mechanisms so AI agents and automated clients can find Oak's public API without hardcoded knowledge.

This was inspired by the agent-readiness checks at https://isitagentready.com/ and the blog https://psd401.ai/blog/build-products-our-agents-can-use

**1. API Catalog (RFC 9727)** — a new endpoint at `/.well-known/api-catalog` returning `application/linkset+json` (RFC 9264). It describes the **Oak Curriculum Open API** via standard link relations:
- `service-desc` → the OpenAPI 3.1 document (`/api/v0/swagger.json`)
- `service-doc` → reference docs (`/docs`) and interactive playground (`/playground`)
- `status` → health endpoint (`/api/health`)

Served through a `next.config` rewrite (`/.well-known/api-catalog` → `/api/well-known/api-catalog`) because the App Router can't route folders beginning with a dot.

**2. Link header (RFC 8288)** — the homepage now returns `Link: </.well-known/api-catalog>; rel="api-catalog"`, so agents discover the catalog from the root document without guessing the well-known path.

### Why this matters

Agentic clients increasingly discover capabilities through well-known URIs and `Link` headers rather than human docs. A machine-readable catalog + link header lets an agent programmatically find Oak's API, spec, docs, and health endpoint. This has **no UI or user-facing impact**.

### What this PR deliberately does **not** do

Other [agent-readiness checks](https://isitagentready.com/www.thenational.academy) were assessed and intentionally skipped, because forcing them to pass here would mean publishing inaccurate metadata or prematurely exposing a private service:

- **MCP Server Card (SEP-1649)** — not added. The OWA is not an MCP server; the card belongs on the MCP server's own domain. Oak's Curriculum MCP (`curriculum-mcp-alpha.oaknational.dev`) is **alpha and invitation-only**, so it's included in the catalog only as a **commented-out entry**, ready to enable when it's public/beta.
- **OAuth/OIDC discovery** — not added. The Open API authenticates with a **static API key**, so there is no authorization server to describe; fabricating `/.well-known/openid-configuration` would mislead agents. (The alpha MCP server already publishes its own OAuth metadata on its domain.)
- **DNS-AID records** — not added. This is DNS infrastructure, and the only agent endpoint to advertise is the held-back alpha MCP. Note: both zones are already DNSSEC-signed, so this is straightforward when the MCP is public.

### What could come next

- **When the Curriculum MCP is public beta:** uncomment the MCP entry in the catalog; publish its **MCP Server Card** and **DNS-AID** SVCB/HTTPS records on its own domain.

## How to test

1. **API catalog:** `curl -i "[OWA Preview URL]/.well-known/api-catalog"` → expect `200`, `Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`, and a `linkset` array with `anchor`, `service-desc`, `service-doc`, `status`.
2. **Link header:** `curl -I "[OWA Preview URL]/"` → expect `Link: </.well-known/api-catalog>; rel="api-catalog"`.
3. **Automated check (if possible):** `POST https://isitagentready.com/api/scan` with `{"url":"[OWA Preview URL]"}` → `checks.discovery.apiCatalog.status` and `checks.discoverability.linkHeaders.status` should be `"pass"`.
4. **Unit tests:** `pnpm test src/app/api/well-known/api-catalog/route.test.ts` (3 tests).

## Screenshots

n/a — no UI changes (API endpoint + response header only).

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices — n/a (no UI)
- [x] Considered impact on accessibility — n/a (no UI)
- [x] Design sign-off — n/a
- [x] Approved by product owner
- [x] Does this PR update a package with a breaking change — **No**
