### PR TITLE
Cache Curriculum+Sanity data plus enable ISR for the IJ LESQ 2060

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -32,9 +32,19 @@ global.SubmitEvent =
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useId: () => "react-use-id-test-result",
+  // Jest does not load the RSC server build; passthrough cache for getCached* helpers.
+  cache: (fn) => fn,
 }));
 
 jest.mock("next/dist/client/router", () => require("next-router-mock"));
+
+jest.mock("next/cache", () => {
+  const actual = jest.requireActual("next/cache");
+  return {
+    ...actual,
+    unstable_cache: (fn) => fn,
+  };
+});
 
 jest.mock("@bugsnag/js", () => ({
   __esModule: true,

--- a/src/app/(core)/layout.tsx
+++ b/src/app/(core)/layout.tsx
@@ -4,10 +4,13 @@ import LayoutSiteFooter from "@/components/AppComponents/LayoutSiteFooter";
 import TopNav from "@/components/AppComponents/TopNav/TopNav";
 import OakError from "@/errors/OakError";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { cacheData } from "@/node-lib/cache";
 
 // TD: [integrated journey] get revalidate from env somehow
 // revalidate in layout controls revalidation of child pages in route
 export const revalidate = 7200;
+
+const getTopNav = cacheData(() => curriculumApi2023.topNav(), ["top-nav"]);
 
 export default async function CoreLayout({
   children,
@@ -15,7 +18,7 @@ export default async function CoreLayout({
   children: React.ReactNode;
 }>) {
   try {
-    const topNavProps = await curriculumApi2023.topNav();
+    const topNavProps = await getTopNav();
 
     return (
       <>

--- a/src/app/(core)/teachers/eyfs/[subjectSlug]/getCachedEyfsPageData.ts
+++ b/src/app/(core)/teachers/eyfs/[subjectSlug]/getCachedEyfsPageData.ts
@@ -1,10 +1,10 @@
-import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { cacheData } from "@/node-lib/cache";
 
 export const getCachedEyfsPageData = cache(
-  unstable_cache(
+  cacheData(
     async (subjectSlug: string) => {
       return curriculumApi2023.eyfsPage({ subjectSlug });
     },

--- a/src/app/(core)/teachers/eyfs/[subjectSlug]/getCachedEyfsPageData.ts
+++ b/src/app/(core)/teachers/eyfs/[subjectSlug]/getCachedEyfsPageData.ts
@@ -1,0 +1,13 @@
+import { unstable_cache } from "next/cache";
+import { cache } from "react";
+
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+
+export const getCachedEyfsPageData = cache(
+  unstable_cache(
+    async (subjectSlug: string) => {
+      return curriculumApi2023.eyfsPage({ subjectSlug });
+    },
+    ["eyfs-page"],
+  ),
+);

--- a/src/app/(core)/teachers/eyfs/[subjectSlug]/layout.tsx
+++ b/src/app/(core)/teachers/eyfs/[subjectSlug]/layout.tsx
@@ -2,9 +2,9 @@ import { notFound } from "next/navigation";
 
 import { EYFSHeader } from "./components/EyfsHeader/EyfsHeader";
 import { EYFSNavigation } from "./components/EyfsNavigation";
+import { getCachedEyfsPageData } from "./getCachedEyfsPageData";
 
 import OakError from "@/errors/OakError";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import { OakFlex } from "@/styles/oakThemeApp";
 
 export default async function EYFSLayout({
@@ -17,7 +17,7 @@ export default async function EYFSLayout({
   const { subjectSlug } = await params;
 
   try {
-    const eyfsPageData = await curriculumApi2023.eyfsPage({ subjectSlug });
+    const eyfsPageData = await getCachedEyfsPageData(subjectSlug);
 
     return (
       <OakFlex

--- a/src/app/(core)/teachers/eyfs/[subjectSlug]/page.tsx
+++ b/src/app/(core)/teachers/eyfs/[subjectSlug]/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from "next";
 
 import { EyfsUnitSection } from "./components/EyfsUnits/EyfsUnits";
+import { getCachedEyfsPageData } from "./getCachedEyfsPageData";
 
 import withPageErrorHandling from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 export const metadata: Metadata = {
   title: "Early years foundation stage lesson resources",
@@ -24,7 +24,7 @@ const InnerEyfsPage = async ({
 }>) => {
   const { subjectSlug } = await params;
 
-  const eyfsPageData = await curriculumApi2023.eyfsPage({ subjectSlug });
+  const eyfsPageData = await getCachedEyfsPageData(subjectSlug);
   const units = Object.values(eyfsPageData.units);
 
   return <EyfsUnitSection units={units} />;

--- a/src/app/(core)/teachers/eyfs/[subjectSlug]/page.tsx
+++ b/src/app/(core)/teachers/eyfs/[subjectSlug]/page.tsx
@@ -17,6 +17,8 @@ export const metadata: Metadata = {
   },
 };
 
+export const dynamic = "force-static";
+
 const InnerEyfsPage = async ({
   params,
 }: Readonly<{

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
@@ -35,17 +35,6 @@ jest.mock("next/navigation", () => {
   };
 });
 
-// Jest is not setup to test RSCs, so it does not load the server build
-// so we mock the cache function.
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 jest.mock("@/node-lib/cms", () => ({
   __esModule: true,
   default: {

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
@@ -4,8 +4,8 @@ import { cache } from "react";
 
 import { ProgrammeView } from "./Components/ProgrammeView";
 import { isTabSlug } from "./tabSchema";
-import { getProgrammeData } from "./getProgrammeData";
 import { getMetaTitle } from "./getMetaTitle";
+import { getProgrammeData } from "./getProgrammeData";
 
 import {
   createDownloadsData,
@@ -15,7 +15,6 @@ import {
 import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
 import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 import OakError from "@/errors/OakError";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 import {
   isValidSubjectPhaseSlug,
   getKs4RedirectSlug,
@@ -24,23 +23,68 @@ import errorReporter from "@/common-lib/error-reporter";
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import CMSClient from "@/node-lib/cms";
-import { getMvRefreshTime } from "@/pages-helpers/curriculum/downloads/getMvRefreshTime";
 import { resolveOakHref } from "@/common-lib/urls";
 import { getSubjectPhaseSlug } from "@/components/TeacherComponents/helpers/getSubjectPhaseSlug";
 import { resolveFilterFromSearchParams } from "@/utils/curriculum/filtersUrl";
 import { redirectProgrammeSlugIfNeeded } from "@/utils/integratedJourney/legacyProgrammeUnitsRedirect";
+import { cacheData } from "@/node-lib/cache";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import CMSClient from "@/node-lib/cms";
+import { getMvRefreshTime } from "@/pages-helpers/curriculum/downloads/getMvRefreshTime";
 
 const reportError = errorReporter("programme-page::app");
 
-// Single cached function to fetch all common programme data
-// This deduplicates requests between generateMetadata and page component
-const getCachedProgrammeData = cache(async (subjectPhaseSlug: string) => {
-  return getProgrammeData(curriculumApi2023, subjectPhaseSlug);
-});
-
 type ProgrammePageParams = { slug: string; tab: string };
 export type PageSearchParms = { [key: string]: string | string[] | undefined };
+
+const getCachedProgrammeData = cache(
+  cacheData(
+    async (subjectPhaseSlug: string) => {
+      return getProgrammeData(curriculumApi2023, subjectPhaseSlug);
+    },
+    ["programme-data"],
+  ),
+);
+
+export type ProgrammeCmsParams = {
+  subjectPhaseSlug: string;
+  nonCurriculum: boolean;
+  subjectTitle: string;
+  phaseSlug: string;
+  programmePageSlug: string;
+};
+
+const getCachedProgrammeCms = cache(
+  cacheData(
+    async ({
+      nonCurriculum,
+      subjectTitle,
+      phaseSlug,
+      programmePageSlug,
+    }: ProgrammeCmsParams) => {
+      const [curriculumCMSInfo, subjectPhaseSanityData, mvRefreshTime] =
+        await Promise.all([
+          nonCurriculum
+            ? null
+            : CMSClient.curriculumOverviewPage({
+                previewMode: false,
+                subjectTitle,
+                phaseSlug,
+              }),
+          CMSClient.programmePageBySlug(programmePageSlug),
+          getMvRefreshTime(),
+        ]);
+
+      return {
+        curriculumCMSInfo,
+        subjectPhaseSanityData,
+        mvRefreshTime,
+      };
+    },
+    ["programme-cms"],
+  ),
+);
+
 export async function generateMetadata({
   params,
   searchParams,
@@ -153,20 +197,14 @@ const InnerProgrammePage = async (props: AppPageProps<ProgrammePageParams>) => {
     }
   }
 
-  const [curriculumCMSInfo, subjectPhaseSanityData, mvRefreshTime] =
-    await Promise.all([
-      programmeUnitsData.nonCurriculum
-        ? null
-        : CMSClient.curriculumOverviewPage({
-            previewMode: false, // TD: [integrated-journey] preview mode
-            subjectTitle: programmeUnitsData.subjectTitle,
-            phaseSlug: subjectPhaseKeystageSlugs.phaseSlug,
-          }),
-      CMSClient.programmePageBySlug(
-        `${subjectPhaseKeystageSlugs.subjectSlug}-${subjectPhaseKeystageSlugs.phaseSlug}`,
-      ),
-      getMvRefreshTime(),
-    ]);
+  const { curriculumCMSInfo, subjectPhaseSanityData, mvRefreshTime } =
+    await getCachedProgrammeCms({
+      subjectPhaseSlug,
+      nonCurriculum: programmeUnitsData.nonCurriculum,
+      subjectTitle: programmeUnitsData.subjectTitle,
+      phaseSlug: subjectPhaseKeystageSlugs.phaseSlug,
+      programmePageSlug: `${subjectPhaseKeystageSlugs.subjectSlug}-${subjectPhaseKeystageSlugs.phaseSlug}`,
+    });
 
   if (!curriculumCMSInfo && !programmeUnitsData.nonCurriculum) {
     return notFound();

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.test.tsx
@@ -12,17 +12,6 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
-// Jest is not setup to test RSCs, so it does not load the server build
-// so we mock the cache function.
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 const mockLessonDownloads = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.tsx
@@ -8,10 +8,10 @@ import { LessonDownloads } from "@/components/TeacherViews/LessonDownloads.view"
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { LessonDownloadsPageData } from "@/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.schema";
 import { resolveOakHref } from "@/common-lib/urls";
 import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { cacheData } from "@/node-lib/cache";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 type LessonDownloadsPageParams = {
   slug: string;
@@ -20,17 +20,16 @@ type LessonDownloadsPageParams = {
 };
 
 const getCachedLessonDownloadsData = cache(
-  async (
-    programmeSlug: string,
-    unitSlug: string,
-    lessonSlug: string,
-  ): Promise<LessonDownloadsPageData> => {
-    return curriculumApi2023.lessonDownloads({
-      programmeSlug,
-      unitSlug,
-      lessonSlug,
-    });
-  },
+  cacheData(
+    async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {
+      return curriculumApi2023.lessonDownloads({
+        programmeSlug,
+        unitSlug,
+        lessonSlug,
+      });
+    },
+    ["lesson-downloads"],
+  ),
 );
 
 export async function generateMetadata(

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/page.tsx
@@ -19,6 +19,8 @@ type LessonDownloadsPageParams = {
   lessonSlug: string;
 };
 
+export const dynamic = "force-static";
+
 const getCachedLessonDownloadsData = cache(
   cacheData(
     async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.test.tsx
@@ -10,17 +10,6 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
-// Jest is not setup to test RSCs, so it does not load the server build
-// so we mock the cache function.
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 const mockTeachersUnitOverview = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
@@ -1,13 +1,13 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { cache } from "react";
+
+import { getCachedUnitData } from "../../../getCachedUnitData";
 
 import { DownloadSuccessView } from "./Components/DownloadSuccessView";
 
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 type LessonDownloadsSuccessPageParams = {
   slug: string;
@@ -15,35 +15,34 @@ type LessonDownloadsSuccessPageParams = {
   lessonSlug: string;
 };
 
-const getCachedSuccessData = cache(
-  async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {
-    const unitData = await curriculumApi2023.teachersUnitOverview({
-      programmeSlug,
-      unitSlug,
-    });
+const getSuccessData = async (
+  programmeSlug: string,
+  unitSlug: string,
+  lessonSlug: string,
+) => {
+  const unitData = await getCachedUnitData(programmeSlug, unitSlug);
 
-    const lesson = unitData.lessons.find((l) => l.lessonSlug === lessonSlug);
-    if (!lesson?.lessonReleaseDate) {
-      return null;
-    }
+  const lesson = unitData.lessons.find((l) => l.lessonSlug === lessonSlug);
+  if (!lesson?.lessonReleaseDate) {
+    return null;
+  }
 
-    return {
-      lessonTitle: lesson.lessonTitle,
-      lessonSlug: lesson.lessonSlug,
-      programmeSlug: unitData.programmeSlug,
-      unitSlug: unitData.unitSlug,
-      unitTitle: unitData.unitTitle,
-      unitDescription: unitData.unitDescription,
-      lessons: unitData.lessons,
-      unitvariantId: unitData.unitvariantId,
-      keyStageSlug: unitData.keyStageSlug,
-      keyStageTitle: unitData.keyStageTitle,
-      subjectSlug: unitData.subjectSlug,
-      subjectTitle: unitData.subjectTitle,
-      lessonReleaseDate: lesson.lessonReleaseDate,
-    };
-  },
-);
+  return {
+    lessonTitle: lesson.lessonTitle,
+    lessonSlug: lesson.lessonSlug,
+    programmeSlug: unitData.programmeSlug,
+    unitSlug: unitData.unitSlug,
+    unitTitle: unitData.unitTitle,
+    unitDescription: unitData.unitDescription,
+    lessons: unitData.lessons,
+    unitvariantId: unitData.unitvariantId,
+    keyStageSlug: unitData.keyStageSlug,
+    keyStageTitle: unitData.keyStageTitle,
+    subjectSlug: unitData.subjectSlug,
+    subjectTitle: unitData.subjectTitle,
+    lessonReleaseDate: lesson.lessonReleaseDate,
+  };
+};
 
 export async function generateMetadata(
   props: AppPageProps<LessonDownloadsSuccessPageParams>,
@@ -51,11 +50,7 @@ export async function generateMetadata(
   const { slug: programmeSlug, unitSlug, lessonSlug } = await props.params;
 
   try {
-    const data = await getCachedSuccessData(
-      programmeSlug,
-      unitSlug,
-      lessonSlug,
-    );
+    const data = await getSuccessData(programmeSlug, unitSlug, lessonSlug);
     if (!data) {
       return {};
     }
@@ -77,7 +72,7 @@ const InnerLessonDownloadsSuccessPage = async (
   props: AppPageProps<LessonDownloadsSuccessPageParams>,
 ) => {
   const { slug: programmeSlug, unitSlug, lessonSlug } = await props.params;
-  const data = await getCachedSuccessData(programmeSlug, unitSlug, lessonSlug);
+  const data = await getSuccessData(programmeSlug, unitSlug, lessonSlug);
   if (!data) {
     return notFound();
   }

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
@@ -15,6 +15,8 @@ type LessonDownloadsSuccessPageParams = {
   lessonSlug: string;
 };
 
+export const dynamic = "force-static";
+
 const getSuccessData = async (
   programmeSlug: string,
   unitSlug: string,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.test.tsx
@@ -13,15 +13,6 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 const mockLessonMediaClips = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.tsx
@@ -21,6 +21,8 @@ type LessonMediaPageParams = {
   lessonSlug: string;
 };
 
+export const dynamic = "force-static";
+
 const getCachedLessonMediaClipsData = cache(
   cacheData(
     async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/media/page.tsx
@@ -9,10 +9,11 @@ import { LessonMedia } from "@/components/TeacherViews/LessonMedia/LessonMedia.v
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { LessonMediaClipsData } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
 import { populateMediaClipsWithTranscripts } from "@/utils/handleTranscript";
 import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { LessonMediaClipsData } from "@/node-lib/curriculum-api-2023/queries/lessonMediaClips/lessonMediaClips.schema";
+import { cacheData } from "@/node-lib/cache";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 type LessonMediaPageParams = {
   slug: string;
@@ -21,13 +22,16 @@ type LessonMediaPageParams = {
 };
 
 const getCachedLessonMediaClipsData = cache(
-  async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {
-    return curriculumApi2023.lessonMediaClips<LessonMediaClipsData>({
-      programmeSlug,
-      unitSlug,
-      lessonSlug,
-    });
-  },
+  cacheData(
+    async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {
+      return curriculumApi2023.lessonMediaClips<LessonMediaClipsData>({
+        programmeSlug,
+        unitSlug,
+        lessonSlug,
+      });
+    },
+    ["lesson-media-clips"],
+  ),
 );
 
 export async function generateMetadata(

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.test.tsx
@@ -12,17 +12,6 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
-// Jest is not setup to test RSCs, so it does not load the server build
-// so we mock the cache function.
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 const mockLessonOverview = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
@@ -24,6 +24,8 @@ type LessonPageParams = {
   lessonSlug: string;
 };
 
+export const dynamic = "force-static";
+
 const getCachedLessonData = cache(
   cacheData(
     async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/page.tsx
@@ -14,9 +14,9 @@ import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
-import { TeachersLessonOverviewPageData } from "@/node-lib/curriculum-api-2023/queries/teachersLessonOverview/teachersLessonOverview.schema";
 import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { cacheData } from "@/node-lib/cache";
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 type LessonPageParams = {
   slug: string;
@@ -25,17 +25,16 @@ type LessonPageParams = {
 };
 
 const getCachedLessonData = cache(
-  async (
-    programmeSlug: string,
-    unitSlug: string,
-    lessonSlug: string,
-  ): Promise<TeachersLessonOverviewPageData> => {
-    return curriculumApi2023.teachersLessonOverview({
-      programmeSlug,
-      unitSlug,
-      lessonSlug,
-    });
-  },
+  cacheData(
+    async (programmeSlug: string, unitSlug: string, lessonSlug: string) => {
+      return curriculumApi2023.teachersLessonOverview({
+        programmeSlug,
+        unitSlug,
+        lessonSlug,
+      });
+    },
+    ["teachers-lesson-overview"],
+  ),
 );
 
 export async function generateMetadata(

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/getCachedUnitData.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/getCachedUnitData.ts
@@ -1,0 +1,16 @@
+import { unstable_cache } from "next/cache";
+import { cache } from "react";
+
+import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+
+export const getCachedUnitData = cache(
+  unstable_cache(
+    async (programmeSlug: string, unitSlug: string) => {
+      return curriculumApi2023.teachersUnitOverview({
+        programmeSlug,
+        unitSlug,
+      });
+    },
+    ["teachers-unit-overview"],
+  ),
+);

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/getCachedUnitData.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/getCachedUnitData.ts
@@ -1,10 +1,10 @@
-import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import { cacheData } from "@/node-lib/cache";
 
 export const getCachedUnitData = cache(
-  unstable_cache(
+  cacheData(
     async (programmeSlug: string, unitSlug: string) => {
       return curriculumApi2023.teachersUnitOverview({
         programmeSlug,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.test.tsx
@@ -12,17 +12,6 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
-// Jest is not setup to test RSCs, so it does not load the server build
-// so we mock the cache function.
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  return {
-    ...actualReact,
-    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
-  };
-});
-
 const mockTeachersUnitOverview = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.tsx
@@ -1,24 +1,14 @@
 import { Metadata } from "next";
-import { cache } from "react";
 
 import { UnitView } from "./Components/UnitView";
+import { getCachedUnitData } from "./getCachedUnitData";
 
 import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
-import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
 
 type LessonsPageParams = { slug: string; unitSlug: string };
-
-const getCachedUnitData = cache(
-  async (subjectPhaseSlug: string, unitSlug: string) => {
-    return curriculumApi2023.teachersUnitOverview({
-      programmeSlug: subjectPhaseSlug,
-      unitSlug,
-    });
-  },
-);
 
 export async function generateMetadata(
   props: AppPageProps<LessonsPageParams>,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/page.tsx
@@ -10,6 +10,8 @@ import withPageErrorHandling, {
 
 type LessonsPageParams = { slug: string; unitSlug: string };
 
+export const dynamic = "force-static";
+
 export async function generateMetadata(
   props: AppPageProps<LessonsPageParams>,
 ): Promise<Metadata> {

--- a/src/hocs/withPageErrorHandling.tsx
+++ b/src/hocs/withPageErrorHandling.tsx
@@ -56,10 +56,9 @@ function withPageErrorHandling<T extends PageParams>(
         /**
          * Report error to error reporting service
          */
-        const { params, searchParams } = props;
+        const { params } = props;
         await errorReporter(page)(error, {
           ...(await params),
-          ...(await searchParams),
         });
       }
 

--- a/src/node-lib/cache/index.test.ts
+++ b/src/node-lib/cache/index.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { unstable_cache } from "next/cache";
+
+import { cacheData } from ".";
+
+jest.mock("next/cache", () => ({
+  unstable_cache: jest.fn(),
+}));
+
+const mockUnstableCache = jest.mocked(unstable_cache);
+
+describe("cacheData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("applies default revalidate of 7200 when options are omitted", () => {
+    const fn = async () => "result";
+    cacheData(fn, ["test-key"]);
+
+    expect(mockUnstableCache).toHaveBeenCalledWith(fn, ["test-key"], {
+      revalidate: 7200,
+    });
+  });
+
+  it("allows overriding revalidate", () => {
+    const fn = async () => "result";
+    cacheData(fn, ["test-key"], { revalidate: 60, tags: ["cms"] });
+
+    expect(mockUnstableCache).toHaveBeenCalledWith(fn, ["test-key"], {
+      revalidate: 60,
+      tags: ["cms"],
+    });
+  });
+});

--- a/src/node-lib/cache/index.ts
+++ b/src/node-lib/cache/index.ts
@@ -1,0 +1,21 @@
+import { unstable_cache } from "next/cache";
+
+export const DEFAULT_PAGE_DATA_REVALIDATE_SECONDS = 7200;
+
+type CacheDataOptions = NonNullable<Parameters<typeof unstable_cache>[2]>;
+
+/**
+ * `unstable_cache` with a default `revalidate`
+ *
+ * Note: Once we upgrade to Next 16, we can switch to a `use cache` directive
+ */
+export function cacheData<Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>,
+  keyParts: string[],
+  options?: CacheDataOptions,
+): (...args: Args) => Promise<Result> {
+  return unstable_cache(fn, keyParts, {
+    ...options,
+    revalidate: options?.revalidate ?? DEFAULT_PAGE_DATA_REVALIDATE_SECONDS,
+  });
+}


### PR DESCRIPTION
## Description

Music year: 1961

Ensures that IJ pages are fully cached where possible and/or API requests are fully cached 

- Programme pages cannot be ISRd as they use `searchParams`, instead we cache every API call with Vercel so that we don't hit Sanity or the Curriculum API on every request
- Cache is for 2 hours to match the ISR cache value
- Other pages with dynamic segments that weren't previously caching for ISR have `export const dynamic = "force-static";` set which will force them to be cached

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2060cache-curri-6172e2.vercel.thenational.academy/teachers/programmes/citizenship-secondary-gcse/units
2. Soft reload
3. The page should load very fast
4. Click on a unit
5. Open dev tools
6. Soft reload
7. You should see a `HIT` for the `x-vercel-cache` header which indicates the page was cached
8. Same for lesson and EYFS pages

## Screenshots

What you're looking for in the Vercel logs if you want to delve in. https://vercel.com/oak-national-academy/oak-web-application-website/logs?search=environment%3Apreview+host%3Aoak-web-application-website-git-fix-lesq-2060cache-curri-6172e2.vercel.thenational.academy

** Fully cached page log **

<img width="1705" height="1671" alt="Screenshot 2026-06-01 at 17 34 18" src="https://github.com/user-attachments/assets/18dce825-6485-4a68-a45f-080ea76d0e86" />

** Cached API calls **

<img width="2240" height="1671" alt="Screenshot 2026-06-01 at 17 35 59" src="https://github.com/user-attachments/assets/897965a8-1066-4596-9a2c-86f73be4f6dd" />



## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
