### PR TITLE
fix(PUPIL-1748): link form field errors via aria-describedby (defect 2)

### DIFF
--- a/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
+++ b/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
@@ -33,6 +33,7 @@ import LoginRequiredButton from "@/components/TeacherComponents/LoginRequiredBut
 import NoResourcesToDownload from "@/components/TeacherComponents/NoResourcesToDownload";
 import TermsAgreementForm from "@/components/TeacherComponents/TermsAgreementForm";
 import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { LessonDownloadsPageData } from "@/node-lib/curriculum-api-2023/queries/lessonDownloads/lessonDownloads.schema";
 import { DownloadTypeLabel } from "@/components/CurriculumComponents/CurriculumDownloadView/helper";
 
@@ -188,7 +189,7 @@ export const DownloadPageWithAccordionContent = (
 
   return (
     <OakFlex $flexDirection={"column"} $gap={"spacing-48"}>
-      <FieldError id={"downloads-error"} withoutMarginBottom>
+      <FieldError id={SHARE_FORM_ERROR_IDS.resources} withoutMarginBottom>
         {errors?.resources?.message}
       </FieldError>
       <OakDownloadsAccordion

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -156,7 +156,7 @@ describe("lesson share card group", () => {
         "aria-describedby",
         SHARE_FORM_ERROR_IDS.resources,
       );
-      expect(checkbox).toHaveAttribute("aria-invalid", "true");
+      expect(checkbox).not.toHaveAttribute("aria-invalid");
     }
   });
 });

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -9,12 +9,14 @@ import LessonShareCardGroup, {
 } from "./LessonShareCardGroup";
 
 import { getActivityDownloadCardAriaLabel } from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 import { LessonShareData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 
 const ComponentWrapper = (props: {
   shareableResources: LessonShareData["shareableResources"];
   shareLink: string;
+  hasError?: boolean;
 }) => {
   const { control, trigger } = useForm<ResourceFormValues>();
 
@@ -25,6 +27,7 @@ const ComponentWrapper = (props: {
       triggerForm={trigger}
       shareableResources={props.shareableResources}
       hideCheckboxes={false}
+      hasError={props.hasError}
     />
   );
 };
@@ -128,5 +131,32 @@ describe("lesson share card group", () => {
 
     await user.click(checkboxLabel);
     expect(checkbox).not.toBeChecked();
+  });
+
+  it("links resource selection errors to activity checkboxes", () => {
+    const shareableResources = [
+      {
+        exists: true,
+        type: "video" as const,
+        metadata: "5min",
+        label: "Video",
+      },
+    ];
+    renderWithTheme(
+      <ComponentWrapper
+        shareableResources={shareableResources}
+        shareLink="www.fake.com"
+        hasError
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toHaveAttribute(
+        "aria-describedby",
+        SHARE_FORM_ERROR_IDS.resources,
+      );
+      expect(checkbox).toHaveAttribute("aria-invalid", "true");
+    }
   });
 });

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.test.tsx
@@ -151,6 +151,8 @@ describe("lesson share card group", () => {
     );
 
     const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+
     for (const checkbox of checkboxes) {
       expect(checkbox).toHaveAttribute(
         "aria-describedby",

--- a/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
+++ b/src/components/TeacherComponents/LessonShareCardGroup/LessonShareCardGroup.tsx
@@ -5,6 +5,7 @@ import { OakDownloadCard, OakFlex, OakGrid } from "@oaknational/oak-components";
 import ResourceCard, {
   getActivityDownloadCardAriaLabel,
 } from "@/components/TeacherComponents/ShareResourceCard/ShareResourceCard";
+import { getDownloadCardFieldErrorAriaProps } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { sortShareResources } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/sortResources";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { SharePageNumberedHeading } from "@/components/TeacherComponents/SharePageNumberedHeading/SharePageNumberedHeading";
@@ -100,6 +101,7 @@ const LessonShareCardGroup: FC<LessonShareCardGroupProps> = (props) => {
                       FULL_ONLINE_LESSON_TITLE,
                       FULL_ONLINE_LESSON_FORMAT,
                     )}
+                    {...getDownloadCardFieldErrorAriaProps(props.hasError)}
                     checked={["exit-quiz", "starter-quiz", "video"].every(
                       (section) => fieldValue.includes(section),
                     )}

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
@@ -109,6 +109,6 @@ describe("ResourceCard", () => {
       "aria-describedby",
       SHARE_FORM_ERROR_IDS.resources,
     );
-    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).not.toHaveAttribute("aria-invalid");
   });
 });

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import ResourceCard from "./ResourceCard";
 
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
 describe("ResourceCard", () => {
@@ -86,5 +87,28 @@ describe("ResourceCard", () => {
     );
 
     expect(getByText("Editable")).toBeInTheDocument();
+  });
+
+  it("links resource selection errors to the download checkbox", () => {
+    const { getByRole } = renderWithTheme(
+      <ResourceCard
+        id="unique-123"
+        name="downloadResources"
+        label="Worksheet"
+        subtitle="PDF"
+        checked={false}
+        onChange={jest.fn()}
+        resourceType="worksheet-pdf"
+        useDownloadPageLayout
+        hasError
+      />,
+    );
+
+    const input = getByRole("checkbox");
+    expect(input).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.resources,
+    );
+    expect(input).toHaveAttribute("aria-invalid", "true");
   });
 });

--- a/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
+++ b/src/components/TeacherComponents/ResourceCard/ResourceCard.tsx
@@ -7,6 +7,7 @@ import {
 import styled from "styled-components";
 
 import type { DownloadResourceType } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { getDownloadCardFieldErrorAriaProps } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { CheckboxProps } from "@/components/SharedComponents/Checkbox/Checkbox";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 
@@ -66,6 +67,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
     disabled,
     asRadio = false,
     useDownloadPageLayout = false,
+    hasError = false,
   } = props;
 
   const isCurriculumIcon = resourceType === "curriculum-pdf";
@@ -85,6 +87,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
         value={id}
         name={name}
         title={label}
+        {...getDownloadCardFieldErrorAriaProps(hasError)}
         checked={checked}
         disabled={disabled}
         onChange={onChange}

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.test.tsx
@@ -136,9 +136,11 @@ describe("ResourcePageSchoolDetails", () => {
       "aria-invalid",
       "true",
     );
-    expect(screen.getByTestId("checkbox-download")).toHaveAttribute(
+    const notListedCheckbox = screen.getByTestId("checkbox-download");
+    expect(notListedCheckbox).toHaveAttribute(
       "aria-describedby",
       SHARE_FORM_ERROR_IDS.school,
     );
+    expect(notListedCheckbox).not.toHaveAttribute("aria-invalid");
   });
 });

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import ResourcePageSchoolDetails from "./ResourcePageSchoolDetails";
 
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import waitForNextTick from "@/__tests__/__helpers__/waitForNextTick";
 import useSchoolPicker from "@/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker";
@@ -111,5 +112,33 @@ describe("ResourcePageSchoolDetails", () => {
     await waitForNextTick();
     rerender(<ResourcePageSchoolDetails {...props} />);
     expect(setSchool).toBeCalled();
+  });
+
+  it("links school field errors to the combobox and not-listed checkbox", () => {
+    render(
+      <ResourcePageSchoolDetails
+        {...props}
+        errors={{
+          school: {
+            message:
+              "Select school, type 'homeschool' or tick 'My school isn't listed'",
+            type: "too_small",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("search-combobox-input")).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.school,
+    );
+    expect(screen.getByTestId("search-combobox-input")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByTestId("checkbox-download")).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.school,
+    );
   });
 });

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -110,7 +110,6 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
           name={"checkbox-not-listed"}
           displayValue={"My school isn't listed"}
           data-testid={"checkbox-download"}
-          aria-invalid={errors?.school ? true : undefined}
           aria-describedby={
             errors?.school ? SHARE_FORM_ERROR_IDS.school : undefined
           }

--- a/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails.tsx
@@ -7,6 +7,7 @@ import {
   OakFieldset,
 } from "@oaknational/oak-components";
 
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import ResourcePageSchoolPicker from "@/components/TeacherComponents/ResourcePageSchoolPicker";
 import useSchoolPicker from "@/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker";
 
@@ -91,14 +92,13 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
       </OakBox>
       <ResourcePageSchoolPicker
         hasError={errors?.school !== undefined}
+        errorId={errors?.school ? SHARE_FORM_ERROR_IDS.school : undefined}
         schoolPickerInputValue={schoolPickerInputValue}
         setSchoolPickerInputValue={onSchoolPickerInputChange}
         schools={schools}
         label={"School"}
         setSelectedSchool={setSelectedSchool}
         required={true}
-        aria-invalid={errors?.school?.message ? true : false}
-        aria-describedby={"school-error"}
         withHomeschool={withHomeschool}
       />
       <OakFlex $mt="spacing-12" $mb="spacing-48">
@@ -110,9 +110,9 @@ const ResourcePageSchoolDetails: FC<ResourcePageSchoolDetailsProps> = ({
           name={"checkbox-not-listed"}
           displayValue={"My school isn't listed"}
           data-testid={"checkbox-download"}
-          aria-invalid={errors?.school?.message ? true : false}
+          aria-invalid={errors?.school ? true : undefined}
           aria-describedby={
-            errors?.school?.message ? "school-error" : undefined
+            errors?.school ? SHARE_FORM_ERROR_IDS.school : undefined
           }
         />
       </OakFlex>

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 
 import ResourcePageTermsAndConditionsCheckbox from "./ResourcePageTermsAndConditionsCheckbox";
 
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
 describe("ResourcePageTermsAndConditionsCheckbox", () => {
@@ -32,5 +33,14 @@ describe("ResourcePageTermsAndConditionsCheckbox", () => {
 
     const termsError = screen.getByText("Please select the checkbox");
     expect(termsError).toBeInTheDocument();
+    expect(termsError).toHaveAttribute("id", SHARE_FORM_ERROR_IDS.terms);
+    expect(screen.getByTestId("termsCheckboxInput")).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.terms,
+    );
+    expect(screen.getByTestId("termsCheckboxInput")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
   });
 });

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
@@ -39,20 +39,7 @@ describe("ResourcePageTermsAndConditionsCheckbox", () => {
       "aria-describedby",
       SHARE_FORM_ERROR_IDS.terms,
     );
-    expect(termsInput).toBeRequired();
     expect(termsInput).not.toHaveAttribute("aria-invalid");
-  });
-
-  it("marks the terms checkbox as required", () => {
-    renderWithTheme(
-      <ResourcePageTermsAndConditionsCheckbox
-        checked={false}
-        onChange={jest.fn()}
-        id={"123"}
-        name={"terms"}
-      />,
-    );
-
-    expect(screen.getByTestId("termsCheckboxInput")).toBeRequired();
+    expect(termsInput).not.toBeRequired();
   });
 });

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.test.tsx
@@ -34,13 +34,25 @@ describe("ResourcePageTermsAndConditionsCheckbox", () => {
     const termsError = screen.getByText("Please select the checkbox");
     expect(termsError).toBeInTheDocument();
     expect(termsError).toHaveAttribute("id", SHARE_FORM_ERROR_IDS.terms);
-    expect(screen.getByTestId("termsCheckboxInput")).toHaveAttribute(
+    const termsInput = screen.getByTestId("termsCheckboxInput");
+    expect(termsInput).toHaveAttribute(
       "aria-describedby",
       SHARE_FORM_ERROR_IDS.terms,
     );
-    expect(screen.getByTestId("termsCheckboxInput")).toHaveAttribute(
-      "aria-invalid",
-      "true",
+    expect(termsInput).toBeRequired();
+    expect(termsInput).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("marks the terms checkbox as required", () => {
+    renderWithTheme(
+      <ResourcePageTermsAndConditionsCheckbox
+        checked={false}
+        onChange={jest.fn()}
+        id={"123"}
+        name={"terms"}
+      />,
     );
+
+    expect(screen.getByTestId("termsCheckboxInput")).toBeRequired();
   });
 });

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
@@ -53,9 +53,11 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
         onChange={onChange}
         uncheckedBorderColor={errorMessage ? "border-error" : undefined}
         data-testid="termsCheckboxInput"
-        aria-invalid={errorMessage ? true : undefined}
         aria-describedby={errorMessage ? SHARE_FORM_ERROR_IDS.terms : undefined}
         {...props}
+        // OakCheckBox forwards required to the native input but omits it from types.
+        // @ts-expect-error required is valid on checkbox inputs
+        required
       />
       <OakLabel htmlFor={props.id} data-testid="termsCheckboxLabel">
         I accept the{" "}

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
@@ -55,9 +55,6 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
         data-testid="termsCheckboxInput"
         aria-describedby={errorMessage ? SHARE_FORM_ERROR_IDS.terms : undefined}
         {...props}
-        // OakCheckBox forwards required to the native input but omits it from types.
-        // @ts-expect-error required is valid on checkbox inputs
-        required
       />
       <OakLabel htmlFor={props.id} data-testid="termsCheckboxLabel">
         I accept the{" "}

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
@@ -9,6 +9,7 @@ import {
 
 import BrushBorders from "@/components/SharedComponents/SpriteSheet/BrushSvgs/BrushBorders";
 import FieldError from "@/components/SharedComponents/FieldError";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { resolveOakHref } from "@/common-lib/urls/urls";
 
 export type ResourcePageTermsAndConditionsCheckboxProps = {
@@ -26,7 +27,11 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
   <>
     {errorMessage && (
       <OakBox $mb="spacing-16">
-        <FieldError ariaLive="polite" id={"terms-error"} withoutMarginBottom>
+        <FieldError
+          ariaLive="polite"
+          id={SHARE_FORM_ERROR_IDS.terms}
+          withoutMarginBottom
+        >
           {errorMessage}
         </FieldError>
       </OakBox>
@@ -48,6 +53,8 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
         onChange={onChange}
         uncheckedBorderColor={errorMessage ? "border-error" : undefined}
         data-testid="termsCheckboxInput"
+        aria-invalid={errorMessage ? true : undefined}
+        aria-describedby={errorMessage ? SHARE_FORM_ERROR_IDS.terms : undefined}
         {...props}
       />
       <OakLabel htmlFor={props.id} data-testid="termsCheckboxLabel">

--- a/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
+++ b/src/components/TeacherComponents/SharePageLayout/SharePageLayout.tsx
@@ -24,6 +24,7 @@ import { ResourceFormValues } from "@/components/TeacherComponents/types/downloa
 import { ResourcePageDetailsCompletedProps } from "@/components/TeacherComponents/ResourcePageDetailsCompleted/ResourcePageDetailsCompleted";
 import { ResourcePageSchoolDetailsProps } from "@/components/TeacherComponents/ResourcePageSchoolDetails/ResourcePageSchoolDetails";
 import { getFormErrorMessages } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/getDownloadFormErrorMessage";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import TermsAgreementForm from "@/components/TeacherComponents/TermsAgreementForm";
 import NoResourcesToShare from "@/components/TeacherComponents/NoResourcesToShare";
 import FieldError from "@/components/SharedComponents/FieldError";
@@ -85,7 +86,10 @@ const SharePageLayout: FC<SharePageLayoutProps> = (props) => {
               $gap={"spacing-16"}
               $width={"100%"}
             >
-              <FieldError id={"downloads-error"} withoutMarginBottom>
+              <FieldError
+                id={SHARE_FORM_ERROR_IDS.resources}
+                withoutMarginBottom
+              >
                 {props.errors?.resources?.message}
               </FieldError>
               {props.cardGroup}

--- a/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
+++ b/src/components/TeacherComponents/ShareResourceCard/ShareResourceCard.tsx
@@ -3,6 +3,7 @@ import { OakIconName, OakDownloadCard } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import { CheckboxProps } from "@/components/SharedComponents/Checkbox/Checkbox";
+import { getDownloadCardFieldErrorAriaProps } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { LessonShareResourceData } from "@/node-lib/curriculum-api-2023/queries/lessonShare/lessonShare.schema";
 import { getValidSubjectIconName } from "@/utils/getValidSubjectIconName";
 
@@ -53,6 +54,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
     disabled,
     asRadio = false,
     useDownloadPageLayout = false,
+    hasError = false,
   } = props;
 
   const iconName = subjectIcon
@@ -71,6 +73,7 @@ const ResourceCard: FC<ResourceCardProps> = (props) => {
         name={name}
         title={label}
         aria-label={getActivityDownloadCardAriaLabel(label, subtitle)}
+        {...getDownloadCardFieldErrorAriaProps(hasError)}
         checked={checked}
         disabled={disabled}
         onChange={onChange}

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
@@ -42,7 +42,11 @@ describe("TermsAgreementForm (School, email and terms form within the teacher an
     };
     const { container } = render(<Wrapper errors={errors} />);
 
-    const error = queryByAttribute("id", container, "school-error");
+    const error = queryByAttribute(
+      "id",
+      container,
+      SHARE_FORM_ERROR_IDS.school,
+    );
     expect(error).toBeInTheDocument();
     expect(error).toHaveTextContent(errorMessage);
     expect(screen.getByTestId("search-combobox-input")).toHaveAttribute(

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { queryByAttribute, act } from "@testing-library/react";
+import { queryByAttribute, act, screen } from "@testing-library/react";
 import { FieldErrors, useForm } from "react-hook-form";
 
 import TermsAgreementForm, {
@@ -7,6 +7,7 @@ import TermsAgreementForm, {
 } from "./TermsAgreementForm";
 
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 type TermsAgreementFormPropsOptionalForm = Omit<
@@ -44,6 +45,33 @@ describe("TermsAgreementForm (School, email and terms form within the teacher an
     const error = queryByAttribute("id", container, "school-error");
     expect(error).toBeInTheDocument();
     expect(error).toHaveTextContent(errorMessage);
+    expect(screen.getByTestId("search-combobox-input")).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.school,
+    );
+  });
+
+  it("links email field errors to the email input", () => {
+    const errorMessage = "Please enter a valid email address";
+    const errors: FieldErrors<ResourceFormValues> = {
+      email: {
+        message: errorMessage,
+        type: "invalid_string",
+      },
+    };
+    const { container } = render(<Wrapper errors={errors} />);
+
+    const error = queryByAttribute("id", container, SHARE_FORM_ERROR_IDS.email);
+    expect(error).toBeInTheDocument();
+    expect(error).toHaveTextContent(errorMessage);
+    expect(screen.getByTestId("inputEmail")).toHaveAttribute(
+      "aria-describedby",
+      SHARE_FORM_ERROR_IDS.email,
+    );
+    expect(screen.getByTestId("inputEmail")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
   });
 
   it("Shows loading", async () => {

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -20,7 +20,10 @@ import FieldError from "@/components/SharedComponents/FieldError";
 import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
 import ResourcePageSchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
 import ResourcePageTermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
-import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
+import {
+  getEmailFieldErrorAriaProps,
+  SHARE_FORM_ERROR_IDS,
+} from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { resolveOakHref } from "@/common-lib/urls";
 
@@ -56,6 +59,7 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
 }) => {
   const [emailHasFocus, setEmailHasFocus] = useState(false);
   const { ref, ...emailProps } = form.register("email");
+  const hasEmailError = Boolean(form.errors?.email);
 
   return (
     <>
@@ -115,19 +119,19 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                 ref={ref}
                 $mb="spacing-16"
               >
-                {form.errors?.email && (
+                {hasEmailError && (
                   <FieldError
                     id={SHARE_FORM_ERROR_IDS.email}
                     withoutMarginBottom
                   >
-                    {form.errors.email.message}
+                    {form.errors.email?.message}
                   </FieldError>
                 )}
                 <OakJauntyAngleLabel
                   label={"Email (optional)"}
                   as="label"
                   $color={
-                    form.errors?.email || emailHasFocus
+                    hasEmailError || emailHasFocus
                       ? "text-inverted"
                       : "text-primary"
                   }
@@ -135,7 +139,7 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                   id={"email-label"}
                   $font={"heading-7"}
                   $background={
-                    form.errors?.email
+                    hasEmailError
                       ? "bg-error"
                       : emailHasFocus
                         ? "bg-inverted"
@@ -159,10 +163,7 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                     emailProps.onBlur(e);
                     setEmailHasFocus(false);
                   }}
-                  aria-describedby={
-                    form.errors?.email ? SHARE_FORM_ERROR_IDS.email : undefined
-                  }
-                  aria-invalid={form.errors?.email ? true : undefined}
+                  {...getEmailFieldErrorAriaProps(hasEmailError)}
                   $pv="spacing-0"
                   wrapperWidth="100%"
                   $height="spacing-56"

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -14,13 +14,13 @@ import {
   OakLink,
   OakTextInput,
   OakJauntyAngleLabel,
-  OakFieldError,
 } from "@oaknational/oak-components";
 
 import FieldError from "@/components/SharedComponents/FieldError";
 import ResourcePageDetailsCompleted from "@/components/TeacherComponents/ResourcePageDetailsCompleted";
 import ResourcePageSchoolDetails from "@/components/TeacherComponents/ResourcePageSchoolDetails";
 import ResourcePageTermsAndConditionsCheckbox from "@/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox";
+import { SHARE_FORM_ERROR_IDS } from "@/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { resolveOakHref } from "@/common-lib/urls";
 
@@ -71,7 +71,7 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
         </OakHeading>
       )}
       {form?.errors.school && (
-        <FieldError ariaLive="polite" id="school-error">
+        <FieldError ariaLive="polite" id={SHARE_FORM_ERROR_IDS.school}>
           {form.errors.school?.message}
         </FieldError>
       )}
@@ -116,13 +116,12 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                 $mb="spacing-16"
               >
                 {form.errors?.email && (
-                  <OakBox
-                    id={form.errors?.email.message}
-                    role="alert"
-                    $mv="spacing-16"
+                  <FieldError
+                    id={SHARE_FORM_ERROR_IDS.email}
+                    withoutMarginBottom
                   >
-                    <OakFieldError>{form.errors?.email.message}</OakFieldError>
-                  </OakBox>
+                    {form.errors.email.message}
+                  </FieldError>
                 )}
                 <OakJauntyAngleLabel
                   label={"Email (optional)"}
@@ -160,6 +159,10 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                     emailProps.onBlur(e);
                     setEmailHasFocus(false);
                   }}
+                  aria-describedby={
+                    form.errors?.email ? SHARE_FORM_ERROR_IDS.email : undefined
+                  }
+                  aria-invalid={form.errors?.email ? true : undefined}
                   $pv="spacing-0"
                   wrapperWidth="100%"
                   $height="spacing-56"

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
@@ -1,0 +1,23 @@
+import { InputHTMLAttributes } from "react";
+
+export const SHARE_FORM_ERROR_IDS = {
+  resources: "downloads-error",
+  school: "school-error",
+  email: "email-error",
+  terms: "terms-error",
+} as const;
+
+export type FieldErrorAriaProps = Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  "aria-describedby" | "aria-invalid"
+>;
+
+export const getDownloadCardFieldErrorAriaProps = (
+  hasError?: boolean,
+): FieldErrorAriaProps =>
+  hasError
+    ? {
+        "aria-describedby": SHARE_FORM_ERROR_IDS.resources,
+        "aria-invalid": true,
+      }
+    : {};

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
@@ -12,12 +12,23 @@ export type FieldErrorAriaProps = Pick<
   "aria-describedby" | "aria-invalid"
 >;
 
-export const getDownloadCardFieldErrorAriaProps = (
-  hasError?: boolean,
+const getFieldErrorAriaProps = (
+  hasError: boolean | undefined,
+  errorId: string,
 ): FieldErrorAriaProps =>
   hasError
     ? {
-        "aria-describedby": SHARE_FORM_ERROR_IDS.resources,
+        "aria-describedby": errorId,
         "aria-invalid": true,
       }
     : {};
+
+export const getDownloadCardFieldErrorAriaProps = (
+  hasError?: boolean,
+): FieldErrorAriaProps =>
+  getFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.resources);
+
+export const getEmailFieldErrorAriaProps = (
+  hasError?: boolean,
+): FieldErrorAriaProps =>
+  getFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.email);

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
@@ -7,15 +7,30 @@ export const SHARE_FORM_ERROR_IDS = {
   terms: "terms-error",
 } as const;
 
-export type FieldErrorAriaProps = Pick<
+export type CheckboxFieldErrorAriaProps = Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  "aria-describedby"
+>;
+
+export type TextFieldErrorAriaProps = Pick<
   InputHTMLAttributes<HTMLInputElement>,
   "aria-describedby" | "aria-invalid"
 >;
 
-const getFieldErrorAriaProps = (
+const getCheckboxFieldErrorAriaProps = (
   hasError: boolean | undefined,
   errorId: string,
-): FieldErrorAriaProps =>
+): CheckboxFieldErrorAriaProps =>
+  hasError
+    ? {
+        "aria-describedby": errorId,
+      }
+    : {};
+
+const getTextFieldErrorAriaProps = (
+  hasError: boolean | undefined,
+  errorId: string,
+): TextFieldErrorAriaProps =>
   hasError
     ? {
         "aria-describedby": errorId,
@@ -25,10 +40,10 @@ const getFieldErrorAriaProps = (
 
 export const getDownloadCardFieldErrorAriaProps = (
   hasError?: boolean,
-): FieldErrorAriaProps =>
-  getFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.resources);
+): CheckboxFieldErrorAriaProps =>
+  getCheckboxFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.resources);
 
 export const getEmailFieldErrorAriaProps = (
   hasError?: boolean,
-): FieldErrorAriaProps =>
-  getFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.email);
+): TextFieldErrorAriaProps =>
+  getTextFieldErrorAriaProps(hasError, SHARE_FORM_ERROR_IDS.email);

--- a/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
+++ b/src/components/TeacherComponents/helpers/downloadAndShareHelpers/shareDownloadFormErrorIds.ts
@@ -7,12 +7,12 @@ export const SHARE_FORM_ERROR_IDS = {
   terms: "terms-error",
 } as const;
 
-export type CheckboxFieldErrorAriaProps = Pick<
+type CheckboxFieldErrorAriaProps = Pick<
   InputHTMLAttributes<HTMLInputElement>,
   "aria-describedby"
 >;
 
-export type TextFieldErrorAriaProps = Pick<
+type TextFieldErrorAriaProps = Pick<
   InputHTMLAttributes<HTMLInputElement>,
   "aria-describedby" | "aria-invalid"
 >;


### PR DESCRIPTION
## Description
[Teacher /share page](https://oak-web-application-website-git-fix-pupil-1748-field-err-a1dbb8.vercel.thenational.academy/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/share)

Form-level validation errors should be associated with their corresponding form inputs using aria-describedby so that the errors are read out when you focus on each item.

Includes:
Lesson checkboxes = Select at least one resource to continue
School entered / My School isn’t listed = Select school, type ‘homeschool’ or tick ‘My school isn’t listed’
I accept terms and conditions (required) = Accept terms and conditions to continue

Music year: 2002

- Link share/download validation errors to inputs with `aria-describedby` (PUPIL-1748 defect 2)
- Add shared `SHARE_FORM_ERROR_IDS` helpers; fix school combobox and email error id wiring
- Checkboxes: `aria-describedby` only (no `aria-invalid`) to avoid VoiceOver “invalid data” on untick
- Text inputs (email, school combobox): `aria-describedby` + `aria-invalid`
- Complements #4284 (validation summary `role="alert"` on submit)

**Pages:** lesson `/share`, lesson `/downloads`, programme `/download` (school / email / terms only — programme resource cards not wired)

## Issue(s)

Fixes [PUPIL-1748 (defect 2)](https://www.notion.so/oaknationalacademy/Share-Page-Follow-up-Accessibility-Defects-36c26cc4e1b180219f83e8ddb0d06978?source=copy_link)

## How to test

1. Open https://oak-web-application-website-git-fix-pupil-1748-field-err-a1dbb8.vercel.thenational.academy/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/share (not onboarded; clear download `localStorage` if needed
2. Submit without selecting resources / school / terms (optional invalid email)
3. Confirm validation summary is announced (#4284)
4. Tab to each invalid control — screen reader should read that field’s error via `aria-describedby`
5. Untick terms while in error — should not hear “invalid data”
6. Repeat on lesson `/downloads`

### Regression test on pages impacted by the shared component: 
[Example Share Page](http://localhost:3000/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/share?preselected=all) (with linked form field errors)
[Download Page](https://oak-web-application-website-git-fix-pupil-1748-field-err-a1dbb8.vercel.thenational.academy/teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/comparing-digital-writing-to-using-a-pencil/downloads) 
[Download curriculum resources](https://oak-web-application-website-git-fix-pupil-1748-field-err-a1dbb8.vercel.thenational.academy/teachers/programmes/history-primary/download)

## Screenshots

How it used to look (delete if n/a):
n/a — no visual change

How it should now look:
n/a

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change