### PR TITLE
fix: double navigation when following subject link in top nav

### DIFF
--- a/src/components/AppComponents/TopNav/TopNavDropdown/TopNavSubjectButtons.tsx
+++ b/src/components/AppComponents/TopNav/TopNavDropdown/TopNavSubjectButtons.tsx
@@ -3,7 +3,7 @@ import {
   OakSubjectIconButton,
   OakUL,
 } from "@oaknational/oak-components";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 import { DropdownFocusManager } from "../DropdownFocusManager/DropdownFocusManager";
 
@@ -33,11 +33,9 @@ const TopNavSubjectButtons = ({
   focusManager?: DropdownFocusManager<TeachersData>;
   onExamBoardPanelOpen?: (subject: SubjectsNavItem) => void;
 }) => {
-  const router = useRouter();
   const handleSubjectClick = (
     e: React.MouseEvent<HTMLButtonElement>,
     subject: SubjectsNavItem,
-    href?: string,
   ) => {
     if (
       keyStageSlug === "ks4" &&
@@ -49,10 +47,6 @@ const TopNavSubjectButtons = ({
       return;
     }
 
-    if (href) {
-      e.preventDefault();
-      router.push(href);
-    }
     handleClick(subject.slug, keyStageSlug);
   };
 
@@ -88,12 +82,12 @@ const TopNavSubjectButtons = ({
             <OakLI key={subject.title}>
               <OakSubjectIconButton
                 variant={"horizontal"}
-                element={subject.examBoards?.length ? "button" : "a"}
+                element={subject.examBoards?.length ? "button" : Link}
                 data-testid={`topnav-subject-button-${slug}`}
                 subjectIconName={getValidSubjectIconName(slug)}
                 selected={selectedSubject?.title === subject.title}
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
-                  handleSubjectClick(e, subject, href)
+                  handleSubjectClick(e, subject)
                 }
                 href={href}
                 onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {

--- a/src/components/AppComponents/TopNav/TopNavDropdown/TopNavSubjectButtons.tsx
+++ b/src/components/AppComponents/TopNav/TopNavDropdown/TopNavSubjectButtons.tsx
@@ -50,6 +50,7 @@ const TopNavSubjectButtons = ({
     }
 
     if (href) {
+      e.preventDefault();
       router.push(href);
     }
     handleClick(subject.slug, keyStageSlug);


### PR DESCRIPTION
When following a subject link in the top nav, the link would be followed through a browser nav and we immediately call router.push which would navigate to the subject page again. These compete with the router.

## How to test

1. Go to https://oak-web-application-website-git-fix-double-navigation-in-b0ef31.vercel.thenational.academy/teachers/programmes/computing-primary/units?keystages=ks1
2. Click through the top nav links 
3. Nav should not stop working

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
