### PR TITLE
LESQ-2095 Add aria-label to search link in header

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -4618,6 +4618,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c48 c49 c50"
                 >
                   <a
+                    aria-label="Search"
                     class="c51 c52"
                     href="/teachers/search"
                   >

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -4452,6 +4452,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   class="c48 c49 c50"
                 >
                   <a
+                    aria-label="Search"
                     class="c51 c52"
                     href="/teachers/search"
                   >

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -4810,6 +4810,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c48 c49 c50"
                 >
                   <a
+                    aria-label="Search"
                     class="c51 c52"
                     href="/teachers/search"
                   >

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -4637,6 +4637,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c48 c49 c50"
                 >
                   <a
+                    aria-label="Search"
                     class="c51 c52"
                     href="/teachers/search"
                   >

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -3287,6 +3287,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   class="c48 c49 c50"
                 >
                   <a
+                    aria-label="Search"
                     class="c51 c52"
                     href="/teachers/search"
                   >

--- a/src/components/AppComponents/SearchBar/SearchBar.tsx
+++ b/src/components/AppComponents/SearchBar/SearchBar.tsx
@@ -42,6 +42,7 @@ const SearchBar = () => {
       <OakBox $display={["block", "none"]}>
         <OakTertiaryButton
           element={Link}
+          aria-label="Search"
           href={resolveOakHref({ page: "search" })}
           iconName="search"
         />


### PR DESCRIPTION
## Description

Music year: [1989](https://www.youtube.com/watch?v=bLaSXpqp__E)

- Adds `aria-label="Search"` to the search link in the mobile header, so that it has an accessible name and is exposed to iOS VoiceOver.

## Issue(s)

Fixes #LESQ-2095

## How to test

1. Go to https://oak-web-application-website-git-lesq-2095-header-search-6c73b4.vercel.thenational.academy/ on an iPhone, with VoiceOver enabled
2. Navigate to the search link in the mobile header
3. The link should have an accessible name of 'Search' and be clickable

## Screenshots

N/A - no visual change

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
