### PR TITLE
fix: correct path to share page

### DIFF
--- a/src/common-lib/urls/urls.test.ts
+++ b/src/common-lib/urls/urls.test.ts
@@ -184,7 +184,7 @@ describe("urls.ts", () => {
           lessonSlug: "solving-equations-456",
         }),
       ).toBe(
-        "/programmes/maths-secondary-year-10-aqa/units/algebra-123/lessons/solving-equations-456/share",
+        "/teachers/programmes/maths-secondary-year-10-aqa/units/algebra-123/lessons/solving-equations-456/share",
       );
     });
     it("Integrated lesson media", () => {

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -960,7 +960,7 @@ export const OAK_PAGES: {
   }),
   "integrated-lesson-share": createOakPageConfig({
     pathPattern:
-      "/programmes/:programmeSlug/units/:unitSlug/lessons/:lessonSlug/share",
+      "/teachers/programmes/:programmeSlug/units/:unitSlug/lessons/:lessonSlug/share",
     analyticsPageName: "Lesson Share",
     configType: "internal",
     pageType: "integrated-lesson-share",


### PR DESCRIPTION
## Description

Music year: 1953

Fixes broken link to share page

## How to test

1. Go to https://oak-web-application-website-git-fix-share-link.vercel.thenational.academy/teachers/programmes/citizenship-secondary-ks3/units/citizenship-whats-it-all-about/lessons/what-is-citizenship
2. Click on "Share lesson with pupils"
3. You should see the share page

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
