### PR TITLE
Incorrect unit count in threads LESQ-2043

### DIFF
--- a/src/utils/curriculum/filtering.test.ts
+++ b/src/utils/curriculum/filtering.test.ts
@@ -1104,6 +1104,36 @@ describe("highlightedUnitCount", () => {
     ]);
     expect(result).toEqual(2);
   });
+
+  it("excludes units outside the active keystage", () => {
+    // ks3 = years 7,8,9 — ks4 = years 10,11
+    const ks3Thread = createThread({ slug: "ks3-thread" });
+    const mixedYearData = {
+      // year 7 is in ks3
+      "7": createYearData({
+        units: [
+          createUnit({ threads: [ks3Thread] }),
+          createUnit({ threads: [ks3Thread] }),
+        ],
+      }),
+      // year 10 is in ks4
+      "10": createYearData({
+        units: [createUnit({ threads: [ks3Thread] })],
+      }),
+    };
+    // filters.years covers all years; keystages restricts to ks4 only
+    const ks4Filters = createFilter({
+      years: ["7", "10"],
+      keystages: ["ks4"],
+      threads: [ks3Thread.slug],
+    });
+
+    const result = highlightedUnitCount(mixedYearData, ks4Filters, [
+      ks3Thread.slug,
+    ]);
+    // Only the 1 unit in year 10 (ks4) should be counted, not the 2 in year 7
+    expect(result).toEqual(1);
+  });
 });
 
 describe("filteringFromYears", () => {

--- a/src/utils/curriculum/filtersUrl.ts
+++ b/src/utils/curriculum/filtersUrl.ts
@@ -222,9 +222,10 @@ export function highlightedUnitCount(
   selectedThreads: Thread["slug"][] | null,
 ): number {
   let count = 0;
+  const effectiveYears = scopeYearsToKeystageFilter(filters);
   Object.entries(yearData).forEach(([year, yearDataItem]) => {
     const units = yearDataItem.units;
-    if (units && filters.years.includes(year)) {
+    if (units && effectiveYears.includes(year)) {
       units.forEach((unit) => {
         const yearBasedFilters = filteringFromYears(yearDataItem, filters);
 


### PR DESCRIPTION
Music year: 1950

## Description

- Fix `highlightedUnitCount` to respect active keystage filters — unit count in the thread filter panel now matches the highlighted units visible in the unit list
- Add test coverage for keystage-scoped thread unit counting

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-2043incorrect-9449be.vercel.thenational.academy/teachers/programmes/science-secondary-aqa/units?threads=bq03-biology-how-do-living-things-live-together-in-their-environments&keystages=ks4
2. Look at the thread filter panel — the selected thread should show a unit count badge
3. You should see **2 units highlighted** (not 4) — the count should match the number of highlighted units visible in the unit list

**Also verify with a different keystage:**

4. Change `keystages=ks4` to `keystages=ks3` in the URL
5. You should see the thread count update to reflect only units in KS3 years (7, 8, 9)

**And verify no regression for year filters:**

6. Go to https://oak-web-application-website-git-feat-lesq-2043incorrect-9449be.vercel.thenational.academy/teachers/programmes/science-secondary-aqa/units?threads=bq03-biology-how-do-living-things-live-together-in-their-environments
7. Select a specific year filter from the filter panel
8. You should see the thread unit count update to reflect only units in that year

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
