### PR TITLE
fix(PUPIL-1748): Group share page controls for assistive technology (defects 3 & 4)

### DIFF
--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -35,6 +35,9 @@ describe("lesson share card group", () => {
     expect(
       screen.getByRole("heading", { name: /select activities/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /select activities/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Full online lesson")).toBeInTheDocument();
   });
   it("should render with resources", () => {

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -36,7 +36,7 @@ describe("lesson share card group", () => {
       screen.getByRole("heading", { name: /select activities/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("group", { name: /select activities/i }),
+      screen.getByRole("group", { name: "Select activities" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Full online lesson")).toBeInTheDocument();
   });

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -4,7 +4,9 @@ import userEvent from "@testing-library/user-event";
 
 import { ResourceFormValues } from "../types/downloadAndShare.types";
 
-import LessonShareCardGroup from "./LessonShareCardGroup";
+import LessonShareCardGroup, {
+  SHARE_SELECT_ACTIVITIES_HEADING_ID,
+} from "./LessonShareCardGroup";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
@@ -38,7 +40,32 @@ describe("lesson share card group", () => {
     expect(
       screen.getByRole("group", { name: "Select activities" }),
     ).toBeInTheDocument();
+    expect(
+      document.getElementById(SHARE_SELECT_ACTIVITIES_HEADING_ID),
+    ).toHaveTextContent("Select activities");
+    const fieldset = screen.getByRole("group", { name: "Select activities" });
+    expect(fieldset).toHaveAttribute(
+      "aria-labelledby",
+      SHARE_SELECT_ACTIVITIES_HEADING_ID,
+    );
     expect(screen.getByText("Full online lesson")).toBeInTheDocument();
+  });
+
+  it("should toggle the full online lesson checkbox", async () => {
+    renderWithTheme(
+      <ComponentWrapper shareableResources={[]} shareLink="www.fake.com" />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /full online lesson/i,
+    });
+    const user = userEvent.setup();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
   });
   it("should render with resources", () => {
     const shareableResources = [

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -6,7 +6,11 @@ import ResourceCard from "@/components/TeacherComponents/ShareResourceCard/Share
 import { sortShareResources } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { SharePageNumberedHeading } from "@/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading";
+import { Fieldset } from "@/components/CurriculumComponents/OakComponentsKitchen/Fieldset";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+
+export const SHARE_SELECT_ACTIVITIES_HEADING_ID =
+  "share-select-activities-heading";
 
 export type LessonShareCardGroupProps = {
   shareableResources: LessonShareData["shareableResources"];
@@ -51,93 +55,96 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
       <SharePageNumberedHeading
         number={1}
         title={"Select activities"}
+        titleId={SHARE_SELECT_ACTIVITIES_HEADING_ID}
         paragraph={
           "Select the activities you want to share. You must select at least one activity."
         }
       />
-      <OakGrid
-        $display="grid"
-        $gridTemplateColumns={["1fr", "1fr 1fr"]}
-        $cg="spacing-16"
-        $rg="spacing-32"
-        $maxWidth={"spacing-960"}
-      >
-        <OakFlex
-          $flexDirection={"row"}
-          $gap={"spacing-16"}
-          $justifyContent={"stretch"}
+      <Fieldset aria-labelledby={SHARE_SELECT_ACTIVITIES_HEADING_ID}>
+        <OakGrid
+          $display="grid"
+          $gridTemplateColumns={["1fr", "1fr 1fr"]}
+          $cg="spacing-16"
+          $rg="spacing-32"
+          $maxWidth={"spacing-960"}
         >
-          <Controller
-            data-testid="lessonResourcesToShare"
-            control={props.control}
-            name="resources"
-            defaultValue={[]}
-            key={`${"all"}`}
-            render={({
-              field: { value: fieldValue, onChange, name, onBlur },
-            }) => {
-              return (
-                <OakDownloadCard
-                  format="Share the whole lesson (starter quiz, lesson video, worksheet and exit quiz) and view results"
-                  id={"download-card-wrapping-long"}
-                  data-testid="resourceCard"
-                  value={"all"}
-                  name={name}
-                  title="Full online lesson"
-                  checked={["exit-quiz", "starter-quiz", "video"].every(
-                    (section) => fieldValue.includes(section),
-                  )}
-                  onChange={(e) => {
-                    checkboxOnChangeHandler(e, onChange, fieldValue, [
-                      "exit-quiz",
-                      "starter-quiz",
-                      "video",
-                    ]);
-                  }}
-                  onBlur={onBlur}
-                  iconName={["quiz", "video", "worksheet", "quiz"]}
-                />
-              );
-            }}
-          />
-        </OakFlex>
-        <OakFlex $flexDirection={"column"} $gap={"spacing-32"}>
-          {sortedResources.map((resource, i) => (
+          <OakFlex
+            $flexDirection={"row"}
+            $gap={"spacing-16"}
+            $justifyContent={"stretch"}
+          >
             <Controller
               data-testid="lessonResourcesToShare"
               control={props.control}
               name="resources"
               defaultValue={[]}
-              key={`${resource.type}-${i}`}
+              key={`${"all"}`}
               render={({
                 field: { value: fieldValue, onChange, name, onBlur },
               }) => {
                 return (
-                  <ResourceCard
-                    id={resource.type}
+                  <OakDownloadCard
+                    format="Share the whole lesson (starter quiz, lesson video, worksheet and exit quiz) and view results"
+                    id={"download-card-wrapping-long"}
+                    data-testid="resourceCard"
+                    value={"all"}
                     name={name}
-                    label={resource.label}
-                    subtitle={resource.metadata!}
-                    resourceType={resource.type}
+                    title="Full online lesson"
+                    checked={["exit-quiz", "starter-quiz", "video"].every(
+                      (section) => fieldValue.includes(section),
+                    )}
                     onChange={(e) => {
-                      checkboxOnChangeHandler(
-                        e,
-                        onChange,
-                        fieldValue,
-                        resource.type,
-                      );
+                      checkboxOnChangeHandler(e, onChange, fieldValue, [
+                        "exit-quiz",
+                        "starter-quiz",
+                        "video",
+                      ]);
                     }}
-                    checked={fieldValue.includes(resource.type)}
                     onBlur={onBlur}
-                    hasError={props.hasError}
-                    useDownloadPageLayout={false}
+                    iconName={["quiz", "video", "worksheet", "quiz"]}
                   />
                 );
               }}
             />
-          ))}
-        </OakFlex>
-      </OakGrid>
+          </OakFlex>
+          <OakFlex $flexDirection={"column"} $gap={"spacing-32"}>
+            {sortedResources.map((resource, i) => (
+              <Controller
+                data-testid="lessonResourcesToShare"
+                control={props.control}
+                name="resources"
+                defaultValue={[]}
+                key={`${resource.type}-${i}`}
+                render={({
+                  field: { value: fieldValue, onChange, name, onBlur },
+                }) => {
+                  return (
+                    <ResourceCard
+                      id={resource.type}
+                      name={name}
+                      label={resource.label}
+                      subtitle={resource.metadata!}
+                      resourceType={resource.type}
+                      onChange={(e) => {
+                        checkboxOnChangeHandler(
+                          e,
+                          onChange,
+                          fieldValue,
+                          resource.type,
+                        );
+                      }}
+                      checked={fieldValue.includes(resource.type)}
+                      onBlur={onBlur}
+                      hasError={props.hasError}
+                      useDownloadPageLayout={false}
+                    />
+                  );
+                }}
+              />
+            ))}
+          </OakFlex>
+        </OakGrid>
+      </Fieldset>
     </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
@@ -37,7 +37,7 @@ describe("LessonShareLinks", () => {
     expect(shareHeader).toBeInTheDocument();
     expect(shareHeader).toHaveTextContent("Share with pupils");
     expect(
-      screen.getByRole("group", { name: /share with pupils/i }),
+      screen.getByRole("group", { name: "Share with pupils" }),
     ).toBeInTheDocument();
   });
   it("should update copy link button", async () => {

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
@@ -2,7 +2,9 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 
-import LessonShareLinks from "./LessonShareLinks";
+import LessonShareLinks, {
+  SHARE_WITH_PUPILS_HEADING_ID,
+} from "./LessonShareLinks";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
@@ -36,9 +38,15 @@ describe("LessonShareLinks", () => {
     const shareHeader = screen.getByRole("heading");
     expect(shareHeader).toBeInTheDocument();
     expect(shareHeader).toHaveTextContent("Share with pupils");
+    const shareGroup = screen.getByRole("group", { name: "Share with pupils" });
+    expect(shareGroup).toBeInTheDocument();
+    expect(shareGroup).toHaveAttribute(
+      "aria-labelledby",
+      SHARE_WITH_PUPILS_HEADING_ID,
+    );
     expect(
-      screen.getByRole("group", { name: "Share with pupils" }),
-    ).toBeInTheDocument();
+      document.getElementById(SHARE_WITH_PUPILS_HEADING_ID),
+    ).toHaveTextContent("Share with pupils");
   });
   it("should update copy link button", async () => {
     renderWithProviders()(

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.test.tsx
@@ -36,6 +36,9 @@ describe("LessonShareLinks", () => {
     const shareHeader = screen.getByRole("heading");
     expect(shareHeader).toBeInTheDocument();
     expect(shareHeader).toHaveTextContent("Share with pupils");
+    expect(
+      screen.getByRole("group", { name: /share with pupils/i }),
+    ).toBeInTheDocument();
   });
   it("should update copy link button", async () => {
     renderWithProviders()(

--- a/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
+++ b/src/components/TeacherComponents/LessonShareLinks/LessonShareLinks.tsx
@@ -12,6 +12,8 @@ import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNot
 import { getLessonShareVariantSlug } from "@/pages-helpers/pupil";
 import { LessonSection } from "@/components/PupilComponents/lessonSections";
 
+export const SHARE_WITH_PUPILS_HEADING_ID = "share-with-pupils-heading";
+
 const LessonShareLinks: FC<{
   disabled: boolean;
   lessonSlug: string;
@@ -92,11 +94,18 @@ const LessonShareLinks: FC<{
       <SharePageNumberedHeading
         number={2}
         title={"Share with pupils"}
+        titleId={SHARE_WITH_PUPILS_HEADING_ID}
         paragraph={
           "Use one of the links below to share the selected activities with your pupils."
         }
       />
-      <OakFlex $flexWrap={"wrap"} $width={"100%"} $gap={"spacing-12"}>
+      <OakFlex
+        role="group"
+        aria-labelledby={SHARE_WITH_PUPILS_HEADING_ID}
+        $flexWrap={"wrap"}
+        $width={"100%"}
+        $gap={"spacing-12"}
+      >
         <OakSecondaryButton
           element="button"
           iconName={shareLinkConfig.copy.icon}

--- a/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.test.tsx
+++ b/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.test.tsx
@@ -1,0 +1,39 @@
+import { screen } from "@testing-library/react";
+
+import { SharePageNumberedHeading } from "./SharePageNumberedHeading";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+describe("SharePageNumberedHeading", () => {
+  it("renders the numbered heading and paragraph", () => {
+    renderWithTheme(
+      <SharePageNumberedHeading
+        number={1}
+        title="Select activities"
+        paragraph="Select the activities you want to share."
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /select activities/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Select the activities you want to share."),
+    ).toBeInTheDocument();
+  });
+
+  it("applies titleId to the title span for aria-labelledby", () => {
+    renderWithTheme(
+      <SharePageNumberedHeading
+        number={2}
+        title="Share with pupils"
+        paragraph="Use one of the links below."
+        titleId="share-with-pupils-heading"
+      />,
+    );
+
+    expect(
+      document.getElementById("share-with-pupils-heading"),
+    ).toHaveTextContent("Share with pupils");
+  });
+});

--- a/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.tsx
+++ b/src/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading.tsx
@@ -9,10 +9,12 @@ export const SharePageNumberedHeading = ({
   number,
   title,
   paragraph,
+  titleId,
 }: {
   number: number;
   title: string;
   paragraph: string;
+  titleId?: string;
 }) => {
   return (
     <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
@@ -31,7 +33,9 @@ export const SharePageNumberedHeading = ({
           >
             <OakSpan $font={"body-1-bold"}>{number}</OakSpan>
           </OakFlex>
-          <OakSpan $ml={"spacing-16"}>{title}</OakSpan>
+          <OakSpan $ml={"spacing-16"} id={titleId}>
+            {title}
+          </OakSpan>
         </OakFlex>
       </OakHeading>
       <OakP $font={"body-1"}>{paragraph}</OakP>


### PR DESCRIPTION
## Description

Music year: n/a

- Group activity checkboxes in a `<fieldset aria-labelledby="…">` labelled by the **Select activities** heading (defect 3)
- Group share action buttons in `role="group"` labelled by the **Share with pupils** heading (defect 4)
- Add optional `titleId` to `SharePageNumberedHeading` so group names exclude the step number badge (e.g. "Share with pupils" not "2 Share with pupils")
- Add unit tests asserting both groups are exposed to assistive technology

Fixes accessibility defects **#3** and **#4** from Share Page follow-up work (WCAG 1.3.1, 4.1.2, 2.4.6).

## Issue(s)

Fixes PUPIL-1748

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/teachers/programmes/{programme}/units/{unit}/lessons/{lesson}/share
2. Enable VoiceOver (or another screen reader)
3. Tab to an activity checkbox — you should hear **Select activities, group** before the individual option
4. Tab to **Copy link** (or another share button) — you should hear **Share with pupils, group** before the button name (without a "2" prefix)

## Screenshots
<img width="969" height="843" alt="Screenshot 2026-06-08 at 15 04 36" src="https://github.com/user-attachments/assets/8646fd01-e536-495c-a657-1d991751dfdb" />
<img width="1034" height="686" alt="Screenshot 2026-06-08 at 15 05 52" src="https://github.com/user-attachments/assets/9b20d855-adcf-4718-a15a-9a78aa51ffbc" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)