### PR TITLE
fix: check for showing create with ai

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.test.tsx
@@ -283,6 +283,14 @@ describe("Lesson resources", () => {
     expect(createWithAiButton).not.toBeInTheDocument();
   });
 
+  it("does not render create with ai button when excludedFromTeachingMaterials is true", () => {
+    render(<LessonView {...baseProps} excludedFromTeachingMaterials={true} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Create more with AI" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not create with ai button when the lesson has no complex copyright", () => {
     render(<LessonView {...baseProps} />);
 

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonView.tsx
@@ -63,6 +63,7 @@ export default function LessonView(
     phaseSlug,
     actions,
     subjectCategories,
+    excludedFromTeachingMaterials,
   } = props;
 
   const {
@@ -230,7 +231,7 @@ export default function LessonView(
               <LessonActionsBar
                 showPupilShare={showPupilShare}
                 createWithAiProps={
-                  contentRestricted
+                  contentRestricted || excludedFromTeachingMaterials
                     ? undefined
                     : {
                         lessonSlug,


### PR DESCRIPTION
## Description

Music year: 1994

- Fixed bug where "create with ai' button is shown for excluded lessons 

error - https://oaknationalacademy.slack.com/archives/C05Q9HZ5VRN/p1780495620878619
## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page

teachers/programmes/rshe-pshe-secondary-ks4/units/power-in-relationships-what-does-a-healthy-relationships-feel-like/lessons/recognising-abuse-and-violence

No longer shows teach with ai button

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
