### PR TITLE
feat: make unshared sessions visible but disabled

### DIFF
--- a/src/components/PupilComponents/Views/ViewHelpers/Overview/buildOverviewSectionItems.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Overview/buildOverviewSectionItems.test.ts
@@ -1,6 +1,6 @@
 import { buildOverviewSectionItems } from "./buildOverviewSectionItems";
 
-import { LessonReviewSection } from "@/components/PupilComponents/LessonEngineProvider";
+import type { LessonReviewSection } from "@/components/PupilComponents/lessonSections";
 
 describe("buildOverviewSectionItems", () => {
   it("builds section items with progress, hrefs and quiz metadata", () => {
@@ -79,7 +79,17 @@ describe("buildOverviewSectionItems", () => {
 
     expect(items).toEqual([
       expect.objectContaining({
+        section: "intro",
+        href: "#",
+        disabled: true,
+      }),
+      expect.objectContaining({
         section: "starter-quiz",
+        href: "#",
+        disabled: true,
+      }),
+      expect.objectContaining({
+        section: "video",
         href: "#",
         disabled: true,
       }),
@@ -103,5 +113,56 @@ describe("buildOverviewSectionItems", () => {
     });
 
     expect(() => items[0]?.onClick()).not.toThrow();
+  });
+
+  it("always includes every lesson nav section and disables sections outside the variant", () => {
+    const onSectionClick = jest.fn();
+    const getSectionHref = jest.fn(
+      (section: LessonReviewSection) => `/lesson/${section}`,
+    );
+
+    const items = buildOverviewSectionItems({
+      lessonReviewSections: ["intro", "video"],
+      sectionResults: {},
+      isReadOnly: false,
+      isHydratingInitialProgress: false,
+      starterQuizNumQuestions: 3,
+      exitQuizNumQuestions: 4,
+      onSectionClick,
+      getSectionHref,
+    });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        section: "intro",
+        href: "/lesson/intro",
+      }),
+      expect.objectContaining({
+        section: "starter-quiz",
+        href: "#",
+        disabled: true,
+      }),
+      expect.objectContaining({
+        section: "video",
+        href: "/lesson/video",
+      }),
+      expect.objectContaining({
+        section: "exit-quiz",
+        href: "#",
+        disabled: true,
+      }),
+    ]);
+
+    expect(items[0]).not.toHaveProperty("disabled");
+    expect(items[2]).not.toHaveProperty("disabled");
+
+    items[1]?.onClick();
+    items[2]?.onClick();
+
+    expect(onSectionClick).toHaveBeenCalledTimes(1);
+    expect(onSectionClick).toHaveBeenCalledWith("video");
+    expect(getSectionHref).toHaveBeenCalledTimes(2);
+    expect(getSectionHref).toHaveBeenCalledWith("intro");
+    expect(getSectionHref).toHaveBeenCalledWith("video");
   });
 });

--- a/src/components/PupilComponents/Views/ViewHelpers/Overview/buildOverviewSectionItems.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Overview/buildOverviewSectionItems.ts
@@ -2,10 +2,11 @@ import { pickSectionProgress } from "../Shared";
 
 import type { LessonOverviewSectionName } from "@/components/PupilComponents/Views/PupilLessonOverview";
 import type { SectionNavItem } from "@/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewSectionsNav/PupilLessonOverviewSectionsNav";
-import type {
-  LessonReviewSection,
-  LessonSectionResults,
-} from "@/components/PupilComponents/LessonEngineProvider";
+import type { LessonSectionResults } from "@/components/PupilComponents/LessonEngineProvider";
+import {
+  allLessonReviewSections,
+  type LessonReviewSection,
+} from "@/components/PupilComponents/lessonSections";
 
 type BuildOverviewSectionItemsParams = {
   lessonReviewSections: Readonly<LessonReviewSection[]>;
@@ -28,49 +29,54 @@ export const buildOverviewSectionItems = ({
   onSectionClick = () => {},
   getSectionHref,
 }: BuildOverviewSectionItemsParams): SectionNavItem[] => {
-  const sectionItems: SectionNavItem[] = [];
-
-  lessonReviewSections.forEach((section) => {
+  return allLessonReviewSections.map((section) => {
     const overviewSection = section as LessonOverviewSectionName;
-    const onClick = () => onSectionClick(section);
-    const href = getSectionHref(section) ?? "#";
+    const isSectionAvailable = lessonReviewSections.includes(section);
+    const onClick = isSectionAvailable
+      ? () => onSectionClick(section)
+      : () => {};
+    const href = isSectionAvailable ? (getSectionHref(section) ?? "#") : "#";
+    const disabled = !isSectionAvailable;
 
     if (section === "starter-quiz") {
-      sectionItems.push({
+      return {
         section: overviewSection,
         href,
         progress: pickSectionProgress({ section, sectionResults }),
         numQuestions: starterQuizNumQuestions,
         grade: sectionResults[section]?.grade ?? 0,
-        disabled: sectionResults[section]?.isComplete || isReadOnly,
+        disabled:
+          disabled ||
+          Boolean(sectionResults[section]?.isComplete) ||
+          isReadOnly,
         isLoading: isHydratingInitialProgress,
         onClick,
-      });
-      return;
+      };
     }
 
     if (section === "exit-quiz") {
-      sectionItems.push({
+      return {
         section: overviewSection,
         href,
         progress: pickSectionProgress({ section, sectionResults }),
         numQuestions: exitQuizNumQuestions,
         grade: sectionResults[section]?.grade ?? 0,
-        disabled: sectionResults[section]?.isComplete || isReadOnly,
+        disabled:
+          disabled ||
+          Boolean(sectionResults[section]?.isComplete) ||
+          isReadOnly,
         isLoading: isHydratingInitialProgress,
         onClick,
-      });
-      return;
+      };
     }
 
-    sectionItems.push({
+    return {
       section: overviewSection,
       href,
       progress: pickSectionProgress({ section, sectionResults }),
+      ...(disabled ? { disabled } : {}),
       isLoading: isHydratingInitialProgress,
       onClick,
-    });
+    };
   });
-
-  return sectionItems;
 };

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { GetStaticProps, GetStaticPropsContext, PreviewData } from "next";
 import { useRouter } from "next/router";
 import { useShallow } from "zustand/react/shallow";
+import { OakInlineBanner } from "@oaknational/oak-components";
 
 import getPageProps from "@/node-lib/getPageProps";
 import { getStaticPaths as getStaticPathsTemplate } from "@/pages-helpers/get-static-paths";
@@ -217,18 +218,24 @@ const OverviewPageContent = ({
           ) : undefined
         }
         bannerSlot={
-          <TakedownBanner
-            isExpiring={getIsLessonExpiring({
-              expirationDate,
-              displayExpiringBanner: actions?.displayExpiringBanner,
-            })}
-            isLegacy={isSlugLegacy(programmeSlug)}
-            hasNewUnits={getDoesSubjectHaveNewUnits(subjectSlug)}
-            subjectSlug={subjectSlug}
-            userType="pupil"
-            onwardHref={unitListingHref}
-            isSingle
-          />
+          <>
+            <TakedownBanner
+              isExpiring={getIsLessonExpiring({
+                expirationDate,
+                displayExpiringBanner: actions?.displayExpiringBanner,
+              })}
+              isLegacy={isSlugLegacy(programmeSlug)}
+              hasNewUnits={getDoesSubjectHaveNewUnits(subjectSlug)}
+              subjectSlug={subjectSlug}
+              userType="pupil"
+              onwardHref={unitListingHref}
+              isSingle
+            />
+            <OakInlineBanner
+              message="You can only click on the activities your teacher has shared with you today."
+              isOpen={true}
+            />
+          </>
         }
         header={{
           lessonTitle: lessonTitle ?? "",


### PR DESCRIPTION
## Description

Music year: N/A

- Always show lesson overview nav items for intro, starter quiz, video, and exit quiz.
- Disable nav items for sections that are not included in the current shared lesson variant.
- Preserve existing quiz disabled behaviour for completed/read-only quiz sections.

## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/pupils/lessons/{lessonSlug}/shared/{variant}/overview
2. Use a shared lesson variant where one or more sections are excluded.
3. You should see nav items for intro, starter quiz, video, and exit quiz.
4. Sections included in the variant should be clickable.
5. Sections excluded from the variant should appear disabled and should not navigate.

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

### Acceptance criteria

- [x]  When opening a shared variant page all section cards are visible
- [x]  When opening a variant page where only specific sections were shared, sections not shared should show as disabled and are not clickable
- [x]  When continuing through a lesson, sections that are not shared should be skipped
- [x]  On the lesson review page only sections completed should be visible. Lesson components not shared should not be visible
- [x]  Banner displayed explaining why there are disabled parts
- [x]  Students should be taken to the lesson review page after completing the enabled sections


