### PR TITLE
Fix/lesq 2071/science caching [LESQ-2071]

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.test.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.test.ts
@@ -14,26 +14,23 @@ const mockKs4Options = [
   { slug: "ocr", title: "OCR" },
 ];
 
-const getMockCurriculumPhaseOptions = (withKsOptions: boolean) => ({
-  tab: "units" as const,
-  subjects: [
-    {
-      slug: "maths",
-      title: "Maths",
-      phases: [
-        { slug: "primary", title: "Primary" },
-        { slug: "secondary", title: "Secondary" },
-      ],
-      keystages: [
-        { slug: "ks1", title: "Key Stage 1" },
-        { slug: "ks2", title: "Key Stage 2" },
-        { slug: "ks3", title: "Key Stage 3" },
-        { slug: "ks4", title: "Key Stage 4" },
-      ],
-      ks4_options: withKsOptions ? mockKs4Options : null,
-    },
-  ],
-});
+const getMockCurriculumPhaseOptions = (withKsOptions: boolean) => [
+  {
+    slug: "maths",
+    title: "Maths",
+    phases: [
+      { slug: "primary", title: "Primary" },
+      { slug: "secondary", title: "Secondary" },
+    ],
+    keystages: [
+      { slug: "ks1", title: "Key Stage 1" },
+      { slug: "ks2", title: "Key Stage 2" },
+      { slug: "ks3", title: "Key Stage 3" },
+      { slug: "ks4", title: "Key Stage 4" },
+    ],
+    ks4_options: withKsOptions ? mockKs4Options : null,
+  },
+];
 
 const mockCurriculumUnitsData = {
   units: [
@@ -63,8 +60,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         {},
@@ -77,8 +76,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { threads: "thread-1" },
@@ -91,8 +92,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { tiers: "foundation" },
@@ -105,8 +108,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         {},
@@ -119,8 +124,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { tiers: "foundation" },
@@ -136,8 +143,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { keystages: "ks3" },
@@ -148,8 +157,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { keystages: "ks4" },
@@ -162,8 +173,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { tiers: "foundation", keystages: "ks4" },
@@ -176,8 +189,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { tiers: "foundation", keystages: "ks4" },
@@ -193,8 +208,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { years: "7" },
@@ -205,8 +222,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "11" },
@@ -219,8 +238,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(false),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { years: "7", tiers: "higher" },
@@ -233,8 +254,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "7", tiers: "foundation" },
@@ -247,8 +270,10 @@ describe("getMetaTitle", () => {
       const result = getMetaTitle(
         {
           programmeUnitsData: mockProgrammeUnitsData,
-          curriculumPhaseOptions: getMockCurriculumPhaseOptions(true),
           curriculumUnitsData: mockCurriculumUnitsData,
+        },
+        {
+          subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "7", tiers: "foundation", threads: "thread-1" },

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.test.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.test.ts
@@ -1,13 +1,5 @@
 import { getMetaTitle } from "./getMetaTitle";
 
-import { createUnit } from "@/fixtures/curriculum/unit";
-
-const mockProgrammeUnitsData = {
-  curriculaDesc: "curriculum",
-  subjectTitle: "Maths",
-  phaseTitle: "Secondary",
-  nonCurriculum: false,
-};
 const mockKs4Options = [
   { slug: "aqa", title: "AQA" },
   { slug: "core", title: "Core" },
@@ -32,22 +24,6 @@ const getMockCurriculumPhaseOptions = (withKsOptions: boolean) => [
   },
 ];
 
-const mockCurriculumUnitsData = {
-  units: [
-    createUnit({
-      slug: "unit-1",
-      title: "Unit 1",
-      order: 1,
-      examboard: null,
-      examboard_slug: null,
-      year: "5",
-      subject_slug: "maths",
-      phase_slug: "secondary",
-      threads: [{ slug: "thread-1", title: "Thread 1", order: 1 }],
-    }),
-  ],
-};
-
 const getMockSubjectPhaseKeystageSlugs = (withKs4OptionSlug: boolean) => ({
   phaseSlug: "secondary",
   subjectSlug: "maths",
@@ -59,80 +35,60 @@ describe("getMetaTitle", () => {
     it("returns a default title with subject and phase", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         {},
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Secondary Maths Lesson & Curriculum Resources",
       );
     });
     it("returns a title with subject phase and thread", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { threads: "thread-1" },
       );
-      expect(result).toEqual(
-        "Free Secondary Maths - Thread 1 Lesson & Curriculum Resources",
+      expect(result.title).toEqual(
+        "Free Secondary Maths - thread 1 Lesson & Curriculum Resources",
       );
     });
     it("returns a title with subject phase and tier", () => {
       const result = getMetaTitle(
-        {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
         {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { tiers: "foundation" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Secondary Maths Foundation Lesson & Curriculum Resources",
       );
     });
     it("returns a title with subject, phase and examboard", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         {},
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Secondary Maths AQA Lesson & Curriculum Resources",
       );
     });
     it("returns a title with subject, phase, examboard and tier", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { tiers: "foundation" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Secondary Maths Foundation AQA Lesson & Curriculum Resources",
       );
     });
@@ -142,62 +98,48 @@ describe("getMetaTitle", () => {
     it("returns a title with keystage", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { keystages: "ks3" },
       );
-      expect(result).toEqual("Free KS3 Maths Lesson & Curriculum Resources");
+      expect(result.title).toEqual(
+        "Free KS3 Maths Lesson & Curriculum Resources",
+      );
     });
     it("returns a title with keystage and examboard", () => {
       const result = getMetaTitle(
-        {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
         {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { keystages: "ks4" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free KS4 Maths AQA Lesson & Curriculum Resources",
       );
     });
     it("returns a title with keystage and tier", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { tiers: "foundation", keystages: "ks4" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free KS4 Maths Foundation Lesson & Curriculum Resources",
       );
     });
     it("returns a title with keystage, examboard and tier", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { tiers: "foundation", keystages: "ks4" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free KS4 Maths Foundation AQA Lesson & Curriculum Resources",
       );
     });
@@ -207,79 +149,61 @@ describe("getMetaTitle", () => {
     it("returns a title with year", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { years: "7" },
       );
-      expect(result).toEqual("Free Y7 Maths Lesson & Curriculum Resources");
+      expect(result.title).toEqual(
+        "Free Y7 Maths Lesson & Curriculum Resources",
+      );
     });
     it("returns a title with year and examboard", () => {
       const result = getMetaTitle(
-        {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
         {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "11" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Y11 Maths AQA Lesson & Curriculum Resources",
       );
     });
     it("returns a title with year and tier", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(false),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(false),
         },
         { years: "7", tiers: "higher" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Y7 Maths Higher Lesson & Curriculum Resources",
       );
     });
     it("returns a title with year examboard and tier", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "7", tiers: "foundation" },
       );
-      expect(result).toEqual(
+      expect(result.title).toEqual(
         "Free Y7 Maths Foundation AQA Lesson & Curriculum Resources",
       );
     });
     it("returns a title with year and thread", () => {
       const result = getMetaTitle(
         {
-          programmeUnitsData: mockProgrammeUnitsData,
-          curriculumUnitsData: mockCurriculumUnitsData,
-        },
-        {
           subjects: getMockCurriculumPhaseOptions(true),
           subjectPhaseKeystageSlugs: getMockSubjectPhaseKeystageSlugs(true),
         },
         { years: "7", tiers: "foundation", threads: "thread-1" },
       );
-      expect(result).toEqual(
-        "Free Y7 Maths Foundation AQA - Thread 1 Lesson & Curriculum Resources",
+      expect(result.title).toEqual(
+        "Free Y7 Maths Foundation AQA - thread 1 Lesson & Curriculum Resources",
       );
     });
   });

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.ts
@@ -1,26 +1,24 @@
-import { getProgrammeData } from "./getProgrammeData";
+import { getProgrammeData, getSubjectPhaseOptions } from "./getProgrammeData";
 import { PageSearchParms } from "./page";
 
 import { formatCurriculumUnitsData } from "@/pages-helpers/curriculum/docx/tab-helpers";
 
 export const getMetaTitle = (
   programmePageData: NonNullable<Awaited<ReturnType<typeof getProgrammeData>>>,
+  subjectPhaseData: NonNullable<
+    Awaited<ReturnType<typeof getSubjectPhaseOptions>>
+  >,
   searchParams: PageSearchParms,
 ) => {
-  const {
-    programmeUnitsData,
-    curriculumUnitsData,
-    curriculumPhaseOptions,
-    subjectPhaseKeystageSlugs,
-  } = programmePageData;
+  const { programmeUnitsData, curriculumUnitsData } = programmePageData;
+  const { subjects, subjectPhaseKeystageSlugs } = subjectPhaseData;
 
   const curriculumUnitsFormattedData =
     formatCurriculumUnitsData(curriculumUnitsData);
 
   const ks4Options =
-    curriculumPhaseOptions.subjects.find(
-      (s) => s.slug === subjectPhaseKeystageSlugs.subjectSlug,
-    )?.ks4_options ?? [];
+    subjects.find((s) => s.slug === subjectPhaseKeystageSlugs.subjectSlug)
+      ?.ks4_options ?? [];
   const ks4Option = ks4Options.find(
     (ks4opt) => ks4opt.slug === subjectPhaseKeystageSlugs.ks4OptionSlug,
   );

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getMetaTitle.ts
@@ -1,31 +1,36 @@
-import { getProgrammeData, getSubjectPhaseOptions } from "./getProgrammeData";
+import { getSubjectPhaseOptions } from "./getProgrammeData";
 import { PageSearchParms } from "./page";
 
-import { formatCurriculumUnitsData } from "@/pages-helpers/curriculum/docx/tab-helpers";
-
 export const getMetaTitle = (
-  programmePageData: NonNullable<Awaited<ReturnType<typeof getProgrammeData>>>,
   subjectPhaseData: NonNullable<
     Awaited<ReturnType<typeof getSubjectPhaseOptions>>
   >,
   searchParams: PageSearchParms,
 ) => {
-  const { programmeUnitsData, curriculumUnitsData } = programmePageData;
   const { subjects, subjectPhaseKeystageSlugs } = subjectPhaseData;
 
-  const curriculumUnitsFormattedData =
-    formatCurriculumUnitsData(curriculumUnitsData);
+  const currentSubject = subjects.find(
+    (s) => s.slug === subjectPhaseKeystageSlugs.subjectSlug,
+  );
 
-  const ks4Options =
-    subjects.find((s) => s.slug === subjectPhaseKeystageSlugs.subjectSlug)
-      ?.ks4_options ?? [];
+  if (!currentSubject) {
+    return {
+      title: "Free lesson and curriculum resources",
+      description: "Get fully sequenced teaching resources and lesson plans",
+    };
+  }
+
+  const ks4Options = currentSubject?.ks4_options ?? [];
   const ks4Option = ks4Options.find(
     (ks4opt) => ks4opt.slug === subjectPhaseKeystageSlugs.ks4OptionSlug,
   );
 
   const { threads, years, keystages, tiers } = searchParams;
 
-  const phaseSubjectSegment = `${programmeUnitsData.phaseTitle} ${programmeUnitsData.subjectTitle}`;
+  const phaseTitle = currentSubject.phases.find(
+    (p) => p.slug === subjectPhaseKeystageSlugs.phaseSlug,
+  )?.title;
+  const phaseSubjectSegment = `${phaseTitle} ${currentSubject.title}`;
 
   const keystageSegment =
     typeof keystages === "string" ? keystages.toUpperCase() : null;
@@ -34,24 +39,28 @@ export const getMetaTitle = (
     year === "all-years" ? "All Years" : `Y${year}`;
   const yearSegment = typeof years === "string" ? getYearTitle(years) : "";
 
-  const threadTitle = curriculumUnitsFormattedData.threadOptions.find(
-    (t) => t.slug === threads,
-  )?.title;
-  const threadSegment =
-    typeof threads === "string" && threadTitle ? ` - ${threadTitle}` : "";
+  const threadTitle =
+    typeof threads === "string" && threads
+      ? threads.replaceAll("-", " ")
+      : undefined;
+  const threadSegment = threadTitle ? ` - ${threadTitle}` : "";
   const tierSegment =
     typeof tiers === "string"
       ? ` ${tiers[0]?.toLocaleUpperCase() + tiers.slice(1)}`
       : "";
   const examboardSegment = ks4Option ? ` ${ks4Option.title}` : "";
 
+  let title = `Free ${phaseSubjectSegment}${tierSegment}${examboardSegment}${threadSegment} Lesson & Curriculum Resources`;
+
   if (yearSegment) {
-    return `Free ${yearSegment} ${programmeUnitsData.subjectTitle}${tierSegment}${examboardSegment}${threadSegment} Lesson & Curriculum Resources`;
+    title = `Free ${yearSegment} ${currentSubject.title}${tierSegment}${examboardSegment}${threadSegment} Lesson & Curriculum Resources`;
   }
 
   if (keystageSegment) {
-    return `Free ${keystageSegment} ${programmeUnitsData.subjectTitle}${tierSegment}${examboardSegment} Lesson & Curriculum Resources`;
+    title = `Free ${keystageSegment} ${currentSubject.title}${tierSegment}${examboardSegment} Lesson & Curriculum Resources`;
   }
 
-  return `Free ${phaseSubjectSegment}${tierSegment}${examboardSegment}${threadSegment} Lesson & Curriculum Resources`;
+  const description = `Get fully sequenced teaching resources and lesson plans for ${phaseTitle} ${currentSubject.title}`;
+
+  return { title, description };
 };

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.test.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.test.ts
@@ -89,7 +89,6 @@ describe("getProgrammeData", () => {
         excludeUnitsWithNoPublishedLessons: true,
         excludeCoreUnits: true,
       });
-      expect(mockApi.curriculumPhaseOptions).toHaveBeenCalled();
     });
 
     it("should sort units with examboard versions first, then by order", async () => {
@@ -357,20 +356,6 @@ describe("getProgrammeData", () => {
     it("should propagate errors from curriculumSequence", async () => {
       const mockApi = createMockCurriculumApi({
         curriculumSequence: jest
-          .fn()
-          .mockRejectedValue(
-            new OakError({ code: "curriculum-api/not-found" }),
-          ),
-      });
-
-      await expect(getProgrammeData(mockApi, "maths-primary")).rejects.toThrow(
-        "Resource not found",
-      );
-    });
-
-    it("should propagate errors from curriculumPhaseOptions", async () => {
-      const mockApi = createMockCurriculumApi({
-        curriculumPhaseOptions: jest
           .fn()
           .mockRejectedValue(
             new OakError({ code: "curriculum-api/not-found" }),

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.test.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { getProgrammeData } from "./getProgrammeData";
+import { getProgrammeData, getSubjectPhaseOptions } from "./getProgrammeData";
 
 import { CurriculumApi } from "@/node-lib/curriculum-api-2023";
 import { createUnit } from "@/fixtures/curriculum/unit";
@@ -55,14 +55,21 @@ describe("getProgrammeData", () => {
   describe("with valid subject phase slug", () => {
     it("should return programme data with sorted units", async () => {
       const mockApi = createMockCurriculumApi();
-      const result = await getProgrammeData(mockApi, "maths-primary");
+      const programmeResults = await getProgrammeData(mockApi, "maths-primary");
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "maths-primary",
+      );
 
-      expect(result).not.toBeNull();
-      expect(result?.programmeUnitsData.subjectTitle).toBe("Maths");
-      expect(result?.curriculumUnitsData.units).toHaveLength(2);
-      expect(result?.curriculumPhaseOptions.tab).toBe("units");
-      expect(result?.subjectPhaseKeystageSlugs.subjectSlug).toBe("maths");
-      expect(result?.subjectPhaseKeystageSlugs.phaseSlug).toBe("primary");
+      expect(programmeResults).not.toBeNull();
+      expect(programmeResults?.programmeUnitsData.subjectTitle).toBe("Maths");
+      expect(programmeResults?.curriculumUnitsData.units).toHaveLength(2);
+      expect(subjectResults?.subjectPhaseKeystageSlugs.subjectSlug).toBe(
+        "maths",
+      );
+      expect(subjectResults?.subjectPhaseKeystageSlugs.phaseSlug).toBe(
+        "primary",
+      );
     });
 
     it("should call curriculumApi methods with correct parameters", async () => {
@@ -135,21 +142,21 @@ describe("getProgrammeData", () => {
 
       const result = await getProgrammeData(mockApi, "maths-primary");
 
-      expect(result!.curriculumUnitsData.units).toHaveLength(4);
+      expect(result?.curriculumUnitsData.units).toHaveLength(4);
       // Note: The sorting logic sorts by examboard first, then by order globally
       // So units are sorted: examboard-1 (order 1), regular-1 (order 1), examboard-2 (order 2), regular-2 (order 2)
-      expect(result!.curriculumUnitsData.units[0]!.slug).toBe(
+      expect(result?.curriculumUnitsData.units[0]!.slug).toBe(
         "unit-examboard-1",
       );
-      expect(result!.curriculumUnitsData.units[0]!.examboard).toBeTruthy();
-      expect(result!.curriculumUnitsData.units[1]!.slug).toBe("unit-regular-1");
-      expect(result!.curriculumUnitsData.units[1]!.examboard).toBeFalsy();
-      expect(result!.curriculumUnitsData.units[2]!.slug).toBe(
+      expect(result?.curriculumUnitsData.units[0]!.examboard).toBeTruthy();
+      expect(result?.curriculumUnitsData.units[1]!.slug).toBe("unit-regular-1");
+      expect(result?.curriculumUnitsData.units[1]!.examboard).toBeFalsy();
+      expect(result?.curriculumUnitsData.units[2]!.slug).toBe(
         "unit-examboard-2",
       );
-      expect(result!.curriculumUnitsData.units[2]!.examboard).toBeTruthy();
-      expect(result!.curriculumUnitsData.units[3]!.slug).toBe("unit-regular-2");
-      expect(result!.curriculumUnitsData.units[3]!.examboard).toBeFalsy();
+      expect(result?.curriculumUnitsData.units[2]!.examboard).toBeTruthy();
+      expect(result?.curriculumUnitsData.units[3]!.slug).toBe("unit-regular-2");
+      expect(result?.curriculumUnitsData.units[3]!.examboard).toBeFalsy();
     });
 
     it("should filter curriculum phase options", async () => {
@@ -169,10 +176,13 @@ describe("getProgrammeData", () => {
         ]),
       });
 
-      const result = await getProgrammeData(mockApi, "maths-primary");
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "maths-primary",
+      );
 
-      expect(result?.curriculumPhaseOptions.subjects).toHaveLength(1);
-      const englishSubject = result?.curriculumPhaseOptions.subjects[0];
+      expect(subjectResults?.subjects).toHaveLength(1);
+      const englishSubject = subjectResults?.subjects[0];
       expect(englishSubject?.ks4_options).toHaveLength(2);
       // GCSE should be removed if it's not first and there are examboard options
       const gcseOption = englishSubject?.ks4_options?.find(
@@ -204,20 +214,34 @@ describe("getProgrammeData", () => {
       });
 
       const result = await getProgrammeData(mockApi, "science-secondary");
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "science-secondary",
+      );
 
       expect(result).not.toBeNull();
-      expect(result!.programmeUnitsData.subjectTitle).toBe("Science");
-      expect(result!.programmeUnitsData.phaseTitle).toBe("Secondary");
-      expect(result!.subjectPhaseKeystageSlugs.subjectSlug).toBe("science");
-      expect(result!.subjectPhaseKeystageSlugs.phaseSlug).toBe("secondary");
+      expect(result?.programmeUnitsData.subjectTitle).toBe("Science");
+      expect(result?.programmeUnitsData.phaseTitle).toBe("Secondary");
+      expect(subjectResults?.subjectPhaseKeystageSlugs.subjectSlug).toBe(
+        "science",
+      );
+      expect(subjectResults?.subjectPhaseKeystageSlugs.phaseSlug).toBe(
+        "secondary",
+      );
     });
 
     it("should handle ks4 option slug", async () => {
       const mockApi = createMockCurriculumApi();
       const result = await getProgrammeData(mockApi, "maths-secondary-aqa");
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "maths-secondary-aqa",
+      );
 
       expect(result).not.toBeNull();
-      expect(result!.subjectPhaseKeystageSlugs.ks4OptionSlug).toBe("aqa");
+      expect(subjectResults?.subjectPhaseKeystageSlugs.ks4OptionSlug).toBe(
+        "aqa",
+      );
       expect(mockApi.curriculumSequence).toHaveBeenCalledWith({
         subjectSlug: "maths",
         phaseSlug: "secondary",
@@ -244,9 +268,11 @@ describe("getProgrammeData", () => {
         ]),
       });
 
-      const result = await getProgrammeData(mockApi, "maths-secondary-aqa");
-
-      expect(result?.curriculumPhaseOptions.subjects[0]?.ks4_options).toEqual([
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "maths-secondary-aqa",
+      );
+      expect(subjectResults?.subjects[0]?.ks4_options).toEqual([
         { title: "AQA", slug: "aqa" },
       ]);
     });
@@ -259,7 +285,7 @@ describe("getProgrammeData", () => {
             slug: "maths",
             phases: [{ title: "Secondary", slug: "secondary" }],
             ks4_options: [
-              { title: "AQA", slug: "aqa" },
+              { title: "GCSE", slug: "gcse" },
               { title: "Core", slug: "core" },
             ],
             keystages: [],
@@ -267,8 +293,11 @@ describe("getProgrammeData", () => {
         ]),
       });
 
-      const result = await getProgrammeData(mockApi, "maths-secondary-core");
-
+      const subjectResults = await getSubjectPhaseOptions(
+        mockApi,
+        "maths-secondary-core",
+      );
+      await getProgrammeData(mockApi, "maths-secondary-core");
       expect(mockApi.curriculumSequence).toHaveBeenCalledWith({
         subjectSlug: "maths",
         phaseSlug: "secondary",
@@ -277,8 +306,8 @@ describe("getProgrammeData", () => {
         excludeUnitsWithNoPublishedLessons: true,
         excludeCoreUnits: false,
       });
-      expect(result?.curriculumPhaseOptions.subjects[0]?.ks4_options).toEqual([
-        { title: "AQA", slug: "aqa" },
+      expect(subjectResults?.subjects[0]?.ks4_options).toEqual([
+        { title: "GCSE", slug: "gcse" },
         { title: "Core", slug: "core" },
       ]);
     });

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.ts
@@ -78,7 +78,6 @@ export async function getProgrammeData(
       excludeUnitsWithNoPublishedLessons: true,
       excludeCoreUnits,
     }),
-    curriculumApi2023.curriculumPhaseOptions({ includeNonCurriculum: true }),
   ]);
 
   // Sort units to have examboard versions first, then by unit order

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/getProgrammeData.ts
@@ -29,6 +29,29 @@ const excludeCoreFromSubjects = (subjects: CurriculumPhaseOptions) => {
   }));
 };
 
+export async function getSubjectPhaseOptions(
+  curriculumApi2023: CurriculumApi,
+  subjectPhaseSlug: string,
+) {
+  const subjectPhaseKeystageSlugs = parseSubjectPhaseSlug(subjectPhaseSlug);
+
+  if (!subjectPhaseKeystageSlugs) {
+    return null;
+  }
+  const originalSubjects = await curriculumApi2023.curriculumPhaseOptions({
+    includeNonCurriculum: true,
+  });
+  let subjects = filterValidCurriculumPhaseOptions(originalSubjects);
+  // We exclude core units when the ks4 option is not core
+  // TD: after the integrated journey launches we should make this the default in the query
+  const excludeCoreUnits = subjectPhaseKeystageSlugs.ks4OptionSlug !== "core";
+  if (excludeCoreUnits) {
+    subjects = excludeCoreFromSubjects(subjects);
+  }
+
+  return { subjects, subjectPhaseKeystageSlugs };
+}
+
 export async function getProgrammeData(
   curriculumApi2023: CurriculumApi,
   subjectPhaseSlug: string,
@@ -43,32 +66,20 @@ export async function getProgrammeData(
   // TD: after the integrated journey launches we should make this the default in the query
   const excludeCoreUnits = subjectPhaseKeystageSlugs.ks4OptionSlug !== "core";
 
-  const [programmeUnitsData, curriculumUnitsData, originalSubjects] =
-    await Promise.all([
-      curriculumApi2023.curriculumOverview({
-        subjectSlug: subjectPhaseKeystageSlugs.subjectSlug,
-        phaseSlug: subjectPhaseKeystageSlugs.phaseSlug,
-        includeNonCurriculum: true,
-      }),
-      curriculumApi2023.curriculumSequence({
-        ...subjectPhaseKeystageSlugs,
-        includeNonCurriculum: true,
-        excludeUnitsWithNoPublishedLessons: true,
-        excludeCoreUnits,
-      }),
-      curriculumApi2023.curriculumPhaseOptions({ includeNonCurriculum: true }),
-    ]);
-
-  let subjects = filterValidCurriculumPhaseOptions(originalSubjects);
-
-  if (excludeCoreUnits) {
-    subjects = excludeCoreFromSubjects(subjects);
-  }
-
-  const curriculumPhaseOptions = {
-    subjects,
-    tab: "units" as const,
-  };
+  const [programmeUnitsData, curriculumUnitsData] = await Promise.all([
+    curriculumApi2023.curriculumOverview({
+      subjectSlug: subjectPhaseKeystageSlugs.subjectSlug,
+      phaseSlug: subjectPhaseKeystageSlugs.phaseSlug,
+      includeNonCurriculum: true,
+    }),
+    curriculumApi2023.curriculumSequence({
+      ...subjectPhaseKeystageSlugs,
+      includeNonCurriculum: true,
+      excludeUnitsWithNoPublishedLessons: true,
+      excludeCoreUnits,
+    }),
+    curriculumApi2023.curriculumPhaseOptions({ includeNonCurriculum: true }),
+  ]);
 
   // Sort units to have examboard versions first, then by unit order
   curriculumUnitsData.units = sortUnits(curriculumUnitsData.units);
@@ -76,7 +87,5 @@ export async function getProgrammeData(
   return {
     programmeUnitsData,
     curriculumUnitsData,
-    curriculumPhaseOptions,
-    subjectPhaseKeystageSlugs,
   };
 }

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
@@ -372,7 +372,7 @@ describe("generateMetadata", () => {
         curriculumPhaseOptionsFixture(),
       ),
       subjectPhaseKeystageSlugs: {
-        subjectSlug: "compputing",
+        subjectSlug: "computing",
         phaseSlug: "secondary",
         examboardSlug: "aqa",
         ks4OptionSlug: null,

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
@@ -284,8 +284,8 @@ describe("generateMetadata", () => {
     expect(getProgrammeData).not.toHaveBeenCalled();
   });
 
-  it("returns empty object when no programme data is found", async () => {
-    jest.mocked(getProgrammeData).mockResolvedValueOnce(null);
+  it("returns empty object when no subject data is found", async () => {
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValueOnce(null);
 
     const result = await generateMetadata({
       params: Promise.resolve({
@@ -299,27 +299,10 @@ describe("generateMetadata", () => {
   });
 
   it("generates metadata with title, description, and canonical URL", async () => {
-    const mockProgrammeData = {
-      programmeUnitsData: curriculumOverviewMVFixture({
-        subjectTitle: "Maths",
-      }),
-      curriculumUnitsData: {
-        units: [
-          createUnit({
-            slug: "unit-1",
-            year: "5",
-            keystage_slug: "ks2",
-            subject_slug: "maths",
-            phase_slug: "primary",
-          }),
-        ],
-      },
-      curriculumPhaseOptions: {
-        subjects: filterValidCurriculumPhaseOptions(
-          curriculumPhaseOptionsFixture(),
-        ),
-        tab: "units" as const,
-      },
+    const mockSubjectData = {
+      subjects: filterValidCurriculumPhaseOptions(
+        curriculumPhaseOptionsFixture(),
+      ),
       subjectPhaseKeystageSlugs: {
         subjectSlug: "maths",
         phaseSlug: "primary",
@@ -327,7 +310,7 @@ describe("generateMetadata", () => {
       },
     };
 
-    jest.mocked(getProgrammeData).mockResolvedValue(mockProgrammeData);
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValue(mockSubjectData);
 
     const result = await generateMetadata({
       params: Promise.resolve({
@@ -338,10 +321,10 @@ describe("generateMetadata", () => {
     });
 
     expect(result.title).toBe(
-      "Free Secondary Maths Lesson & Curriculum Resources",
+      "Free Primary Maths Lesson & Curriculum Resources",
     );
     expect(result.description).toContain(
-      "Get fully sequenced teaching resources and lesson plans for Secondary Maths",
+      "Get fully sequenced teaching resources and lesson plans for Primary Maths",
     );
 
     expect(result.alternates?.canonical).toBe(
@@ -354,21 +337,23 @@ describe("generateMetadata", () => {
       ).toString(),
     );
     expect(result.openGraph?.title).toBe(
-      "Free Secondary Maths Lesson & Curriculum Resources",
+      "Free Primary Maths Lesson & Curriculum Resources",
     );
     expect(result.openGraph?.description).toContain(
-      "Get fully sequenced teaching resources and lesson plans for Secondary Maths",
+      "Get fully sequenced teaching resources and lesson plans for Primary Maths",
     );
     expect(result.twitter?.title).toBe(
-      "Free Secondary Maths Lesson & Curriculum Resources",
+      "Free Primary Maths Lesson & Curriculum Resources",
     );
     expect(result.twitter?.description).toContain(
-      "Get fully sequenced teaching resources and lesson plans for Secondary Maths",
+      "Get fully sequenced teaching resources and lesson plans for Primary Maths",
     );
   });
 
   it("handles errors gracefully and returns empty object", async () => {
-    jest.mocked(getProgrammeData).mockRejectedValue(new Error("Test error"));
+    jest
+      .mocked(getSubjectPhaseOptions)
+      .mockRejectedValue(new Error("Test error"));
 
     const result = await generateMetadata({
       params: Promise.resolve({
@@ -382,35 +367,18 @@ describe("generateMetadata", () => {
   });
 
   it("includes noindex robots metadata for the download tab", async () => {
-    const mockProgrammeData = {
-      programmeUnitsData: curriculumOverviewMVFixture({
-        subjectTitle: "Computing",
-      }),
-      curriculumUnitsData: {
-        units: [
-          createUnit({
-            slug: "unit-1",
-            year: "10",
-            keystage_slug: "ks4",
-            subject_slug: "computing",
-            phase_slug: "secondary",
-          }),
-        ],
-      },
-      curriculumPhaseOptions: {
-        subjects: filterValidCurriculumPhaseOptions(
-          curriculumPhaseOptionsFixture(),
-        ),
-        tab: "units" as const,
-      },
+    const mockSubjectData = {
+      subjects: filterValidCurriculumPhaseOptions(
+        curriculumPhaseOptionsFixture(),
+      ),
       subjectPhaseKeystageSlugs: {
-        subjectSlug: "computing",
+        subjectSlug: "compputing",
         phaseSlug: "secondary",
-        ks4OptionSlug: "ocr",
+        examboardSlug: "aqa",
+        ks4OptionSlug: null,
       },
     };
-
-    jest.mocked(getProgrammeData).mockResolvedValue(mockProgrammeData);
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValue(mockSubjectData);
 
     const result = await generateMetadata({
       params: Promise.resolve({

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { getProgrammeData } from "./getProgrammeData";
+import { getProgrammeData, getSubjectPhaseOptions } from "./getProgrammeData";
 import ProgrammePageTabs, { generateMetadata } from "./page";
 
 import getBrowserConfig from "@/browser-lib/getBrowserConfig";
@@ -84,6 +84,7 @@ jest.mock("@/browser-lib/getBrowserConfig", () => ({
 
 jest.mock("./getProgrammeData", () => ({
   getProgrammeData: jest.fn(),
+  getSubjectPhaseOptions: jest.fn(),
 }));
 
 const mockErrorReporter = jest.fn();
@@ -134,12 +135,12 @@ describe("Programme page tabs", () => {
           }),
         ],
       },
-      curriculumPhaseOptions: {
-        subjects: filterValidCurriculumPhaseOptions(
-          curriculumPhaseOptionsFixture().filter((s) => s.slug === "maths"),
-        ),
-        tab: "units" as const,
-      },
+    });
+
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValue({
+      subjects: filterValidCurriculumPhaseOptions(
+        curriculumPhaseOptionsFixture().filter((s) => s.slug === "maths"),
+      ),
       subjectPhaseKeystageSlugs: {
         subjectSlug: "maths",
         phaseSlug: "primary",
@@ -174,17 +175,17 @@ describe("Programme page tabs", () => {
           }),
         ],
       },
-      curriculumPhaseOptions: {
-        subjects: filterValidCurriculumPhaseOptions([
-          {
-            slug: "financial-education",
-            title: "Financial education",
-            phases: [{ slug: "primary", title: "Primary" }],
-            ks4_options: [],
-          },
-        ]),
-        tab: "units",
-      },
+    });
+
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValue({
+      subjects: filterValidCurriculumPhaseOptions([
+        {
+          slug: "financial-education",
+          title: "Financial education",
+          phases: [{ slug: "primary", title: "Primary" }],
+          ks4_options: [],
+        },
+      ]),
       subjectPhaseKeystageSlugs: {
         subjectSlug: "financial-education",
         phaseSlug: "primary",
@@ -224,12 +225,12 @@ describe("Programme page tabs", () => {
           }),
         ],
       },
-      curriculumPhaseOptions: {
-        subjects: filterValidCurriculumPhaseOptions(
-          curriculumPhaseOptionsFixture().filter((s) => s.slug === "maths"),
-        ),
-        tab: "units" as const,
-      },
+    });
+
+    jest.mocked(getSubjectPhaseOptions).mockResolvedValue({
+      subjects: filterValidCurriculumPhaseOptions(
+        curriculumPhaseOptionsFixture().filter((s) => s.slug === "maths"),
+      ),
       subjectPhaseKeystageSlugs: {
         subjectSlug: "maths",
         phaseSlug: "primary",

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
@@ -106,8 +106,9 @@ export async function generateMetadata({
   redirectProgrammeSlugIfNeeded(slug, pageSearchParams);
 
   try {
-    const cachedData = await getCachedProgrammeData(slug);
-    if (!cachedData) {
+    const cachedProgrammeData = await getCachedProgrammeData(slug);
+    const cachedSubjectData = await getCachedSubjectOptionData(slug);
+    if (!cachedProgrammeData || !cachedSubjectData) {
       return {};
     }
 
@@ -119,8 +120,12 @@ export async function generateMetadata({
       getBrowserConfig("seoAppUrl"),
     ).toString();
 
-    const title = getMetaTitle(cachedData, pageSearchParams);
-    const description = `Get fully sequenced teaching resources and lesson plans for ${cachedData.programmeUnitsData.phaseTitle} ${cachedData.programmeUnitsData.subjectTitle}`;
+    const title = getMetaTitle(
+      cachedProgrammeData,
+      cachedSubjectData,
+      pageSearchParams,
+    );
+    const description = `Get fully sequenced teaching resources and lesson plans for ${cachedProgrammeData.programmeUnitsData.phaseTitle} ${cachedProgrammeData.programmeUnitsData.subjectTitle}`;
 
     return {
       title,

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
@@ -5,7 +5,7 @@ import { cache } from "react";
 import { ProgrammeView } from "./Components/ProgrammeView";
 import { isTabSlug } from "./tabSchema";
 import { getMetaTitle } from "./getMetaTitle";
-import { getProgrammeData } from "./getProgrammeData";
+import { getSubjectPhaseOptions, getProgrammeData } from "./getProgrammeData";
 
 import {
   createDownloadsData,
@@ -43,6 +43,14 @@ const getCachedProgrammeData = cache(
       return getProgrammeData(curriculumApi2023, subjectPhaseSlug);
     },
     ["programme-data"],
+  ),
+);
+
+const getCachedSubjectOptionData = cache(
+  cacheData(
+    async (subjectPhaseSlug: string) =>
+      getSubjectPhaseOptions(curriculumApi2023, subjectPhaseSlug),
+    ["subject-phase-data"],
   ),
 );
 
@@ -143,36 +151,31 @@ export async function generateMetadata({
 }
 
 const InnerProgrammePage = async (props: AppPageProps<ProgrammePageParams>) => {
-  const { slug, tab } = await props.params;
+  const { slug: subjectPhaseSlug, tab } = await props.params;
   const searchParams = await props.searchParams;
 
-  redirectProgrammeSlugIfNeeded(slug, searchParams ?? {});
-
-  const subjectPhaseSlug = slug;
+  redirectProgrammeSlugIfNeeded(subjectPhaseSlug, searchParams ?? {});
 
   if (!isTabSlug(tab)) {
     return redirect("units");
   }
-  const cachedData = await getCachedProgrammeData(subjectPhaseSlug);
 
-  if (!cachedData) {
+  const cachedSubjectData = await getCachedSubjectOptionData(subjectPhaseSlug);
+
+  if (!cachedSubjectData) {
     return notFound();
   }
 
-  const {
-    programmeUnitsData,
-    curriculumUnitsData,
-    curriculumPhaseOptions,
-    subjectPhaseKeystageSlugs,
-  } = cachedData;
+  const { subjects, subjectPhaseKeystageSlugs } = cachedSubjectData;
 
-  const isValid = isValidSubjectPhaseSlug(
-    curriculumPhaseOptions.subjects,
+  const isSlugValid = isValidSubjectPhaseSlug(
+    subjects,
     subjectPhaseKeystageSlugs,
   );
-  if (!isValid) {
+
+  if (!isSlugValid) {
     const redirectParams = getKs4RedirectSlug(
-      curriculumPhaseOptions.subjects,
+      subjects,
       subjectPhaseKeystageSlugs,
     );
     if (redirectParams) {
@@ -196,6 +199,19 @@ const InnerProgrammePage = async (props: AppPageProps<ProgrammePageParams>) => {
       });
     }
   }
+
+  const cachedProgrammeData = await getCachedProgrammeData(subjectPhaseSlug);
+
+  if (!cachedProgrammeData) {
+    return notFound();
+  }
+
+  const { programmeUnitsData, curriculumUnitsData } = cachedProgrammeData;
+
+  const curriculumPhaseOptions = {
+    subjects,
+    tab: "units" as const,
+  };
 
   const { curriculumCMSInfo, subjectPhaseSanityData, mvRefreshTime } =
     await getCachedProgrammeCms({
@@ -266,7 +282,7 @@ const InnerProgrammePage = async (props: AppPageProps<ProgrammePageParams>) => {
     curriculumCMSInfo,
     ks4Options,
     trackingData: curriculumUnitsTrackingData,
-    curriculumInfo: cachedData.programmeUnitsData,
+    curriculumInfo: cachedProgrammeData.programmeUnitsData,
     curriculumDownloadsTabData,
     mvRefreshTime,
     initialFilter: resolvedFilter,

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/page.tsx
@@ -106,9 +106,8 @@ export async function generateMetadata({
   redirectProgrammeSlugIfNeeded(slug, pageSearchParams);
 
   try {
-    const cachedProgrammeData = await getCachedProgrammeData(slug);
     const cachedSubjectData = await getCachedSubjectOptionData(slug);
-    if (!cachedProgrammeData || !cachedSubjectData) {
+    if (!cachedSubjectData) {
       return {};
     }
 
@@ -120,12 +119,10 @@ export async function generateMetadata({
       getBrowserConfig("seoAppUrl"),
     ).toString();
 
-    const title = getMetaTitle(
-      cachedProgrammeData,
+    const { title, description } = getMetaTitle(
       cachedSubjectData,
       pageSearchParams,
     );
-    const description = `Get fully sequenced teaching resources and lesson plans for ${cachedProgrammeData.programmeUnitsData.phaseTitle} ${cachedProgrammeData.programmeUnitsData.subjectTitle}`;
 
     return {
       title,


### PR DESCRIPTION
## Description

Music year: 2014

- Splits `getProgrammeData` up so we can just fetch the subject phase options first
- Use the subject phase options to determine whether the slug is valid and redirect before fetching the full programme data
- Refactor `getMetaTitle` to only require subject data. The only thing we need from the programme data is the thread title so I opted to instead use the thread slug here as for SEO it should serve the same purpose and avoids having to fetch extra data in `generateMetadata`

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2071science-caching.vercel.thenational.academy/teachers/programmes/science-secondary/units *note no examboard
2. Check the[ vercel logs for the deployment](https://vercel.com/oak-national-academy/oak-web-application-website/7HAD8C83ghNAfEmFzrAarsPxUvDf/logs?refreshedAt=1780562229170&search=science-secondary%2Funits&panelState=closed&selectedLogId=vfjq2-1780562089354-7bfdfb688d2f)
3. You should not see any warnings that the response was too large to be cached
4. You should see a cache hit on the request 
<img width="544" height="263" alt="Screenshot 2026-06-04 at 09 38 50" src="https://github.com/user-attachments/assets/37ab41e4-5ce8-46c5-a840-6c615b33ed33" />


