### PR TITLE
fix(PUPIL-1748): add programmatic labels to share activity checkboxes (defect 7)

### DIFF
--- a/src/common-lib/urls/getDeploymentTestUrls.js
+++ b/src/common-lib/urls/getDeploymentTestUrls.js
@@ -56,6 +56,7 @@ function getDeploymentTestUrls() {
     "/teachers/programmes/physical-education-primary-ks2/units/invasion-games-principles-of-attack-and-defence-through-ball-games/lessons/passing-and-receiving-skills", // practical PE lesson
     "/teachers/programmes/computing-primary-ks1/units/building-sequences-in-programs/lessons/building-blocks-to-create-a-sequence", // lesson with media clips and additional materials
     "/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil", // lesson with lesson files,
+    "/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/share", // lesson share page (PUPIL-1748)
 
     // Canonical lesson pages
     "/teachers/lessons/duncan-as-a-father-figure",

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -6,6 +6,7 @@ import { ResourceFormValues } from "../types/downloadAndShare.types";
 
 import LessonShareCardGroup from "./LessonShareCardGroup";
 
+import { getActivityDownloadCardAriaLabel } from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 
@@ -36,6 +37,18 @@ describe("lesson share card group", () => {
       screen.getByRole("heading", { name: /select activities/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("Full online lesson")).toBeInTheDocument();
+
+    const fullLessonCheckbox = screen.getByRole("checkbox", {
+      name: /full online lesson/i,
+    });
+    expect(fullLessonCheckbox).toHaveAttribute(
+      "aria-label",
+      getActivityDownloadCardAriaLabel(
+        "Full online lesson",
+        "Share the whole lesson (starter quiz, lesson video, worksheet and exit quiz) and view results",
+      ),
+    );
+    expect(fullLessonCheckbox).not.toHaveAttribute("title");
   });
   it("should render with resources", () => {
     const shareableResources = [
@@ -74,6 +87,8 @@ describe("lesson share card group", () => {
     );
     const checkbox = screen.getByRole("checkbox", { name: "Video 5min" });
     expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute("aria-label", "Video 5min");
+    expect(checkbox).not.toHaveAttribute("title");
     expect(checkbox).not.toBeChecked();
 
     const user = userEvent.setup();

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -2,11 +2,17 @@ import { ChangeEvent, FC } from "react";
 import { Control, Controller } from "react-hook-form";
 import { OakDownloadCard, OakFlex, OakGrid } from "@oaknational/oak-components";
 
-import ResourceCard from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
+import ResourceCard, {
+  getActivityDownloadCardAriaLabel,
+} from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
 import { sortShareResources } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { SharePageNumberedHeading } from "@/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
+
+const FULL_ONLINE_LESSON_TITLE = "Full online lesson";
+const FULL_ONLINE_LESSON_FORMAT =
+  "Share the whole lesson (starter quiz, lesson video, worksheet and exit quiz) and view results";
 
 export type LessonShareCardGroupProps = {
   shareableResources: LessonShareData["shareableResources"];
@@ -78,12 +84,16 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
             }) => {
               return (
                 <OakDownloadCard
-                  format="Share the whole lesson (starter quiz, lesson video, worksheet and exit quiz) and view results"
+                  format={FULL_ONLINE_LESSON_FORMAT}
                   id={"download-card-wrapping-long"}
                   data-testid="resourceCard"
                   value={"all"}
                   name={name}
-                  title="Full online lesson"
+                  title={FULL_ONLINE_LESSON_TITLE}
+                  aria-label={getActivityDownloadCardAriaLabel(
+                    FULL_ONLINE_LESSON_TITLE,
+                    FULL_ONLINE_LESSON_FORMAT,
+                  )}
                   checked={["exit-quiz", "starter-quiz", "video"].every(
                     (section) => fieldValue.includes(section),
                   )}

--- a/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
+++ b/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
@@ -25,6 +25,11 @@ export type ResourceCardProps = Omit<CheckboxProps, "checked"> & {
   checked?: boolean;
 };
 
+export const getActivityDownloadCardAriaLabel = (
+  title: string,
+  format: string,
+) => `${title} ${format}`;
+
 const RESOURCE_TYPE_ICON_MAP: Record<
   LessonShareResourceData["type"],
   OakIconName
@@ -65,6 +70,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
         value={id}
         name={name}
         title={label}
+        aria-label={getActivityDownloadCardAriaLabel(label, subtitle)}
         checked={checked}
         disabled={disabled}
         onChange={onChange}


### PR DESCRIPTION
## Description

PUPIL-1748 **defect 7** — activity checkboxes on the lesson share page used visible `title` text only, with no programmatic label (`label-title-only` / WCAG 3.3.2, 4.1.2).

- Pass `aria-label` through `OakDownloadCard` on each share activity card, composed from visible title + format via `getActivityDownloadCardAriaLabel`.
- Apply to individual activity cards (`ShareResourceCard`) and the “Full online lesson” card in `LessonShareCardGroup`.
- Add unit tests asserting `aria-label` is present and `title` is not used as the sole label on the native checkbox input.
- Add the computing primary share page to `getDeploymentTestUrls` so post-deploy **Pa11y** and **Percy** cover this flow.

**Merge notes:** No dependency on #4280 or #4284. Possible trivial conflict with [#4281](https://github.com/oaknational/Oak-Web-Application/pull/4281) in `LessonShareCardGroup.tsx` / `.test.tsx` if merged second.

## Issue(s)

Fixes PUPIL-1748 (defect 7 — share activity checkbox labels)

## How to test

### Automated

1. Run unit tests:
   ```bash
   pnpm jest src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
   ```
2. Confirm CI passes on the PR (including pre-push hook suite).

### Manual — share page (VoiceOver / NVDA)

1. Open the Vercel preview from the bot comment on this PR.
2. Go to:
   ```
   /teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/share
   ```
3. Tab to an individual activity checkbox (e.g. **Video**).
4. You should hear the composed accessible name including title and format (e.g. **“Video 5min”**), not silence or a generic “checkbox” only.
5. Tab to the **Full online lesson** checkbox.
6. You should hear **“Full online lesson”** plus the format description (starter quiz, lesson video, worksheet, exit quiz).
7. Confirm visible labels on screen still match what the screen reader announces (Label in Name).

### Post-deploy checks (after merge / on preview deployment)

8. **Pa11y:** Post-deploy workflow should include the share URL; confirm no `label-title-only` violations on that page.
9. **Percy:** Approve **new** baseline snapshots for the share URL path (375px + 1280px). “Missing” on other URLs is unrelated unless the share page also fails to load.

### Optional local Pa11y (single URL)

1. With `pnpm dev` running, temporarily limit `getDeploymentTestUrls` to the share URL only.
2. Run `pnpm run pa11y` and confirm the share page passes.

## Screenshots
<img width="1166" height="684" alt="Screenshot 2026-06-09 at 14 10 31" src="https://github.com/user-attachments/assets/96360316-c9fd-46fa-a995-8e6b153153fa" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change