### PR TITLE
Add an experiment for the download success CTA LESQ-2042

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.stories.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.stories.tsx
@@ -105,5 +105,23 @@ export const Default: Story = {
   ],
   args: {
     lesson: lessonWithUnitList,
+    ctaVariant: "control",
+  },
+};
+
+export const TestVariant: Story = {
+  decorators: [
+    (Story) => {
+      __setMockAuthState({
+        isSignedIn: true,
+        isOnboarded: true,
+        isRegionAuthorised: true,
+      });
+      return <Story />;
+    },
+  ],
+  args: {
+    lesson: lessonWithUnitList,
+    ctaVariant: "test",
   },
 };

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.test.tsx
@@ -108,7 +108,7 @@ describe("DownloadSuccessView", () => {
 
   it("renders the confirmation heading and intro copy", () => {
     const { getByRole, getByText } = renderComponent(
-      <DownloadSuccessView lesson={baseLesson} />,
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="control" />,
     );
 
     expect(
@@ -121,7 +121,7 @@ describe("DownloadSuccessView", () => {
 
   it("back to lesson links to the lesson overview", () => {
     const { getByRole } = renderComponent(
-      <DownloadSuccessView lesson={baseLesson} />,
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="control" />,
     );
 
     const link = getByRole("link", { name: "Back to lesson" });
@@ -139,7 +139,7 @@ describe("DownloadSuccessView", () => {
   it("calls onwardContentSelected when Back to lesson is clicked", async () => {
     const user = userEvent.setup();
     const { getByRole } = renderComponent(
-      <DownloadSuccessView lesson={baseLesson} />,
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="control" />,
     );
 
     await user.click(getByRole("link", { name: "Back to lesson" }));
@@ -171,7 +171,7 @@ describe("DownloadSuccessView", () => {
       unitDescription: "Unit description text",
     };
     const { getByText } = renderComponent(
-      <DownloadSuccessView lesson={lesson} />,
+      <DownloadSuccessView lesson={lesson} ctaVariant="control" />,
     );
 
     expect(getByText("Ready to keep going?")).toBeInTheDocument();
@@ -185,7 +185,7 @@ describe("DownloadSuccessView", () => {
     );
 
     const { getByText } = renderComponent(
-      <DownloadSuccessView lesson={baseLesson} />,
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="control" />,
     );
 
     expect(
@@ -201,7 +201,7 @@ describe("DownloadSuccessView", () => {
     );
 
     const { queryByText } = renderComponent(
-      <DownloadSuccessView lesson={baseLesson} />,
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="control" />,
     );
 
     expect(
@@ -209,5 +209,16 @@ describe("DownloadSuccessView", () => {
         /Click the question mark in the bottom-right of the page if you need extra help with this/i,
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders test variant CTA copy when ctaVariant is test", () => {
+    const { getByText, queryByText } = renderComponent(
+      <DownloadSuccessView lesson={baseLesson} ctaVariant="test" />,
+    );
+
+    expect(
+      getByText("Everything you need to plan a unit in one click"),
+    ).toBeInTheDocument();
+    expect(queryByText("Ready to keep going?")).not.toBeInTheDocument();
   });
 });

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
@@ -9,6 +9,7 @@ import {
   OakSpan,
 } from "@oaknational/oak-components";
 import { useEffect } from "react";
+import styled from "styled-components";
 
 import { LessonList } from "@/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/LessonList";
 import { DownloadSuccessHeader } from "@/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/DownloadSuccessHeader/DownloadSuccessHeader";
@@ -40,10 +41,19 @@ type DownloadSuccessViewLesson = {
 
 export type DownloadSuccessViewProps = {
   lesson: DownloadSuccessViewLesson;
+  ctaVariant: "control" | "test";
 };
+
+// Oak-components is a little out of sync with Figma
+// with letter-spacing on headings. Applying a temporary
+// fix here until we update the tokens to match.
+const TightenedOakSpan = styled(OakSpan)`
+  letter-spacing: -0.64px;
+`;
 
 export function DownloadSuccessView({
   lesson,
+  ctaVariant,
 }: Readonly<DownloadSuccessViewProps>) {
   const {
     lessonTitle,
@@ -120,19 +130,39 @@ export function DownloadSuccessView({
           $cg="spacing-12"
         >
           <OakGridArea $colSpan={[12, 8]} $colStart={[1, 3]} $gap="spacing-48">
-            <OakFlex
-              $font="heading-light-6"
-              $mh="auto"
-              $alignItems="center"
-              $gap="spacing-12"
-            >
-              <OakIcon iconName="arrow-down" $colorFilter="text-success" />
-              <span>
-                <OakSpan $font="heading-6">Ready to keep going?</OakSpan>{" "}
-                Explore the lessons in this unit sequence.
-              </span>
-              <OakIcon iconName="arrow-down" $colorFilter="text-success" />
-            </OakFlex>
+            {ctaVariant === "test" ? (
+              <OakFlex $mh="auto" $alignItems="center" $gap="spacing-12">
+                <OakIcon
+                  iconName="arrow-down"
+                  $colorFilter="text-success"
+                  $width="spacing-48"
+                  $height="spacing-48"
+                />
+                <TightenedOakSpan $font="heading-4">
+                  Everything you need to plan a unit in one click
+                </TightenedOakSpan>
+                <OakIcon
+                  iconName="arrow-down"
+                  $colorFilter="text-success"
+                  $width="spacing-48"
+                  $height="spacing-48"
+                />
+              </OakFlex>
+            ) : (
+              <OakFlex
+                $font="heading-light-6"
+                $mh="auto"
+                $alignItems="center"
+                $gap="spacing-12"
+              >
+                <OakIcon iconName="arrow-down" $colorFilter="text-success" />
+                <span>
+                  <OakSpan $font="heading-6">Ready to keep going?</OakSpan>{" "}
+                  Explore the lessons in this unit sequence.
+                </span>
+                <OakIcon iconName="arrow-down" $colorFilter="text-success" />
+              </OakFlex>
+            )}
             <LessonList
               programmeSlug={lesson.programmeSlug}
               unitSlug={lesson.unitSlug}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.test.tsx
@@ -10,6 +10,11 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
+const featureFlagMock = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/utils/featureFlags", () => ({
+  getFeatureFlagValue: () => featureFlagMock(),
+}));
+
 const mockTeachersUnitOverview = jest.fn();
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,
@@ -50,6 +55,7 @@ const teachersUnitOverviewFixture = {
 describe("LessonDownloadsSuccessPage", () => {
   beforeEach(() => {
     mockTeachersUnitOverview.mockResolvedValue(teachersUnitOverviewFixture);
+    featureFlagMock.mockResolvedValue(undefined);
   });
 
   it("fetches unit data and renders success confirmation", async () => {
@@ -69,9 +75,32 @@ describe("LessonDownloadsSuccessPage", () => {
           lessonSlug: "solid-and-liquid-states",
           unitvariantId: 123,
         }),
+        ctaVariant: "control",
       },
     });
   });
+
+  it.each([
+    { flagValue: undefined, expectedVariant: "control" },
+    { flagValue: "control", expectedVariant: "control" },
+    { flagValue: "test", expectedVariant: "test" },
+  ])(
+    "passes ctaVariant $expectedVariant when feature flag is $flagValue",
+    async ({ flagValue, expectedVariant }) => {
+      featureFlagMock.mockResolvedValue(flagValue);
+
+      const result = await LessonDownloadsSuccessPage({
+        params: Promise.resolve(defaultParams),
+        searchParams: Promise.resolve({}),
+      });
+
+      expect(result).toMatchObject({
+        props: {
+          ctaVariant: expectedVariant,
+        },
+      });
+    },
+  );
 
   it("renders 404 when lesson release date is missing", async () => {
     mockTeachersUnitOverview.mockResolvedValue({

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/page.tsx
@@ -8,6 +8,7 @@ import { DownloadSuccessView } from "./Components/DownloadSuccessView";
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
+import { getFeatureFlagValue } from "@/utils/featureFlags";
 
 type LessonDownloadsSuccessPageParams = {
   slug: string;
@@ -15,7 +16,7 @@ type LessonDownloadsSuccessPageParams = {
   lessonSlug: string;
 };
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 const getSuccessData = async (
   programmeSlug: string,
@@ -79,7 +80,13 @@ const InnerLessonDownloadsSuccessPage = async (
     return notFound();
   }
 
-  return <DownloadSuccessView lesson={data} />;
+  const variantKey = await getFeatureFlagValue(
+    "download-success-cta-experiment",
+    "string",
+  );
+  const ctaVariant = variantKey === "test" ? "test" : "control";
+
+  return <DownloadSuccessView lesson={data} ctaVariant={ctaVariant} />;
 };
 
 const LessonDownloadsSuccessPage = withPageErrorHandling(


### PR DESCRIPTION
## Description

Music year: 1956

## Description

- Add server-side PostHog A/B test on the download success page CTA via `download-success-cta-experiment` (`control` / `test`)
- Switch download success page from `force-static` to `force-dynamic` so feature flags are evaluated per request from the PostHog cookie
- Pass `ctaVariant` from the server page to `DownloadSuccessView` and conditionally render CTA copy and styling
- **Control:** "Ready to keep going? Explore the lessons in this unit sequence." with default arrow icons
- **Test:** "Everything you need to plan a unit in one click" at `heading-4` with larger (`spacing-48`) arrow icons
- Users without a PostHog distinct ID fall back to control (not enrolled in the experiment)
- Add/update unit and component tests for both variants; add Storybook `TestVariant` story

Dev feature flag: https://eu.posthog.com/project/124/feature_flags/201294
Production: https://eu.posthog.com/project/125/feature_flags/201332

## How to test

⚠️ You'll need the https://eu.posthog.com/project/124/feature_flags/201294 feature flag set to the "test" variant for this to work. Give me a shout with your distinct id if you need it (The posthog UI is a nightmare)

1. Go to https://oak-web-application-website-git-feat-lesq-2042a-b-test-a-8d7fac.vercel.thenational.academy/teachers/programmes/science-secondary-ks3/units/solid-liquid-gas-states-and-changes-of-state/lessons/solid-and-liquid-states/downloads
2. Select resources and complete a download so you are redirected to the success page (or go directly to `/teachers/programmes/science-secondary-ks3/units/solid-liquid-gas-states-and-changes-of-state/lessons/solid-and-liquid-states/downloads/success`)
3. With the PostHog flag set to **control** (or no PostHog cookie), you should see the heading **"Ready to keep going?"** followed by **"Explore the lessons in this unit sequence."**, with default-sized green arrow-down icons on either side

**Also verify the test variant:**

4. In PostHog, override your user to the **`test`** variant for `download-success-cta-experiment`, then hard-refresh the success page URL above
5. You should see **"Everything you need to plan a unit in one click"** in larger heading text (`heading-4`), with noticeably larger green arrow-down icons (`spacing-48`) on either side, and **no** "Ready to keep going?" text

**And verify no regression for the rest of the success page:**

6. On either variant, confirm the page still shows **"Thanks for downloading!"**, the **Back to lesson** link, the unit lesson list with the current lesson marked, and the **Download complete unit** button
7. Click **Back to lesson** — you should land on the lesson overview page for `solid-and-liquid-states`

<img width="1789" height="1524" alt="Screenshot 2026-06-08 at 16 41 59" src="https://github.com/user-attachments/assets/c3b7f53b-3aed-43ac-9b31-d1d87d7fcc66" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
