### PR TITLE
feat: add track to integrated share button

### DIFF
--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 
 import LessonActionsBar from "./LessonActionsBar";
 
@@ -10,9 +10,14 @@ const defaultProps = {
   lessonSlug: "lesson-1",
   unitSlug: "unit-1",
   programmeSlug: "programme-1",
+  onClickShare: jest.fn(),
 };
 
-describe("LessonShareBar", () => {
+describe("LessonActionsBar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders pupil share link when showPupilShare is true", () => {
     renderWithTheme(<LessonActionsBar {...defaultProps} />);
     const pupilShareLink = screen.getByRole("link", {
@@ -33,6 +38,19 @@ describe("LessonShareBar", () => {
       "rel",
       expect.stringContaining("nofollow"),
     );
+  });
+
+  it("calls onClickShare when pupil share link is clicked", () => {
+    const onClickShare = jest.fn();
+    renderWithTheme(
+      <LessonActionsBar {...defaultProps} onClickShare={onClickShare} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("link", { name: "Share lesson with pupils" }),
+    );
+
+    expect(onClickShare).toHaveBeenCalledTimes(1);
   });
 
   it("does not render pupil share link when showPupilShare is false", () => {

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonActionsBar/LessonActionsBar.tsx
@@ -19,6 +19,7 @@ type LessonShareBarProps = {
   lessonSlug: string;
   unitSlug: string;
   programmeSlug: string;
+  onClickShare: () => void;
   createWithAiProps?: LessonOverviewCreateWithAiProps;
 };
 
@@ -35,6 +36,7 @@ export default function LessonActionsBar({
   lessonSlug,
   unitSlug,
   programmeSlug,
+  onClickShare,
 }: Readonly<LessonShareBarProps>) {
   if (!showPupilShare && !createWithAiProps) {
     return null;
@@ -62,6 +64,7 @@ export default function LessonActionsBar({
           iconName="share"
           isTrailingIcon
           rel="nofollow"
+          onClick={onClickShare}
         >
           Share lesson with pupils
         </OakSmallTertiaryInvertedButton>

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
@@ -11,6 +11,7 @@ import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
 
 const lessonResourceDownloadStarted = jest.fn();
 const lessonMediaClipsStarted = jest.fn();
+const lessonShareStarted = jest.fn();
 const mockCreateTeachingMaterialsInitiated = jest.fn();
 const mockTeachingMaterialsSelected = jest.fn();
 
@@ -22,6 +23,7 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
         lessonMediaClipsStarted(...args),
       lessonResourceDownloadStarted: (...args: unknown[]) =>
         lessonResourceDownloadStarted(...args),
+      lessonShareStarted: (...args: unknown[]) => lessonShareStarted(...args),
       createTeachingMaterialsInitiated: (...args: unknown[]) =>
         mockCreateTeachingMaterialsInitiated(...args),
       teachingMaterialsSelected: (...args: unknown[]) =>
@@ -417,6 +419,30 @@ describe("Tracking callbacks", () => {
         eventVersion: "2.0.0",
         analyticsUseCase: "Teacher",
         mediaClipsButtonName: "play all",
+      }),
+    );
+  });
+
+  it("calls lessonShareStarted when share lesson with pupils is clicked", () => {
+    render(<LessonView {...baseProps} />);
+
+    const shareButton = screen.getByRole("link", {
+      name: "Share lesson with pupils",
+    });
+    act(() => {
+      shareButton.click();
+    });
+
+    expect(lessonShareStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keyStageSlug: baseProps.keyStageSlug,
+        keyStageTitle: baseProps.keyStageTitle,
+        subjectSlug: baseProps.subjectSlug,
+        subjectTitle: baseProps.subjectTitle,
+        unitSlug: baseProps.unitSlug,
+        unitName: baseProps.unitTitle,
+        lessonSlug: baseProps.lessonSlug,
+        lessonName: baseProps.lessonTitle,
       }),
     );
   });

--- a/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/programmes/[subjectPhaseSlug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -142,6 +142,10 @@ export default function LessonView(
     });
   };
 
+  const trackShare = () => {
+    track.lessonShareStarted(browsePathwayData);
+  };
+
   const lessonResources = getLessonResources({
     browsePathwayData,
     data: props,
@@ -264,6 +268,7 @@ export default function LessonView(
                 lessonSlug={lessonSlug}
                 unitSlug={unitSlug}
                 programmeSlug={programmeSlug}
+                onClickShare={trackShare}
               />
             </OakGridArea>
             <OakGridArea


### PR DESCRIPTION
## Description

Music year: 2008

- List of changes
Add tracking event to share with pupil button 

## Issue(s)

Fixes #
https://app.notion.com/p/oaknationalacademy/26-Winter-OKRs-Sprint-6-32626cc4e1b180c5b47cc942bdb8ce18?p=36f26cc4e1b180f9ad91d234fa014a7e&pm=s

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
