### PR TITLE
fix(PUPIL-1748): Hide decorative separator from screen readers (defect 5)

### DIFF
--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -71,6 +71,15 @@ describe("Downloads/Share Layout", () => {
     expect(apiErrorAfterRerender).toBeInTheDocument();
   });
 
+  it("hides the decorative separator from assistive technology", () => {
+    renderWithTheme(<ComponentWrapper {...props} />);
+
+    expect(screen.getByTestId("share-decorative-separator")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
   it("shows loading spinner", () => {
     const { getByTestId } = renderWithTheme(
       <ComponentWrapper {...props} isLoading={true} />,

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -158,6 +158,8 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
                     </OakBox>
                   )}
                   <OakHandDrawnHR
+                    aria-hidden
+                    data-testid="share-decorative-separator"
                     $height={"spacing-2"}
                     $width={"100%"}
                     $mb={"spacing-16"}


### PR DESCRIPTION
## Description

Music year: n/a

- Mark the decorative `OakHandDrawnHR` above share/download actions in `SharePageLayout` as `aria-hidden` so screen readers no longer announce the rule as image/separator content
- Add unit test asserting the separator is hidden from assistive technology

Fixes accessibility defect **#5** (WCAG 1.1.1 / 4.1.2) from Share Page follow-up work.

## Issue(s)

Fixes PUPIL-1748 - defect 5

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/teachers/programmes/{programme}/units/{unit}/lessons/{lesson}/share
2. Enable VoiceOver (or another screen reader)
3. Starting at **Share with pupils**, move line by line backward across the decorative rule above it
4. You should hear **no announcement** for the separator (previously announced as image/separator)

## Screenshots

How it used to look (delete if n/a):
n/a

How it should now look:
n/a

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)