### PR TITLE
fix(PUPIL-1748): announce share validation errors to screen readers (defect 1)

### DIFF
--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -102,6 +102,26 @@ describe("Downloads/Share Layout", () => {
     );
   });
 
+  it("does not render validation summary when errors have no summary messages", () => {
+    renderWithTheme(
+      <ComponentWrapper
+        {...props}
+        errors={
+          {
+            schoolName: {
+              type: "custom",
+              message: "enter a school name",
+            },
+          } satisfies FieldErrors<ResourceFormValues>
+        }
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("share-validation-summary"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows loading spinner", () => {
     const { getByTestId } = renderWithTheme(
       <ComponentWrapper {...props} isLoading={true} />,

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { useForm } from "react-hook-form";
+import { useForm , FieldErrors } from "react-hook-form";
 
 import ResourcePageLayoutB, { SharePageLayoutProps } from "./SharePageLayout";
 
@@ -75,10 +75,18 @@ describe("Downloads/Share Layout", () => {
     renderWithTheme(
       <ComponentWrapper
         {...props}
-        errors={{
-          resources: { message: "select at least one resource to continue" },
-          terms: { message: "accept terms and conditions to continue" },
-        }}
+        errors={
+          {
+            resources: {
+              type: "custom",
+              message: "select at least one resource to continue",
+            },
+            terms: {
+              type: "custom",
+              message: "accept terms and conditions to continue",
+            },
+          } satisfies FieldErrors<ResourceFormValues>
+        }
         validationSummaryKey={1}
       />,
     );

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -102,6 +102,39 @@ describe("Downloads/Share Layout", () => {
     );
   });
 
+  it("remounts validation summary when validationSummaryKey changes", () => {
+    const validationErrors = {
+      resources: {
+        type: "custom",
+        message: "select at least one resource to continue",
+      },
+    } satisfies FieldErrors<ResourceFormValues>;
+
+    const { rerender } = renderWithTheme(
+      <ComponentWrapper
+        {...props}
+        errors={validationErrors}
+        validationSummaryKey={1}
+      />,
+    );
+
+    const firstValidationSummary = screen.getByTestId(
+      "share-validation-summary",
+    );
+
+    rerender(
+      <ComponentWrapper
+        {...props}
+        errors={validationErrors}
+        validationSummaryKey={2}
+      />,
+    );
+
+    expect(screen.getByTestId("share-validation-summary")).not.toBe(
+      firstValidationSummary,
+    );
+  });
+
   it("does not render validation summary when errors have no summary messages", () => {
     renderWithTheme(
       <ComponentWrapper

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -71,6 +71,29 @@ describe("Downloads/Share Layout", () => {
     expect(apiErrorAfterRerender).toBeInTheDocument();
   });
 
+  it("exposes validation summary as an alert for assistive technology", () => {
+    renderWithTheme(
+      <ComponentWrapper
+        {...props}
+        errors={{
+          resources: { message: "select at least one resource to continue" },
+          terms: { message: "accept terms and conditions to continue" },
+        }}
+        validationSummaryKey={1}
+      />,
+    );
+
+    const validationSummary = screen.getByTestId("share-validation-summary");
+    expect(validationSummary).toHaveAttribute("role", "alert");
+    expect(validationSummary).toHaveAttribute("aria-atomic", "true");
+    expect(validationSummary).toHaveTextContent(
+      "select at least one resource to continue",
+    );
+    expect(validationSummary).toHaveTextContent(
+      "accept terms and conditions to continue",
+    );
+  });
+
   it("shows loading spinner", () => {
     const { getByTestId } = renderWithTheme(
       <ComponentWrapper {...props} isLoading={true} />,

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { useForm , FieldErrors } from "react-hook-form";
+import { useForm, FieldErrors } from "react-hook-form";
 
 import ResourcePageLayoutB, { SharePageLayoutProps } from "./SharePageLayout";
 
@@ -92,13 +92,13 @@ describe("Downloads/Share Layout", () => {
     );
 
     const validationSummary = screen.getByTestId("share-validation-summary");
+    const validationSummarySr = screen.getByTestId(
+      "share-validation-summary-sr",
+    );
     expect(validationSummary).toHaveAttribute("role", "alert");
     expect(validationSummary).toHaveAttribute("aria-atomic", "true");
-    expect(validationSummary).toHaveTextContent(
-      "select at least one resource to continue",
-    );
-    expect(validationSummary).toHaveTextContent(
-      "accept terms and conditions to continue",
+    expect(validationSummarySr).toHaveTextContent(
+      "To complete correct the following: select at least one resource to continue. accept terms and conditions to continue",
     );
   });
 

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -53,9 +53,8 @@ export type SharePageLayoutProps = ResourcePageDetailsCompletedProps &
 const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
   const hasFormErrors = Object.keys(props.errors).length > 0;
   const validationErrorMessages = getFormErrorMessages(props.errors);
-  const validationSummaryAnnouncement = validationErrorMessages.length
-    ? `To complete correct the following: ${validationErrorMessages.join(". ")}`
-    : "";
+  const hasValidationSummary = validationErrorMessages.length > 0;
+  const validationSummaryAnnouncement = `To complete correct the following: ${validationErrorMessages.join(". ")}`;
   return (
     <OakBox $maxWidth={"spacing-960"} $mb={"spacing-48"}>
       <OakFlex
@@ -122,7 +121,7 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
                       oglCopyrightYear={props.updatedAt}
                     />
                   )}
-                  {hasFormErrors && (
+                  {hasValidationSummary && (
                     <OakFlex
                       role="alert"
                       aria-atomic="true"

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -27,6 +27,7 @@ import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/dow
 import TermsAgreementForm from "@/components/TeacherComponents/TermsAgreementForm";
 import NoResourcesToShare from "@/components/TeacherComponents/NoResourcesToShare";
 import FieldError from "@/components/SharedComponents/FieldError";
+import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
 
 export type SharePageLayoutProps = ResourcePageDetailsCompletedProps &
   ResourcePageSchoolDetailsProps & {
@@ -51,6 +52,10 @@ export type SharePageLayoutProps = ResourcePageDetailsCompletedProps &
 
 const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
   const hasFormErrors = Object.keys(props.errors).length > 0;
+  const validationErrorMessages = getFormErrorMessages(props.errors);
+  const validationSummaryAnnouncement = validationErrorMessages.length
+    ? `To complete correct the following: ${validationErrorMessages.join(". ")}`
+    : "";
   return (
     <OakBox $maxWidth={"spacing-960"} $mb={"spacing-48"}>
       <OakFlex
@@ -123,28 +128,31 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
                       aria-atomic="true"
                       data-testid="share-validation-summary"
                       key={props.validationSummaryKey}
-                      $flexDirection={"row"}
+                      $flexDirection={"column"}
                     >
-                      <OakIcon
-                        iconName="content-guidance"
-                        $colorFilter={"icon-error"}
-                        $width={"spacing-24"}
-                        $height={"spacing-24"}
-                      />
-                      <OakFlex $flexDirection={"column"}>
-                        <OakP $ml="spacing-4" $color={"text-error"}>
-                          To complete correct the following:
-                        </OakP>
-                        <OakUL $mr="spacing-24">
-                          {getFormErrorMessages(props.errors).map((err) => {
-                            return (
+                      <OakFlex aria-hidden={true} $flexDirection={"row"}>
+                        <OakIcon
+                          iconName="content-guidance"
+                          $colorFilter={"icon-error"}
+                          $width={"spacing-24"}
+                          $height={"spacing-24"}
+                        />
+                        <OakFlex $flexDirection={"column"}>
+                          <OakP $ml="spacing-4" $color={"text-error"}>
+                            To complete correct the following:
+                          </OakP>
+                          <OakUL $mr="spacing-24">
+                            {validationErrorMessages.map((err) => (
                               <OakLI $color={"text-error"} key={err}>
                                 {err}
                               </OakLI>
-                            );
-                          })}
-                        </OakUL>
+                            ))}
+                          </OakUL>
+                        </OakFlex>
                       </OakFlex>
+                      <ScreenReaderOnly data-testid="share-validation-summary-sr">
+                        {validationSummaryAnnouncement}
+                      </ScreenReaderOnly>
                     </OakFlex>
                   )}
 

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -46,6 +46,7 @@ export type SharePageLayoutProps = ResourcePageDetailsCompletedProps &
     updatedAt: string;
     showTermsAgreement: boolean;
     isLoading: boolean;
+    validationSummaryKey?: number;
   };
 
 const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
@@ -117,7 +118,13 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
                     />
                   )}
                   {hasFormErrors && (
-                    <OakFlex $flexDirection={"row"}>
+                    <OakFlex
+                      role="alert"
+                      aria-atomic="true"
+                      data-testid="share-validation-summary"
+                      key={props.validationSummaryKey}
+                      $flexDirection={"row"}
+                    >
                       <OakIcon
                         iconName="content-guidance"
                         $colorFilter={"icon-error"}

--- a/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
+++ b/src/components/TeacherComponents/hooks/downloadAndShareHooks/useResourceFormState.tsx
@@ -263,7 +263,7 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
     [setValue, schoolNameFromLocalStorage],
   );
 
-  const { errors } = formState;
+  const { errors, submitCount } = formState;
   const hasFormErrors = Object.keys(errors)?.length > 0;
   const selectedResources = watch("resources") as ResourceType[];
 
@@ -420,6 +420,7 @@ export const useResourceFormState = (props: UseResourceFormStateProps) => {
       formState,
       getInitialResourcesState,
       errors,
+      submitCount,
       control,
       register,
       handleSubmit,

--- a/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
+++ b/src/components/TeacherViews/LessonShare/LessonShare.view.tsx
@@ -244,6 +244,7 @@ export function LessonShare(props: LessonShareProps) {
         </OakBox>
         <SharePageLayout
           errors={form.errors}
+          validationSummaryKey={form.submitCount}
           header="Share your lesson"
           showNoResources={!hasResources || Boolean(expired)}
           showLoading={isLocalStorageLoading}


### PR DESCRIPTION
## Description

- Adds `role="alert"` and `aria-atomic="true"` to the share page validation summary so assistive technology announces errors on invalid submit (WCAG 4.1.3 / 3.3.1).
- Keys the alert container with React Hook Form `submitCount` so the summary is re-announced on repeated submit attempts without fixing errors.
- Adds unit test coverage for alert semantics on `SharePageLayout`.

### Issue(s)

Fixes PUPIL-1748 (defect 1 — announce validation errors to screen readers)

## Possible Follow-up (deferred)

VoiceOver testing found the alert reads list semantics as "bullet" between errors (`OakUL`/`OakLI` inside `aria-atomic` alert). A possible future improvement would be to replace the list with prose/CSS bullets inside the live region.

## Merge notes

- No conflict with [#4281](https://github.com/oaknational/Oak-Web-Application/pull/4281) (grouping).
- Possible trivial test-file conflict with [#4280](https://github.com/oaknational/Oak-Web-Application/pull/4280) in `SharePageLayout.test.tsx` if merged second.

## Test plan

- [x] 1 - VoiceOver: unselect all 'activities' → hear validation errors 'Select at least one resource to continue'
- [x] 2 - VoiceOver: click copy link with empty School (required) and 'my school isn't listed' unticked -> hear validation error 'Select school, type 'homeschool' or tick 'My school isn't listed''
- [x] 3 - VoiceOver: click copy link with terms and conditions unselected -> hear validation error: 'accept terms and conditions to continue'
- [x] 4 - VoiceOver: Unselect all required fields and click 'copy link / share with Microsoft Teams /  Share via Google Classom' -> Hear ALL validation errors. 
- [x] 5 - VoiceOver: click share again without fixing → summary re-announced

## Screenshots:
<img width="1141" height="780" alt="Screenshot 2026-06-09 at 08 35 50" src="https://github.com/user-attachments/assets/5578d257-d91f-495d-85ff-7134568d61f9" />
<img width="904" height="728" alt="Screenshot 2026-06-09 at 08 37 02" src="https://github.com/user-attachments/assets/bab0ccea-dc65-4772-8fc8-ba9f0bfda5df" />
<img width="904" height="753" alt="Screenshot 2026-06-09 at 08 37 31" src="https://github.com/user-attachments/assets/c047bb23-e951-42e5-8cfe-ec76e35cf461" />
<img width="1105" height="800" alt="Screenshot 2026-06-09 at 08 39 54" src="https://github.com/user-attachments/assets/04810526-40b6-4e97-8a57-f2049cf036c4" />



Made with [Cursor](https://cursor.com)