### PR TITLE
Feat/lesq 2041/sticky download button

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -2,21 +2,11 @@
 
 exports[`pages/about/get-involved.tsx renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c2 {
   position: absolute;
   top: 5.75rem;
   left: 1.5rem;
@@ -27,7 +17,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c6 {
+.c3 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -36,7 +26,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,16 +35,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c11 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   position: absolute;
   top: 10rem;
   left: 1.5rem;
@@ -62,7 +52,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c16 {
+.c13 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 1rem;
@@ -71,14 +61,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c15 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c21 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -88,7 +78,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   max-height: 5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -100,7 +90,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
@@ -109,19 +99,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -142,17 +132,17 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c43:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c47 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -160,7 +150,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -171,7 +161,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -180,12 +170,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -205,7 +195,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c64 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -215,28 +205,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c71 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c72 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -245,7 +235,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -253,7 +243,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c80 {
+.c77 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -263,41 +253,41 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c82 {
+.c79 {
   background: #e3e9fb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c83 {
+.c80 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c86 {
   height: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c88 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c94 {
+.c91 {
   background: #ffffff;
   border-radius: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c95 {
+.c92 {
   padding: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c104 {
+.c101 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -308,26 +298,26 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c110 {
+.c107 {
   width: 100%;
   aspect-ratio: 16/9;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c114 {
+.c111 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c115 {
+.c112 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c113 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -342,26 +332,26 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c117 {
+.c114 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c119 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c121 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c124 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -371,7 +361,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c125 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -382,14 +372,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c130 {
+.c127 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c132 {
+.c129 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -401,12 +391,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c132 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c134 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -420,36 +410,36 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c137 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c157 {
+.c154 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c160 {
+.c157 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c160 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c164 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c171 {
+.c168 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -459,13 +449,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c172 {
+.c169 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c171 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -477,12 +467,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c177 {
+.c174 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c179 {
+.c176 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -494,18 +484,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c183 {
+.c180 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c181 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c185 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -514,7 +504,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -522,7 +512,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c190 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -533,7 +523,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c194 {
+.c191 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -544,7 +534,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c193 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -552,12 +542,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c195 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c202 {
+.c199 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -575,7 +565,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c204 {
+.c201 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -591,6 +581,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   transform: translate(0%,32%);
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
+}
+
+.c203 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c206 {
@@ -647,28 +647,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c12 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -687,7 +672,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c17 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -699,7 +684,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -711,7 +696,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -730,7 +715,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c37 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -749,7 +734,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c40 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -761,7 +746,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c44 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -772,14 +757,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c53 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -798,7 +783,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c55 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -813,7 +798,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c63 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -829,7 +814,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c84 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -839,7 +824,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c74 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -855,7 +840,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c75 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -866,7 +851,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c90 {
+.c87 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -877,7 +862,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: flex-end;
 }
 
-.c96 {
+.c93 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -888,7 +873,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c97 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -899,7 +884,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c100 {
+.c97 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -910,7 +895,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c102 {
+.c99 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -921,7 +906,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c105 {
+.c102 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -932,7 +917,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.25rem;
 }
 
-.c106 {
+.c103 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -946,7 +931,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c107 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -957,7 +942,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c109 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -968,7 +953,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c112 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -987,7 +972,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   row-gap: 1.5rem;
 }
 
-.c118 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -998,7 +983,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c125 {
+.c122 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1013,7 +998,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c129 {
+.c126 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1024,7 +1009,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c136 {
+.c133 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1038,7 +1023,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c175 {
+.c172 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1056,7 +1041,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c187 {
+.c184 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1067,7 +1052,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c190 {
+.c187 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1083,7 +1068,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c197 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1101,7 +1086,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c199 {
+.c196 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1112,6 +1097,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   gap: 1rem;
+}
+
+.c204 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c210 {
@@ -1151,7 +1151,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1163,7 +1163,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: left;
 }
 
-.c21 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1175,11 +1175,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: left;
 }
 
-.c29 {
+.c26 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1191,7 +1191,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: left;
 }
 
-.c58 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1202,14 +1202,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c77 {
+.c74 {
   background: #a0b6f2;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c151 {
+.c148 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1220,7 +1220,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c165 {
+.c162 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1242,7 +1242,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c173 {
+.c170 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1251,7 +1251,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c9 {
+.c6 {
   background: none;
   color: inherit;
   border: none;
@@ -1274,12 +1274,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c9:disabled {
+.c6:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c17 {
   background: none;
   color: inherit;
   border: none;
@@ -1305,12 +1305,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c20:disabled {
+.c17:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -1336,12 +1336,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c22:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c35 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1364,12 +1364,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c35:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c51 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1383,12 +1383,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c51:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c60 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1401,12 +1401,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1436,12 +1436,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c66:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c69 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1465,12 +1465,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-style: none;
 }
 
-.c69:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c168 {
+.c165 {
   background: none;
   color: inherit;
   border: none;
@@ -1494,7 +1494,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c168:disabled {
+.c165:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1527,35 +1527,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c25 {
+.c22 {
   object-fit: contain;
 }
 
-.c39 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c57 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c203 {
+.c200 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c205 {
+.c202 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c31 {
+.c28 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1564,7 +1564,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c111 {
+.c108 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1573,13 +1573,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: cover;
 }
 
-.c10 {
+.c7 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c10:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -1587,37 +1587,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c10:hover [data-state="selected"] {
+.c7:hover [data-state="selected"] {
   display: none;
 }
 
-.c10:active {
+.c7:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c10:active [data-state="selected"] {
+.c7:active [data-state="selected"] {
   display: none;
 }
 
-.c10:disabled {
+.c7:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c10:disabled [data-state="selected"] {
+.c7:disabled [data-state="selected"] {
   display: none;
 }
 
-.c23 {
+.c20 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c23:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -1625,37 +1625,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c23:hover [data-state="selected"] {
+.c20:hover [data-state="selected"] {
   display: none;
 }
 
-.c23:active {
+.c20:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c23:active [data-state="selected"] {
+.c20:active [data-state="selected"] {
   display: none;
 }
 
-.c23:disabled {
+.c20:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c23:disabled [data-state="selected"] {
+.c20:disabled [data-state="selected"] {
   display: none;
 }
 
-.c36 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c36:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1663,37 +1663,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c36:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c36:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c36:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c36:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c36:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c67 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c67:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1701,148 +1701,148 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c67:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c67:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c67:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c67:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c67:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c4 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c4 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:hover),
-.c7 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c4 .yellow-shadow:has(+ .internal-button:hover),
+.c4 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:hover) {
+.c4 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:active) {
+.c4 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:active) {
+.c4 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c16 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c16 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c16 .yellow-shadow:has(+ .internal-button:hover),
+.c16 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c16 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c16 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c16 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c52 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c52:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c52:active {
+.c49:active {
   color: #222222;
 }
 
-.c52:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c50 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c50 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c50 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c50 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c191 > :first-child:focus-visible .shadow {
+.c188 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c191 > :first-child:hover .shadow {
+.c188 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c191 > :first-child:active .shadow {
+.c188 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c191 > :first-child:disabled .icon-container {
+.c188 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c191 > :first-child:hover .icon-container {
+.c188 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c191 > :first-child:active .icon-container {
+.c188 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c76 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1853,7 +1853,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c87 {
+.c84 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1864,7 +1864,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c98 {
+.c95 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1875,7 +1875,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c119 {
+.c116 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1887,7 +1887,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: center;
 }
 
-.c138 {
+.c135 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1898,7 +1898,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c178 {
+.c175 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1911,7 +1911,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c34 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1919,7 +1919,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c181 {
+.c178 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1928,7 +1928,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c78 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1939,7 +1939,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c99 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1950,13 +1950,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c139 {
+.c136 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c169 {
+.c166 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1969,7 +1969,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c170 {
+.c167 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1981,7 +1981,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c200 {
+.c197 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1992,7 +1992,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c201 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2003,7 +2003,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c180 {
+.c177 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2014,7 +2014,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c33 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2035,14 +2035,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c186 {
+.c183 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c28 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2066,47 +2066,47 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c28 .c185 {
+.c25 .c182 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c28:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c28:visited {
+.c25:visited {
   color: #081676;
 }
 
-.c28:visited .c185 {
+.c25:visited .c182 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28:active {
+.c25:active {
   color: #081676;
   outline: 1px solid #081676;
 }
 
-.c28:active .c185 {
+.c25:active .c182 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c28[disabled] .c185 {
+.c25[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c182 {
+.c179 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2130,42 +2130,42 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c182 .c185 {
+.c179 .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c182:focus-visible {
+.c179:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c182:visited {
+.c179:visited {
   color: #222222;
 }
 
-.c182:visited .c185 {
+.c179:visited .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c182:active {
+.c179:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c182:active .c185 {
+.c179:active .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c182[disabled] {
+.c179[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c182[disabled] .c185 {
+.c179[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2203,7 +2203,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c215 .c185 {
+.c215 .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -2218,7 +2218,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c215:visited .c185 {
+.c215:visited .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2228,7 +2228,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c215:active .c185 {
+.c215:active .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2238,12 +2238,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #808080;
 }
 
-.c215[disabled] .c185 {
+.c215[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c46 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2259,49 +2259,49 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   width: 100%;
 }
 
-.c46::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c46::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c46:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c46::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c46::-webkit-search-decoration,
-.c46::-webkit-search-cancel-button,
-.c46::-webkit-search-results-button,
-.c46::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c46:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c45 {
+.c42 {
   background: #ffffff;
 }
 
-.c45:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c45:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c85 {
+.c82 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2311,7 +2311,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(4,1fr);
 }
 
-.c101 {
+.c98 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2320,13 +2320,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c133 {
+.c130 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c86 {
+.c83 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2337,7 +2337,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 1;
 }
 
-.c88 {
+.c85 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2348,7 +2348,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 3;
 }
 
-.c93 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2359,7 +2359,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 2;
 }
 
-.c103 {
+.c100 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2369,7 +2369,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c108 {
+.c105 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2379,7 +2379,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c134 {
+.c131 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2388,7 +2388,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c176 {
+.c173 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2397,55 +2397,80 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c123 {
+.c120 {
   box-shadow: none;
 }
 
-.c123:has(a:hover,button:hover) {
+.c120:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c123:has( a, button) {
+.c120:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c123:has( a, button)  a,
-.c123:has( a, button) button {
+.c120:has( a, button)  a,
+.c120:has( a, button) button {
   outline: none;
 }
 
-.c123:has(a:active,button:active) {
+.c120:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c61:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c61:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2 {
+.c205 {
   top: 82px;
 }
 
-.c192 .icon-container > *:first-child {
+.c189 .icon-container > *:first-child {
   border: 0;
 }
 
-.c154 {
+.c151 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c139 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
   color: #222222;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c139::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c139::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c139::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c142 {
+  position: relative;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2468,32 +2493,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   background-color: #999999;
 }
 
-.c145 {
-  position: relative;
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c145::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c145::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c145::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c147 {
+.c144 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2501,23 +2501,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c147::-webkit-scrollbar-track {
+.c144::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c147::-webkit-scrollbar {
+.c144::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c147::-webkit-scrollbar-thumb {
+.c144::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c161 {
+.c158 {
   background: none;
   color: inherit;
   border: none;
@@ -2528,29 +2528,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c143 {
+.c140 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c195 {
+.c192 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c126:hover {
+.c123:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c121 {
+.c118 {
   padding: 0;
   margin: 0;
 }
 
-.c120 {
+.c117 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2562,7 +2562,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c146 {
+.c143 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2574,7 +2574,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c152 {
+.c149 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2585,32 +2585,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c152::-webkit-input-placeholder {
+.c149::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c152::-moz-placeholder {
+.c149::-moz-placeholder {
   color: #575757;
 }
 
-.c152:-ms-input-placeholder {
+.c149:-ms-input-placeholder {
   color: #575757;
 }
 
-.c152::placeholder {
+.c149::placeholder {
   color: #575757;
 }
 
-.c152::-webkit-search-decoration,
-.c152::-webkit-search-cancel-button,
-.c152::-webkit-search-results-button,
-.c152::-webkit-search-results-decoration {
+.c149::-webkit-search-decoration,
+.c149::-webkit-search-cancel-button,
+.c149::-webkit-search-results-button,
+.c149::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c149 {
+.c146 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2620,7 +2620,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c156 {
+.c153 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2633,7 +2633,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c150 {
+.c147 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2644,16 +2644,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c144:focus-within .c148 {
+.c141:focus-within .c145 {
   background: #374cf1;
   color: #fff;
 }
 
-.c144:focus-within .c155 {
+.c141:focus-within .c152 {
   display: inline;
 }
 
-.c153 {
+.c150 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2669,7 +2669,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: none;
 }
 
-.c153::-webkit-input-placeholder {
+.c150::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2677,7 +2677,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c153::-moz-placeholder {
+.c150::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2685,7 +2685,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c153:-ms-input-placeholder {
+.c150:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2693,7 +2693,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c153::placeholder {
+.c150::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2701,40 +2701,40 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c153:valid:not([value=""]) {
+.c150:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c153:valid:not([value=""])::-webkit-input-placeholder {
+.c150:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c153:valid:not([value=""])::-moz-placeholder {
+.c150:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c153:valid:not([value=""]):-ms-input-placeholder {
+.c150:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c153:valid:not([value=""])::placeholder {
+.c150:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c159 {
+.c156 {
   display: none;
 }
 
-.c158:focus-within .c148 {
+.c155:focus-within .c145 {
   background: #374cf1;
   color: #fff;
 }
 
-.c162 {
+.c159 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2761,43 +2761,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #575757;
 }
 
-.c164 {
+.c161 {
   max-width: calc(100% - 20px);
 }
 
-.c166 {
+.c163 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c141 {
+.c138 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c128 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c79 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c81 {
+.c78 {
   height: 125%;
   -webkit-filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
   filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
 }
 
-.c92 {
+.c89 {
   height: 260px;
 }
 
-.c113 {
+.c110 {
   max-height: 40px;
   height: auto;
   width: auto;
@@ -2805,13 +2805,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    right: 1.5rem;
+  .c13 {
+    padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c13 {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c15 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2819,75 +2825,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    padding-left: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c0 {
-    padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-left: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-right: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-top: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-bottom: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c41 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2896,19 +2870,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2916,37 +2890,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c65 {
     display: none;
   }
 }
@@ -2960,79 +2934,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c80 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c80 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3041,7 +3015,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3050,13 +3024,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c113 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c113 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3064,7 +3038,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c113 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3072,79 +3046,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c129 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c129 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c174 {
+  .c171 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c174 {
+  .c171 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c177 {
+  .c174 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c183 {
+  .c180 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c189 {
+  .c186 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c193 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c195 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3153,13 +3127,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c199 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c199 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3167,7 +3141,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c202 {
+  .c199 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3175,8 +3149,34 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c204 {
+  .c201 {
     display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    padding-left: 0rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    padding-right: 0rem;
   }
 }
 
@@ -3232,16 +3232,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c17 {
+  .c14 {
     -webkit-box-pack: left;
     -webkit-justify-content: left;
     -ms-flex-pack: left;
@@ -3250,19 +3241,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3279,31 +3270,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c102 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3312,7 +3303,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c102 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3321,25 +3312,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c102 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c106 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c109 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3347,7 +3338,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c109 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3355,19 +3346,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c118 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c187 {
+  .c184 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3376,13 +3367,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c190 {
+  .c187 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3390,7 +3381,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3399,7 +3390,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3408,11 +3399,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c196 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c204 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -3493,43 +3493,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3538,7 +3538,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3574,67 +3574,67 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3643,7 +3643,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3652,43 +3652,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3697,7 +3697,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3706,43 +3706,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c95 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c95 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c95 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c95 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c95 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c95 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c95 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3751,7 +3751,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c95 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3760,43 +3760,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c119 {
+  .c116 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c119 {
+  .c116 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c119 {
+  .c116 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c119 {
+  .c116 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c119 {
+  .c116 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c119 {
+  .c116 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c119 {
+  .c116 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3805,7 +3805,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c119 {
+  .c116 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3814,43 +3814,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3859,7 +3859,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3868,25 +3868,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3895,14 +3895,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     margin-right: 1.5rem;
   }
 }
 
 @media (hover:hover) {
-  .c28:hover,
-  .c28:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3910,16 +3910,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c28:hover .c185,
-  .c28:visited:hover .c185 {
+  .c25:hover .c182,
+  .c25:visited:hover .c182 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c182:hover,
-  .c182:visited:hover {
+  .c179:hover,
+  .c179:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3927,8 +3927,8 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c182:hover .c185,
-  .c182:visited:hover .c185 {
+  .c179:hover .c182,
+  .c179:visited:hover .c182 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -3944,288 +3944,288 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c215:hover .c185,
-  .c215:visited:hover .c185 {
+  .c215:hover .c182,
+  .c215:visited:hover .c182 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c46 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c45:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c85 {
+  .c82 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     grid-template-columns: repeat(8,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c85 {
+  .c82 {
     grid-template-columns: repeat(12,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c98 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c101 {
+  .c98 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c98 {
     -webkit-column-gap: 2.5rem;
     column-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c101 {
+  .c98 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     grid-column: 2 / span 3;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c85 {
     grid-column: 3 / span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c85 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     grid-column: 5 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c90 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     grid-column-start: 5;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c90 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c100 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c103 {
+  .c100 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c103 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c105 {
     grid-column: 6 / span 7;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c105 {
     grid-column-start: 6;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c131 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c176 {
+  .c173 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c120 {
+  .c117 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c153 {
+  .c150 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c128 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c79 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c78 {
     min-width: 400px;
   }
 }
 
 @media (min-width:921px) and (max-width:1050px) {
-  .c81 {
+  .c78 {
     display: block;
     -webkit-translate: 14% -35%;
     translate: 14% -35%;
@@ -4236,7 +4236,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1051px) and (max-width:1180px) {
-  .c81 {
+  .c78 {
     -webkit-translate: 21% -33%;
     translate: 21% -33%;
     -webkit-transform: scale(1.6) rotate(-9deg);
@@ -4246,7 +4246,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1181px) and (max-width:1279px) {
-  .c81 {
+  .c78 {
     -webkit-transform: scale(1.55) rotate(-8.5deg);
     -ms-transform: scale(1.55) rotate(-8.5deg);
     transform: scale(1.55) rotate(-8.5deg);
@@ -4256,7 +4256,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c81 {
+  .c78 {
     -webkit-translate: 20% -41%;
     translate: 20% -41%;
     -webkit-transform: scale(1.7) rotate(-8deg);
@@ -4266,25 +4266,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     height: 380px;
   }
 }
 
 @media (min-width:1280px) {
-  .c92 {
+  .c89 {
     height: 430px;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     max-height: 56px;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     max-height: 64px;
   }
 }
@@ -4293,10 +4293,6 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   <div
     data-overlay-container="true"
   >
-    <div
-      aria-live="polite"
-      class="c0 c1 c2"
-    />
     <fake-head>
       <title>
         Get Involved | NEXT_PUBLIC_SEO_APP_NAME
@@ -4360,31 +4356,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
       </script>
     </fake-head>
     <div
-      class="c3 c4"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c2"
       >
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 grey-shadow"
+            class="c5 grey-shadow"
           />
           <div
-            class="c8 yellow-shadow"
+            class="c5 yellow-shadow"
           />
           <a
-            class="c9 c10 internal-button"
+            class="c6 c7 internal-button"
             data-testid="skip-link"
             href="#main"
             style="position: absolute; left: -10000px;"
           >
             <div
-              class="c11 c12"
+              class="c8 c9"
             >
               <span
-                class="c13"
+                class="c10"
               >
                 Skip to content
               </span>
@@ -4393,32 +4389,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </div>
       </div>
       <header
-        class="c14"
+        class="c11"
         data-testid="app-topnav"
       >
         <div
-          class="c15"
+          class="c12"
         >
           <div
-            class="c6 c7"
+            class="c3 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
-              class="c9 c10 internal-button"
+              class="c6 c7 internal-button"
               data-testid="skip-link"
               href="#main"
               style="position: absolute; left: -10000px;"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c13"
+                  class="c10"
                 >
                   Skip to content
                 </span>
@@ -4427,27 +4423,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </div>
         <div
-          class="c16 c17"
+          class="c13 c14"
         >
           <div
-            class="c18 c19"
+            class="c15 c16"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="true"
-              class="c20 c10 internal-button"
+              class="c17 c7 internal-button"
               href="/"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Teachers
                 </span>
@@ -4455,34 +4451,34 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </a>
           </div>
           <div
-            class="c18 c7"
+            class="c15 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="false"
-              class="c22 c23 internal-button"
+              class="c19 c20 internal-button"
               href="/pupils/years"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Go to 
                   pupils
                 </span>
                 <span
-                  class="c24"
+                  class="c21"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4495,22 +4491,22 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </div>
         <nav
-          class="c26 c27"
+          class="c23 c24"
         >
           <a
             aria-label="Home"
-            class="c28"
+            class="c25"
             href="/"
           >
             <span
-              class="c29"
+              class="c26"
             >
               <span
-                class="c30"
+                class="c27"
               >
                 <img
                   alt=""
-                  class="c31"
+                  class="c28"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4521,40 +4517,40 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c11 c32"
+            class="c8 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
             <div
-              class="c11"
+              class="c8"
             >
               <ul
-                class="c33"
+                class="c30"
               >
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4563,29 +4559,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4594,29 +4590,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4625,29 +4621,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4656,38 +4652,38 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4702,24 +4698,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c11 c40"
+              class="c8 c37"
             >
               <form
                 action="/teachers/search"
-                class="c41"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c42"
+                  class="c39"
                 >
                   <div
-                    class="c43 c44 c45"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c46"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4727,32 +4723,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c44"
                 >
                   <div
-                    class="c48 c49 c50"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c51 c52"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c11 c53"
+                        class="c8 c50"
                       >
                         <div
-                          class="c54 c55 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c56 shadow"
+                            class="c53 shadow"
                           />
                           <span
-                            class="c24"
+                            class="c21"
                             data-icon-for="button"
                           >
                             <img
                               alt=""
-                              class="c57"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4762,7 +4758,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c58"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4770,32 +4766,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c59"
+                class="c56"
               >
                 <div
-                  class="c48 c49 c50"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c54 c55 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c56 shadow"
+                          class="c53 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c57"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4805,7 +4801,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4813,19 +4809,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c60 c61"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c62 c63 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c64"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4834,29 +4830,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c65"
+                    class="c62"
                   >
                     My library
                   </div>
                 </div>
               </a>
               <div
-                class="c6 c7"
+                class="c3 c4"
               >
                 <div
-                  class="c8 grey-shadow"
+                  class="c5 grey-shadow"
                 />
                 <div
-                  class="c8 yellow-shadow"
+                  class="c5 yellow-shadow"
                 />
                 <button
-                  class="c66 c67 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c11 c37"
+                    class="c8 c34"
                   >
                     <span
-                      class="c38"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4866,32 +4862,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c69 c10 internal-button"
+                class="c66 c7 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c11 c53"
+                  class="c8 c50"
                 >
                   <span
-                    class="c24"
+                    class="c21"
                   >
                     <img
                       alt=""
-                      class="c39"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4900,7 +4896,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                   </span>
                   <span
-                    class="c13"
+                    class="c10"
                   />
                 </div>
               </button>
@@ -4909,46 +4905,46 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c70 c4"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c71"
+          class="c68"
         >
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c73 c74"
+              class="c70 c71"
             >
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <h1
-                  class="c76"
+                  class="c73"
                 >
                   <span
-                    class="c77"
+                    class="c74"
                   >
                     Get involved
                   </span>
                 </h1>
                 <p
-                  class="c78"
+                  class="c75"
                 >
                   We need your help to understand what's needed in the classroom. Want to get involved? We can't wait to hear from you.
                 </p>
               </div>
               <div
-                class="c11 c79"
+                class="c8 c76"
               >
                 <span
-                  class="c80 c81"
+                  class="c77 c78"
                   data-testid="about-shared-loop"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4960,38 +4956,38 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c82"
+            class="c79"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c83 c84"
+                class="c80 c81"
               >
                 <div
-                  class="c11 c85"
+                  class="c8 c82"
                 >
                   <div
-                    class="c11 c49 c86"
+                    class="c8 c46 c83"
                   >
                     <h2
-                      class="c87"
+                      class="c84"
                     >
                       Collaborate with us
                     </h2>
                   </div>
                   <div
-                    class="c11 c49 c88"
+                    class="c8 c46 c85"
                   >
                     <div
-                      class="c89 c90"
+                      class="c86 c87"
                     >
                       <span
-                        class="c91 c92"
+                        class="c88 c89"
                       >
                         <img
                           alt=""
-                          class="c31"
+                          class="c28"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5002,63 +4998,63 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c11 c49 c93"
+                    class="c8 c46 c90"
                   >
                     <div
-                      class="c11 c75"
+                      class="c8 c72"
                     >
                       <div
-                        class="c94"
+                        class="c91"
                       >
                         <div
-                          class="c95 c96"
+                          class="c92 c93"
                         >
                           <div
-                            class="c11 c97"
+                            class="c8 c94"
                           >
                             <h3
-                              class="c98"
+                              class="c95"
                             >
                               Join our teacher research panel
                             </h3>
                             <p
-                              class="c99"
+                              class="c96"
                             >
                               Share your story and we'll send you a gift voucher as a thanks for your time. Whether you've planned more efficiently, strengthened your subject knowledge or refreshed your curriculum design, your experience can inspire other teachers.
                             </p>
                           </div>
                           <div
-                            class="c11 c100"
+                            class="c8 c97"
                           >
                             <div
-                              class="c6 c7"
+                              class="c3 c4"
                             >
                               <div
-                                class="c8 grey-shadow"
+                                class="c5 grey-shadow"
                               />
                               <div
-                                class="c8 yellow-shadow"
+                                class="c5 yellow-shadow"
                               />
                               <a
-                                class="c9 c10 internal-button"
+                                class="c6 c7 internal-button"
                                 href="https://share.hsforms.com/1dv2FiLvTQraZIZmhUUURmQbvumd"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <div
-                                  class="c11 c12"
+                                  class="c8 c9"
                                 >
                                   <span
-                                    class="c13"
+                                    class="c10"
                                   >
                                     Join the research panel
                                   </span>
                                   <span
-                                    class="c24"
+                                    class="c21"
                                   >
                                     <img
                                       alt="external"
-                                      class="c25"
+                                      class="c22"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5070,23 +5066,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </a>
                             </div>
                             <div
-                              class="c6 c7"
+                              class="c3 c4"
                             >
                               <div
-                                class="c8 grey-shadow"
+                                class="c5 grey-shadow"
                               />
                               <div
-                                class="c8 yellow-shadow"
+                                class="c5 yellow-shadow"
                               />
                               <a
-                                class="c9 c10 internal-button"
+                                class="c6 c7 internal-button"
                                 href="/blog/categories/research-and-insights"
                               >
                                 <div
-                                  class="c11 c12"
+                                  class="c8 c9"
                                 >
                                   <span
-                                    class="c13"
+                                    class="c10"
                                   >
                                     Explore our research
                                   </span>
@@ -5097,57 +5093,57 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c94"
+                        class="c91"
                       >
                         <div
-                          class="c95 c96"
+                          class="c92 c93"
                         >
                           <div
-                            class="c11 c97"
+                            class="c8 c94"
                           >
                             <h3
-                              class="c98"
+                              class="c95"
                             >
                               Give your feedback
                             </h3>
                             <p
-                              class="c99"
+                              class="c96"
                             >
                               Teachers are at the heart of everything we build. Have your say by taking part in research or road-testing new resources in your school. 
                             </p>
                           </div>
                           <div
-                            class="c11 c100"
+                            class="c8 c97"
                           >
                             <div
-                              class="c6 c7"
+                              class="c3 c4"
                             >
                               <div
-                                class="c8 grey-shadow"
+                                class="c5 grey-shadow"
                               />
                               <div
-                                class="c8 yellow-shadow"
+                                class="c5 yellow-shadow"
                               />
                               <a
-                                class="c9 c10 internal-button"
+                                class="c6 c7 internal-button"
                                 href="https://share.hsforms.com/2pi1ZLqVKQNyKznqJrpqsgwbvumd"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <div
-                                  class="c11 c12"
+                                  class="c8 c9"
                                 >
                                   <span
-                                    class="c13"
+                                    class="c10"
                                   >
                                     Get in touch
                                   </span>
                                   <span
-                                    class="c24"
+                                    class="c21"
                                   >
                                     <img
                                       alt="external"
-                                      class="c25"
+                                      class="c22"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5168,67 +5164,67 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c83 c101"
+              class="c80 c98"
             >
               <div
-                class="c11 c102 c103"
+                class="c8 c99 c100"
               >
                 <div
-                  class="c11 c96"
+                  class="c8 c93"
                 >
                   <div
-                    class="c11 c75"
+                    class="c8 c72"
                   >
                     <h2
-                      class="c87"
+                      class="c84"
                     >
                       Work with us
                     </h2>
                     <div
-                      class="c104 c105"
+                      class="c101 c102"
                     >
                       <p
-                        class="c99"
+                        class="c96"
                       >
                         We're a fast-paced and innovative team, working to support and inspire teachers to deliver great teaching, so every pupil benefits. All our roles are remote-first. If you want to be part of something unique that's making a difference to millions of children's lives, we'd love to hear from you.
                       </p>
                     </div>
                   </div>
                   <div
-                    class="c11 c106"
+                    class="c8 c103"
                   >
                     <div
-                      class="c6 c7"
+                      class="c3 c4"
                     >
                       <div
-                        class="c8 grey-shadow"
+                        class="c5 grey-shadow"
                       />
                       <div
-                        class="c8 yellow-shadow"
+                        class="c5 yellow-shadow"
                       />
                       <a
-                        class="c9 c10 internal-button"
+                        class="c6 c7 internal-button"
                         href="https://app.beapplied.com/org/1574/oak-national-academy/"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
                         <div
-                          class="c11 c12"
+                          class="c8 c9"
                         >
                           <span
-                            class="c13"
+                            class="c10"
                           >
                             Permanent roles
                           </span>
                           <span
-                            class="c24"
+                            class="c21"
                           >
                             <img
                               alt="external"
-                              class="c25"
+                              class="c22"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5240,34 +5236,34 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c6 c7"
+                      class="c3 c4"
                     >
                       <div
-                        class="c8 grey-shadow"
+                        class="c5 grey-shadow"
                       />
                       <div
-                        class="c8 yellow-shadow"
+                        class="c5 yellow-shadow"
                       />
                       <a
-                        class="c9 c10 internal-button"
+                        class="c6 c7 internal-button"
                         href="https://app.beapplied.com/org/1767/oak-national-academy-freelancers/"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
                         <div
-                          class="c11 c12"
+                          class="c8 c9"
                         >
                           <span
-                            class="c13"
+                            class="c10"
                           >
                             Freelance roles
                           </span>
                           <span
-                            class="c24"
+                            class="c21"
                           >
                             <img
                               alt="external"
-                              class="c25"
+                              class="c22"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5282,20 +5278,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c107 c108"
+                class="c8 c104 c105"
               >
                 <div
-                  class="c11 c109"
+                  class="c8 c106"
                 >
                   <div
-                    class="c110 c49"
+                    class="c107 c46"
                   >
                     <span
-                      class="c91"
+                      class="c88"
                     >
                       <img
                         alt=""
-                        class="c111"
+                        class="c108"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -5307,21 +5303,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c11 c112"
+                    class="c8 c109"
                   >
                     <img
                       alt="'In Escape the City's top 1% of employers'"
-                      class="c113"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/top-1-percent-logo_hyga8g.svg"
                     />
                     <img
                       alt="Awarded Gold in Investors In People"
-                      class="c113"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/investor-in-people_eymeqv.svg"
                     />
                     <img
                       alt="Certified as Disability Confident Committed"
-                      class="c113"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/disability-confident_ym07wl.png"
                     />
                   </div>
@@ -5330,19 +5326,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c114"
+            class="c111"
             style="margin-top: -72px;"
           >
             <div
-              class="c115"
+              class="c112"
             >
               <span
-                class="c116"
+                class="c113"
                 style="pointer-events: none;"
               >
                 <img
                   alt=""
-                  class="c25"
+                  class="c22"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -5351,13 +5347,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c72"
+                class="c69"
               >
                 <div
-                  class="c117 c118"
+                  class="c114 c115"
                 >
                   <h2
-                    class="c119"
+                    class="c116"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5366,31 +5362,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c120"
+                      class="c117"
                     >
                       <li
-                        class="c121"
+                        class="c118"
                       >
                         <div
-                          class="c122 c123"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c124 c125 c126"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c127"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5400,19 +5396,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c128 c129"
+                                class="c125 c126"
                               >
                                 About Oak
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c80"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5426,28 +5422,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c121"
+                        class="c118"
                       >
                         <div
-                          class="c122 c123"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c124 c125 c126"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c127"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5457,19 +5453,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c128 c129"
+                                class="c125 c126"
                               >
                                 Oak's curricula
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c80"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5483,28 +5479,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c121"
+                        class="c118"
                       >
                         <div
-                          class="c122 c123"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c124 c125 c126"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c127"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5514,19 +5510,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c128 c129"
+                                class="c125 c126"
                               >
                                 Meet the team
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c80"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5540,28 +5536,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c121"
+                        class="c118"
                       >
                         <div
-                          class="c122 c123"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c124 c125 c126"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c127"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5571,19 +5567,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c128 c129"
+                                class="c125 c126"
                               >
                                 Get involved
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c80"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5603,33 +5599,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c130"
+            class="c127"
             id="newsletter-signup"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c11 c49 c131"
+                class="c8 c46 c128"
               >
                 <div
-                  class="c132 c4"
+                  class="c129 c1"
                 >
                   <div
-                    class="c11 c133"
+                    class="c8 c130"
                   >
                     <div
-                      class="c11 c49 c134"
+                      class="c8 c46 c131"
                     >
                       <div
-                        class="c135 c136"
+                        class="c132 c133"
                       >
                         <span
-                          class="c137"
+                          class="c134"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5638,24 +5634,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c138"
+                          class="c135"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c139"
+                        class="c136"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
                         Join over 100k teachers and get free resources and other helpful content by email. Unsubscribe at any time. Read our
                          
                         <a
-                          class="c28"
+                          class="c25"
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             privacy policy
                           </span>
@@ -5664,27 +5660,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c140 c49 c134"
+                      class="c137 c46 c131"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c141"
+                        class="c138"
                         novalidate=""
                       >
                         <div
-                          class="c142 c143 c144"
+                          class="c139 c140 c141"
                         >
                           <div
-                            class="c145 "
+                            class="c142 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5709,7 +5705,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5734,7 +5730,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5759,7 +5755,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5784,23 +5780,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c147 "
+                              class="c144 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c148 c149 c150"
+                                class="c145 c146 c147"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
                                 id="react-use-id-test-result-newsletter-signup-name-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Name
                                    
                                   <span
-                                    class="c151"
+                                    class="c148"
                                   >
                                     (required)
                                   </span>
@@ -5811,7 +5807,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c152 c153"
+                              class="c149 c150"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5819,7 +5815,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c154 c155 c156"
+                              class="c151 c152 c153"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5832,19 +5828,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c142 c143 c144"
+                          class="c139 c140 c141"
                         >
                           <div
-                            class="c145 "
+                            class="c142 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5869,7 +5865,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5894,7 +5890,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5919,7 +5915,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c146"
+                                class="c143"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5944,23 +5940,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c147 "
+                              class="c144 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c148 c149 c150"
+                                class="c145 c146 c147"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
                                 id="react-use-id-test-result-newsletter-signup-email-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Email
                                    
                                   <span
-                                    class="c151"
+                                    class="c148"
                                   >
                                     (required)
                                   </span>
@@ -5971,7 +5967,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c152 c153"
+                              class="c149 c150"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5979,7 +5975,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c154 c155 c156"
+                              class="c151 c152 c153"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5992,16 +5988,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c157 c84 c158"
+                          class="c154 c81 c155"
                         >
                           <div
                             aria-hidden="true"
-                            class="c11"
+                            class="c8"
                             data-testid="brush-borders"
                           >
                             <svg
                               aria-hidden="true"
-                              class="c146"
+                              class="c143"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -6026,7 +6022,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c146"
+                              class="c143"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -6051,7 +6047,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c146"
+                              class="c143"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6076,7 +6072,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c146"
+                              class="c143"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6102,7 +6098,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c154 c155 c156 c159"
+                            class="c151 c152 c153 c156"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6113,10 +6109,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c160 c49"
+                            class="c157 c46"
                           >
                             <label
-                              class="c148 c149 c150"
+                              class="c145 c146 c147"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6128,16 +6124,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c161 c162"
+                            class="c158 c159"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c163 c44 c164"
+                              class="c160 c41 c161"
                             >
                               <span
-                                class="c165 c166"
+                                class="c162 c163"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6146,11 +6142,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c24"
+                              class="c21"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6161,22 +6157,22 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c167 c7"
+                          class="c164 c4"
                         >
                           <div
-                            class="c8 grey-shadow"
+                            class="c5 grey-shadow"
                           />
                           <div
-                            class="c8 yellow-shadow"
+                            class="c5 yellow-shadow"
                           />
                           <button
-                            class="c168 c23 internal-button"
+                            class="c165 c20 internal-button"
                           >
                             <div
-                              class="c11 c12"
+                              class="c8 c9"
                             >
                               <span
-                                class="c13"
+                                class="c10"
                               >
                                 Sign up to the newsletter
                               </span>
@@ -6185,12 +6181,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c169"
+                          class="c166"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c170"
+                          class="c167"
                         />
                       </form>
                     </div>
@@ -6202,14 +6198,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c171"
+        class="c168"
       >
         <div
-          class="c172 c49"
+          class="c169 c46"
         >
           <svg
             aria-hidden="true"
-            class="c173"
+            class="c170"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6232,37 +6228,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c174 c175"
+            class="c171 c172"
           >
             <div
-              class="c11 c133"
+              class="c8 c130"
             >
               <div
-                class="c11 c49 c176"
+                class="c8 c46 c173"
               >
                 <div
-                  class="c177 c84"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c178"
+                    class="c175"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c179 c180"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/pupils/years"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Learn online
                           </span>
@@ -6272,72 +6268,72 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c183"
+                  class="c180"
                 />
                 <div
-                  class="c177 c84"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c178"
+                    class="c175"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c179 c180"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             EYFS
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/lesson-planning"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Plan a lesson
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c184"
+                            class="c181"
                           >
                             <span
-                              class="c80 c185 c186"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6349,14 +6345,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/blog"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Blog
                           </span>
@@ -6367,115 +6363,115 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c176"
+                class="c8 c46 c173"
               >
                 <div
-                  class="c177 c84"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c178"
+                    class="c175"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c179 c180"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Home
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/about-us/who-we-are"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             About us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Oak's curricula
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/about-us/get-involved"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Get involved
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/about-us/meet-the-team"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Meet the team
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c182 "
+                          class="c179 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Careers
                           </span>
                           <div
-                            class="c184"
+                            class="c181"
                           >
                             <span
-                              class="c80 c185 c186"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6487,42 +6483,42 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/contact-us"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Contact us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c182 "
+                          class="c179 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Help
                           </span>
                           <div
-                            class="c184"
+                            class="c181"
                           >
                             <span
-                              class="c80 c185 c186"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6534,42 +6530,42 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/webinars"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Webinars
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c182 "
+                          class="c179 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Status
                           </span>
                           <div
-                            class="c184"
+                            class="c181"
                           >
                             <span
-                              class="c80 c185 c186"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6585,156 +6581,156 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c176"
+                class="c8 c46 c173"
               >
                 <div
-                  class="c177 c84"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c178"
+                    class="c175"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c179 c180"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Terms & conditions
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Privacy policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/cookie-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Cookie policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <button
-                          class="c182 "
+                          class="c179 "
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Manage cookie settings
                           </span>
                         </button>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/copyright-notice"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Copyright notice
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/accessibility-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Accessibility statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Safeguarding statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Physical activity disclaimer
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/complaints"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Complaints
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c181"
+                        class="c178"
                       >
                         <a
-                          class="c182 "
+                          class="c179 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Freedom of information requests
                           </span>
@@ -6745,20 +6741,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c176"
+                class="c8 c46 c173"
               >
                 <div
-                  class="c177 c187"
+                  class="c174 c184"
                 >
                   <div
-                    class="c42"
+                    class="c39"
                   >
                     <span
-                      class="c188"
+                      class="c185"
                     >
                       <img
                         alt=""
-                        class="c31"
+                        class="c28"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6768,32 +6764,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c189 c190"
+                    class="c186 c187"
                   >
                     <div
-                      class="c48 c49 c191 c192"
+                      class="c45 c46 c188 c189"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c193 c55 icon-container"
+                            class="c190 c52 icon-container"
                           >
                             <div
-                              class="c194 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6803,35 +6799,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c191 c192"
+                      class="c45 c46 c188 c189"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c193 c55 icon-container"
+                            class="c190 c52 icon-container"
                           >
                             <div
-                              class="c194 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6841,35 +6837,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c191 c192"
+                      class="c45 c46 c188 c189"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c193 c55 icon-container"
+                            class="c190 c52 icon-container"
                           >
                             <div
-                              class="c194 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6879,7 +6875,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6889,12 +6885,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c91 c195"
+              class="c88 c192"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c31"
+                class="c28"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6905,35 +6901,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c196 c197"
+              class="c193 c194"
             >
               <div
-                class="c198 c199"
+                class="c195 c196"
               >
                 <div
-                  class="c48 c49 c191 c192"
+                  class="c45 c46 c188 c189"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c193 c55 icon-container"
+                        class="c190 c52 icon-container"
                       >
                         <div
-                          class="c194 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6943,35 +6939,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c191 c192"
+                  class="c45 c46 c188 c189"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c193 c55 icon-container"
+                        class="c190 c52 icon-container"
                       >
                         <div
-                          class="c194 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6981,35 +6977,35 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c191 c192"
+                  class="c45 c46 c188 c189"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c193 c55 icon-container"
+                        class="c190 c52 icon-container"
                       >
                         <div
-                          class="c194 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7019,21 +7015,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c59"
+                class="c56"
               >
                 <span
-                  class="c188"
+                  class="c185"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -7043,15 +7039,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c177 c84"
+                class="c174 c81"
               >
                 <p
-                  class="c200"
+                  class="c197"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c201"
+                  class="c198"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7060,11 +7056,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c202"
+          class="c199"
         >
           <img
             alt=""
-            class="c203"
+            class="c200"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7073,11 +7069,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c204"
+          class="c201"
         >
           <img
             alt=""
-            class="c205"
+            class="c202"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7087,6 +7083,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </span>
       </footer>
     </div>
+    <div
+      aria-live="polite"
+      class="c203 c204 c205"
+    />
   </div>
   <div
     class="c206"
@@ -7113,10 +7113,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c213"
+            class="c8 c213"
           >
             <div
-              class="c214 c44"
+              class="c214 c41"
             >
               <button
                 class="c215"
@@ -7124,29 +7124,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 type="button"
               >
                 <span
-                  class="c29"
+                  class="c26"
                 >
                   Reject non-essential cookies
                 </span>
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c9 c10 internal-button"
+                class="c6 c7 internal-button"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Cookie settings
                   </span>
@@ -7154,23 +7154,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c216 c23 internal-button"
+                class="c216 c20 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Accept all cookies
                   </span>

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -2,21 +2,11 @@
 
 exports[`pages/about/meet-the-team.tsx renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c2 {
   position: absolute;
   top: 5.75rem;
   left: 1.5rem;
@@ -27,7 +17,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c6 {
+.c3 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -36,7 +26,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,16 +35,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c11 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   position: absolute;
   top: 10rem;
   left: 1.5rem;
@@ -62,7 +52,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c16 {
+.c13 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 1rem;
@@ -71,14 +61,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c15 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c21 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -88,7 +78,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   max-height: 5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -100,7 +90,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
@@ -109,19 +99,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -142,17 +132,17 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c43:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c47 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -160,7 +150,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -171,7 +161,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -180,12 +170,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -205,7 +195,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c64 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -215,34 +205,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c97 {
+.c94 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c71 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c72 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -251,7 +241,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -259,7 +249,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c80 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -267,12 +257,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c81 {
+.c78 {
   padding-bottom: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c83 {
+.c80 {
   position: -webkit-sticky;
   position: sticky;
   top: 1.25rem;
@@ -282,7 +272,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c86 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -293,14 +283,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c92 {
+.c89 {
   padding: 1rem;
   background: #fff7cc;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c97 {
   width: 100%;
   height: 100%;
   background: #ffffff;
@@ -308,21 +298,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c99 {
   height: 100%;
   padding: 1rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c104 {
+.c101 {
   height: 100%;
   padding-top: 0rem;
   padding-bottom: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -333,20 +323,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c112 {
+.c109 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c113 {
+.c110 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c114 {
+.c111 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -361,26 +351,26 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c115 {
+.c112 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c117 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c119 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c122 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -390,7 +380,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c123 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -401,7 +391,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c128 {
+.c125 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -411,14 +401,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c126 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c128 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -430,12 +420,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c131 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c136 {
+.c133 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -449,36 +439,36 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c136 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c155 {
+.c152 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c159 {
+.c156 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c162 {
+.c159 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c166 {
+.c163 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c167 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -488,13 +478,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c171 {
+.c168 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c173 {
+.c170 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -506,12 +496,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c176 {
+.c173 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c178 {
+.c175 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -523,18 +513,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c182 {
+.c179 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c183 {
+.c180 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c187 {
+.c184 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -543,7 +533,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c185 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -551,7 +541,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c189 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -562,7 +552,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c190 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -573,14 +563,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c194 {
+.c191 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c193 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -588,12 +578,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c195 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c202 {
+.c199 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -611,7 +601,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c204 {
+.c201 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -627,6 +617,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   transform: translate(0%,32%);
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
+}
+
+.c203 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c206 {
@@ -683,28 +683,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c12 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -723,7 +708,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c17 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -735,7 +720,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -747,7 +732,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -766,7 +751,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c37 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -785,7 +770,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c40 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -797,7 +782,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c44 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -808,14 +793,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c53 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -834,7 +819,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c55 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -849,7 +834,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c63 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -865,7 +850,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c156 {
+.c153 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -875,7 +860,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c74 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -891,7 +876,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c75 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -902,7 +887,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c82 {
+.c79 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -910,7 +895,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c87 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -925,7 +910,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c91 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -940,7 +925,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c93 {
+.c90 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -951,7 +936,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c94 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -962,7 +947,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c105 {
+.c102 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -977,7 +962,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c108 {
+.c105 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -992,7 +977,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c116 {
+.c113 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1003,7 +988,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c123 {
+.c120 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1018,7 +1003,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c127 {
+.c124 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1029,7 +1014,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c135 {
+.c132 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1043,7 +1028,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c174 {
+.c171 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1061,7 +1046,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c186 {
+.c183 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1072,7 +1057,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c189 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1088,7 +1073,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c197 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1106,7 +1091,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c199 {
+.c196 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1117,6 +1102,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   gap: 1rem;
+}
+
+.c204 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c210 {
@@ -1156,7 +1156,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1168,7 +1168,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: left;
 }
 
-.c21 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1180,11 +1180,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: left;
 }
 
-.c29 {
+.c26 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1196,7 +1196,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: left;
 }
 
-.c58 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1207,14 +1207,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c77 {
+.c74 {
   background: #ffe555;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c85 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -1226,7 +1226,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c109 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1237,7 +1237,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c164 {
+.c161 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1259,7 +1259,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c172 {
+.c169 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1268,7 +1268,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c9 {
+.c6 {
   background: none;
   color: inherit;
   border: none;
@@ -1291,12 +1291,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c9:disabled {
+.c6:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c17 {
   background: none;
   color: inherit;
   border: none;
@@ -1322,12 +1322,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c20:disabled {
+.c17:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -1353,12 +1353,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c22:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c35 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1381,12 +1381,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c35:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c51 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1400,12 +1400,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c51:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c60 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1418,12 +1418,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1453,12 +1453,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c66:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c69 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1482,12 +1482,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-style: none;
 }
 
-.c69:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c167 {
+.c164 {
   background: none;
   color: inherit;
   border: none;
@@ -1511,7 +1511,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c167:disabled {
+.c164:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1544,35 +1544,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c25 {
+.c22 {
   object-fit: contain;
 }
 
-.c39 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c57 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c203 {
+.c200 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c205 {
+.c202 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c31 {
+.c28 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1581,13 +1581,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c10 {
+.c7 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c10:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -1595,37 +1595,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c10:hover [data-state="selected"] {
+.c7:hover [data-state="selected"] {
   display: none;
 }
 
-.c10:active {
+.c7:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c10:active [data-state="selected"] {
+.c7:active [data-state="selected"] {
   display: none;
 }
 
-.c10:disabled {
+.c7:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c10:disabled [data-state="selected"] {
+.c7:disabled [data-state="selected"] {
   display: none;
 }
 
-.c23 {
+.c20 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c23:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -1633,37 +1633,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c23:hover [data-state="selected"] {
+.c20:hover [data-state="selected"] {
   display: none;
 }
 
-.c23:active {
+.c20:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c23:active [data-state="selected"] {
+.c20:active [data-state="selected"] {
   display: none;
 }
 
-.c23:disabled {
+.c20:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c23:disabled [data-state="selected"] {
+.c20:disabled [data-state="selected"] {
   display: none;
 }
 
-.c36 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c36:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1671,37 +1671,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c36:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c36:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c36:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c36:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c36:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c67 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c67:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1709,148 +1709,148 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c67:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c67:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c67:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c67:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c67:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c4 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c4 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:hover),
-.c7 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c4 .yellow-shadow:has(+ .internal-button:hover),
+.c4 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:hover) {
+.c4 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:active) {
+.c4 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:active) {
+.c4 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c16 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c16 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c16 .yellow-shadow:has(+ .internal-button:hover),
+.c16 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c16 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c16 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c16 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c52 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c52:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c52:active {
+.c49:active {
   color: #222222;
 }
 
-.c52:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c50 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c50 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c50 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c50 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c190 > :first-child:focus-visible .shadow {
+.c187 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c190 > :first-child:hover .shadow {
+.c187 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c190 > :first-child:active .shadow {
+.c187 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c190 > :first-child:disabled .icon-container {
+.c187 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c190 > :first-child:hover .icon-container {
+.c187 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c190 > :first-child:active .icon-container {
+.c187 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c76 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1861,7 +1861,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c95 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1872,7 +1872,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c106 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1883,7 +1883,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c117 {
+.c114 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1895,7 +1895,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: center;
 }
 
-.c137 {
+.c134 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1906,7 +1906,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c177 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1919,7 +1919,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c34 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1927,7 +1927,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c180 {
+.c177 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1936,7 +1936,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c78 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1947,7 +1947,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c96 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -1958,18 +1958,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c107 {
+.c104 {
   font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 
-.c138 {
+.c135 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c168 {
+.c165 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1982,7 +1982,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c169 {
+.c166 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1994,7 +1994,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c200 {
+.c197 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2005,7 +2005,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c201 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2016,7 +2016,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c111 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2027,7 +2027,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c179 {
+.c176 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2038,7 +2038,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c33 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2059,7 +2059,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c84 {
+.c81 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2079,14 +2079,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c185 {
+.c182 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c28 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2110,47 +2110,47 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c28 .c184 {
+.c25 .c181 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c28:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c28:visited {
+.c25:visited {
   color: #081676;
 }
 
-.c28:visited .c184 {
+.c25:visited .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28:active {
+.c25:active {
   color: #081676;
   outline: 1px solid #081676;
 }
 
-.c28:active .c184 {
+.c25:active .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c28[disabled] .c184 {
+.c25[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c181 {
+.c178 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2174,42 +2174,42 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c181 .c184 {
+.c178 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c181:focus-visible {
+.c178:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c181:visited {
+.c178:visited {
   color: #222222;
 }
 
-.c181:visited .c184 {
+.c178:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c181:active {
+.c178:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c181:active .c184 {
+.c178:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c181[disabled] {
+.c178[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c181[disabled] .c184 {
+.c178[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2247,7 +2247,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c215 .c184 {
+.c215 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -2262,7 +2262,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c215:visited .c184 {
+.c215:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2272,7 +2272,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c215:active .c184 {
+.c215:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2282,12 +2282,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #808080;
 }
 
-.c215[disabled] .c184 {
+.c215[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c46 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2303,49 +2303,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   width: 100%;
 }
 
-.c46::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c46::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c46:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c46::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c46::-webkit-search-decoration,
-.c46::-webkit-search-cancel-button,
-.c46::-webkit-search-results-button,
-.c46::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c46:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c45 {
+.c42 {
   background: #ffffff;
 }
 
-.c45:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c45:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c98 {
+.c95 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2355,13 +2355,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(auto-fit,minmax(200px,1fr));
 }
 
-.c132 {
+.c129 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c133 {
+.c130 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2370,7 +2370,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c175 {
+.c172 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2379,52 +2379,52 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c101 {
+.c98 {
   box-shadow: none;
 }
 
-.c101:has(a:hover,button:hover) {
+.c98:has(a:hover,button:hover) {
   background-color: #f2f2f2;
   box-shadow: none;
 }
 
-.c101:has( a, button) {
+.c98:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c101:has( a, button)  a,
-.c101:has( a, button) button {
+.c98:has( a, button)  a,
+.c98:has( a, button) button {
   outline: none;
 }
 
-.c101:has(a:active,button:active) {
+.c98:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c121 {
+.c118 {
   box-shadow: none;
 }
 
-.c121:has(a:hover,button:hover) {
+.c118:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c121:has( a, button) {
+.c118:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c121:has( a, button)  a,
-.c121:has( a, button) button {
+.c118:has( a, button)  a,
+.c118:has( a, button) button {
   outline: none;
 }
 
-.c121:has(a:active,button:active) {
+.c118:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c103 {
+.c100 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2432,31 +2432,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c103:hover h1,
-.c103:hover h2,
-.c103:hover h3,
-.c103:hover h4,
-.c103:hover h5,
-.c103:hover h6,
-.c103:hover span {
+.c100:hover h1,
+.c100:hover h2,
+.c100:hover h3,
+.c100:hover h4,
+.c100:hover h5,
+.c100:hover h6,
+.c100:hover span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c103:hover span {
+.c100:hover span {
   -webkit-text-decoration-thickness: 18%;
   text-decoration-thickness: 18%;
 }
 
-.c61:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c61:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c85 {
+.c82 {
   -webkit-text-decoration: none;
   text-decoration: none;
   display: -webkit-box;
@@ -2481,13 +2481,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   padding-right: 0rem;
 }
 
-.c85:focus-visible {
+.c82:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
   border-color: transparent;
   border-radius: 4px;
 }
 
-.c90 {
+.c87 {
   -webkit-text-decoration: none;
   text-decoration: none;
   display: -webkit-box;
@@ -2512,13 +2512,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   padding-right: 0rem;
 }
 
-.c90:focus-visible {
+.c87:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
   border-color: transparent;
   border-radius: 4px;
 }
 
-.c86 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2527,25 +2527,50 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c2 {
+.c205 {
   top: 82px;
 }
 
-.c191 .icon-container > *:first-child {
+.c188 .icon-container > *:first-child {
   border: 0;
 }
 
-.c152 {
+.c149 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c141 {
+.c138 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
   color: #222222;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c138::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c138::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c138::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c141 {
+  position: relative;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2568,32 +2593,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   background-color: #999999;
 }
 
-.c144 {
-  position: relative;
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c144::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c144::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c144::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c146 {
+.c143 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2601,23 +2601,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c146::-webkit-scrollbar-track {
+.c143::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c146::-webkit-scrollbar {
+.c143::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c146::-webkit-scrollbar-thumb {
+.c143::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c160 {
+.c157 {
   background: none;
   color: inherit;
   border: none;
@@ -2628,34 +2628,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c142 {
+.c139 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c195 {
+.c192 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c79 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c124:hover {
+.c121:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c119 {
+.c116 {
   padding: 0;
   margin: 0;
 }
 
-.c118 {
+.c115 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2667,7 +2667,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c145 {
+.c142 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2679,7 +2679,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c150 {
+.c147 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2690,32 +2690,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c150::-webkit-input-placeholder {
+.c147::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c150::-moz-placeholder {
+.c147::-moz-placeholder {
   color: #575757;
 }
 
-.c150:-ms-input-placeholder {
+.c147:-ms-input-placeholder {
   color: #575757;
 }
 
-.c150::placeholder {
+.c147::placeholder {
   color: #575757;
 }
 
-.c150::-webkit-search-decoration,
-.c150::-webkit-search-cancel-button,
-.c150::-webkit-search-results-button,
-.c150::-webkit-search-results-decoration {
+.c147::-webkit-search-decoration,
+.c147::-webkit-search-cancel-button,
+.c147::-webkit-search-results-button,
+.c147::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c148 {
+.c145 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2725,7 +2725,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c154 {
+.c151 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2738,7 +2738,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c149 {
+.c146 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2749,16 +2749,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c143:focus-within .c147 {
+.c140:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c143:focus-within .c153 {
+.c140:focus-within .c150 {
   display: inline;
 }
 
-.c151 {
+.c148 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2774,7 +2774,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: none;
 }
 
-.c151::-webkit-input-placeholder {
+.c148::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2782,7 +2782,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c151::-moz-placeholder {
+.c148::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2790,7 +2790,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c151:-ms-input-placeholder {
+.c148:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2798,7 +2798,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c151::placeholder {
+.c148::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2806,40 +2806,40 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c151:valid:not([value=""]) {
+.c148:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c151:valid:not([value=""])::-webkit-input-placeholder {
+.c148:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c151:valid:not([value=""])::-moz-placeholder {
+.c148:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c151:valid:not([value=""]):-ms-input-placeholder {
+.c148:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c151:valid:not([value=""])::placeholder {
+.c148:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c158 {
+.c155 {
   display: none;
 }
 
-.c157:focus-within .c147 {
+.c154:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c161 {
+.c158 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2866,39 +2866,45 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #575757;
 }
 
-.c163 {
+.c160 {
   max-width: calc(100% - 20px);
 }
 
-.c165 {
+.c162 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c140 {
+.c137 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c127 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c99 {
+.c96 {
   list-style: none;
 }
 
 @media (min-width:750px) {
-  .c0 {
-    right: 1.5rem;
+  .c13 {
+    padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c13 {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c15 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2906,75 +2912,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    padding-left: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c0 {
-    padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-left: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-right: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-top: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-bottom: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c41 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2983,19 +2957,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -3003,37 +2977,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c65 {
     display: none;
   }
 }
@@ -3047,97 +3021,97 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c86 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c92 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3146,7 +3120,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3155,13 +3129,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3169,7 +3143,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c111 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3177,79 +3151,79 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c115 {
+  .c112 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c115 {
+  .c112 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c115 {
+  .c112 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c115 {
+  .c112 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c128 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c128 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c173 {
+  .c170 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c173 {
+  .c170 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c176 {
+  .c173 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c182 {
+  .c179 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c188 {
+  .c185 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c193 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c195 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3258,13 +3232,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c199 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c199 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3272,7 +3246,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c202 {
+  .c199 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3280,8 +3254,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c204 {
+  .c201 {
     display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    padding-left: 0rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c203 {
+    padding-right: 0rem;
   }
 }
 
@@ -3337,16 +3337,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c17 {
+  .c14 {
     -webkit-box-pack: left;
     -webkit-justify-content: left;
     -ms-flex-pack: left;
@@ -3355,19 +3346,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3384,31 +3375,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3416,38 +3407,38 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c84 {
     -webkit-column-gap: 0.25rem;
     column-gap: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c113 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c113 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c186 {
+  .c183 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3456,13 +3447,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c189 {
+  .c186 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3470,7 +3461,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3479,7 +3470,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3488,11 +3479,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c196 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c204 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -3573,43 +3573,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3618,7 +3618,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3654,67 +3654,67 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3723,7 +3723,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3732,43 +3732,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c95 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c95 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c95 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3777,7 +3777,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c95 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3786,43 +3786,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c114 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3831,7 +3831,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c117 {
+  .c114 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3840,43 +3840,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3885,7 +3885,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3894,49 +3894,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c135 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3945,7 +3945,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3954,8 +3954,8 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (hover:hover) {
-  .c28:hover,
-  .c28:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3963,16 +3963,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c28:hover .c184,
-  .c28:visited:hover .c184 {
+  .c25:hover .c181,
+  .c25:visited:hover .c181 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c181:hover,
-  .c181:visited:hover {
+  .c178:hover,
+  .c178:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3980,8 +3980,8 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c181:hover .c184,
-  .c181:visited:hover .c184 {
+  .c178:hover .c181,
+  .c178:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -3997,44 +3997,44 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c215:hover .c184,
-  .c215:visited:hover .c184 {
+  .c215:hover .c181,
+  .c215:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c46 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c45:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c133 {
+  .c130 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c175 {
+  .c172 {
     grid-column: span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     border-left: 4px solid #222222;
   }
 
-  .c85:hover {
+  .c82:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #575757;
@@ -4042,7 +4042,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4050,7 +4050,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4059,23 +4059,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     padding-right: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     border-left: 4px solid transparent;
   }
 
-  .c90:hover {
+  .c87:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
@@ -4083,7 +4083,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4091,7 +4091,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4100,37 +4100,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     padding-right: 0.75rem;
   }
 }
 
 @media (max-width:920px) {
-  .c79 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:800px) {
-  .c118 {
+  .c115 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c151 {
+  .c148 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c127 {
     max-width: 870px;
   }
 }
@@ -4139,10 +4139,6 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   <div
     data-overlay-container="true"
   >
-    <div
-      aria-live="polite"
-      class="c0 c1 c2"
-    />
     <fake-head>
       <title>
         Meet the Team | NEXT_PUBLIC_SEO_APP_NAME
@@ -4206,31 +4202,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
       </script>
     </fake-head>
     <div
-      class="c3 c4"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c2"
       >
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 grey-shadow"
+            class="c5 grey-shadow"
           />
           <div
-            class="c8 yellow-shadow"
+            class="c5 yellow-shadow"
           />
           <a
-            class="c9 c10 internal-button"
+            class="c6 c7 internal-button"
             data-testid="skip-link"
             href="#main"
             style="position: absolute; left: -10000px;"
           >
             <div
-              class="c11 c12"
+              class="c8 c9"
             >
               <span
-                class="c13"
+                class="c10"
               >
                 Skip to content
               </span>
@@ -4239,32 +4235,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </div>
       </div>
       <header
-        class="c14"
+        class="c11"
         data-testid="app-topnav"
       >
         <div
-          class="c15"
+          class="c12"
         >
           <div
-            class="c6 c7"
+            class="c3 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
-              class="c9 c10 internal-button"
+              class="c6 c7 internal-button"
               data-testid="skip-link"
               href="#main"
               style="position: absolute; left: -10000px;"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c13"
+                  class="c10"
                 >
                   Skip to content
                 </span>
@@ -4273,27 +4269,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </div>
         <div
-          class="c16 c17"
+          class="c13 c14"
         >
           <div
-            class="c18 c19"
+            class="c15 c16"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="true"
-              class="c20 c10 internal-button"
+              class="c17 c7 internal-button"
               href="/"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Teachers
                 </span>
@@ -4301,34 +4297,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </a>
           </div>
           <div
-            class="c18 c7"
+            class="c15 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="false"
-              class="c22 c23 internal-button"
+              class="c19 c20 internal-button"
               href="/pupils/years"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Go to 
                   pupils
                 </span>
                 <span
-                  class="c24"
+                  class="c21"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4341,22 +4337,22 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </div>
         <nav
-          class="c26 c27"
+          class="c23 c24"
         >
           <a
             aria-label="Home"
-            class="c28"
+            class="c25"
             href="/"
           >
             <span
-              class="c29"
+              class="c26"
             >
               <span
-                class="c30"
+                class="c27"
               >
                 <img
                   alt=""
-                  class="c31"
+                  class="c28"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4367,40 +4363,40 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c11 c32"
+            class="c8 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
             <div
-              class="c11"
+              class="c8"
             >
               <ul
-                class="c33"
+                class="c30"
               >
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4409,29 +4405,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4440,29 +4436,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4471,29 +4467,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4502,38 +4498,38 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4548,24 +4544,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c11 c40"
+              class="c8 c37"
             >
               <form
                 action="/teachers/search"
-                class="c41"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c42"
+                  class="c39"
                 >
                   <div
-                    class="c43 c44 c45"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c46"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4573,32 +4569,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c44"
                 >
                   <div
-                    class="c48 c49 c50"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c51 c52"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c11 c53"
+                        class="c8 c50"
                       >
                         <div
-                          class="c54 c55 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c56 shadow"
+                            class="c53 shadow"
                           />
                           <span
-                            class="c24"
+                            class="c21"
                             data-icon-for="button"
                           >
                             <img
                               alt=""
-                              class="c57"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4608,7 +4604,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c58"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4616,32 +4612,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c59"
+                class="c56"
               >
                 <div
-                  class="c48 c49 c50"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c54 c55 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c56 shadow"
+                          class="c53 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c57"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4651,7 +4647,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4659,19 +4655,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c60 c61"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c62 c63 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c64"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4680,29 +4676,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c65"
+                    class="c62"
                   >
                     My library
                   </div>
                 </div>
               </a>
               <div
-                class="c6 c7"
+                class="c3 c4"
               >
                 <div
-                  class="c8 grey-shadow"
+                  class="c5 grey-shadow"
                 />
                 <div
-                  class="c8 yellow-shadow"
+                  class="c5 yellow-shadow"
                 />
                 <button
-                  class="c66 c67 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c11 c37"
+                    class="c8 c34"
                   >
                     <span
-                      class="c38"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4712,32 +4708,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c69 c10 internal-button"
+                class="c66 c7 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c11 c53"
+                  class="c8 c50"
                 >
                   <span
-                    class="c24"
+                    class="c21"
                   >
                     <img
                       alt=""
-                      class="c39"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4746,7 +4742,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                   </span>
                   <span
-                    class="c13"
+                    class="c10"
                   />
                 </div>
               </button>
@@ -4755,45 +4751,45 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c70 c4"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c71"
+          class="c68"
         >
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c73 c74"
+              class="c70 c71"
             >
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <h1
-                  class="c76"
+                  class="c73"
                 >
                   <span
-                    class="c77"
+                    class="c74"
                   >
                     Meet the team
                   </span>
                 </h1>
                 <p
-                  class="c78"
+                  class="c75"
                 >
                   Learn more about the experts from across education, technology, school support and education who make up our leadership team and board.
                 </p>
               </div>
               <div
-                class="c11 c79"
+                class="c8 c76"
               >
                 <span
-                  class="c80"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4807,44 +4803,44 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c81 c82"
+              class="c78 c79"
             >
               <div
-                class="c81"
+                class="c78"
               >
                 <nav
                   aria-label="page sections"
-                  class="c83"
+                  class="c80"
                 >
                   <ul
-                    class="c84"
+                    class="c81"
                   >
                     <li
-                      class="c34"
+                      class="c31"
                     >
                       <a
                         aria-current="true"
-                        class="c85 c86"
+                        class="c82 c83"
                         href="#our-leadership"
                       >
                         <div
-                          class="c11 c87"
+                          class="c8 c84"
                         >
                           <span
-                            class="c88"
+                            class="c85"
                           >
                             Our leadership
                           </span>
                         </div>
                         <span
-                          class="c89"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4855,27 +4851,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c34"
+                      class="c31"
                     >
                       <a
-                        class="c90 c86"
+                        class="c87 c83"
                         href="#our-board"
                       >
                         <div
-                          class="c11 c87"
+                          class="c8 c84"
                         >
                           <span
-                            class="c88"
+                            class="c85"
                           >
                             Our board
                           </span>
                         </div>
                         <span
-                          class="c89"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4886,27 +4882,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c34"
+                      class="c31"
                     >
                       <a
-                        class="c90 c86"
+                        class="c87 c83"
                         href="#documents"
                       >
                         <div
-                          class="c11 c87"
+                          class="c8 c84"
                         >
                           <span
-                            class="c88"
+                            class="c85"
                           >
                             Documents
                           </span>
                         </div>
                         <span
-                          class="c89"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4920,76 +4916,76 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </nav>
               </div>
               <div
-                class="c11 c91"
+                class="c8 c88"
               >
                 <div
-                  class="c92"
+                  class="c89"
                   id="our-leadership"
                 >
                   <div
-                    class="c11 c93"
+                    class="c8 c90"
                   >
                     <div
-                      class="c11 c94"
+                      class="c8 c91"
                     >
                       <h2
-                        class="c95"
+                        class="c92"
                       >
                         Our leadership
                       </h2>
                       <p
-                        class="c96"
+                        class="c93"
                       >
                         Our leadership team brings together experts to deliver the best support to teachers and value for money for the public.
                       </p>
                     </div>
                     <ul
-                      class="c97 c98"
+                      class="c94 c95"
                     >
                       <li
-                        class="c99"
+                        class="c96"
                       >
                         <div
-                          class="c100 c101"
+                          class="c97 c98"
                         >
                           <a
-                            class="c102 c94 c103"
+                            class="c99 c91 c100"
                             href="/about-us/meet-the-team/ed-southall?section=leadership"
                           >
                             <div
-                              class="c104 c105"
+                              class="c101 c102"
                             >
                               <div
-                                class="c11 c94"
+                                class="c8 c91"
                               >
                                 <h3
-                                  class="c106"
+                                  class="c103"
                                 >
                                   Ed Southall
                                 </h3>
                                 <p
-                                  class="c107"
+                                  class="c104"
                                 >
                                   Subject Lead (maths)
                                 </p>
                               </div>
                               <div
-                                class="c11 c108"
+                                class="c8 c105"
                               >
                                 <div
-                                  class="c11 c44"
+                                  class="c8 c41"
                                 >
                                   <span
-                                    class="c109"
+                                    class="c106"
                                   >
                                     See bio
                                   </span>
                                   <span
-                                    class="c24"
+                                    class="c21"
                                   >
                                     <img
                                       alt=""
-                                      class="c25"
+                                      class="c22"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5007,73 +5003,73 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c92"
+                  class="c89"
                   id="our-board"
                 >
                   <div
-                    class="c11 c93"
+                    class="c8 c90"
                   >
                     <div
-                      class="c11 c94"
+                      class="c8 c91"
                     >
                       <h2
-                        class="c95"
+                        class="c92"
                       >
                         Our board
                       </h2>
                       <p
-                        class="c96"
+                        class="c93"
                       >
                         Our Board oversees all of our work at Oak National Academy. They provide strategic direction and safeguard our independence.
                       </p>
                     </div>
                     <ul
-                      class="c97 c98"
+                      class="c94 c95"
                     >
                       <li
-                        class="c99"
+                        class="c96"
                       >
                         <div
-                          class="c100 c101"
+                          class="c97 c98"
                         >
                           <a
-                            class="c102 c94 c103"
+                            class="c99 c91 c100"
                             href="/about-us/meet-the-team/ed-southall?section=board"
                           >
                             <div
-                              class="c104 c105"
+                              class="c101 c102"
                             >
                               <div
-                                class="c11 c94"
+                                class="c8 c91"
                               >
                                 <h3
-                                  class="c106"
+                                  class="c103"
                                 >
                                   Ed Southall
                                 </h3>
                                 <p
-                                  class="c107"
+                                  class="c104"
                                 >
                                   Subject Lead (maths)
                                 </p>
                               </div>
                               <div
-                                class="c11 c108"
+                                class="c8 c105"
                               >
                                 <div
-                                  class="c11 c44"
+                                  class="c8 c41"
                                 >
                                   <span
-                                    class="c109"
+                                    class="c106"
                                   >
                                     See bio
                                   </span>
                                   <span
-                                    class="c24"
+                                    class="c21"
                                   >
                                     <img
                                       alt=""
-                                      class="c25"
+                                      class="c22"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5091,15 +5087,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c11 c94"
+                  class="c8 c91"
                 >
                   <h2
-                    class="c95"
+                    class="c92"
                   >
                     Governance
                   </h2>
                   <div
-                    class="c110 c111"
+                    class="c107 c108"
                   >
                     <p>
                       Test governance text
@@ -5110,19 +5106,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c112"
+            class="c109"
             style="margin-top: -72px;"
           >
             <div
-              class="c113"
+              class="c110"
             >
               <span
-                class="c114"
+                class="c111"
                 style="pointer-events: none;"
               >
                 <img
                   alt=""
-                  class="c25"
+                  class="c22"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -5131,13 +5127,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c72"
+                class="c69"
               >
                 <div
-                  class="c115 c116"
+                  class="c112 c113"
                 >
                   <h2
-                    class="c117"
+                    class="c114"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5146,31 +5142,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c118"
+                      class="c115"
                     >
                       <li
-                        class="c119"
+                        class="c116"
                       >
                         <div
-                          class="c120 c121"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c122 c123 c124"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c125"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5180,19 +5176,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c126 c127"
+                                class="c123 c124"
                               >
                                 About Oak
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c128"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5206,28 +5202,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c119"
+                        class="c116"
                       >
                         <div
-                          class="c120 c121"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c122 c123 c124"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c125"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5237,19 +5233,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c126 c127"
+                                class="c123 c124"
                               >
                                 Oak's curricula
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c128"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5263,28 +5259,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c119"
+                        class="c116"
                       >
                         <div
-                          class="c120 c121"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c122 c123 c124"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c125"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5294,19 +5290,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c126 c127"
+                                class="c123 c124"
                               >
                                 Meet the team
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c128"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5320,28 +5316,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c119"
+                        class="c116"
                       >
                         <div
-                          class="c120 c121"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c122 c123 c124"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c125"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5351,19 +5347,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c126 c127"
+                                class="c123 c124"
                               >
                                 Get involved
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c128"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5383,33 +5379,33 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c129"
+            class="c126"
             id="newsletter-signup"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c11 c49 c130"
+                class="c8 c46 c127"
               >
                 <div
-                  class="c131 c4"
+                  class="c128 c1"
                 >
                   <div
-                    class="c11 c132"
+                    class="c8 c129"
                   >
                     <div
-                      class="c11 c49 c133"
+                      class="c8 c46 c130"
                     >
                       <div
-                        class="c134 c135"
+                        class="c131 c132"
                       >
                         <span
-                          class="c136"
+                          class="c133"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5418,24 +5414,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c137"
+                          class="c134"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c138"
+                        class="c135"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
                         Join over 100k teachers and get free resources and other helpful content by email. Unsubscribe at any time. Read our
                          
                         <a
-                          class="c28"
+                          class="c25"
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             privacy policy
                           </span>
@@ -5444,27 +5440,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c139 c49 c133"
+                      class="c136 c46 c130"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c140"
+                        class="c137"
                         novalidate=""
                       >
                         <div
-                          class="c141 c142 c143"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c144 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5489,7 +5485,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5514,7 +5510,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5539,7 +5535,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5564,23 +5560,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c146 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c147 c148 c149"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
                                 id="react-use-id-test-result-newsletter-signup-name-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Name
                                    
                                   <span
-                                    class="c109"
+                                    class="c106"
                                   >
                                     (required)
                                   </span>
@@ -5591,7 +5587,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c150 c151"
+                              class="c147 c148"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5599,7 +5595,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c152 c153 c154"
+                              class="c149 c150 c151"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5612,19 +5608,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c141 c142 c143"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c144 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5649,7 +5645,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5674,7 +5670,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5699,7 +5695,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c145"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5724,23 +5720,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c146 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c147 c148 c149"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
                                 id="react-use-id-test-result-newsletter-signup-email-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Email
                                    
                                   <span
-                                    class="c109"
+                                    class="c106"
                                   >
                                     (required)
                                   </span>
@@ -5751,7 +5747,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c150 c151"
+                              class="c147 c148"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5759,7 +5755,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c152 c153 c154"
+                              class="c149 c150 c151"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5772,16 +5768,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c155 c156 c157"
+                          class="c152 c153 c154"
                         >
                           <div
                             aria-hidden="true"
-                            class="c11"
+                            class="c8"
                             data-testid="brush-borders"
                           >
                             <svg
                               aria-hidden="true"
-                              class="c145"
+                              class="c142"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5806,7 +5802,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c145"
+                              class="c142"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5831,7 +5827,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c145"
+                              class="c142"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5856,7 +5852,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c145"
+                              class="c142"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5882,7 +5878,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c152 c153 c154 c158"
+                            class="c149 c150 c151 c155"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5893,10 +5889,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c159 c49"
+                            class="c156 c46"
                           >
                             <label
-                              class="c147 c148 c149"
+                              class="c144 c145 c146"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5908,16 +5904,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c160 c161"
+                            class="c157 c158"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c162 c44 c163"
+                              class="c159 c41 c160"
                             >
                               <span
-                                class="c164 c165"
+                                class="c161 c162"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5926,11 +5922,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c24"
+                              class="c21"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5941,22 +5937,22 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c166 c7"
+                          class="c163 c4"
                         >
                           <div
-                            class="c8 grey-shadow"
+                            class="c5 grey-shadow"
                           />
                           <div
-                            class="c8 yellow-shadow"
+                            class="c5 yellow-shadow"
                           />
                           <button
-                            class="c167 c23 internal-button"
+                            class="c164 c20 internal-button"
                           >
                             <div
-                              class="c11 c12"
+                              class="c8 c9"
                             >
                               <span
-                                class="c13"
+                                class="c10"
                               >
                                 Sign up to the newsletter
                               </span>
@@ -5965,12 +5961,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c168"
+                          class="c165"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c169"
+                          class="c166"
                         />
                       </form>
                     </div>
@@ -5982,14 +5978,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c170"
+        class="c167"
       >
         <div
-          class="c171 c49"
+          class="c168 c46"
         >
           <svg
             aria-hidden="true"
-            class="c172"
+            class="c169"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6012,37 +6008,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c173 c174"
+            class="c170 c171"
           >
             <div
-              class="c11 c132"
+              class="c8 c129"
             >
               <div
-                class="c11 c49 c175"
+                class="c8 c46 c172"
               >
                 <div
-                  class="c176 c156"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c177"
+                    class="c174"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c178 c179"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/pupils/years"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Learn online
                           </span>
@@ -6052,72 +6048,72 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c182"
+                  class="c179"
                 />
                 <div
-                  class="c176 c156"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c177"
+                    class="c174"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c178 c179"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             EYFS
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/lesson-planning"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Plan a lesson
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c183"
+                            class="c180"
                           >
                             <span
-                              class="c128 c184 c185"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6129,14 +6125,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/blog"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Blog
                           </span>
@@ -6147,115 +6143,115 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c175"
+                class="c8 c46 c172"
               >
                 <div
-                  class="c176 c156"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c177"
+                    class="c174"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c178 c179"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Home
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/about-us/who-we-are"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             About us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Oak's curricula
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/about-us/get-involved"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Get involved
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/about-us/meet-the-team"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Meet the team
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c181 "
+                          class="c178 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Careers
                           </span>
                           <div
-                            class="c183"
+                            class="c180"
                           >
                             <span
-                              class="c128 c184 c185"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6267,42 +6263,42 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/contact-us"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Contact us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c181 "
+                          class="c178 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Help
                           </span>
                           <div
-                            class="c183"
+                            class="c180"
                           >
                             <span
-                              class="c128 c184 c185"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6314,42 +6310,42 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/webinars"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Webinars
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c181 "
+                          class="c178 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Status
                           </span>
                           <div
-                            class="c183"
+                            class="c180"
                           >
                             <span
-                              class="c128 c184 c185"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6365,156 +6361,156 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c175"
+                class="c8 c46 c172"
               >
                 <div
-                  class="c176 c156"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c177"
+                    class="c174"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c178 c179"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Terms & conditions
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Privacy policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/cookie-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Cookie policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <button
-                          class="c181 "
+                          class="c178 "
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Manage cookie settings
                           </span>
                         </button>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/copyright-notice"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Copyright notice
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/accessibility-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Accessibility statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Safeguarding statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Physical activity disclaimer
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/complaints"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Complaints
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c180"
+                        class="c177"
                       >
                         <a
-                          class="c181 "
+                          class="c178 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Freedom of information requests
                           </span>
@@ -6525,20 +6521,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c175"
+                class="c8 c46 c172"
               >
                 <div
-                  class="c176 c186"
+                  class="c173 c183"
                 >
                   <div
-                    class="c42"
+                    class="c39"
                   >
                     <span
-                      class="c187"
+                      class="c184"
                     >
                       <img
                         alt=""
-                        class="c31"
+                        class="c28"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6548,32 +6544,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c188 c189"
+                    class="c185 c186"
                   >
                     <div
-                      class="c48 c49 c190 c191"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c192 c55 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c193 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6583,35 +6579,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c190 c191"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c192 c55 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c193 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6621,35 +6617,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c190 c191"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c192 c55 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c193 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6659,7 +6655,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6669,12 +6665,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c194 c195"
+              class="c191 c192"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c31"
+                class="c28"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6685,35 +6681,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c196 c197"
+              class="c193 c194"
             >
               <div
-                class="c198 c199"
+                class="c195 c196"
               >
                 <div
-                  class="c48 c49 c190 c191"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c192 c55 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c193 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6723,35 +6719,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c190 c191"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c192 c55 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c193 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6761,35 +6757,35 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c190 c191"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c192 c55 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c193 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6799,21 +6795,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c59"
+                class="c56"
               >
                 <span
-                  class="c187"
+                  class="c184"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -6823,15 +6819,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c176 c156"
+                class="c173 c153"
               >
                 <p
-                  class="c200"
+                  class="c197"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c201"
+                  class="c198"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6840,11 +6836,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c202"
+          class="c199"
         >
           <img
             alt=""
-            class="c203"
+            class="c200"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6853,11 +6849,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c204"
+          class="c201"
         >
           <img
             alt=""
-            class="c205"
+            class="c202"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6867,6 +6863,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </span>
       </footer>
     </div>
+    <div
+      aria-live="polite"
+      class="c203 c204 c205"
+    />
   </div>
   <div
     class="c206"
@@ -6893,10 +6893,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c213"
+            class="c8 c213"
           >
             <div
-              class="c214 c44"
+              class="c214 c41"
             >
               <button
                 class="c215"
@@ -6904,29 +6904,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 type="button"
               >
                 <span
-                  class="c29"
+                  class="c26"
                 >
                   Reject non-essential cookies
                 </span>
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c9 c10 internal-button"
+                class="c6 c7 internal-button"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Cookie settings
                   </span>
@@ -6934,23 +6934,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c216 c23 internal-button"
+                class="c216 c20 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Accept all cookies
                   </span>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -2,21 +2,11 @@
 
 exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c2 {
   position: absolute;
   top: 5.75rem;
   left: 1.5rem;
@@ -27,7 +17,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c6 {
+.c3 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -36,7 +26,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,16 +35,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c11 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   position: absolute;
   top: 10rem;
   left: 1.5rem;
@@ -62,7 +52,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c16 {
+.c13 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 1rem;
@@ -71,14 +61,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c15 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c21 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -88,7 +78,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   max-height: 5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -100,7 +90,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
@@ -109,19 +99,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -142,17 +132,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c43:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c47 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -160,7 +150,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -171,7 +161,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -180,12 +170,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -205,7 +195,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c64 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -215,34 +205,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c84 {
+.c81 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c71 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c72 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -251,7 +241,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -259,7 +249,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c80 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -267,18 +257,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c81 {
+.c78 {
   background: #f5e9f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c82 {
+.c79 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c87 {
+.c84 {
   padding: 1.5rem;
   background: #ffffff;
   border: 0.125rem solid;
@@ -287,7 +277,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c86 {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -298,7 +288,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c88 {
   position: relative;
   width: 5rem;
   min-width: 5rem;
@@ -309,7 +299,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c92 {
+.c89 {
   position: relative;
   width: 4.5rem;
   min-width: 4.5rem;
@@ -320,7 +310,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c93 {
+.c90 {
   position: relative;
   width: 4rem;
   min-width: 4rem;
@@ -331,21 +321,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c94 {
+.c91 {
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c101 {
+.c98 {
   position: relative;
   width: 100%;
   height: 22.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c99 {
   position: relative;
   object-position: center;
   width: 100%;
@@ -354,33 +344,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c103 {
+.c100 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c105 {
+.c102 {
   background: transparent;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c106 {
+.c103 {
   padding-right: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c108 {
+.c105 {
   width: 0.5rem;
   background: #deb7d5;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c112 {
+.c109 {
   max-width: 40rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c115 {
+.c112 {
   position: relative;
   top: 0.5rem;
   left: 0.5rem;
@@ -408,7 +398,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 298;
 }
 
-.c116 {
+.c113 {
   position: relative;
   border: 0.125rem solid;
   border-color: #222222;
@@ -417,7 +407,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 150;
 }
 
-.c117 {
+.c114 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -425,12 +415,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c117 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c119 {
   width: 100%;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0rem;
@@ -439,7 +429,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c123 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -447,7 +437,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c126 {
   position: relative;
   width: 0.125rem;
   height: 3rem;
@@ -455,7 +445,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c132 {
+.c129 {
   width: 100%;
   border-top-left-radius: 0rem;
   border-top-right-radius: 0.25rem;
@@ -464,14 +454,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c130 {
   padding-left: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c131 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -483,7 +473,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c135 {
+.c132 {
   position: absolute;
   right: 0rem;
   width: -webkit-fit-content;
@@ -497,13 +487,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 3;
 }
 
-.c138 {
+.c135 {
   padding-top: 5rem;
   padding-bottom: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c144 {
+.c141 {
   position: relative;
   width: 100%;
   height: 100%;
@@ -511,20 +501,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c145 {
+.c142 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c146 {
+.c143 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c147 {
+.c144 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -539,26 +529,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c148 {
+.c145 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c153 {
+.c150 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c155 {
+.c152 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c155 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -568,7 +558,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c159 {
+.c156 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -579,7 +569,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c161 {
+.c158 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -589,14 +579,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c162 {
+.c159 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c164 {
+.c161 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -608,12 +598,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c164 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c169 {
+.c166 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -627,36 +617,36 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c172 {
+.c169 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c186 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c189 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c192 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c196 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c203 {
+.c200 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -666,13 +656,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c204 {
+.c201 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c203 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -684,23 +674,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c209 {
+.c206 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c214 {
+.c211 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c215 {
+.c212 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c219 {
+.c216 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -709,7 +699,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c220 {
+.c217 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -717,7 +707,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c224 {
+.c221 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -728,7 +718,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c225 {
+.c222 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -739,14 +729,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c226 {
+.c223 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c228 {
+.c225 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -754,12 +744,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c230 {
+.c227 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c234 {
+.c231 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -777,7 +767,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c236 {
+.c233 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -793,6 +783,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transform: translate(0%,32%);
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
+}
+
+.c235 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c238 {
@@ -849,28 +849,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c12 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -889,7 +874,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c17 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -901,7 +886,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -913,7 +898,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -932,7 +917,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c37 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -951,7 +936,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c40 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -963,7 +948,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c44 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -974,14 +959,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c53 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1000,7 +985,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c55 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1015,7 +1000,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c63 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1031,7 +1016,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c140 {
+.c137 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1042,7 +1027,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c98 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1052,7 +1037,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c74 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1068,7 +1053,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c75 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1079,7 +1064,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c83 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1090,7 +1075,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c85 {
+.c82 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1105,7 +1090,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c88 {
+.c85 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1126,7 +1111,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-basis: 0;
 }
 
-.c95 {
+.c92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1142,7 +1127,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c97 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1164,7 +1149,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 4rem;
 }
 
-.c104 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1175,7 +1160,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3rem;
 }
 
-.c107 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1187,7 +1172,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   column-gap: 1.5rem;
 }
 
-.c109 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1197,7 +1182,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c113 {
+.c110 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1208,7 +1193,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c118 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1227,7 +1212,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c119 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1245,7 +1230,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c121 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1255,7 +1240,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-self: stretch;
 }
 
-.c131 {
+.c128 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1266,14 +1251,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c136 {
+.c133 {
   display: none;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.c149 {
+.c146 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1284,7 +1269,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c156 {
+.c153 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1299,7 +1284,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c160 {
+.c157 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1310,7 +1295,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c168 {
+.c165 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1324,7 +1309,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c207 {
+.c204 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1342,7 +1327,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c218 {
+.c215 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1353,7 +1338,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c221 {
+.c218 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1369,7 +1354,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c229 {
+.c226 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1387,7 +1372,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c231 {
+.c228 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1398,6 +1383,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   gap: 1rem;
+}
+
+.c236 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c242 {
@@ -1437,7 +1437,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1449,7 +1449,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: left;
 }
 
-.c21 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1461,11 +1461,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: left;
 }
 
-.c29 {
+.c26 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1477,7 +1477,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: left;
 }
 
-.c58 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1488,14 +1488,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c77 {
+.c74 {
   background: #deb7d5;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c124 {
   color: #222222;
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1508,7 +1508,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c183 {
+.c180 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1519,7 +1519,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c197 {
+.c194 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1541,7 +1541,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c205 {
+.c202 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1550,7 +1550,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c9 {
+.c6 {
   background: none;
   color: inherit;
   border: none;
@@ -1573,12 +1573,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c9:disabled {
+.c6:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c17 {
   background: none;
   color: inherit;
   border: none;
@@ -1604,12 +1604,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c20:disabled {
+.c17:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -1635,12 +1635,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c22:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c35 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1663,12 +1663,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c35:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c51 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1682,12 +1682,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c51:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c60 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1700,12 +1700,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1735,12 +1735,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c66:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c69 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1764,12 +1764,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-style: none;
 }
 
-.c69:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c137 {
+.c134 {
   background: none;
   color: inherit;
   border: none;
@@ -1792,12 +1792,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c137:disabled {
+.c134:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c200 {
+.c197 {
   background: none;
   color: inherit;
   border: none;
@@ -1821,40 +1821,40 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c200:disabled {
+.c197:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c25 {
+.c22 {
   object-fit: contain;
 }
 
-.c39 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c57 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c235 {
+.c232 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c237 {
+.c234 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c31 {
+.c28 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1863,13 +1863,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c10 {
+.c7 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c10:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -1877,37 +1877,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c10:hover [data-state="selected"] {
+.c7:hover [data-state="selected"] {
   display: none;
 }
 
-.c10:active {
+.c7:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c10:active [data-state="selected"] {
+.c7:active [data-state="selected"] {
   display: none;
 }
 
-.c10:disabled {
+.c7:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c10:disabled [data-state="selected"] {
+.c7:disabled [data-state="selected"] {
   display: none;
 }
 
-.c23 {
+.c20 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c23:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -1915,37 +1915,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c23:hover [data-state="selected"] {
+.c20:hover [data-state="selected"] {
   display: none;
 }
 
-.c23:active {
+.c20:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c23:active [data-state="selected"] {
+.c20:active [data-state="selected"] {
   display: none;
 }
 
-.c23:disabled {
+.c20:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c23:disabled [data-state="selected"] {
+.c20:disabled [data-state="selected"] {
   display: none;
 }
 
-.c36 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c36:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1953,37 +1953,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c36:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c36:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c36:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c36:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c36:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c67 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c67:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1991,148 +1991,148 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c67:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c67:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c67:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c67:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c67:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c4 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c4 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:hover),
-.c7 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c4 .yellow-shadow:has(+ .internal-button:hover),
+.c4 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:hover) {
+.c4 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:active) {
+.c4 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:active) {
+.c4 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c16 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c16 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c16 .yellow-shadow:has(+ .internal-button:hover),
+.c16 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c16 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c16 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c16 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c52 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c52:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c52:active {
+.c49:active {
   color: #222222;
 }
 
-.c52:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c50 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c50 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c50 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c50 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c222 > :first-child:focus-visible .shadow {
+.c219 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c222 > :first-child:hover .shadow {
+.c219 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c222 > :first-child:active .shadow {
+.c219 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c222 > :first-child:disabled .icon-container {
+.c219 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c222 > :first-child:hover .icon-container {
+.c219 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c222 > :first-child:active .icon-container {
+.c219 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c76 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2143,7 +2143,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c99 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2154,7 +2154,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c110 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2167,7 +2167,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c114 {
+.c111 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2178,7 +2178,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c139 {
+.c136 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2189,7 +2189,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c150 {
+.c147 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2201,7 +2201,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: center;
 }
 
-.c170 {
+.c167 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2212,7 +2212,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c210 {
+.c207 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -2225,7 +2225,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c34 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2233,7 +2233,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c143 {
+.c140 {
   overflow: hidden;
   aspect-ratio: 1/1;
   border-color: #cacaca;
@@ -2249,7 +2249,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c212 {
+.c209 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2258,7 +2258,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c78 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -2269,7 +2269,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c90 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
@@ -2282,7 +2282,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c100 {
+.c97 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2295,7 +2295,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-bottom: 0.75rem;
 }
 
-.c111 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2306,7 +2306,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c128 {
+.c125 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2318,7 +2318,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c141 {
+.c138 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2329,13 +2329,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c171 {
+.c168 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c201 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2348,7 +2348,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c202 {
+.c199 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2360,7 +2360,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c232 {
+.c229 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2371,7 +2371,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c233 {
+.c230 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2382,7 +2382,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c208 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2393,7 +2393,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c33 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2414,14 +2414,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c217 {
+.c214 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c28 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2445,47 +2445,47 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c28 .c216 {
+.c25 .c213 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c28:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c28:visited {
+.c25:visited {
   color: #081676;
 }
 
-.c28:visited .c216 {
+.c25:visited .c213 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28:active {
+.c25:active {
   color: #081676;
   outline: 1px solid #081676;
 }
 
-.c28:active .c216 {
+.c25:active .c213 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c28[disabled] .c216 {
+.c25[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c213 {
+.c210 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2509,42 +2509,42 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c213 .c216 {
+.c210 .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c213:focus-visible {
+.c210:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c213:visited {
+.c210:visited {
   color: #222222;
 }
 
-.c213:visited .c216 {
+.c210:visited .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c213:active {
+.c210:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c213:active .c216 {
+.c210:active .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c213[disabled] {
+.c210[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c213[disabled] .c216 {
+.c210[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2582,7 +2582,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c247 .c216 {
+.c247 .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -2597,7 +2597,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c247:visited .c216 {
+.c247:visited .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2607,7 +2607,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c247:active .c216 {
+.c247:active .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2617,12 +2617,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #808080;
 }
 
-.c247[disabled] .c216 {
+.c247[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c46 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2638,49 +2638,49 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   width: 100%;
 }
 
-.c46::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c46::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c46:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c46::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c46::-webkit-search-decoration,
-.c46::-webkit-search-cancel-button,
-.c46::-webkit-search-results-button,
-.c46::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c46:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c45 {
+.c42 {
   background: #ffffff;
 }
 
-.c45:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c45:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c142 {
+.c139 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2690,13 +2690,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c165 {
+.c162 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c166 {
+.c163 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2705,7 +2705,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c208 {
+.c205 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2714,76 +2714,101 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c123 {
+.c120 {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c123:has(a:hover,button:hover) {
+.c120:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c123:has( a, button) {
+.c120:has( a, button) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c123:has( a, button)  a,
-.c123:has( a, button) button {
+.c120:has( a, button)  a,
+.c120:has( a, button) button {
   outline: none;
 }
 
-.c123:has(a:active,button:active) {
+.c120:has(a:active,button:active) {
   box-shadow: none;
 }
 
-.c154 {
+.c151 {
   box-shadow: none;
 }
 
-.c154:has(a:hover,button:hover) {
+.c151:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c154:has( a, button) {
+.c151:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c154:has( a, button)  a,
-.c154:has( a, button) button {
+.c151:has( a, button)  a,
+.c151:has( a, button) button {
   outline: none;
 }
 
-.c154:has(a:active,button:active) {
+.c151:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c61:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c61:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2 {
+.c237 {
   top: 82px;
 }
 
-.c223 .icon-container > *:first-child {
+.c220 .icon-container > *:first-child {
   border: 0;
 }
 
-.c186 {
+.c183 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c171 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
   color: #222222;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c171::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c171::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c171::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c174 {
+  position: relative;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2806,32 +2831,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   background-color: #999999;
 }
 
-.c177 {
-  position: relative;
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c177::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c177::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c177::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c179 {
+.c176 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2839,23 +2839,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c179::-webkit-scrollbar-track {
+.c176::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c179::-webkit-scrollbar {
+.c176::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c179::-webkit-scrollbar-thumb {
+.c176::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c193 {
+.c190 {
   background: none;
   color: inherit;
   border: none;
@@ -2866,29 +2866,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c175 {
+.c172 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c227 {
+.c224 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c157:hover {
+.c154:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c152 {
+.c149 {
   padding: 0;
   margin: 0;
 }
 
-.c151 {
+.c148 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2900,7 +2900,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c130 {
+.c127 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2913,7 +2913,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c178 {
+.c175 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2925,7 +2925,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c184 {
+.c181 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2936,32 +2936,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c184::-webkit-input-placeholder {
+.c181::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c184::-moz-placeholder {
+.c181::-moz-placeholder {
   color: #575757;
 }
 
-.c184:-ms-input-placeholder {
+.c181:-ms-input-placeholder {
   color: #575757;
 }
 
-.c184::placeholder {
+.c181::placeholder {
   color: #575757;
 }
 
-.c184::-webkit-search-decoration,
-.c184::-webkit-search-cancel-button,
-.c184::-webkit-search-results-button,
-.c184::-webkit-search-results-decoration {
+.c181::-webkit-search-decoration,
+.c181::-webkit-search-cancel-button,
+.c181::-webkit-search-results-button,
+.c181::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c181 {
+.c178 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2971,7 +2971,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c188 {
+.c185 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2984,7 +2984,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c182 {
+.c179 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2995,16 +2995,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c176:focus-within .c180 {
+.c173:focus-within .c177 {
   background: #374cf1;
   color: #fff;
 }
 
-.c176:focus-within .c187 {
+.c173:focus-within .c184 {
   display: inline;
 }
 
-.c185 {
+.c182 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -3020,7 +3020,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: none;
 }
 
-.c185::-webkit-input-placeholder {
+.c182::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3028,7 +3028,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c185::-moz-placeholder {
+.c182::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3036,7 +3036,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c185:-ms-input-placeholder {
+.c182:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3044,7 +3044,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c185::placeholder {
+.c182::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3052,40 +3052,40 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c185:valid:not([value=""]) {
+.c182:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c185:valid:not([value=""])::-webkit-input-placeholder {
+.c182:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c185:valid:not([value=""])::-moz-placeholder {
+.c182:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c185:valid:not([value=""]):-ms-input-placeholder {
+.c182:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c185:valid:not([value=""])::placeholder {
+.c182:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c191 {
+.c188 {
   display: none;
 }
 
-.c190:focus-within .c180 {
+.c187:focus-within .c177 {
   background: #374cf1;
   color: #fff;
 }
 
-.c194 {
+.c191 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -3112,37 +3112,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #575757;
 }
 
-.c196 {
+.c193 {
   max-width: calc(100% - 20px);
 }
 
-.c198 {
+.c195 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c173 {
+.c170 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c160 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c79 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c124 {
+.c121 {
   box-shadow: none;
 }
 
-.c125 {
+.c122 {
   background: none;
   width: 100%;
   border: none;
@@ -3156,13 +3156,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: pointer;
 }
 
-.c96 {
+.c93 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c86 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3174,13 +3174,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    right: 1.5rem;
+  .c13 {
+    padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c13 {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c15 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3188,75 +3194,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    padding-left: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c0 {
-    padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-left: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-right: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-top: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-bottom: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c41 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3265,19 +3239,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -3285,37 +3259,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c65 {
     display: none;
   }
 }
@@ -3329,151 +3303,151 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c79 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c79 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c94 {
+  .c91 {
     padding: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c94 {
+  .c91 {
     padding: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c101 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c101 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c100 {
     padding-bottom: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c119 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c119 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c119 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c119 {
+    border-bottom-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c129 {
+    border-top-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c129 {
+    border-top-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c129 {
+    border-bottom-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c129 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
   .c132 {
-    border-top-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c132 {
-    border-top-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c132 {
-    border-bottom-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c132 {
-    border-bottom-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c135 {
     max-width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c132 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c147 {
+  .c144 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c147 {
+  .c144 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3481,7 +3455,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c147 {
+  .c144 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3489,79 +3463,79 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c148 {
+  .c145 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c148 {
+  .c145 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c148 {
+  .c145 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c148 {
+  .c145 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c164 {
+  .c161 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c164 {
+  .c161 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c203 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c203 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c206 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c214 {
+  .c211 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c220 {
+  .c217 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c228 {
+  .c225 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c230 {
+  .c227 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3570,13 +3544,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c231 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c231 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3584,7 +3558,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c234 {
+  .c231 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3592,8 +3566,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c236 {
+  .c233 {
     display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c235 {
+    right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c235 {
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+  }
+}
+
+@media (min-width:750px) {
+  .c235 {
+    padding-left: 0rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c235 {
+    padding-right: 0rem;
   }
 }
 
@@ -3649,16 +3649,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c17 {
+  .c14 {
     -webkit-box-pack: left;
     -webkit-justify-content: left;
     -ms-flex-pack: left;
@@ -3667,19 +3658,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3696,19 +3687,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3716,19 +3707,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     gap: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c95 {
+  .c92 {
     gap: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c94 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3737,7 +3728,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c94 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3746,7 +3737,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
@@ -3755,7 +3746,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c101 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -3763,19 +3754,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c115 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3783,25 +3774,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c133 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c149 {
+  .c146 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c149 {
+  .c146 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c215 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3810,13 +3801,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c221 {
+  .c218 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c229 {
+  .c226 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3824,7 +3815,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c229 {
+  .c226 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3833,7 +3824,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c229 {
+  .c226 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3842,11 +3833,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c231 {
+  .c228 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c236 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -3927,43 +3927,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3972,7 +3972,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4008,67 +4008,67 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4077,7 +4077,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4086,25 +4086,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c96 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4113,43 +4113,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4158,7 +4158,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4167,43 +4167,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c139 {
+  .c136 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c139 {
+  .c136 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c139 {
+  .c136 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4212,7 +4212,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c139 {
+  .c136 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4221,43 +4221,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c150 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c150 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c150 {
+  .c147 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c150 {
+  .c147 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c150 {
+  .c147 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c150 {
+  .c147 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c150 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4266,7 +4266,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c150 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4275,43 +4275,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4320,7 +4320,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4329,25 +4329,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c138 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c138 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c138 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c138 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4356,14 +4356,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c171 {
+  .c168 {
     margin-right: 1.5rem;
   }
 }
 
 @media (hover:hover) {
-  .c28:hover,
-  .c28:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4371,16 +4371,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c28:hover .c216,
-  .c28:visited:hover .c216 {
+  .c25:hover .c213,
+  .c25:visited:hover .c213 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c213:hover,
-  .c213:visited:hover {
+  .c210:hover,
+  .c210:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4388,8 +4388,8 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c213:hover .c216,
-  .c213:visited:hover .c216 {
+  .c210:hover .c213,
+  .c210:visited:hover .c213 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -4405,76 +4405,76 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c247:hover .c216,
-  .c247:visited:hover .c216 {
+  .c247:hover .c213,
+  .c247:visited:hover .c213 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c46 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c45:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c139 {
     grid-template-columns: repeat(5,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c142 {
+  .c139 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c166 {
+  .c163 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c205 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c151 {
+  .c148 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c185 {
+  .c182 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c163 {
+  .c160 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c79 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:920px) {
-  .c96 {
+  .c93 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -4485,10 +4485,6 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   <div
     data-overlay-container="true"
   >
-    <div
-      aria-live="polite"
-      class="c0 c1 c2"
-    />
     <fake-head>
       <title>
         Oak's Curricula | NEXT_PUBLIC_SEO_APP_NAME
@@ -4552,31 +4548,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
       </script>
     </fake-head>
     <div
-      class="c3 c4"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c2"
       >
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 grey-shadow"
+            class="c5 grey-shadow"
           />
           <div
-            class="c8 yellow-shadow"
+            class="c5 yellow-shadow"
           />
           <a
-            class="c9 c10 internal-button"
+            class="c6 c7 internal-button"
             data-testid="skip-link"
             href="#main"
             style="position: absolute; left: -10000px;"
           >
             <div
-              class="c11 c12"
+              class="c8 c9"
             >
               <span
-                class="c13"
+                class="c10"
               >
                 Skip to content
               </span>
@@ -4585,32 +4581,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </div>
       </div>
       <header
-        class="c14"
+        class="c11"
         data-testid="app-topnav"
       >
         <div
-          class="c15"
+          class="c12"
         >
           <div
-            class="c6 c7"
+            class="c3 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
-              class="c9 c10 internal-button"
+              class="c6 c7 internal-button"
               data-testid="skip-link"
               href="#main"
               style="position: absolute; left: -10000px;"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c13"
+                  class="c10"
                 >
                   Skip to content
                 </span>
@@ -4619,27 +4615,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </div>
         <div
-          class="c16 c17"
+          class="c13 c14"
         >
           <div
-            class="c18 c19"
+            class="c15 c16"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="true"
-              class="c20 c10 internal-button"
+              class="c17 c7 internal-button"
               href="/"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Teachers
                 </span>
@@ -4647,34 +4643,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </a>
           </div>
           <div
-            class="c18 c7"
+            class="c15 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="false"
-              class="c22 c23 internal-button"
+              class="c19 c20 internal-button"
               href="/pupils/years"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Go to 
                   pupils
                 </span>
                 <span
-                  class="c24"
+                  class="c21"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4687,22 +4683,22 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </div>
         <nav
-          class="c26 c27"
+          class="c23 c24"
         >
           <a
             aria-label="Home"
-            class="c28"
+            class="c25"
             href="/"
           >
             <span
-              class="c29"
+              class="c26"
             >
               <span
-                class="c30"
+                class="c27"
               >
                 <img
                   alt=""
-                  class="c31"
+                  class="c28"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4713,40 +4709,40 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c11 c32"
+            class="c8 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
             <div
-              class="c11"
+              class="c8"
             >
               <ul
-                class="c33"
+                class="c30"
               >
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4755,29 +4751,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4786,29 +4782,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4817,29 +4813,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4848,38 +4844,38 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4894,24 +4890,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c11 c40"
+              class="c8 c37"
             >
               <form
                 action="/teachers/search"
-                class="c41"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c42"
+                  class="c39"
                 >
                   <div
-                    class="c43 c44 c45"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c46"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4919,32 +4915,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c44"
                 >
                   <div
-                    class="c48 c49 c50"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c51 c52"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c11 c53"
+                        class="c8 c50"
                       >
                         <div
-                          class="c54 c55 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c56 shadow"
+                            class="c53 shadow"
                           />
                           <span
-                            class="c24"
+                            class="c21"
                             data-icon-for="button"
                           >
                             <img
                               alt=""
-                              class="c57"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4954,7 +4950,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c58"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4962,32 +4958,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c59"
+                class="c56"
               >
                 <div
-                  class="c48 c49 c50"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c54 c55 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c56 shadow"
+                          class="c53 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c57"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4997,7 +4993,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -5005,19 +5001,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c60 c61"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c62 c63 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c64"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -5026,29 +5022,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c65"
+                    class="c62"
                   >
                     My library
                   </div>
                 </div>
               </a>
               <div
-                class="c6 c7"
+                class="c3 c4"
               >
                 <div
-                  class="c8 grey-shadow"
+                  class="c5 grey-shadow"
                 />
                 <div
-                  class="c8 yellow-shadow"
+                  class="c5 yellow-shadow"
                 />
                 <button
-                  class="c66 c67 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c11 c37"
+                    class="c8 c34"
                   >
                     <span
-                      class="c38"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -5058,32 +5054,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c69 c10 internal-button"
+                class="c66 c7 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c11 c53"
+                  class="c8 c50"
                 >
                   <span
-                    class="c24"
+                    class="c21"
                   >
                     <img
                       alt=""
-                      class="c39"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -5092,7 +5088,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                   </span>
                   <span
-                    class="c13"
+                    class="c10"
                   />
                 </div>
               </button>
@@ -5101,45 +5097,45 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c70 c4"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c71"
+          class="c68"
         >
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c73 c74"
+              class="c70 c71"
             >
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <h1
-                  class="c76"
+                  class="c73"
                 >
                   <span
-                    class="c77"
+                    class="c74"
                   >
                     Oak's curricula
                   </span>
                 </h1>
                 <p
-                  class="c78"
+                  class="c75"
                 >
                   Oak offers complete curriculum support for clarity and coherence in every national curriculum subject.
                 </p>
               </div>
               <div
-                class="c11 c79"
+                class="c8 c76"
               >
                 <span
-                  class="c80"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -5153,30 +5149,30 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c81"
+            class="c78"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c82 c83"
+                class="c79 c80"
               >
                 <ul
-                  class="c84 c85"
+                  class="c81 c82"
                 >
                   <li
-                    class="c86"
+                    class="c83"
                   >
                     <div
-                      class="c87 c88"
+                      class="c84 c85"
                     >
                       <span
-                        class="c89"
+                        class="c86"
                         data-testid="icon-clipboard"
                       >
                         <img
                           alt=""
-                          class="c25"
+                          class="c22"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5185,25 +5181,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c90"
+                        class="c87"
                       >
                         National curriculum and exam board aligned
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c86"
+                    class="c83"
                   >
                     <div
-                      class="c87 c88"
+                      class="c84 c85"
                     >
                       <span
-                        class="c91"
+                        class="c88"
                         data-testid="icon-free-tag"
                       >
                         <img
                           alt=""
-                          class="c25"
+                          class="c22"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5212,25 +5208,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c90"
+                        class="c87"
                       >
                         Free and always will be
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c86"
+                    class="c83"
                   >
                     <div
-                      class="c87 c88"
+                      class="c84 c85"
                     >
                       <span
-                        class="c92"
+                        class="c89"
                         data-testid="icon-book-steps"
                       >
                         <img
                           alt=""
-                          class="c25"
+                          class="c22"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5239,25 +5235,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c90"
+                        class="c87"
                       >
                         Covers key stages 1-4 across 20 subjects
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c86"
+                    class="c83"
                   >
                     <div
-                      class="c87 c88"
+                      class="c84 c85"
                     >
                       <span
-                        class="c93"
+                        class="c90"
                         data-testid="icon-threads"
                       >
                         <img
                           alt=""
-                          class="c25"
+                          class="c22"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5266,7 +5262,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c90"
+                        class="c87"
                       >
                         Fully sequenced and ready to adapt
                       </p>
@@ -5274,34 +5270,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </li>
                 </ul>
                 <div
-                  class="c94 c95 c96"
+                  class="c91 c92 c93"
                 >
                   <div
-                    class="c11 c97"
+                    class="c8 c94"
                   >
                     <div
-                      class="c11 c98"
+                      class="c8 c95"
                     >
                       <h2
-                        class="c99"
+                        class="c96"
                       >
                         Our guiding principles
                       </h2>
                       <p
-                        class="c100"
+                        class="c97"
                       >
                         Our guiding principles guide our approach.
                       </p>
                     </div>
                     <div
-                      class="c101 c49"
+                      class="c98 c46"
                     >
                       <span
-                        class="c102"
+                        class="c99"
                       >
                         <img
                           alt=""
-                          class="c31"
+                          class="c28"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5314,29 +5310,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c103 c104"
+                    class="c100 c101"
                   >
                     <div
-                      class="c105"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c106 c107"
+                        class="c103 c104"
                       >
                         <div
-                          class="c108 c109"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c11 c98"
+                          class="c8 c95"
                         >
                           <h3
-                            class="c110"
+                            class="c107"
                           >
                             Evidence-informed
                           </h3>
                           <p
-                            class="c111"
+                            class="c108"
                           >
                             Our approach enables the rigorous application of research outcomes.
                           </p>
@@ -5344,26 +5340,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c105"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c106 c107"
+                        class="c103 c104"
                       >
                         <div
-                          class="c108 c109"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c11 c98"
+                          class="c8 c95"
                         >
                           <h3
-                            class="c110"
+                            class="c107"
                           >
                             Knowledge and vocabulary rich
                           </h3>
                           <p
-                            class="c111"
+                            class="c108"
                           >
                             Our curriculum is knowledge and vocabulary rich.
                           </p>
@@ -5373,57 +5369,57 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c112 c113"
+                  class="c109 c110"
                 >
                   <h2
-                    class="c114"
+                    class="c111"
                   >
                     See Oak's curricula in practice
                   </h2>
                   <nav
                     aria-labelledby="choose-curriculum-label"
-                    class="c70"
+                    class="c67"
                   >
                     <div
-                      class="c115"
+                      class="c112"
                       id="choose-curriculum-label"
                     >
                       Choose a curriculum
                     </div>
                     <div
-                      class="c116"
+                      class="c113"
                       data-testid="lot-picker"
                     >
                       <div
-                        class="c117 c118"
+                        class="c114 c115"
                       >
                         <div
-                          class="c70 c119"
+                          class="c67 c116"
                         >
                           <div
-                            class="c120 c121"
+                            class="c117 c118"
                             style="width: 50%;"
                           >
                             <div
-                              class="c122 c123 c124"
+                              class="c119 c120 c121"
                             >
                               <button
                                 aria-expanded="false"
-                                class="c125"
+                                class="c122"
                                 data-testid="subject-picker-button"
                                 title="Subject"
                               >
                                 <div
-                                  class="c126"
+                                  class="c123"
                                 >
                                   <span
-                                    class="c127"
+                                    class="c124"
                                     data-testid="subject-picker-button-heading"
                                   >
                                     Subject
                                   </span>
                                   <p
-                                    class="c128"
+                                    class="c125"
                                   >
                                     Select
                                   </p>
@@ -5432,16 +5428,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </div>
                           </div>
                           <div
-                            class="c129"
+                            class="c126"
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c130"
+                                class="c127"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5467,32 +5463,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </div>
                           </div>
                           <div
-                            class="c14"
+                            class="c11"
                             style="width: 50%;"
                           >
                             <div
-                              class="c120 c131"
+                              class="c117 c128"
                             >
                               <div
-                                class="c132 c123 c124"
+                                class="c129 c120 c121"
                               >
                                 <button
                                   aria-expanded="false"
-                                  class="c125"
+                                  class="c122"
                                   data-testid="phase-picker-button"
                                   title="Phase"
                                 >
                                   <div
-                                    class="c133"
+                                    class="c130"
                                   >
                                     <span
-                                      class="c127"
+                                      class="c124"
                                       data-testid="phase-picker-button-heading"
                                     >
                                       School phase
                                     </span>
                                     <div
-                                      class="c134"
+                                      class="c131"
                                     >
                                       Select
                                     </div>
@@ -5500,35 +5496,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </button>
                               </div>
                               <div
-                                class="c135 c136"
+                                class="c132 c133"
                               >
                                 <div
-                                  class="c6 c7"
+                                  class="c3 c4"
                                 >
                                   <div
-                                    class="c8 grey-shadow"
+                                    class="c5 grey-shadow"
                                   />
                                   <div
-                                    class="c8 yellow-shadow"
+                                    class="c5 yellow-shadow"
                                   />
                                   <button
-                                    class="c137 c23 internal-button"
+                                    class="c134 c20 internal-button"
                                     data-testid="lot-picker-view-curriculum-button"
                                   >
                                     <div
-                                      class="c11 c12"
+                                      class="c8 c9"
                                     >
                                       <span
-                                        class="c13"
+                                        class="c10"
                                       >
                                         View
                                       </span>
                                       <span
-                                        class="c24"
+                                        class="c21"
                                       >
                                         <img
                                           alt=""
-                                          class="c57"
+                                          class="c54"
                                           data-nimg="fill"
                                           decoding="async"
                                           loading="lazy"
@@ -5551,48 +5547,48 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c138 c83"
+              class="c135 c80"
             >
               <h2
-                class="c139"
+                class="c136"
               >
                 Curriculum partners
               </h2>
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <div
-                  class="c11 c140"
+                  class="c8 c137"
                 >
                   <h3
-                    class="c114"
+                    class="c111"
                   >
                     Current
                   </h3>
                   <p
-                    class="c141"
+                    class="c138"
                   >
                     Our current partners
                   </p>
                 </div>
                 <div
-                  class="c11"
+                  class="c8"
                 >
                   <ul
-                    class="c84 c142"
+                    class="c81 c139"
                   >
                     <li
-                      class="c143"
+                      class="c140"
                     >
                       <span
-                        class="c144"
+                        class="c141"
                       >
                         <img
                           alt=""
-                          class="c31"
+                          class="c28"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5607,37 +5603,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <div
-                  class="c11 c140"
+                  class="c8 c137"
                 >
                   <h3
-                    class="c114"
+                    class="c111"
                   >
                     Legacy
                   </h3>
                   <p
-                    class="c141"
+                    class="c138"
                   >
                     Our legacy partners
                   </p>
                 </div>
                 <div
-                  class="c11"
+                  class="c8"
                 >
                   <ul
-                    class="c84 c142"
+                    class="c81 c139"
                   >
                     <li
-                      class="c143"
+                      class="c140"
                     >
                       <span
-                        class="c144"
+                        class="c141"
                       >
                         <img
                           alt=""
-                          class="c31"
+                          class="c28"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5654,19 +5650,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c145"
+            class="c142"
             style="margin-top: -72px;"
           >
             <div
-              class="c146"
+              class="c143"
             >
               <span
-                class="c147"
+                class="c144"
                 style="pointer-events: none;"
               >
                 <img
                   alt=""
-                  class="c25"
+                  class="c22"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -5675,13 +5671,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c72"
+                class="c69"
               >
                 <div
-                  class="c148 c149"
+                  class="c145 c146"
                 >
                   <h2
-                    class="c150"
+                    class="c147"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5690,31 +5686,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c151"
+                      class="c148"
                     >
                       <li
-                        class="c152"
+                        class="c149"
                       >
                         <div
-                          class="c153 c154"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c155 c156 c157"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c158"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5724,19 +5720,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c159 c160"
+                                class="c156 c157"
                               >
                                 About Oak
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c161"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5750,28 +5746,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c152"
+                        class="c149"
                       >
                         <div
-                          class="c153 c154"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c155 c156 c157"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c158"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5781,19 +5777,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c159 c160"
+                                class="c156 c157"
                               >
                                 Oak's curricula
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c161"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5807,28 +5803,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c152"
+                        class="c149"
                       >
                         <div
-                          class="c153 c154"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c155 c156 c157"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c158"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5838,19 +5834,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c159 c160"
+                                class="c156 c157"
                               >
                                 Meet the team
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c161"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5864,28 +5860,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c152"
+                        class="c149"
                       >
                         <div
-                          class="c153 c154"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c155 c156 c157"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c158"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5895,19 +5891,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c159 c160"
+                                class="c156 c157"
                               >
                                 Get involved
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c161"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5927,33 +5923,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c162"
+            class="c159"
             id="newsletter-signup"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c11 c49 c163"
+                class="c8 c46 c160"
               >
                 <div
-                  class="c164 c4"
+                  class="c161 c1"
                 >
                   <div
-                    class="c11 c165"
+                    class="c8 c162"
                   >
                     <div
-                      class="c11 c49 c166"
+                      class="c8 c46 c163"
                     >
                       <div
-                        class="c167 c168"
+                        class="c164 c165"
                       >
                         <span
-                          class="c169"
+                          class="c166"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5962,24 +5958,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c170"
+                          class="c167"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c171"
+                        class="c168"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
                         Join over 100k teachers and get free resources and other helpful content by email. Unsubscribe at any time. Read our
                          
                         <a
-                          class="c28"
+                          class="c25"
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             privacy policy
                           </span>
@@ -5988,27 +5984,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c172 c49 c166"
+                      class="c169 c46 c163"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c173"
+                        class="c170"
                         novalidate=""
                       >
                         <div
-                          class="c174 c175 c176"
+                          class="c171 c172 c173"
                         >
                           <div
-                            class="c177 "
+                            class="c174 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -6033,7 +6029,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6058,7 +6054,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6083,7 +6079,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6108,23 +6104,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c179 "
+                              class="c176 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c180 c181 c182"
+                                class="c177 c178 c179"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
                                 id="react-use-id-test-result-newsletter-signup-name-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Name
                                    
                                   <span
-                                    class="c183"
+                                    class="c180"
                                   >
                                     (required)
                                   </span>
@@ -6135,7 +6131,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c184 c185"
+                              class="c181 c182"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -6143,7 +6139,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c186 c187 c188"
+                              class="c183 c184 c185"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6156,19 +6152,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c174 c175 c176"
+                          class="c171 c172 c173"
                         >
                           <div
-                            class="c177 "
+                            class="c174 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -6193,7 +6189,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6218,7 +6214,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6243,7 +6239,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c178"
+                                class="c175"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6268,23 +6264,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c179 "
+                              class="c176 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c180 c181 c182"
+                                class="c177 c178 c179"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
                                 id="react-use-id-test-result-newsletter-signup-email-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Email
                                    
                                   <span
-                                    class="c183"
+                                    class="c180"
                                   >
                                     (required)
                                   </span>
@@ -6295,7 +6291,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c184 c185"
+                              class="c181 c182"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -6303,7 +6299,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c186 c187 c188"
+                              class="c183 c184 c185"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6316,16 +6312,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c189 c98 c190"
+                          class="c186 c95 c187"
                         >
                           <div
                             aria-hidden="true"
-                            class="c11"
+                            class="c8"
                             data-testid="brush-borders"
                           >
                             <svg
                               aria-hidden="true"
-                              class="c178"
+                              class="c175"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -6350,7 +6346,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c178"
+                              class="c175"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -6375,7 +6371,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c178"
+                              class="c175"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6400,7 +6396,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c178"
+                              class="c175"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6426,7 +6422,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c186 c187 c188 c191"
+                            class="c183 c184 c185 c188"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6437,10 +6433,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c192 c49"
+                            class="c189 c46"
                           >
                             <label
-                              class="c180 c181 c182"
+                              class="c177 c178 c179"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6452,16 +6448,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c193 c194"
+                            class="c190 c191"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c195 c44 c196"
+                              class="c192 c41 c193"
                             >
                               <span
-                                class="c197 c198"
+                                class="c194 c195"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6470,11 +6466,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c24"
+                              class="c21"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6485,22 +6481,22 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c199 c7"
+                          class="c196 c4"
                         >
                           <div
-                            class="c8 grey-shadow"
+                            class="c5 grey-shadow"
                           />
                           <div
-                            class="c8 yellow-shadow"
+                            class="c5 yellow-shadow"
                           />
                           <button
-                            class="c200 c23 internal-button"
+                            class="c197 c20 internal-button"
                           >
                             <div
-                              class="c11 c12"
+                              class="c8 c9"
                             >
                               <span
-                                class="c13"
+                                class="c10"
                               >
                                 Sign up to the newsletter
                               </span>
@@ -6509,12 +6505,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c201"
+                          class="c198"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c202"
+                          class="c199"
                         />
                       </form>
                     </div>
@@ -6526,14 +6522,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c203"
+        class="c200"
       >
         <div
-          class="c204 c49"
+          class="c201 c46"
         >
           <svg
             aria-hidden="true"
-            class="c205"
+            class="c202"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6556,37 +6552,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c206 c207"
+            class="c203 c204"
           >
             <div
-              class="c11 c165"
+              class="c8 c162"
             >
               <div
-                class="c11 c49 c208"
+                class="c8 c46 c205"
               >
                 <div
-                  class="c209 c98"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c210"
+                    class="c207"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c134 c211"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/pupils/years"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Learn online
                           </span>
@@ -6596,72 +6592,72 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c214"
+                  class="c211"
                 />
                 <div
-                  class="c209 c98"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c210"
+                    class="c207"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c134 c211"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             EYFS
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/lesson-planning"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Plan a lesson
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c215"
+                            class="c212"
                           >
                             <span
-                              class="c161 c216 c217"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6673,14 +6669,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/blog"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Blog
                           </span>
@@ -6691,115 +6687,115 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c208"
+                class="c8 c46 c205"
               >
                 <div
-                  class="c209 c98"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c210"
+                    class="c207"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c134 c211"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Home
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/about-us/who-we-are"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             About us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Oak's curricula
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/about-us/get-involved"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Get involved
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/about-us/meet-the-team"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Meet the team
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c213 "
+                          class="c210 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Careers
                           </span>
                           <div
-                            class="c215"
+                            class="c212"
                           >
                             <span
-                              class="c161 c216 c217"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6811,42 +6807,42 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/contact-us"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Contact us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c213 "
+                          class="c210 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Help
                           </span>
                           <div
-                            class="c215"
+                            class="c212"
                           >
                             <span
-                              class="c161 c216 c217"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6858,42 +6854,42 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/webinars"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Webinars
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c213 "
+                          class="c210 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Status
                           </span>
                           <div
-                            class="c215"
+                            class="c212"
                           >
                             <span
-                              class="c161 c216 c217"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6909,156 +6905,156 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c208"
+                class="c8 c46 c205"
               >
                 <div
-                  class="c209 c98"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c210"
+                    class="c207"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c134 c211"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Terms & conditions
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Privacy policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/cookie-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Cookie policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <button
-                          class="c213 "
+                          class="c210 "
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Manage cookie settings
                           </span>
                         </button>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/copyright-notice"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Copyright notice
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/accessibility-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Accessibility statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Safeguarding statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Physical activity disclaimer
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/complaints"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Complaints
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c212"
+                        class="c209"
                       >
                         <a
-                          class="c213 "
+                          class="c210 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Freedom of information requests
                           </span>
@@ -7069,20 +7065,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c208"
+                class="c8 c46 c205"
               >
                 <div
-                  class="c209 c218"
+                  class="c206 c215"
                 >
                   <div
-                    class="c42"
+                    class="c39"
                   >
                     <span
-                      class="c219"
+                      class="c216"
                     >
                       <img
                         alt=""
-                        class="c31"
+                        class="c28"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -7092,32 +7088,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c220 c221"
+                    class="c217 c218"
                   >
                     <div
-                      class="c48 c49 c222 c223"
+                      class="c45 c46 c219 c220"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c224 c55 icon-container"
+                            class="c221 c52 icon-container"
                           >
                             <div
-                              class="c225 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7127,35 +7123,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c222 c223"
+                      class="c45 c46 c219 c220"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c224 c55 icon-container"
+                            class="c221 c52 icon-container"
                           >
                             <div
-                              class="c225 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7165,35 +7161,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c222 c223"
+                      class="c45 c46 c219 c220"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c224 c55 icon-container"
+                            class="c221 c52 icon-container"
                           >
                             <div
-                              class="c225 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7203,7 +7199,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -7213,12 +7209,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c226 c227"
+              class="c223 c224"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c31"
+                class="c28"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -7229,35 +7225,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c228 c229"
+              class="c225 c226"
             >
               <div
-                class="c230 c231"
+                class="c227 c228"
               >
                 <div
-                  class="c48 c49 c222 c223"
+                  class="c45 c46 c219 c220"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c224 c55 icon-container"
+                        class="c221 c52 icon-container"
                       >
                         <div
-                          class="c225 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7267,35 +7263,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c222 c223"
+                  class="c45 c46 c219 c220"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c224 c55 icon-container"
+                        class="c221 c52 icon-container"
                       >
                         <div
-                          class="c225 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7305,35 +7301,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c222 c223"
+                  class="c45 c46 c219 c220"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c224 c55 icon-container"
+                        class="c221 c52 icon-container"
                       >
                         <div
-                          class="c225 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7343,21 +7339,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c59"
+                class="c56"
               >
                 <span
-                  class="c219"
+                  class="c216"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -7367,15 +7363,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c209 c98"
+                class="c206 c95"
               >
                 <p
-                  class="c232"
+                  class="c229"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c233"
+                  class="c230"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7384,11 +7380,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c234"
+          class="c231"
         >
           <img
             alt=""
-            class="c235"
+            class="c232"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7397,11 +7393,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c236"
+          class="c233"
         >
           <img
             alt=""
-            class="c237"
+            class="c234"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7411,6 +7407,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </span>
       </footer>
     </div>
+    <div
+      aria-live="polite"
+      class="c235 c236 c237"
+    />
   </div>
   <div
     class="c238"
@@ -7437,10 +7437,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c245"
+            class="c8 c245"
           >
             <div
-              class="c246 c44"
+              class="c246 c41"
             >
               <button
                 class="c247"
@@ -7448,29 +7448,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 type="button"
               >
                 <span
-                  class="c29"
+                  class="c26"
                 >
                   Reject non-essential cookies
                 </span>
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c9 c10 internal-button"
+                class="c6 c7 internal-button"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Cookie settings
                   </span>
@@ -7478,23 +7478,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c137 c23 internal-button"
+                class="c134 c20 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Accept all cookies
                   </span>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -2,21 +2,11 @@
 
 exports[`pages/about/who-we-are.tsx renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c2 {
   position: absolute;
   top: 5.75rem;
   left: 1.5rem;
@@ -27,7 +17,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c6 {
+.c3 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -36,7 +26,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,16 +35,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c11 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   position: absolute;
   top: 10rem;
   left: 1.5rem;
@@ -62,7 +52,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c16 {
+.c13 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 1rem;
@@ -71,14 +61,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c15 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c21 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -88,7 +78,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   max-height: 5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -100,7 +90,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
@@ -109,19 +99,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -142,17 +132,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c43:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c47 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -160,7 +150,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -171,7 +161,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -180,12 +170,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -205,7 +195,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c64 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -215,28 +205,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c71 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c72 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -245,7 +235,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -253,7 +243,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c80 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -261,21 +251,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c81 {
+.c78 {
   margin-left: auto;
   margin-right: auto;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c83 {
+.c80 {
   min-width: 100%;
   aspect-ratio: 4/3;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c86 {
+.c83 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 3.5rem;
@@ -283,17 +273,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c86 {
   background: #ebfbeb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c90 {
+.c87 {
   padding-top: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c95 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -304,12 +294,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c100 {
+.c97 {
   width: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c99 {
   width: 1.5rem;
   height: 1.5rem;
   background: #bef2bd;
@@ -320,7 +310,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c104 {
+.c101 {
   width: 0rem;
   border: 0rem solid;
   border-left: 0.188rem solid;
@@ -329,12 +319,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c105 {
+.c102 {
   margin-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c106 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -345,7 +335,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c108 {
+.c105 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -356,13 +346,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c111 {
+.c108 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c117 {
+.c114 {
   height: 15rem;
   padding: 1.5rem;
   background: #a0b6f2;
@@ -370,20 +360,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c119 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c123 {
+.c120 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c121 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -398,26 +388,26 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c122 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c126 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c128 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c131 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -427,7 +417,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c132 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -438,7 +428,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c136 {
+.c133 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -448,14 +438,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c134 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c136 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -467,12 +457,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c139 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c144 {
+.c141 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -486,36 +476,36 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c147 {
+.c144 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c164 {
+.c161 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c164 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c167 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c171 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c178 {
+.c175 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -525,13 +515,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c179 {
+.c176 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c181 {
+.c178 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -543,12 +533,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c181 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c186 {
+.c183 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -560,18 +550,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c190 {
+.c187 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c188 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c192 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -580,7 +570,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c193 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -588,7 +578,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c200 {
+.c197 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -599,7 +589,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c201 {
+.c198 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -610,14 +600,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c202 {
+.c199 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c204 {
+.c201 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -625,12 +615,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c203 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c210 {
+.c207 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -648,7 +638,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c212 {
+.c209 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -664,6 +654,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   transform: translate(0%,32%);
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
+}
+
+.c211 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c214 {
@@ -720,28 +720,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c12 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -760,7 +745,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c17 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -772,7 +757,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -784,7 +769,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -803,7 +788,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c37 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -822,7 +807,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c40 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -834,7 +819,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c44 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -845,14 +830,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c53 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -871,7 +856,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c55 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -886,7 +871,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c63 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -902,7 +887,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c94 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -913,7 +898,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c98 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -923,7 +908,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c74 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -939,7 +924,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c75 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -950,7 +935,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c84 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -961,7 +946,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c87 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -975,7 +960,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 1;
 }
 
-.c91 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -986,7 +971,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2.5rem;
 }
 
-.c99 {
+.c96 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -994,7 +979,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c101 {
+.c98 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1011,7 +996,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c103 {
+.c100 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1022,7 +1007,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 0;
 }
 
-.c112 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1033,7 +1018,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c119 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1044,7 +1029,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c132 {
+.c129 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1059,7 +1044,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c143 {
+.c140 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1073,7 +1058,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c182 {
+.c179 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1091,7 +1076,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c194 {
+.c191 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1102,7 +1087,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c197 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1118,7 +1103,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c205 {
+.c202 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1136,7 +1121,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c207 {
+.c204 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1147,6 +1132,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   gap: 1rem;
+}
+
+.c212 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c218 {
@@ -1186,7 +1186,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1198,7 +1198,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c21 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1210,11 +1210,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c29 {
+.c26 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1226,7 +1226,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c58 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1237,14 +1237,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c77 {
+.c74 {
   background: #bef2bd;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c155 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1255,7 +1255,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c172 {
+.c169 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1277,7 +1277,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c180 {
+.c177 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1286,7 +1286,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c9 {
+.c6 {
   background: none;
   color: inherit;
   border: none;
@@ -1309,12 +1309,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c9:disabled {
+.c6:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c17 {
   background: none;
   color: inherit;
   border: none;
@@ -1340,12 +1340,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c20:disabled {
+.c17:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -1371,12 +1371,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c22:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c35 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1399,12 +1399,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c35:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c51 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1418,12 +1418,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c51:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c60 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1436,12 +1436,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1471,12 +1471,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c66:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c69 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1500,12 +1500,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-style: none;
 }
 
-.c69:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c175 {
+.c172 {
   background: none;
   color: inherit;
   border: none;
@@ -1529,7 +1529,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c175:disabled {
+.c172:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1562,35 +1562,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c25 {
+.c22 {
   object-fit: contain;
 }
 
-.c39 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c57 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c211 {
+.c208 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c213 {
+.c210 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c31 {
+.c28 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1599,13 +1599,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c10 {
+.c7 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c10:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -1613,37 +1613,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c10:hover [data-state="selected"] {
+.c7:hover [data-state="selected"] {
   display: none;
 }
 
-.c10:active {
+.c7:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c10:active [data-state="selected"] {
+.c7:active [data-state="selected"] {
   display: none;
 }
 
-.c10:disabled {
+.c7:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c10:disabled [data-state="selected"] {
+.c7:disabled [data-state="selected"] {
   display: none;
 }
 
-.c23 {
+.c20 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c23:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -1651,37 +1651,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c23:hover [data-state="selected"] {
+.c20:hover [data-state="selected"] {
   display: none;
 }
 
-.c23:active {
+.c20:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c23:active [data-state="selected"] {
+.c20:active [data-state="selected"] {
   display: none;
 }
 
-.c23:disabled {
+.c20:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c23:disabled [data-state="selected"] {
+.c20:disabled [data-state="selected"] {
   display: none;
 }
 
-.c36 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c36:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1689,37 +1689,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c36:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c36:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c36:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c36:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c36:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c67 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c67:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1727,148 +1727,148 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c67:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c67:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c67:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c67:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c67:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c4 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c4 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:hover),
-.c7 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c4 .yellow-shadow:has(+ .internal-button:hover),
+.c4 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:hover) {
+.c4 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:active) {
+.c4 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:active) {
+.c4 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c16 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c16 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c16 .yellow-shadow:has(+ .internal-button:hover),
+.c16 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c16 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c16 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c16 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c52 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c52:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c52:active {
+.c49:active {
   color: #222222;
 }
 
-.c52:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c50 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c50 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c50 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c50 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c198 > :first-child:focus-visible .shadow {
+.c195 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c198 > :first-child:hover .shadow {
+.c195 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c198 > :first-child:active .shadow {
+.c195 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c198 > :first-child:disabled .icon-container {
+.c195 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c198 > :first-child:hover .icon-container {
+.c195 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c198 > :first-child:active .icon-container {
+.c195 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c76 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1879,7 +1879,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c96 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1890,7 +1890,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c107 {
+.c104 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1901,7 +1901,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c113 {
+.c110 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1913,7 +1913,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c120 {
+.c117 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1924,7 +1924,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c126 {
+.c123 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1936,7 +1936,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: center;
 }
 
-.c145 {
+.c142 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1947,7 +1947,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c185 {
+.c182 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1960,7 +1960,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c34 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1968,7 +1968,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c188 {
+.c185 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1977,7 +1977,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c78 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1988,7 +1988,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c88 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1999,7 +1999,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c109 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2011,7 +2011,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c121 {
+.c118 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2022,13 +2022,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c146 {
+.c143 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c176 {
+.c173 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2041,7 +2041,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c177 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2053,7 +2053,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c208 {
+.c205 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2064,7 +2064,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c209 {
+.c206 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2075,7 +2075,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c187 {
+.c184 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2086,7 +2086,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c33 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2107,14 +2107,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c193 {
+.c190 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c28 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2138,47 +2138,47 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c28 .c192 {
+.c25 .c189 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c28:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c28:visited {
+.c25:visited {
   color: #081676;
 }
 
-.c28:visited .c192 {
+.c25:visited .c189 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28:active {
+.c25:active {
   color: #081676;
   outline: 1px solid #081676;
 }
 
-.c28:active .c192 {
+.c25:active .c189 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c28[disabled] .c192 {
+.c25[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c189 {
+.c186 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2202,42 +2202,42 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c189 .c192 {
+.c186 .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c189:focus-visible {
+.c186:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c189:visited {
+.c186:visited {
   color: #222222;
 }
 
-.c189:visited .c192 {
+.c186:visited .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c189:active {
+.c186:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c189:active .c192 {
+.c186:active .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c189[disabled] {
+.c186[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c189[disabled] .c192 {
+.c186[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2275,7 +2275,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c223 .c192 {
+.c223 .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -2290,7 +2290,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c223:visited .c192 {
+.c223:visited .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2300,7 +2300,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c223:active .c192 {
+.c223:active .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -2310,12 +2310,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #808080;
 }
 
-.c223[disabled] .c192 {
+.c223[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c46 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2331,49 +2331,49 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   width: 100%;
 }
 
-.c46::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c46::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c46:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c46::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c46::-webkit-search-decoration,
-.c46::-webkit-search-cancel-button,
-.c46::-webkit-search-results-button,
-.c46::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c46:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c45 {
+.c42 {
   background: #ffffff;
 }
 
-.c45:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c45:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c92 {
+.c89 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2382,7 +2382,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c114 {
+.c111 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2391,13 +2391,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c140 {
+.c137 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c93 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2407,7 +2407,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c97 {
+.c94 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2417,7 +2417,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c115 {
+.c112 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2426,7 +2426,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c141 {
+.c138 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2435,7 +2435,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c183 {
+.c180 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2444,41 +2444,41 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c130 {
+.c127 {
   box-shadow: none;
 }
 
-.c130:has(a:hover,button:hover) {
+.c127:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c130:has( a, button) {
+.c127:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c130:has( a, button)  a,
-.c130:has( a, button) button {
+.c127:has( a, button)  a,
+.c127:has( a, button) button {
   outline: none;
 }
 
-.c130:has(a:active,button:active) {
+.c127:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c61:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c61:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2 {
+.c213 {
   top: 82px;
 }
 
-.c168 {
+.c165 {
   background: none;
   color: inherit;
   border: none;
@@ -2489,20 +2489,45 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c110:first-child {
+.c107:first-child {
   margin-top: 0;
 }
 
-.c79 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c149 {
+.c146 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
   color: #222222;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c146::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c146::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c146::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c149 {
+  position: relative;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2525,32 +2550,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   background-color: #999999;
 }
 
-.c152 {
-  position: relative;
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c152::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c152::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c152::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c154 {
+.c151 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2558,86 +2558,86 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c154::-webkit-scrollbar-track {
+.c151::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c154::-webkit-scrollbar {
+.c151::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c154::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c85 {
-  object-fit: cover;
-  width: 100%;
-  height: auto;
-}
-
-.c85::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c85::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c85::-webkit-scrollbar-thumb {
-  border-radius: 15px;
-  background-color: #999999;
-}
-
-.c118 {
-  object-fit: contain;
-  width: 100%;
-  height: 100%;
-}
-
-.c118::-webkit-scrollbar-track {
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c118::-webkit-scrollbar {
-  width: 10px;
-  border-radius: 15px;
-  background-color: #ffffff;
-}
-
-.c118::-webkit-scrollbar-thumb {
+.c151::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
 .c82 {
+  object-fit: cover;
+  width: 100%;
+  height: auto;
+}
+
+.c82::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c82::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c82::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c115 {
+  object-fit: contain;
+  width: 100%;
+  height: 100%;
+}
+
+.c115::-webkit-scrollbar-track {
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c115::-webkit-scrollbar {
+  width: 10px;
+  border-radius: 15px;
+  background-color: #ffffff;
+}
+
+.c115::-webkit-scrollbar-thumb {
+  border-radius: 15px;
+  background-color: #999999;
+}
+
+.c79 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
 
-.c116 {
+.c113 {
   grid-column: span 3;
 }
 
-.c133:hover {
+.c130:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c128 {
+.c125 {
   padding: 0;
   margin: 0;
 }
 
-.c127 {
+.c124 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2649,20 +2649,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c161 {
+.c158 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c150 {
+.c147 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c153 {
+.c150 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2674,7 +2674,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c159 {
+.c156 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2685,32 +2685,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c159::-webkit-input-placeholder {
+.c156::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c159::-moz-placeholder {
+.c156::-moz-placeholder {
   color: #575757;
 }
 
-.c159:-ms-input-placeholder {
+.c156:-ms-input-placeholder {
   color: #575757;
 }
 
-.c159::placeholder {
+.c156::placeholder {
   color: #575757;
 }
 
-.c159::-webkit-search-decoration,
-.c159::-webkit-search-cancel-button,
-.c159::-webkit-search-results-button,
-.c159::-webkit-search-results-decoration {
+.c156::-webkit-search-decoration,
+.c156::-webkit-search-cancel-button,
+.c156::-webkit-search-results-button,
+.c156::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c156 {
+.c153 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2720,7 +2720,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c163 {
+.c160 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2733,7 +2733,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c157 {
+.c154 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2744,16 +2744,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c151:focus-within .c155 {
+.c148:focus-within .c152 {
   background: #374cf1;
   color: #fff;
 }
 
-.c151:focus-within .c162 {
+.c148:focus-within .c159 {
   display: inline;
 }
 
-.c160 {
+.c157 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2769,7 +2769,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: none;
 }
 
-.c160::-webkit-input-placeholder {
+.c157::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2777,7 +2777,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c160::-moz-placeholder {
+.c157::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2785,7 +2785,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c160:-ms-input-placeholder {
+.c157:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2793,7 +2793,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c160::placeholder {
+.c157::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2801,40 +2801,40 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c160:valid:not([value=""]) {
+.c157:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c160:valid:not([value=""])::-webkit-input-placeholder {
+.c157:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c160:valid:not([value=""])::-moz-placeholder {
+.c157:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c160:valid:not([value=""]):-ms-input-placeholder {
+.c157:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c160:valid:not([value=""])::placeholder {
+.c157:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c166 {
+.c163 {
   display: none;
 }
 
-.c165:focus-within .c155 {
+.c162:focus-within .c152 {
   background: #374cf1;
   color: #fff;
 }
 
-.c169 {
+.c166 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2861,45 +2861,51 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #575757;
 }
 
-.c171 {
+.c168 {
   max-width: calc(100% - 20px);
 }
 
-.c173 {
+.c170 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c148 {
+.c145 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c138 {
+.c135 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c199 .icon-container > *:first-child {
+.c196 .icon-container > *:first-child {
   border: 0;
 }
 
-.c203 {
+.c200 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
 @media (min-width:750px) {
-  .c0 {
-    right: 1.5rem;
+  .c13 {
+    padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c13 {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c15 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2907,75 +2913,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    padding-left: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c0 {
-    padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-left: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-right: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-top: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-bottom: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c41 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2984,19 +2958,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -3004,37 +2978,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c65 {
     display: none;
   }
 }
@@ -3048,115 +3022,115 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c73 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     padding-left: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     padding-right: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c86 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3165,31 +3139,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c102 {
     margin-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c105 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3198,37 +3172,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c121 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c121 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3236,7 +3210,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c124 {
+  .c121 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3244,79 +3218,79 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c125 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c125 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c136 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c181 {
+  .c178 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c181 {
+  .c178 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c184 {
+  .c181 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c190 {
+  .c187 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c193 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c204 {
+  .c201 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c203 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3325,13 +3299,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c207 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c207 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3339,7 +3313,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c210 {
+  .c207 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3347,8 +3321,34 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c209 {
     display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c211 {
+    right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c211 {
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+  }
+}
+
+@media (min-width:750px) {
+  .c211 {
+    padding-left: 0rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c211 {
+    padding-right: 0rem;
   }
 }
 
@@ -3404,16 +3404,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c17 {
+  .c14 {
     -webkit-box-pack: left;
     -webkit-justify-content: left;
     -ms-flex-pack: left;
@@ -3422,19 +3413,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3451,37 +3442,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c191 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3490,13 +3481,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c194 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c202 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3504,7 +3495,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c202 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3513,7 +3504,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c202 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3522,11 +3513,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c204 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c212 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -3607,43 +3607,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3652,7 +3652,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3688,67 +3688,67 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3757,7 +3757,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c76 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3766,25 +3766,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c96 {
+  .c93 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c96 {
+  .c93 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c96 {
+  .c93 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c96 {
+  .c93 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3793,25 +3793,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c104 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c104 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c104 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c104 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3820,43 +3820,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3865,7 +3865,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3874,55 +3874,55 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3931,7 +3931,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3940,43 +3940,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c126 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c126 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c126 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3985,7 +3985,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c126 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3994,43 +3994,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4039,7 +4039,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4048,25 +4048,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4075,25 +4075,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4102,31 +4102,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c106 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c118 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c118 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c118 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c118 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4135,14 +4135,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c143 {
     margin-right: 1.5rem;
   }
 }
 
 @media (hover:hover) {
-  .c28:hover,
-  .c28:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4150,16 +4150,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c28:hover .c192,
-  .c28:visited:hover .c192 {
+  .c25:hover .c189,
+  .c25:visited:hover .c189 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c189:hover,
-  .c189:visited:hover {
+  .c186:hover,
+  .c186:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4167,8 +4167,8 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c189:hover .c192,
-  .c189:visited:hover .c192 {
+  .c186:hover .c189,
+  .c186:visited:hover .c189 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -4184,94 +4184,94 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c223:hover .c192,
-  .c223:visited:hover .c192 {
+  .c223:hover .c189,
+  .c223:visited:hover .c189 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c46 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c45:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c90 {
     grid-column: 2 / span 9;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c90 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c94 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c94 {
     grid-column: 3 / span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c94 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c94 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c138 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c183 {
+  .c180 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:920px) {
-  .c79 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:1212px) {
-  .c82 {
+  .c79 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4279,31 +4279,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (max-width:1040px) {
-  .c116 {
+  .c113 {
     grid-column: span 6;
   }
 }
 
 @media (max-width:749px) {
-  .c116 {
+  .c113 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:800px) {
-  .c127 {
+  .c124 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c160 {
+  .c157 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c135 {
     max-width: 870px;
   }
 }
@@ -4312,10 +4312,6 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   <div
     data-overlay-container="true"
   >
-    <div
-      aria-live="polite"
-      class="c0 c1 c2"
-    />
     <fake-head>
       <title>
         Who We Are | NEXT_PUBLIC_SEO_APP_NAME
@@ -4379,31 +4375,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
       </script>
     </fake-head>
     <div
-      class="c3 c4"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c2"
       >
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 grey-shadow"
+            class="c5 grey-shadow"
           />
           <div
-            class="c8 yellow-shadow"
+            class="c5 yellow-shadow"
           />
           <a
-            class="c9 c10 internal-button"
+            class="c6 c7 internal-button"
             data-testid="skip-link"
             href="#main"
             style="position: absolute; left: -10000px;"
           >
             <div
-              class="c11 c12"
+              class="c8 c9"
             >
               <span
-                class="c13"
+                class="c10"
               >
                 Skip to content
               </span>
@@ -4412,32 +4408,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </div>
       </div>
       <header
-        class="c14"
+        class="c11"
         data-testid="app-topnav"
       >
         <div
-          class="c15"
+          class="c12"
         >
           <div
-            class="c6 c7"
+            class="c3 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
-              class="c9 c10 internal-button"
+              class="c6 c7 internal-button"
               data-testid="skip-link"
               href="#main"
               style="position: absolute; left: -10000px;"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c13"
+                  class="c10"
                 >
                   Skip to content
                 </span>
@@ -4446,27 +4442,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </div>
         <div
-          class="c16 c17"
+          class="c13 c14"
         >
           <div
-            class="c18 c19"
+            class="c15 c16"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="true"
-              class="c20 c10 internal-button"
+              class="c17 c7 internal-button"
               href="/"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Teachers
                 </span>
@@ -4474,34 +4470,34 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </a>
           </div>
           <div
-            class="c18 c7"
+            class="c15 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="false"
-              class="c22 c23 internal-button"
+              class="c19 c20 internal-button"
               href="/pupils/years"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Go to 
                   pupils
                 </span>
                 <span
-                  class="c24"
+                  class="c21"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4514,22 +4510,22 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </div>
         <nav
-          class="c26 c27"
+          class="c23 c24"
         >
           <a
             aria-label="Home"
-            class="c28"
+            class="c25"
             href="/"
           >
             <span
-              class="c29"
+              class="c26"
             >
               <span
-                class="c30"
+                class="c27"
               >
                 <img
                   alt=""
-                  class="c31"
+                  class="c28"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4540,40 +4536,40 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c11 c32"
+            class="c8 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
             <div
-              class="c11"
+              class="c8"
             >
               <ul
-                class="c33"
+                class="c30"
               >
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4582,29 +4578,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4613,29 +4609,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4644,29 +4640,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4675,38 +4671,38 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4721,24 +4717,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c11 c40"
+              class="c8 c37"
             >
               <form
                 action="/teachers/search"
-                class="c41"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c42"
+                  class="c39"
                 >
                   <div
-                    class="c43 c44 c45"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c46"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4746,32 +4742,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c44"
                 >
                   <div
-                    class="c48 c49 c50"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c51 c52"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c11 c53"
+                        class="c8 c50"
                       >
                         <div
-                          class="c54 c55 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c56 shadow"
+                            class="c53 shadow"
                           />
                           <span
-                            class="c24"
+                            class="c21"
                             data-icon-for="button"
                           >
                             <img
                               alt=""
-                              class="c57"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4781,7 +4777,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c58"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4789,32 +4785,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c59"
+                class="c56"
               >
                 <div
-                  class="c48 c49 c50"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c54 c55 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c56 shadow"
+                          class="c53 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c57"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4824,7 +4820,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4832,19 +4828,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c60 c61"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c62 c63 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c64"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4853,29 +4849,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c65"
+                    class="c62"
                   >
                     My library
                   </div>
                 </div>
               </a>
               <div
-                class="c6 c7"
+                class="c3 c4"
               >
                 <div
-                  class="c8 grey-shadow"
+                  class="c5 grey-shadow"
                 />
                 <div
-                  class="c8 yellow-shadow"
+                  class="c5 yellow-shadow"
                 />
                 <button
-                  class="c66 c67 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c11 c37"
+                    class="c8 c34"
                   >
                     <span
-                      class="c38"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4885,32 +4881,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c69 c10 internal-button"
+                class="c66 c7 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c11 c53"
+                  class="c8 c50"
                 >
                   <span
-                    class="c24"
+                    class="c21"
                   >
                     <img
                       alt=""
-                      class="c39"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4919,7 +4915,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                   </span>
                   <span
-                    class="c13"
+                    class="c10"
                   />
                 </div>
               </button>
@@ -4928,45 +4924,45 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c70 c4"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c71"
+          class="c68"
         >
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c73 c74"
+              class="c70 c71"
             >
               <div
-                class="c11 c75"
+                class="c8 c72"
               >
                 <h1
-                  class="c76"
+                  class="c73"
                 >
                   <span
-                    class="c77"
+                    class="c74"
                   >
                     About Oak
                   </span>
                 </h1>
                 <p
-                  class="c78"
+                  class="c75"
                 >
                   We create free resources for teachers.
                 </p>
               </div>
               <div
-                class="c11 c79"
+                class="c8 c76"
               >
                 <span
-                  class="c80"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4980,14 +4976,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c81 c49 c82"
+            class="c78 c46 c79"
           >
             <div
-              class="c83 c84"
+              class="c80 c81"
             >
               <img
                 alt=""
-                class="c85"
+                class="c82"
                 data-nimg="1"
                 decoding="async"
                 height="300"
@@ -4999,44 +4995,44 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </div>
             <div
-              class="c86 c87"
+              class="c83 c84"
             >
               <p
-                class="c88"
+                class="c85"
               >
                 Oak National Academy was created in response to the pandemic.
               </p>
             </div>
           </div>
           <div
-            class="c89"
+            class="c86"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c90 c91"
+                class="c87 c88"
               >
                 <div
-                  class="c11 c92"
+                  class="c8 c89"
                 >
                   <div
-                    class="c11 c49 c93"
+                    class="c8 c46 c90"
                   >
                     <div
-                      class="c11 c94"
+                      class="c8 c91"
                     >
                       <div
-                        class="c95"
+                        class="c92"
                       >
                         <span
-                          class="c77"
+                          class="c74"
                         >
                           Oak’s story
                         </span>
                       </div>
                       <h2
-                        class="c96"
+                        class="c93"
                       >
                         As teaching evolves, so do we...
                       </h2>
@@ -5044,50 +5040,50 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c11 c92"
+                  class="c8 c89"
                 >
                   <div
-                    class="c11 c49 c97"
+                    class="c8 c46 c94"
                   >
                     <div
-                      class="c11 c98"
+                      class="c8 c95"
                     >
                       <div
-                        class="c11 c99"
+                        class="c8 c96"
                         data-testid="timetable-timeline-item"
                       >
                         <div
-                          class="c100 c101"
+                          class="c97 c98"
                         >
                           <div
-                            class="c102 c103"
+                            class="c99 c100"
                           />
                           <div
-                            class="c104 c84"
+                            class="c101 c81"
                           />
                         </div>
                         <div
-                          class="c105 c94"
+                          class="c102 c91"
                         >
                           <div
-                            class="c106"
+                            class="c103"
                           >
                             <span
-                              class="c77"
+                              class="c74"
                             >
                               Oak is born
                             </span>
                           </div>
                           <h3
-                            class="c107"
+                            class="c104"
                           >
                             2020
                           </h3>
                           <div
-                            class="c108 c98"
+                            class="c105 c95"
                           >
                             <p
-                              class="c109 c110"
+                              class="c106 c107"
                             >
                               Oak launched during lockdown.
                             </p>
@@ -5101,32 +5097,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c72"
+            class="c69"
           >
             <div
-              class="c111 c112"
+              class="c108 c109"
             >
               <h2
-                class="c113"
+                class="c110"
               >
                 We are...
               </h2>
               <div
-                class="c11 c114"
+                class="c8 c111"
               >
                 <div
-                  class="c11 c49 c115 c116"
+                  class="c8 c46 c112 c113"
                   data-testid="who-we-are-desc-item"
                 >
                   <div
-                    class="c11 c75"
+                    class="c8 c72"
                   >
                     <div
-                      class="c117"
+                      class="c114"
                     >
                       <img
                         alt=""
-                        class="c118"
+                        class="c115"
                         data-nimg="1"
                         decoding="async"
                         height="300"
@@ -5138,15 +5134,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       />
                     </div>
                     <div
-                      class="c11 c119"
+                      class="c8 c116"
                     >
                       <h3
-                        class="c120"
+                        class="c117"
                       >
                         Free
                       </h3>
                       <p
-                        class="c121"
+                        class="c118"
                       >
                         All our resources are free.
                       </p>
@@ -5157,19 +5153,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c122"
+            class="c119"
             style="margin-top: -72px;"
           >
             <div
-              class="c123"
+              class="c120"
             >
               <span
-                class="c124"
+                class="c121"
                 style="pointer-events: none;"
               >
                 <img
                   alt=""
-                  class="c25"
+                  class="c22"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -5178,13 +5174,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c72"
+                class="c69"
               >
                 <div
-                  class="c125 c112"
+                  class="c122 c109"
                 >
                   <h2
-                    class="c126"
+                    class="c123"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5193,31 +5189,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c127"
+                      class="c124"
                     >
                       <li
-                        class="c128"
+                        class="c125"
                       >
                         <div
-                          class="c129 c130"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c131 c132 c133"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c134"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5227,19 +5223,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c135 c84"
+                                class="c132 c81"
                               >
                                 About Oak
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c136"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5253,28 +5249,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c128"
+                        class="c125"
                       >
                         <div
-                          class="c129 c130"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c131 c132 c133"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c134"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5284,19 +5280,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c135 c84"
+                                class="c132 c81"
                               >
                                 Oak's curricula
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c136"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5310,28 +5306,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c128"
+                        class="c125"
                       >
                         <div
-                          class="c129 c130"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c131 c132 c133"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c134"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5341,19 +5337,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c135 c84"
+                                class="c132 c81"
                               >
                                 Meet the team
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c136"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5367,28 +5363,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c128"
+                        class="c125"
                       >
                         <div
-                          class="c129 c130"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c131 c132 c133"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c134"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5398,19 +5394,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c135 c84"
+                                class="c132 c81"
                               >
                                 Get involved
                               </div>
                               <div
-                                class="c11 c49"
+                                class="c8 c46"
                               >
                                 <span
-                                  class="c136"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c25"
+                                    class="c22"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5430,33 +5426,33 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c137"
+            class="c134"
             id="newsletter-signup"
           >
             <div
-              class="c72"
+              class="c69"
             >
               <div
-                class="c11 c49 c138"
+                class="c8 c46 c135"
               >
                 <div
-                  class="c139 c4"
+                  class="c136 c1"
                 >
                   <div
-                    class="c11 c140"
+                    class="c8 c137"
                   >
                     <div
-                      class="c11 c49 c141"
+                      class="c8 c46 c138"
                     >
                       <div
-                        class="c142 c143"
+                        class="c139 c140"
                       >
                         <span
-                          class="c144"
+                          class="c141"
                         >
                           <img
                             alt=""
-                            class="c25"
+                            class="c22"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5465,24 +5461,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c145"
+                          class="c142"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c146"
+                        class="c143"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
                         Join over 100k teachers and get free resources and other helpful content by email. Unsubscribe at any time. Read our
                          
                         <a
-                          class="c28"
+                          class="c25"
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             privacy policy
                           </span>
@@ -5491,27 +5487,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c147 c49 c141"
+                      class="c144 c46 c138"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c148"
+                        class="c145"
                         novalidate=""
                       >
                         <div
-                          class="c149 c150 c151"
+                          class="c146 c147 c148"
                         >
                           <div
-                            class="c152 "
+                            class="c149 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5536,7 +5532,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5561,7 +5557,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5586,7 +5582,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5611,23 +5607,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c154 "
+                              class="c151 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c155 c156 c157"
+                                class="c152 c153 c154"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
                                 id="react-use-id-test-result-newsletter-signup-name-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Name
                                    
                                   <span
-                                    class="c158"
+                                    class="c155"
                                   >
                                     (required)
                                   </span>
@@ -5638,7 +5634,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c159 c160"
+                              class="c156 c157"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5646,7 +5642,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c161 c162 c163"
+                              class="c158 c159 c160"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5659,19 +5655,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c149 c150 c151"
+                          class="c146 c147 c148"
                         >
                           <div
-                            class="c152 "
+                            class="c149 "
                           >
                             <div
                               aria-hidden="true"
-                              class="c11"
+                              class="c8"
                               data-testid="brush-borders"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5696,7 +5692,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5721,7 +5717,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5746,7 +5742,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c153"
+                                class="c150"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5771,23 +5767,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c154 "
+                              class="c151 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c155 c156 c157"
+                                class="c152 c153 c154"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
                                 id="react-use-id-test-result-newsletter-signup-email-label"
                               >
                                 <span
-                                  class="c29"
+                                  class="c26"
                                 >
                                   Email
                                    
                                   <span
-                                    class="c158"
+                                    class="c155"
                                   >
                                     (required)
                                   </span>
@@ -5798,7 +5794,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c159 c160"
+                              class="c156 c157"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5806,7 +5802,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c161 c162 c163"
+                              class="c158 c159 c160"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5819,16 +5815,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c164 c98 c165"
+                          class="c161 c95 c162"
                         >
                           <div
                             aria-hidden="true"
-                            class="c11"
+                            class="c8"
                             data-testid="brush-borders"
                           >
                             <svg
                               aria-hidden="true"
-                              class="c153"
+                              class="c150"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5853,7 +5849,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c153"
+                              class="c150"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5878,7 +5874,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c153"
+                              class="c150"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5903,7 +5899,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c153"
+                              class="c150"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5929,7 +5925,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c161 c162 c163 c166"
+                            class="c158 c159 c160 c163"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5940,10 +5936,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c167 c49"
+                            class="c164 c46"
                           >
                             <label
-                              class="c155 c156 c157"
+                              class="c152 c153 c154"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5955,16 +5951,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c168 c169"
+                            class="c165 c166"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c170 c44 c171"
+                              class="c167 c41 c168"
                             >
                               <span
-                                class="c172 c173"
+                                class="c169 c170"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5973,11 +5969,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c24"
+                              class="c21"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5988,22 +5984,22 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c174 c7"
+                          class="c171 c4"
                         >
                           <div
-                            class="c8 grey-shadow"
+                            class="c5 grey-shadow"
                           />
                           <div
-                            class="c8 yellow-shadow"
+                            class="c5 yellow-shadow"
                           />
                           <button
-                            class="c175 c23 internal-button"
+                            class="c172 c20 internal-button"
                           >
                             <div
-                              class="c11 c12"
+                              class="c8 c9"
                             >
                               <span
-                                class="c13"
+                                class="c10"
                               >
                                 Sign up to the newsletter
                               </span>
@@ -6012,12 +6008,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c176"
+                          class="c173"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c177"
+                          class="c174"
                         />
                       </form>
                     </div>
@@ -6029,14 +6025,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c178"
+        class="c175"
       >
         <div
-          class="c179 c49"
+          class="c176 c46"
         >
           <svg
             aria-hidden="true"
-            class="c180"
+            class="c177"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6059,37 +6055,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c181 c182"
+            class="c178 c179"
           >
             <div
-              class="c11 c140"
+              class="c8 c137"
             >
               <div
-                class="c11 c49 c183"
+                class="c8 c46 c180"
               >
                 <div
-                  class="c184 c98"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c185"
+                    class="c182"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c186 c187"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/pupils/years"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Learn online
                           </span>
@@ -6099,72 +6095,72 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c190"
+                  class="c187"
                 />
                 <div
-                  class="c184 c98"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c185"
+                    class="c182"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c186 c187"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             EYFS
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/lesson-planning"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Plan a lesson
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c191"
+                            class="c188"
                           >
                             <span
-                              class="c136 c192 c193"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6176,14 +6172,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/blog"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Blog
                           </span>
@@ -6194,115 +6190,115 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c183"
+                class="c8 c46 c180"
               >
                 <div
-                  class="c184 c98"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c185"
+                    class="c182"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c186 c187"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Home
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/about-us/who-we-are"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             About us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Oak's curricula
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/about-us/get-involved"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Get involved
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/about-us/meet-the-team"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Meet the team
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c189 "
+                          class="c186 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Careers
                           </span>
                           <div
-                            class="c191"
+                            class="c188"
                           >
                             <span
-                              class="c136 c192 c193"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6314,42 +6310,42 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/contact-us"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Contact us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c189 "
+                          class="c186 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Help
                           </span>
                           <div
-                            class="c191"
+                            class="c188"
                           >
                             <span
-                              class="c136 c192 c193"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6361,42 +6357,42 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/webinars"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Webinars
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c189 "
+                          class="c186 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Status
                           </span>
                           <div
-                            class="c191"
+                            class="c188"
                           >
                             <span
-                              class="c136 c192 c193"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6412,156 +6408,156 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c183"
+                class="c8 c46 c180"
               >
                 <div
-                  class="c184 c98"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c185"
+                    class="c182"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c186 c187"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Terms & conditions
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Privacy policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/cookie-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Cookie policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <button
-                          class="c189 "
+                          class="c186 "
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Manage cookie settings
                           </span>
                         </button>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/copyright-notice"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Copyright notice
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/accessibility-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Accessibility statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Safeguarding statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Physical activity disclaimer
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/complaints"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Complaints
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c188"
+                        class="c185"
                       >
                         <a
-                          class="c189 "
+                          class="c186 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Freedom of information requests
                           </span>
@@ -6572,20 +6568,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c183"
+                class="c8 c46 c180"
               >
                 <div
-                  class="c184 c194"
+                  class="c181 c191"
                 >
                   <div
-                    class="c42"
+                    class="c39"
                   >
                     <span
-                      class="c195"
+                      class="c192"
                     >
                       <img
                         alt=""
-                        class="c31"
+                        class="c28"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6595,32 +6591,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c196 c197"
+                    class="c193 c194"
                   >
                     <div
-                      class="c48 c49 c198 c199"
+                      class="c45 c46 c195 c196"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c200 c55 icon-container"
+                            class="c197 c52 icon-container"
                           >
                             <div
-                              class="c201 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6630,35 +6626,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c198 c199"
+                      class="c45 c46 c195 c196"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c200 c55 icon-container"
+                            class="c197 c52 icon-container"
                           >
                             <div
-                              class="c201 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6668,35 +6664,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c198 c199"
+                      class="c45 c46 c195 c196"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c200 c55 icon-container"
+                            class="c197 c52 icon-container"
                           >
                             <div
-                              class="c201 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6706,7 +6702,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6716,12 +6712,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c202 c203"
+              class="c199 c200"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c31"
+                class="c28"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6732,35 +6728,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c204 c205"
+              class="c201 c202"
             >
               <div
-                class="c206 c207"
+                class="c203 c204"
               >
                 <div
-                  class="c48 c49 c198 c199"
+                  class="c45 c46 c195 c196"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c200 c55 icon-container"
+                        class="c197 c52 icon-container"
                       >
                         <div
-                          class="c201 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6770,35 +6766,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c198 c199"
+                  class="c45 c46 c195 c196"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c200 c55 icon-container"
+                        class="c197 c52 icon-container"
                       >
                         <div
-                          class="c201 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6808,35 +6804,35 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c198 c199"
+                  class="c45 c46 c195 c196"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c200 c55 icon-container"
+                        class="c197 c52 icon-container"
                       >
                         <div
-                          class="c201 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6846,21 +6842,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c59"
+                class="c56"
               >
                 <span
-                  class="c195"
+                  class="c192"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -6870,15 +6866,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c184 c98"
+                class="c181 c95"
               >
                 <p
-                  class="c208"
+                  class="c205"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c209"
+                  class="c206"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6887,11 +6883,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c210"
+          class="c207"
         >
           <img
             alt=""
-            class="c211"
+            class="c208"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6900,11 +6896,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c212"
+          class="c209"
         >
           <img
             alt=""
-            class="c213"
+            class="c210"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6914,6 +6910,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </span>
       </footer>
     </div>
+    <div
+      aria-live="polite"
+      class="c211 c212 c213"
+    />
   </div>
   <div
     class="c214"
@@ -6940,10 +6940,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c221"
+            class="c8 c221"
           >
             <div
-              class="c222 c44"
+              class="c222 c41"
             >
               <button
                 class="c223"
@@ -6951,29 +6951,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 type="button"
               >
                 <span
-                  class="c29"
+                  class="c26"
                 >
                   Reject non-essential cookies
                 </span>
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c9 c10 internal-button"
+                class="c6 c7 internal-button"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Cookie settings
                   </span>
@@ -6981,23 +6981,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c224 c23 internal-button"
+                class="c224 c20 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Accept all cookies
                   </span>

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -2,21 +2,11 @@
 
 exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c2 {
   position: absolute;
   top: 5.75rem;
   left: 1.5rem;
@@ -27,7 +17,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 1;
 }
 
-.c6 {
+.c3 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -36,7 +26,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,16 +35,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c11 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   position: absolute;
   top: 10rem;
   left: 1.5rem;
@@ -62,7 +52,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 1;
 }
 
-.c16 {
+.c13 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 1rem;
@@ -71,14 +61,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c15 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c21 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -88,7 +78,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   max-height: 5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -100,7 +90,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
@@ -109,19 +99,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -142,17 +132,17 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c43:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c47 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -160,7 +150,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -171,7 +161,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -180,12 +170,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -205,7 +195,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c64 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -215,22 +205,22 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c71 {
+.c68 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -239,18 +229,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c72 {
+.c69 {
   padding-top: 1.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c70 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c74 {
   overflow: hidden;
   min-width: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -259,7 +249,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c78 {
+.c75 {
   position: relative;
   width: 1.25rem;
   min-width: 1.25rem;
@@ -269,20 +259,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c76 {
   padding-top: 2.5rem;
   padding-bottom: 3.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c82 {
   padding-left: 0rem;
   padding-right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -293,14 +283,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c91 {
+.c88 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   background: #ffe555;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c92 {
+.c89 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -311,7 +301,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c94 {
+.c91 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -323,7 +313,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c100 {
+.c97 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -333,13 +323,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 0;
 }
 
-.c101 {
+.c98 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c103 {
+.c100 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -351,12 +341,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c107 {
+.c104 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c107 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -368,18 +358,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c113 {
+.c110 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c114 {
+.c111 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c115 {
+.c112 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -389,7 +379,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c119 {
+.c116 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -398,7 +388,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c117 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -406,7 +396,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c121 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -417,7 +407,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c122 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -428,14 +418,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c123 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c125 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -443,12 +433,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c127 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c131 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -466,7 +456,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c136 {
+.c133 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -482,6 +472,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   transform: translate(0%,32%);
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
+}
+
+.c135 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c138 {
@@ -538,28 +538,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c12 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -578,7 +563,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c17 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -590,7 +575,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -602,7 +587,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -621,7 +606,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c37 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -640,7 +625,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c40 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -652,7 +637,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c44 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -663,14 +648,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c53 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -689,7 +674,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c55 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,7 +689,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: center;
 }
 
-.c63 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,7 +705,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c108 {
+.c105 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -730,14 +715,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c81 {
+.c78 {
   display: none;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
 }
 
-.c83 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -747,7 +732,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   order: 2;
 }
 
-.c86 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -758,7 +743,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c87 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -769,7 +754,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c97 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -777,7 +762,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c104 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -795,7 +780,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c118 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -806,7 +791,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: left;
 }
 
-.c121 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -822,7 +807,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c129 {
+.c126 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -840,7 +825,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c131 {
+.c128 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -851,6 +836,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   gap: 1rem;
+}
+
+.c136 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c142 {
@@ -890,7 +890,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -902,7 +902,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   text-align: left;
 }
 
-.c21 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -914,11 +914,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   text-align: left;
 }
 
-.c29 {
+.c26 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -930,7 +930,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   text-align: left;
 }
 
-.c58 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -952,7 +952,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c102 {
+.c99 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -961,7 +961,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c9 {
+.c6 {
   background: none;
   color: inherit;
   border: none;
@@ -984,12 +984,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c9:disabled {
+.c6:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c17 {
   background: none;
   color: inherit;
   border: none;
@@ -1015,12 +1015,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c20:disabled {
+.c17:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -1046,12 +1046,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-bottom-right-radius: 0rem;
 }
 
-.c22:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c35 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1074,12 +1074,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c35:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c51 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1093,12 +1093,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c51:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c60 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1111,12 +1111,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1146,12 +1146,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c66:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c69 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1175,12 +1175,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-style: none;
 }
 
-.c69:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c98 {
+.c95 {
   background: none;
   color: inherit;
   border: none;
@@ -1203,7 +1203,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c98:disabled {
+.c95:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1236,35 +1236,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c25 {
+.c22 {
   object-fit: contain;
 }
 
-.c39 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c57 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c135 {
+.c132 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c137 {
+.c134 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c31 {
+.c28 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1273,13 +1273,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c10 {
+.c7 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c10:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -1287,37 +1287,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c10:hover [data-state="selected"] {
+.c7:hover [data-state="selected"] {
   display: none;
 }
 
-.c10:active {
+.c7:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c10:active [data-state="selected"] {
+.c7:active [data-state="selected"] {
   display: none;
 }
 
-.c10:disabled {
+.c7:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c10:disabled [data-state="selected"] {
+.c7:disabled [data-state="selected"] {
   display: none;
 }
 
-.c23 {
+.c20 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c23:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -1325,37 +1325,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c23:hover [data-state="selected"] {
+.c20:hover [data-state="selected"] {
   display: none;
 }
 
-.c23:active {
+.c20:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c23:active [data-state="selected"] {
+.c20:active [data-state="selected"] {
   display: none;
 }
 
-.c23:disabled {
+.c20:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c23:disabled [data-state="selected"] {
+.c20:disabled [data-state="selected"] {
   display: none;
 }
 
-.c36 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c36:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1363,37 +1363,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c36:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c36:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c36:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c36:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c36:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c67 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c67:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1401,37 +1401,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c67:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c67:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c67:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c67:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c67:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c99 {
+.c96 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c99:hover {
+.c96:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1439,148 +1439,148 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c99:hover [data-state="selected"] {
+.c96:hover [data-state="selected"] {
   display: none;
 }
 
-.c99:active {
+.c96:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c99:active [data-state="selected"] {
+.c96:active [data-state="selected"] {
   display: none;
 }
 
-.c99:disabled {
+.c96:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c99:disabled [data-state="selected"] {
+.c96:disabled [data-state="selected"] {
   display: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c4 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c4 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:hover),
-.c7 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c4 .yellow-shadow:has(+ .internal-button:hover),
+.c4 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:hover) {
+.c4 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c7 .grey-shadow:has(+ * + .internal-button:active) {
+.c4 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 .yellow-shadow:has(+ .internal-button:active) {
+.c4 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c16 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c16 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c16 .yellow-shadow:has(+ .internal-button:hover),
+.c16 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c16 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c16 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c16 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c52 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c52:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c52:active {
+.c49:active {
   color: #222222;
 }
 
-.c52:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c50 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c50 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c50 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c50 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c50 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c122 > :first-child:focus-visible .shadow {
+.c119 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c122 > :first-child:hover .shadow {
+.c119 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c122 > :first-child:active .shadow {
+.c119 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c122 > :first-child:disabled .icon-container {
+.c119 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c122 > :first-child:hover .icon-container {
+.c119 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c122 > :first-child:active .icon-container {
+.c119 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c90 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2.5rem;
@@ -1591,7 +1591,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c109 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1604,7 +1604,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c34 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1612,7 +1612,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c112 {
+.c109 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1621,7 +1621,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c95 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1633,7 +1633,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c132 {
+.c129 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1644,7 +1644,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c133 {
+.c130 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1655,7 +1655,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c89 {
+.c86 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1666,7 +1666,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c93 {
+.c90 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1677,7 +1677,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c111 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1688,7 +1688,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c33 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -1709,14 +1709,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c117 {
+.c114 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c28 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1740,47 +1740,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c28 .c116 {
+.c25 .c113 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c28:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c28:visited {
+.c25:visited {
   color: #081676;
 }
 
-.c28:visited .c116 {
+.c25:visited .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28:active {
+.c25:active {
   color: #081676;
   outline: 1px solid #081676;
 }
 
-.c28:active .c116 {
+.c25:active .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
-.c28[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c28[disabled] .c116 {
+.c25[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c76 {
+.c73 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1804,42 +1804,42 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c76 .c116 {
+.c73 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c76:focus-visible {
+.c73:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c76:visited {
+.c73:visited {
   color: #222222;
 }
 
-.c76:visited .c116 {
+.c73:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c76:active {
+.c73:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c76:active .c116 {
+.c73:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c76[disabled] {
+.c73[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c76[disabled] .c116 {
+.c73[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -1877,7 +1877,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c147 .c116 {
+.c147 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -1892,7 +1892,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c147:visited .c116 {
+.c147:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -1902,7 +1902,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c147:active .c116 {
+.c147:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -1912,12 +1912,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #808080;
 }
 
-.c147[disabled] .c116 {
+.c147[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c46 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -1933,49 +1933,49 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   width: 100%;
 }
 
-.c46::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c46::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c46:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c46::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c46::-webkit-search-decoration,
-.c46::-webkit-search-cancel-button,
-.c46::-webkit-search-results-button,
-.c46::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c46:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c45 {
+.c42 {
   background: #ffffff;
 }
 
-.c45:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c45:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c80 {
+.c77 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -1984,13 +1984,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c105 {
+.c102 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c82 {
+.c79 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2002,7 +2002,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c84 {
+.c81 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2014,7 +2014,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c106 {
+.c103 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2023,7 +2023,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c74 {
+.c71 {
   margin: 0rem;
   padding: 0rem;
   list-style: none;
@@ -2043,7 +2043,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-wrap: wrap;
 }
 
-.c75 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2059,40 +2059,46 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   max-width: 100%;
 }
 
-.c61:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c61:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2 {
+.c137 {
   top: 82px;
 }
 
-.c123 .icon-container > *:first-child {
+.c120 .icon-container > *:first-child {
   border: 0;
 }
 
-.c127 {
+.c124 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c96:first-child {
+.c93:first-child {
   margin-top: 0;
 }
 
 @media (min-width:750px) {
-  .c0 {
-    right: 1.5rem;
+  .c13 {
+    padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c13 {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c15 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2100,75 +2106,43 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
-    padding-left: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c0 {
-    padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c16 {
+  .c23 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
-    width: -webkit-max-content;
-    width: -moz-max-content;
-    width: max-content;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-left: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
-    padding-right: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-top: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c23 {
     padding-bottom: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c30 {
+  .c27 {
     height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c41 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2177,19 +2151,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c47 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2197,37 +2171,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c65 {
     display: none;
   }
 }
@@ -2241,61 +2215,61 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c68 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c68 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c76 {
     padding-top: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c76 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c82 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2304,25 +2278,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c89 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2331,25 +2305,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c94 {
+  .c91 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c94 {
+  .c91 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c94 {
+  .c91 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c94 {
+  .c91 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2358,43 +2332,43 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c100 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c100 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c104 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c110 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c117 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c125 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c127 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2403,13 +2377,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c131 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c131 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -2417,7 +2391,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c134 {
+  .c131 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -2425,8 +2399,34 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c133 {
     display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c135 {
+    right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c135 {
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+  }
+}
+
+@media (min-width:750px) {
+  .c135 {
+    padding-left: 0rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c135 {
+    padding-right: 0rem;
   }
 }
 
@@ -2482,16 +2482,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c17 {
+  .c14 {
     -webkit-box-pack: left;
     -webkit-justify-content: left;
     -ms-flex-pack: left;
@@ -2500,19 +2491,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c40 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -2529,13 +2520,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c78 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c115 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -2544,13 +2535,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c118 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c126 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2558,7 +2549,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c126 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2567,7 +2558,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c126 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -2576,11 +2567,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c128 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c136 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -2661,43 +2661,43 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2706,7 +2706,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c18 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2742,49 +2742,49 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c17 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c19 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c87 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2793,25 +2793,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2820,31 +2820,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c92 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c86 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c86 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c86 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c86 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2853,25 +2853,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c90 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2880,8 +2880,8 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (hover:hover) {
-  .c28:hover,
-  .c28:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2889,16 +2889,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c28:hover .c116,
-  .c28:visited:hover .c116 {
+  .c25:hover .c113,
+  .c25:visited:hover .c113 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c76:hover,
-  .c76:visited:hover {
+  .c73:hover,
+  .c73:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2906,8 +2906,8 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c76:hover .c116,
-  .c76:visited:hover .c116 {
+  .c73:hover .c113,
+  .c73:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -2923,47 +2923,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c147:hover .c116,
-  .c147:visited:hover .c116 {
+  .c147:hover .c113,
+  .c147:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c46 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c45:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c80 {
+  .c77 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c79 {
     grid-column: span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c81 {
     grid-column: span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c103 {
     grid-column: span 3;
   }
 }
@@ -2972,10 +2972,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   <div
     data-overlay-container="true"
   >
-    <div
-      aria-live="polite"
-      class="c0 c1 c2"
-    />
     <fake-head>
       <title>
         Ed Southall - Meet the Team | NEXT_PUBLIC_SEO_APP_NAME
@@ -3039,31 +3035,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
       </script>
     </fake-head>
     <div
-      class="c3 c4"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c2"
       >
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 grey-shadow"
+            class="c5 grey-shadow"
           />
           <div
-            class="c8 yellow-shadow"
+            class="c5 yellow-shadow"
           />
           <a
-            class="c9 c10 internal-button"
+            class="c6 c7 internal-button"
             data-testid="skip-link"
             href="#main"
             style="position: absolute; left: -10000px;"
           >
             <div
-              class="c11 c12"
+              class="c8 c9"
             >
               <span
-                class="c13"
+                class="c10"
               >
                 Skip to content
               </span>
@@ -3072,32 +3068,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </div>
       </div>
       <header
-        class="c14"
+        class="c11"
         data-testid="app-topnav"
       >
         <div
-          class="c15"
+          class="c12"
         >
           <div
-            class="c6 c7"
+            class="c3 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
-              class="c9 c10 internal-button"
+              class="c6 c7 internal-button"
               data-testid="skip-link"
               href="#main"
               style="position: absolute; left: -10000px;"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c13"
+                  class="c10"
                 >
                   Skip to content
                 </span>
@@ -3106,27 +3102,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </div>
         <div
-          class="c16 c17"
+          class="c13 c14"
         >
           <div
-            class="c18 c19"
+            class="c15 c16"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="true"
-              class="c20 c10 internal-button"
+              class="c17 c7 internal-button"
               href="/"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Teachers
                 </span>
@@ -3134,34 +3130,34 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </a>
           </div>
           <div
-            class="c18 c7"
+            class="c15 c4"
           >
             <div
-              class="c8 grey-shadow"
+              class="c5 grey-shadow"
             />
             <div
-              class="c8 yellow-shadow"
+              class="c5 yellow-shadow"
             />
             <a
               aria-current="false"
-              class="c22 c23 internal-button"
+              class="c19 c20 internal-button"
               href="/pupils/years"
             >
               <div
-                class="c11 c12"
+                class="c8 c9"
               >
                 <span
-                  class="c21"
+                  class="c18"
                 >
                   Go to 
                   pupils
                 </span>
                 <span
-                  class="c24"
+                  class="c21"
                 >
                   <img
                     alt=""
-                    class="c25"
+                    class="c22"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -3174,22 +3170,22 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </div>
         <nav
-          class="c26 c27"
+          class="c23 c24"
         >
           <a
             aria-label="Home"
-            class="c28"
+            class="c25"
             href="/"
           >
             <span
-              class="c29"
+              class="c26"
             >
               <span
-                class="c30"
+                class="c27"
               >
                 <img
                   alt=""
-                  class="c31"
+                  class="c28"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -3200,40 +3196,40 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c11 c32"
+            class="c8 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
             <div
-              class="c11"
+              class="c8"
             >
               <ul
-                class="c33"
+                class="c30"
               >
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -3242,29 +3238,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -3273,29 +3269,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -3304,29 +3300,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -3335,38 +3331,38 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c34"
+                  class="c31"
                 >
                   <div
-                    class="c6 c19"
+                    class="c3 c16"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c35 c36 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3381,24 +3377,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c11 c40"
+              class="c8 c37"
             >
               <form
                 action="/teachers/search"
-                class="c41"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c42"
+                  class="c39"
                 >
                   <div
-                    class="c43 c44 c45"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c46"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -3406,32 +3402,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c44"
                 >
                   <div
-                    class="c48 c49 c50"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c51 c52"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c11 c53"
+                        class="c8 c50"
                       >
                         <div
-                          class="c54 c55 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c56 shadow"
+                            class="c53 shadow"
                           />
                           <span
-                            class="c24"
+                            class="c21"
                             data-icon-for="button"
                           >
                             <img
                               alt=""
-                              class="c57"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -3441,7 +3437,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c58"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -3449,32 +3445,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c59"
+                class="c56"
               >
                 <div
-                  class="c48 c49 c50"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c54 c55 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c56 shadow"
+                          class="c53 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c57"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3484,7 +3480,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -3492,19 +3488,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c60 c61"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c62 c63 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c64"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3513,29 +3509,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c65"
+                    class="c62"
                   >
                     My library
                   </div>
                 </div>
               </a>
               <div
-                class="c6 c7"
+                class="c3 c4"
               >
                 <div
-                  class="c8 grey-shadow"
+                  class="c5 grey-shadow"
                 />
                 <div
-                  class="c8 yellow-shadow"
+                  class="c5 yellow-shadow"
                 />
                 <button
-                  class="c66 c67 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c11 c37"
+                    class="c8 c34"
                   >
                     <span
-                      class="c38"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -3545,32 +3541,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c69 c10 internal-button"
+                class="c66 c7 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c11 c53"
+                  class="c8 c50"
                 >
                   <span
-                    class="c24"
+                    class="c21"
                   >
                     <img
                       alt=""
-                      class="c39"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3579,7 +3575,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <span
-                    class="c13"
+                    class="c10"
                   />
                 </div>
               </button>
@@ -3588,35 +3584,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c70 c4"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c71"
+          class="c68"
         >
           <div
-            class="c72 c49"
+            class="c69 c46"
           >
             <nav
               aria-label="Breadcrumb"
-              class="c73"
+              class="c70"
             >
               <ul
-                class="c74"
+                class="c71"
               >
                 <li
-                  class="c75"
+                  class="c72"
                 >
                   <a
-                    class="c76"
+                    class="c73"
                     href="/"
                     style="overflow: hidden;"
                   >
                     <span
-                      class="c29"
+                      class="c26"
                     >
                       <div
-                        class="c77"
+                        class="c74"
                       >
                         Home
                       </div>
@@ -3624,14 +3620,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c75"
+                  class="c72"
                 >
                   <span
-                    class="c78"
+                    class="c75"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3640,15 +3636,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <a
-                    class="c76"
+                    class="c73"
                     href="/about-us/meet-the-team"
                     style="overflow: hidden;"
                   >
                     <span
-                      class="c29"
+                      class="c26"
                     >
                       <div
-                        class="c77"
+                        class="c74"
                       >
                         Meet the team
                       </div>
@@ -3656,14 +3652,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c75"
+                  class="c72"
                 >
                   <span
-                    class="c78"
+                    class="c75"
                   >
                     <img
                       alt=""
-                      class="c25"
+                      class="c22"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3673,7 +3669,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </span>
                   <div
                     aria-current="page"
-                    class="c77"
+                    class="c74"
                   >
                     Ed Southall
                   </div>
@@ -3682,79 +3678,79 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </nav>
           </div>
           <div
-            class="c79 c80"
+            class="c76 c77"
           >
             <div
-              class="c42 c81 c82"
+              class="c39 c78 c79"
             />
             <div
-              class="c11 c83 c84"
+              class="c8 c80 c81"
             >
               <div
-                class="c85 c86"
+                class="c82 c83"
               >
                 <div
-                  class="c11 c86"
+                  class="c8 c83"
                 >
                   <div
-                    class="c11 c87"
+                    class="c8 c84"
                   >
                     <div
-                      class="c88 c89"
+                      class="c85 c86"
                     >
                       Our leadership
                     </div>
                     <h1
-                      class="c90"
+                      class="c87"
                     >
                       Ed Southall
                     </h1>
                   </div>
                   <div
-                    class="c91"
+                    class="c88"
                   >
                     <div
-                      class="c92 c93"
+                      class="c89 c90"
                     >
                       Subject Lead (maths)
                     </div>
                   </div>
                 </div>
                 <div
-                  class="c94"
+                  class="c91"
                 >
                   <p
-                    class="c95 c96"
+                    class="c92 c93"
                   >
                     Test bio text
                   </p>
                 </div>
                 <nav
                   aria-label="Team member navigation"
-                  class="c11 c97"
+                  class="c8 c94"
                 >
                   <div
-                    class="c6 c7"
+                    class="c3 c4"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
-                      class="c98 c99 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/previous-member?section=leadership"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3763,7 +3759,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           />
                         </span>
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Previous profile
                         </span>
@@ -3771,32 +3767,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     </a>
                   </div>
                   <div
-                    class="c6 c7"
+                    class="c3 c4"
                   >
                     <div
-                      class="c8 grey-shadow"
+                      class="c5 grey-shadow"
                     />
                     <div
-                      class="c8 yellow-shadow"
+                      class="c5 yellow-shadow"
                     />
                     <a
-                      class="c98 c99 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/next-member?section=board"
                     >
                       <div
-                        class="c11 c37"
+                        class="c8 c34"
                       >
                         <span
-                          class="c38"
+                          class="c35"
                         >
                           Next profile
                         </span>
                         <span
-                          class="c24"
+                          class="c21"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3814,14 +3810,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c100"
+        class="c97"
       >
         <div
-          class="c101 c49"
+          class="c98 c46"
         >
           <svg
             aria-hidden="true"
-            class="c102"
+            class="c99"
             height="100%"
             name="header-underline"
             width="100%"
@@ -3844,37 +3840,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c103 c104"
+            class="c100 c101"
           >
             <div
-              class="c11 c105"
+              class="c8 c102"
             >
               <div
-                class="c11 c49 c106"
+                class="c8 c46 c103"
               >
                 <div
-                  class="c107 c108"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c109"
+                    class="c106"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c110 c111"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/pupils/years"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Learn online
                           </span>
@@ -3884,72 +3880,72 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c113"
+                  class="c110"
                 />
                 <div
-                  class="c107 c108"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c109"
+                    class="c106"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c110 c111"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             EYFS
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/lesson-planning"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Plan a lesson
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c114"
+                            class="c111"
                           >
                             <span
-                              class="c115 c116 c117"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -3961,14 +3957,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/blog"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Blog
                           </span>
@@ -3979,115 +3975,115 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c106"
+                class="c8 c46 c103"
               >
                 <div
-                  class="c107 c108"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c109"
+                    class="c106"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c110 c111"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Home
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/about-us/who-we-are"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             About us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Oak's curricula
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/about-us/get-involved"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Get involved
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/about-us/meet-the-team"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Meet the team
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c76 "
+                          class="c73 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Careers
                           </span>
                           <div
-                            class="c114"
+                            class="c111"
                           >
                             <span
-                              class="c115 c116 c117"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4099,42 +4095,42 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/contact-us"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Contact us
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c76 "
+                          class="c73 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Help
                           </span>
                           <div
-                            class="c114"
+                            class="c111"
                           >
                             <span
-                              class="c115 c116 c117"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4146,42 +4142,42 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/webinars"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Webinars
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c76 "
+                          class="c73 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Status
                           </span>
                           <div
-                            class="c114"
+                            class="c111"
                           >
                             <span
-                              class="c115 c116 c117"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c25"
+                                class="c22"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4197,156 +4193,156 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c106"
+                class="c8 c46 c103"
               >
                 <div
-                  class="c107 c108"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c109"
+                    class="c106"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c110 c111"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Terms & conditions
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/privacy-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Privacy policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/cookie-policy"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Cookie policy
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <button
-                          class="c76 "
+                          class="c73 "
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Manage cookie settings
                           </span>
                         </button>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/copyright-notice"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Copyright notice
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/accessibility-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Accessibility statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Safeguarding statement
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Physical activity disclaimer
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/complaints"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Complaints
                           </span>
                         </a>
                       </li>
                       <li
-                        class="c112"
+                        class="c109"
                       >
                         <a
-                          class="c76 "
+                          class="c73 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
-                            class="c29"
+                            class="c26"
                           >
                             Freedom of information requests
                           </span>
@@ -4357,20 +4353,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c11 c49 c106"
+                class="c8 c46 c103"
               >
                 <div
-                  class="c107 c118"
+                  class="c104 c115"
                 >
                   <div
-                    class="c42"
+                    class="c39"
                   >
                     <span
-                      class="c119"
+                      class="c116"
                     >
                       <img
                         alt=""
-                        class="c31"
+                        class="c28"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -4380,32 +4376,32 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c120 c121"
+                    class="c117 c118"
                   >
                     <div
-                      class="c48 c49 c122 c123"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c124 c55 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c125 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4415,35 +4411,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c122 c123"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c124 c55 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c125 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4453,35 +4449,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c122 c123"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c51 c52"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c11 c53"
+                          class="c8 c50"
                         >
                           <div
-                            class="c124 c55 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c125 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c24"
+                              class="c21"
                               data-icon-for="button"
                             >
                               <img
                                 alt=""
-                                class="c39"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4491,7 +4487,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c58"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -4501,12 +4497,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c126 c127"
+              class="c123 c124"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c31"
+                class="c28"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -4517,35 +4513,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               />
             </span>
             <div
-              class="c128 c129"
+              class="c125 c126"
             >
               <div
-                class="c130 c131"
+                class="c127 c128"
               >
                 <div
-                  class="c48 c49 c122 c123"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c124 c55 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c125 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4555,35 +4551,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c122 c123"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c124 c55 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c125 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4593,35 +4589,35 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c122 c123"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c51 c52"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c11 c53"
+                      class="c8 c50"
                     >
                       <div
-                        class="c124 c55 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c125 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c24"
+                          class="c21"
                           data-icon-for="button"
                         >
                           <img
                             alt=""
-                            class="c39"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4631,21 +4627,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c58"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c59"
+                class="c56"
               >
                 <span
-                  class="c119"
+                  class="c116"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c28"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4655,15 +4651,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c107 c108"
+                class="c104 c105"
               >
                 <p
-                  class="c132"
+                  class="c129"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c133"
+                  class="c130"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -4672,11 +4668,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c134"
+          class="c131"
         >
           <img
             alt=""
-            class="c135"
+            class="c132"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4685,11 +4681,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           />
         </span>
         <span
-          class="c136"
+          class="c133"
         >
           <img
             alt=""
-            class="c137"
+            class="c134"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4699,6 +4695,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </span>
       </footer>
     </div>
+    <div
+      aria-live="polite"
+      class="c135 c136 c137"
+    />
   </div>
   <div
     class="c138"
@@ -4725,10 +4725,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c145"
+            class="c8 c145"
           >
             <div
-              class="c146 c44"
+              class="c146 c41"
             >
               <button
                 class="c147"
@@ -4736,29 +4736,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 type="button"
               >
                 <span
-                  class="c29"
+                  class="c26"
                 >
                   Reject non-essential cookies
                 </span>
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c9 c10 internal-button"
+                class="c6 c7 internal-button"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Cookie settings
                   </span>
@@ -4766,23 +4766,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </button>
             </div>
             <div
-              class="c6 c7"
+              class="c3 c4"
             >
               <div
-                class="c8 grey-shadow"
+                class="c5 grey-shadow"
               />
               <div
-                class="c8 yellow-shadow"
+                class="c5 yellow-shadow"
               />
               <button
-                class="c148 c23 internal-button"
+                class="c148 c20 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div
-                  class="c11 c12"
+                  class="c8 c9"
                 >
                   <span
-                    class="c13"
+                    class="c10"
                   >
                     Accept all cookies
                   </span>

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.test.tsx
@@ -1,8 +1,46 @@
 import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 
 import UnitHeader, { UnitHeaderProps } from "./UnitHeader";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { setUseUserReturn } from "@/__tests__/__helpers__/mockClerk";
+import { mockLoggedIn } from "@/__tests__/__helpers__/mockUser";
+
+const track = {
+  unitDownloadInitiated: jest.fn(),
+};
+jest.mock("@/context/Analytics/useAnalytics", () => ({
+  __esModule: true,
+  default: () => ({ track }),
+}));
+
+const setCurrentToastProps = jest.fn();
+jest.mock("@/context/OakNotifications/useOakNotificationsContext", () => ({
+  useOakNotificationsContext: () => ({ setCurrentToastProps }),
+}));
+
+jest.mock(
+  "@/components/TeacherComponents/hooks/downloadAndShareHooks/useUnitDownloadExistenceCheck",
+  () =>
+    jest.fn(() => ({
+      exists: true,
+      fileSize: "1.2MB",
+      hasCheckedFiles: true,
+    })),
+);
+
+jest.mock(
+  "@/components/SharedComponents/helpers/downloadAndShareHelpers/createAndClickHiddenDownloadLink",
+  () => jest.fn(),
+);
+
+jest.mock(
+  "@/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink",
+  () => ({
+    createUnitDownloadLink: jest.fn(() => Promise.resolve("mockDownloadUrl")),
+  }),
+);
 
 const render = renderWithProviders();
 
@@ -34,11 +72,72 @@ const defaultProps: UnitHeaderProps = {
   },
 };
 
+const mockAdjacentUnit = {
+  slug: "adjacent-unit",
+  title: "Adjacent unit",
+} as UnitHeaderProps["nextUnit"];
+
 describe("UnitHeader", () => {
+  beforeEach(() => {
+    setUseUserReturn(mockLoggedIn);
+    jest.clearAllMocks();
+  });
+
   it("renders a heading", () => {
     render(<UnitHeader {...defaultProps} />);
 
     const heading = screen.getByRole("heading", { name: defaultProps.heading });
     expect(heading).toBeInTheDocument();
+  });
+
+  it("renders previous and next unit links when adjacent units exist", () => {
+    render(
+      <UnitHeader
+        {...defaultProps}
+        phase="secondary"
+        prevUnit={mockAdjacentUnit}
+        nextUnit={mockAdjacentUnit}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Previous unit" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Next unit" })).toBeInTheDocument();
+  });
+
+  it("renders the download button when a download file id is provided", () => {
+    render(<UnitHeader {...defaultProps} unitDownloadFileId="unit-file-id" />);
+
+    expect(
+      screen.getByRole("button", { name: /Download/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("tracks the download and shows a toast when the download succeeds", async () => {
+    render(
+      <UnitHeader
+        {...defaultProps}
+        unitDownloadFileId="unit-file-id"
+        isGeorestrictedUnit={false}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Download/ }));
+
+    expect(track.unitDownloadInitiated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "owa",
+        componentType: "unit_download_button",
+        unitName: "IT and the world of work",
+      }),
+    );
+    expect(setCurrentToastProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Download started. This may take a few minutes.",
+        variant: "success",
+      }),
+    );
   });
 });

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { OakBox, parseSpacing } from "@oaknational/oak-components";
 import styled from "styled-components";
+import { useRef, useState, useEffect } from "react";
 
 import UnitDownloadButton, {
   useUnitDownloadButtonState,
@@ -45,6 +46,28 @@ const NegativeBorderBox = styled(OakBox)`
   margin-block: -${parseSpacing("spacing-8")};
 `;
 
+function useDetectStuck() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [isStuck, setIsStuck] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(entry ? !entry.isIntersecting : false),
+      { threshold: [0], rootMargin: "0px" },
+    );
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, isStuck };
+}
+
 const UnitHeader = (props: UnitHeaderProps) => {
   const {
     subjectPhaseSlug,
@@ -59,6 +82,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
   } = props;
   const { track } = useAnalytics();
   const { setCurrentToastProps } = useOakNotificationsContext();
+  const { ref, isStuck } = useDetectStuck();
 
   const backgroundColorLevel = phase === "primary" ? 4 : 3;
 
@@ -78,6 +102,8 @@ const UnitHeader = (props: UnitHeaderProps) => {
         backgroundColorLevel={backgroundColorLevel}
       />
       <HeaderNavFooter
+        ref={ref}
+        isStuck={isStuck}
         type="unit"
         title={props.heading}
         backgroundColorLevel={backgroundColorLevel}
@@ -108,6 +134,9 @@ const UnitHeader = (props: UnitHeaderProps) => {
           unitDownloadFileId ? (
             <NegativeBorderBox $width={["100%", "auto"]}>
               <UnitDownloadButton
+                isStuck={isStuck}
+                longTextOnMobile={true}
+                fullWidthOnMobile
                 setDownloadError={setDownloadError}
                 setDownloadInProgress={setDownloadInProgress}
                 setShowDownloadMessage={setShowDownloadMessage}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -105,7 +105,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
         }
         actionButton={
           unitDownloadFileId ? (
-            <NegativeBorderBox>
+            <NegativeBorderBox $width={["100%", "auto"]}>
               <UnitDownloadButton
                 setDownloadError={setDownloadError}
                 setDownloadInProgress={setDownloadInProgress}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -79,6 +79,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
       />
       <HeaderNavFooter
         type="unit"
+        title={props.heading}
         backgroundColorLevel={backgroundColorLevel}
         viewHref={resolveOakHref({
           page: "teacher-programme",

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -2,7 +2,6 @@
 import { OakBox, parseSpacing } from "@oaknational/oak-components";
 import styled from "styled-components";
 import { useRef, useState, useEffect } from "react";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import UnitDownloadButton, {
   useUnitDownloadButtonState,
@@ -15,10 +14,7 @@ import { TeachersUnitOverviewAdjacentUnit } from "@/node-lib/curriculum-api-2023
 import { resolveOakHref } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
-import {
-  HeaderNavFooter,
-  StickyHeaderNavFooter,
-} from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
+import { UnitHeaderNavFooter } from "@/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter";
 import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
 
 export type UnitHeaderProps = Omit<
@@ -97,12 +93,6 @@ const UnitHeader = (props: UnitHeaderProps) => {
     downloadInProgress,
     setShowIncompleteMessage,
   } = downloadButtonState;
-  const variant = useFeatureFlagVariantKey("sticky-unit-download-button");
-  const isStickyHeaderExperiement = variant === "test";
-
-  const HeaderFooterComponent = isStickyHeaderExperiement
-    ? StickyHeaderNavFooter
-    : HeaderNavFooter;
 
   return (
     <>
@@ -111,10 +101,9 @@ const UnitHeader = (props: UnitHeaderProps) => {
         layoutVariant="compact"
         backgroundColorLevel={backgroundColorLevel}
       />
-      <HeaderFooterComponent
+      <UnitHeaderNavFooter
         sentinelRef={ref}
         isStuck={isStuck}
-        type="unit"
         title={props.heading}
         backgroundColorLevel={backgroundColorLevel}
         viewHref={resolveOakHref({
@@ -140,7 +129,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
               })
             : undefined
         }
-        actionButton={
+        downloadButton={
           unitDownloadFileId ? (
             <NegativeBorderBox $width={["100%", "auto"]}>
               <UnitDownloadButton

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -1,5 +1,9 @@
 "use client";
-import { OakBox, parseSpacing } from "@oaknational/oak-components";
+import {
+  OakBox,
+  parseSpacing,
+  getMediaQuery,
+} from "@oaknational/oak-components";
 import styled from "styled-components";
 import { useRef, useState, useEffect } from "react";
 
@@ -44,6 +48,10 @@ export type UnitHeaderProps = Omit<
  */
 const NegativeBorderBox = styled(OakBox)`
   margin-block: -${parseSpacing("spacing-8")};
+
+  @media (${getMediaQuery("mobile")}) {
+    margin-block: 0;
+  }
 `;
 
 function useDetectStuck() {

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -97,7 +97,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
     setShowIncompleteMessage,
   } = downloadButtonState;
 
-  const isStickyHeaderExperiement = true;
+  const isStickyHeaderExperiement = false;
 
   const HeaderFooterComponent = isStickyHeaderExperiement
     ? StickyHeaderNavFooter
@@ -111,7 +111,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
         backgroundColorLevel={backgroundColorLevel}
       />
       <HeaderFooterComponent
-        ref={ref}
+        sentinelRef={ref}
         isStuck={isStuck}
         type="unit"
         title={props.heading}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -130,41 +130,45 @@ const UnitHeader = (props: UnitHeaderProps) => {
             : undefined
         }
         downloadButton={
-          unitDownloadFileId ? (
-            <NegativeBorderBox $width={["100%", "auto"]}>
-              <UnitDownloadButton
-                isStuck={isStuck}
-                longTextOnMobile={true}
-                fullWidthOnMobile
-                setDownloadError={setDownloadError}
-                setDownloadInProgress={setDownloadInProgress}
-                setShowDownloadMessage={setShowDownloadMessage}
-                setShowIncompleteMessage={setShowIncompleteMessage}
-                downloadInProgress={downloadInProgress}
-                unitFileId={unitDownloadFileId}
-                onDownloadSuccess={() => {
-                  track.unitDownloadInitiated({
-                    platform: "owa",
-                    product: "teacher lesson resources",
-                    engagementIntent: "use",
-                    componentType: "unit_download_button",
-                    eventVersion: "2.0.0",
-                    analyticsUseCase: "Teacher",
-                    ...trackingProps,
-                  });
-                  setCurrentToastProps({
-                    message: "Download started. This may take a few minutes.",
-                    variant: "success",
-                    autoDismiss: true,
-                    autoDismissDuration: 10000,
-                    showIcon: true,
-                  });
-                }}
-                showNewTag={false}
-                geoRestricted={Boolean(isGeorestrictedUnit)}
-              />
-            </NegativeBorderBox>
-          ) : undefined
+          unitDownloadFileId
+            ? (isStuck: boolean) => (
+                <NegativeBorderBox $width={["100%", "auto"]}>
+                  <UnitDownloadButton
+                    isStuck={isStuck}
+                    longTextOnMobile={true}
+                    fullWidthOnMobile
+                    setDownloadError={setDownloadError}
+                    setDownloadInProgress={setDownloadInProgress}
+                    setShowDownloadMessage={setShowDownloadMessage}
+                    setShowIncompleteMessage={setShowIncompleteMessage}
+                    downloadInProgress={downloadInProgress}
+                    unitFileId={unitDownloadFileId}
+                    onDownloadSuccess={() => {
+                      track.unitDownloadInitiated({
+                        platform: "owa",
+                        product: "teacher lesson resources",
+                        engagementIntent: "use",
+                        componentType: "unit_download_button",
+                        eventVersion: "2.0.0",
+                        analyticsUseCase: "Teacher",
+                        ...trackingProps,
+                      });
+                      setCurrentToastProps({
+                        message:
+                          "Download started. This may take a few minutes.",
+                        variant: "success",
+                        autoDismiss: true,
+                        autoDismissDuration: 10000,
+                        showIcon: true,
+                      });
+                    }}
+                    showNewTag={false}
+                    geoRestricted={Boolean(isGeorestrictedUnit)}
+                    size={isStuck ? "small" : undefined}
+                  />
+                </NegativeBorderBox>
+              )
+            : undefined
         }
       />
     </>

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -97,7 +97,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
     setShowIncompleteMessage,
   } = downloadButtonState;
 
-  const isStickyHeaderExperiement = false;
+  const isStickyHeaderExperiement = true;
 
   const HeaderFooterComponent = isStickyHeaderExperiement
     ? StickyHeaderNavFooter

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -14,7 +14,10 @@ import { TeachersUnitOverviewAdjacentUnit } from "@/node-lib/curriculum-api-2023
 import { resolveOakHref } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
-import HeaderNavFooter from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
+import {
+  HeaderNavFooter,
+  StickyHeaderNavFooter,
+} from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
 import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
 
 export type UnitHeaderProps = Omit<
@@ -94,6 +97,12 @@ const UnitHeader = (props: UnitHeaderProps) => {
     setShowIncompleteMessage,
   } = downloadButtonState;
 
+  const isStickyHeaderExperiement = true;
+
+  const HeaderFooterComponent = isStickyHeaderExperiement
+    ? StickyHeaderNavFooter
+    : HeaderNavFooter;
+
   return (
     <>
       <Header
@@ -101,7 +110,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
         layoutVariant="compact"
         backgroundColorLevel={backgroundColorLevel}
       />
-      <HeaderNavFooter
+      <HeaderFooterComponent
         ref={ref}
         isStuck={isStuck}
         type="unit"

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -2,6 +2,7 @@
 import { OakBox, parseSpacing } from "@oaknational/oak-components";
 import styled from "styled-components";
 import { useRef, useState, useEffect } from "react";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 
 import UnitDownloadButton, {
   useUnitDownloadButtonState,
@@ -96,8 +97,8 @@ const UnitHeader = (props: UnitHeaderProps) => {
     downloadInProgress,
     setShowIncompleteMessage,
   } = downloadButtonState;
-
-  const isStickyHeaderExperiement = true;
+  const variant = useFeatureFlagVariantKey("sticky-unit-download-button");
+  const isStickyHeaderExperiement = variant === "test";
 
   const HeaderFooterComponent = isStickyHeaderExperiement
     ? StickyHeaderNavFooter

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitHeader/UnitHeader.tsx
@@ -102,6 +102,45 @@ const UnitHeader = (props: UnitHeaderProps) => {
     setShowIncompleteMessage,
   } = downloadButtonState;
 
+  const unitDownloadButtonRenderer = unitDownloadFileId
+    ? (isStuck: boolean) => (
+        <NegativeBorderBox $width={["100%", "auto"]}>
+          <UnitDownloadButton
+            isStuck={isStuck}
+            longTextOnMobile={true}
+            fullWidthOnMobile
+            setDownloadError={setDownloadError}
+            setDownloadInProgress={setDownloadInProgress}
+            setShowDownloadMessage={setShowDownloadMessage}
+            setShowIncompleteMessage={setShowIncompleteMessage}
+            downloadInProgress={downloadInProgress}
+            unitFileId={unitDownloadFileId}
+            onDownloadSuccess={() => {
+              track.unitDownloadInitiated({
+                platform: "owa",
+                product: "teacher lesson resources",
+                engagementIntent: "use",
+                componentType: "unit_download_button",
+                eventVersion: "2.0.0",
+                analyticsUseCase: "Teacher",
+                ...trackingProps,
+              });
+              setCurrentToastProps({
+                message: "Download started. This may take a few minutes.",
+                variant: "success",
+                autoDismiss: true,
+                autoDismissDuration: 10000,
+                showIcon: true,
+              });
+            }}
+            showNewTag={false}
+            geoRestricted={Boolean(isGeorestrictedUnit)}
+            size={isStuck ? "small" : undefined}
+          />
+        </NegativeBorderBox>
+      )
+    : undefined;
+
   return (
     <>
       <Header
@@ -137,47 +176,7 @@ const UnitHeader = (props: UnitHeaderProps) => {
               })
             : undefined
         }
-        downloadButton={
-          unitDownloadFileId
-            ? (isStuck: boolean) => (
-                <NegativeBorderBox $width={["100%", "auto"]}>
-                  <UnitDownloadButton
-                    isStuck={isStuck}
-                    longTextOnMobile={true}
-                    fullWidthOnMobile
-                    setDownloadError={setDownloadError}
-                    setDownloadInProgress={setDownloadInProgress}
-                    setShowDownloadMessage={setShowDownloadMessage}
-                    setShowIncompleteMessage={setShowIncompleteMessage}
-                    downloadInProgress={downloadInProgress}
-                    unitFileId={unitDownloadFileId}
-                    onDownloadSuccess={() => {
-                      track.unitDownloadInitiated({
-                        platform: "owa",
-                        product: "teacher lesson resources",
-                        engagementIntent: "use",
-                        componentType: "unit_download_button",
-                        eventVersion: "2.0.0",
-                        analyticsUseCase: "Teacher",
-                        ...trackingProps,
-                      });
-                      setCurrentToastProps({
-                        message:
-                          "Download started. This may take a few minutes.",
-                        variant: "success",
-                        autoDismiss: true,
-                        autoDismissDuration: 10000,
-                        showIcon: true,
-                      });
-                    }}
-                    showNewTag={false}
-                    geoRestricted={Boolean(isGeorestrictedUnit)}
-                    size={isStuck ? "small" : undefined}
-                  />
-                </NegativeBorderBox>
-              )
-            : undefined
-        }
+        downloadButton={unitDownloadButtonRenderer}
       />
     </>
   );

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
@@ -6,7 +6,7 @@ import {
   Header,
   LargeHeaderProps,
 } from "@/components/TeacherComponents/Header/Header";
-import HeaderNavFooter from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
+import { HeaderNavFooter } from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
 import { resolveOakHref } from "@/common-lib/urls";
 import {
   TeachersLessonOverviewAdjacentLesson,

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonHeader/LessonHeader.tsx
@@ -6,7 +6,7 @@ import {
   Header,
   LargeHeaderProps,
 } from "@/components/TeacherComponents/Header/Header";
-import { HeaderNavFooter } from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter";
+import { LessonHeaderNavFooter } from "@/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter";
 import { resolveOakHref } from "@/common-lib/urls";
 import {
   TeachersLessonOverviewAdjacentLesson,
@@ -92,8 +92,7 @@ const LessonHeader = (props: LessonHeaderProps) => {
         backgroundColorLevel={1}
         useSubduedBackground
       />
-      <HeaderNavFooter
-        type="lesson"
+      <LessonHeaderNavFooter
         backgroundColorLevel={1}
         viewHref={resolveOakHref({
           page: "integrated-unit-overview",
@@ -120,7 +119,7 @@ const LessonHeader = (props: LessonHeaderProps) => {
               })
             : undefined
         }
-        actionButton={
+        downloadButton={
           <LoginRequiredButton
             rel="nofollow"
             loginRequired={loginRequired}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
@@ -189,7 +189,7 @@ export function DownloadSuccessView({
                   buttonLabel={
                     <OakSpan>
                       <OakSpan>Download </OakSpan>
-                      <OakBox $display={["none", "inline"]}>
+                      <OakBox $display={["inline", "none", "inline"]}>
                         complete unit
                       </OakBox>
                     </OakSpan>

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
@@ -189,7 +189,7 @@ export function DownloadSuccessView({
                   buttonLabel={
                     <OakSpan>
                       <OakSpan>Download </OakSpan>
-                      <OakBox $display={["inline", "none", "inline"]}>
+                      <OakBox $display={["none", "none", "inline"]}>
                         complete unit
                       </OakBox>
                     </OakSpan>

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -2,16 +2,6 @@
 
 exports[`CurriculumTab renders 1`] = `
 .c0 {
-  position: fixed;
-  right: 0rem;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-  z-index: 1;
-}
-
-.c3 {
   position: relative;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -21,7 +11,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c1 {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -31,7 +21,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c3 {
   width: 100%;
   max-width: 30rem;
   padding-left: 0rem;
@@ -43,17 +33,17 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c5 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c7 {
   width: 40rem;
   padding-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c12 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -64,12 +54,12 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c19 {
+.c16 {
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c20 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
@@ -81,13 +71,13 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c25 {
+.c22 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c23 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -97,18 +87,18 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c27 {
   max-width: 40rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c31 {
+.c28 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c32 {
+.c29 {
   position: relative;
   top: 0.5rem;
   left: 0.5rem;
@@ -136,7 +126,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 298;
 }
 
-.c33 {
+.c30 {
   position: relative;
   border: 0.125rem solid;
   border-color: #222222;
@@ -145,7 +135,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 150;
 }
 
-.c34 {
+.c31 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -153,12 +143,12 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c34 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c36 {
   width: 100%;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0rem;
@@ -167,7 +157,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c40 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -175,7 +165,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c46 {
+.c43 {
   position: relative;
   width: 0.125rem;
   height: 3rem;
@@ -183,12 +173,12 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c45 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c47 {
   width: 100%;
   border-top-left-radius: 0rem;
   border-top-right-radius: 0.25rem;
@@ -197,14 +187,14 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c48 {
   padding-left: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c49 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -216,7 +206,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c53 {
+.c50 {
   position: absolute;
   right: 0rem;
   width: -webkit-fit-content;
@@ -230,7 +220,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 3;
 }
 
-.c55 {
+.c52 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -239,7 +229,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57 {
+.c54 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -248,7 +238,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c59 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -258,16 +248,26 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c65 {
   max-width: 60rem;
   padding-top: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c66 {
+  position: fixed;
+  right: 0rem;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  z-index: 1;
 }
 
 .c69 {
@@ -316,22 +316,7 @@ exports[`CurriculumTab renders 1`] = `
   white-space: nowrap;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.c7 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -345,11 +330,22 @@ exports[`CurriculumTab renders 1`] = `
   flex-grow: 1;
 }
 
-.c9 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .c11 {
@@ -360,20 +356,9 @@ exports[`CurriculumTab renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  gap: 1.5rem;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c20 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -384,7 +369,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 1.5rem;
 }
 
-.c35 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -403,7 +388,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0rem;
 }
 
-.c36 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -421,7 +406,7 @@ exports[`CurriculumTab renders 1`] = `
   justify-content: flex-start;
 }
 
-.c38 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -431,7 +416,7 @@ exports[`CurriculumTab renders 1`] = `
   align-self: stretch;
 }
 
-.c49 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -442,14 +427,14 @@ exports[`CurriculumTab renders 1`] = `
   gap: 1rem;
 }
 
-.c54 {
+.c51 {
   display: none;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.c60 {
+.c57 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -468,7 +453,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0.5rem;
 }
 
-.c65 {
+.c62 {
   display: none;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
@@ -487,7 +472,7 @@ exports[`CurriculumTab renders 1`] = `
   flex-grow: 1;
 }
 
-.c66 {
+.c63 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -496,6 +481,21 @@ exports[`CurriculumTab renders 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.c67 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .c73 {
@@ -546,11 +546,11 @@ exports[`CurriculumTab renders 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c19 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c41 {
   color: #222222;
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -563,7 +563,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c58 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -586,7 +586,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c58 {
+.c55 {
   background: none;
   color: inherit;
   border: none;
@@ -609,7 +609,7 @@ exports[`CurriculumTab renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c58:disabled {
+.c55:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -642,29 +642,29 @@ exports[`CurriculumTab renders 1`] = `
   cursor: default;
 }
 
-.c5 {
+.c2 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(23%) saturate(120%) hue-rotate(71deg) brightness(112%) contrast(97%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(23%) saturate(120%) hue-rotate(71deg) brightness(112%) contrast(97%);
   object-fit: contain;
 }
 
-.c29 {
+.c26 {
   object-fit: contain;
 }
 
-.c63 {
+.c60 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c59 {
+.c56 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c59:hover {
+.c56:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -672,27 +672,27 @@ exports[`CurriculumTab renders 1`] = `
   border-color: #575757;
 }
 
-.c59:hover [data-state="selected"] {
+.c56:hover [data-state="selected"] {
   display: none;
 }
 
-.c59:active {
+.c56:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c59:active [data-state="selected"] {
+.c56:active [data-state="selected"] {
   display: none;
 }
 
-.c59:disabled {
+.c56:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c59:disabled [data-state="selected"] {
+.c56:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -734,32 +734,32 @@ exports[`CurriculumTab renders 1`] = `
   display: none;
 }
 
-.c56 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c53 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c56 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c53 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c56 .yellow-shadow:has(+ .internal-button:hover),
-.c56 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c53 .yellow-shadow:has(+ .internal-button:hover),
+.c53 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c56 .grey-shadow:has(+ * + .internal-button:hover) {
+.c53 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c56 .grey-shadow:has(+ * + .internal-button:active) {
+.c53 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c56 .yellow-shadow:has(+ .internal-button:active) {
+.c53 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c12 {
+.c9 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -771,7 +771,7 @@ exports[`CurriculumTab renders 1`] = `
   color: #222222;
 }
 
-.c13 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -782,7 +782,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c18 {
+.c15 {
   margin-top: 1rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -791,7 +791,7 @@ exports[`CurriculumTab renders 1`] = `
   display: revert;
 }
 
-.c45 {
+.c42 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -803,7 +803,7 @@ exports[`CurriculumTab renders 1`] = `
   color: #222222;
 }
 
-.c16 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -814,7 +814,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c24 {
+.c21 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -825,7 +825,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c17 {
+.c14 {
   margin: 0;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -838,14 +838,14 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c28 {
+.c25 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
   min-height: 1.25em;
 }
 
-.c21 {
+.c18 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -869,42 +869,42 @@ exports[`CurriculumTab renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c21 .c27 {
+.c18 .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c21:focus-visible {
+.c18:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c21:visited {
+.c18:visited {
   color: #222222;
 }
 
-.c21:visited .c27 {
+.c18:visited .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c21:active {
+.c18:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c21:active .c27 {
+.c18:active .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c21[disabled] {
+.c18[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c21[disabled] .c27 {
+.c18[disabled] .c24 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -942,7 +942,7 @@ exports[`CurriculumTab renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c79 .c27 {
+.c79 .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
@@ -957,7 +957,7 @@ exports[`CurriculumTab renders 1`] = `
   color: #222222;
 }
 
-.c79:visited .c27 {
+.c79:visited .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -967,7 +967,7 @@ exports[`CurriculumTab renders 1`] = `
   outline: 1px solid #222222;
 }
 
-.c79:active .c27 {
+.c79:active .c24 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
@@ -977,33 +977,33 @@ exports[`CurriculumTab renders 1`] = `
   color: #808080;
 }
 
-.c79[disabled] .c27 {
+.c79[disabled] .c24 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c40 {
+.c37 {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c40:has(a:hover,button:hover) {
+.c37:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c40:has( a, button) {
+.c37:has( a, button) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c40:has( a, button)  a,
-.c40:has( a, button) button {
+.c37:has( a, button)  a,
+.c37:has( a, button) button {
   outline: none;
 }
 
-.c40:has(a:active,button:active) {
+.c37:has(a:active,button:active) {
   box-shadow: none;
 }
 
-.c67 {
+.c64 {
   object-fit: contain;
   width: 100%;
   height: auto;
@@ -1014,23 +1014,23 @@ exports[`CurriculumTab renders 1`] = `
   transform: none;
 }
 
-.c67::-webkit-scrollbar-track {
+.c64::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c67::-webkit-scrollbar {
+.c64::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c67::-webkit-scrollbar-thumb {
+.c64::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c47 {
+.c44 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -1043,15 +1043,15 @@ exports[`CurriculumTab renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c2 {
+.c68 {
   top: 82px;
 }
 
-.c41 {
+.c38 {
   box-shadow: none;
 }
 
-.c42 {
+.c39 {
   background: none;
   width: 100%;
   border: none;
@@ -1066,13 +1066,145 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c1 {
+    display: none;
+  }
+}
+
+@media (min-width:1280px) {
+  .c1 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+  .c3 {
+    max-width: 80rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c3 {
+    padding-left: 0.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c3 {
+    padding-right: 0.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c27 {
+    display: none;
+  }
+}
+
+@media (min-width:1280px) {
+  .c27 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+  .c36 {
+    border-top-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c36 {
+    border-top-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c36 {
+    border-bottom-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c36 {
+    border-bottom-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c47 {
+    border-top-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c47 {
+    border-top-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c47 {
+    border-bottom-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c47 {
+    border-bottom-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c50 {
+    max-width: 10rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c50 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+  .c61 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:1280px) {
+  .c61 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c65 {
+    display: block;
+  }
+}
+
+@media (min-width:1280px) {
+  .c65 {
+    display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c66 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c66 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -1080,146 +1212,14 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c66 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c66 {
     padding-right: 0rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c4 {
-    display: none;
-  }
-}
-
-@media (min-width:1280px) {
-  .c4 {
-    display: block;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    max-width: 80rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    padding-left: 0.75rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    padding-right: 0.75rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c30 {
-    display: none;
-  }
-}
-
-@media (min-width:1280px) {
-  .c30 {
-    display: block;
-  }
-}
-
-@media (min-width:750px) {
-  .c39 {
-    border-top-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c39 {
-    border-top-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c39 {
-    border-bottom-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c39 {
-    border-bottom-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c50 {
-    border-top-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c50 {
-    border-top-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c50 {
-    border-bottom-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c50 {
-    border-bottom-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c53 {
-    max-width: 10rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c53 {
-    display: block;
-  }
-}
-
-@media (min-width:750px) {
-  .c64 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:1280px) {
-  .c64 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:750px) {
-  .c68 {
-    display: block;
-  }
-}
-
-@media (min-width:1280px) {
-  .c68 {
-    display: none;
   }
 }
 
@@ -1275,16 +1275,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
-    -webkit-align-items: flex-end;
-    -webkit-box-align: flex-end;
-    -ms-flex-align: flex-end;
-    align-items: flex-end;
-  }
-}
-
-@media (min-width:750px) {
-  .c35 {
+  .c32 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1292,13 +1283,13 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c54 {
+  .c51 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c62 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1307,11 +1298,20 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c62 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
+  }
+}
+
+@media (min-width:750px) {
+  .c67 {
+    -webkit-align-items: flex-end;
+    -webkit-box-align: flex-end;
+    -ms-flex-align: flex-end;
+    align-items: flex-end;
   }
 }
 
@@ -1419,43 +1419,43 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c10 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c13 {
+  .c10 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c10 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c13 {
+  .c10 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c10 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c13 {
+  .c10 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c10 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -1464,7 +1464,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c13 {
+  .c10 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -1473,8 +1473,8 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (hover:hover) {
-  .c21:hover,
-  .c21:visited:hover {
+  .c18:hover,
+  .c18:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -1482,8 +1482,8 @@ exports[`CurriculumTab renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c21:hover .c27,
-  .c21:visited:hover .c27 {
+  .c18:hover .c24,
+  .c18:visited:hover .c24 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -1499,15 +1499,15 @@ exports[`CurriculumTab renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c79:hover .c27,
-  .c79:visited:hover .c27 {
+  .c79:hover .c24,
+  .c79:visited:hover .c24 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (min-width:750px) {
-  .c67 {
+  .c64 {
     -webkit-transform: none;
     -ms-transform: none;
     transform: none;
@@ -1515,7 +1515,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c67 {
+  .c64 {
     -webkit-transform: rotate(-2deg);
     -ms-transform: rotate(-2deg);
     transform: rotate(-2deg);
@@ -1528,11 +1528,7 @@ exports[`CurriculumTab renders 1`] = `
       data-overlay-container="true"
     >
       <div
-        aria-live="polite"
-        class="c0 c1 c2"
-      />
-      <div
-        class="c3"
+        class="c0"
       >
         <div
           style="position: absolute; inset: 0; overflow: hidden; pointer-events: none;"
@@ -1541,11 +1537,11 @@ exports[`CurriculumTab renders 1`] = `
             style="position: absolute; bottom: 18px; right: calc(-40rem + 50vw - 200px); width: 529px; height: 420px;"
           >
             <span
-              class="c4"
+              class="c1"
             >
               <img
                 alt=""
-                class="c5"
+                class="c2"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -1556,78 +1552,78 @@ exports[`CurriculumTab renders 1`] = `
           </div>
         </div>
         <div
-          class="c6 c7"
+          class="c3 c4"
         >
           <div
-            class="c8 c9"
+            class="c5 c6"
           >
             <div
-              class="c10 c11"
+              class="c7 c8"
             >
               <h1
-                class="c12"
+                class="c9"
               >
                 Teachers & subject leads
               </h1>
               <h2
-                class="c13"
+                class="c10"
               >
                 Curriculum plans
               </h2>
               <div
-                class="c8 c14"
+                class="c5 c11"
               >
                  
                 <div
-                  class="c15 c16"
+                  class="c12 c13"
                 >
                   All of our curriculum plans are:
                 </div>
                 <ul
-                  class="c17"
+                  class="c14"
                 >
                   <li
-                    class="c18"
+                    class="c15"
                   >
                     National curriculum-aligned
                   </li>
                   <li
-                    class="c18"
+                    class="c15"
                   >
                     Sequenced across year groups
                   </li>
                   <li
-                    class="c18"
+                    class="c15"
                   >
                     Designed by curriculum experts
                   </li>
                 </ul>
               </div>
               <div
-                class="c19 c20"
+                class="c16 c17"
               >
                 <a
-                  class="c21 "
+                  class="c18 "
                   href="/teachers/curriculum"
                 >
                   <span
-                    class="c22"
+                    class="c19"
                   >
                     <span
-                      class="c23 c24"
+                      class="c20 c21"
                     >
                       Our curriculum planning approach
                     </span>
                   </span>
                   <div
-                    class="c25"
+                    class="c22"
                   >
                     <span
-                      class="c26 c27 c28"
+                      class="c23 c24 c25"
                     >
                       <img
                         alt=""
-                        class="c29"
+                        class="c26"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -1639,52 +1635,52 @@ exports[`CurriculumTab renders 1`] = `
                 </a>
               </div>
               <div
-                class="c30"
+                class="c27"
               >
                 <nav
                   aria-labelledby="choose-curriculum-label-large"
-                  class="c31"
+                  class="c28"
                 >
                   <div
-                    class="c32"
+                    class="c29"
                     id="choose-curriculum-label-large"
                   >
                     Choose a curriculum
                   </div>
                   <div
-                    class="c33"
+                    class="c30"
                     data-testid="lot-picker"
                   >
                     <div
-                      class="c34 c35"
+                      class="c31 c32"
                     >
                       <div
-                        class="c31 c36"
+                        class="c28 c33"
                       >
                         <div
-                          class="c37 c38"
+                          class="c34 c35"
                           style="width: 50%;"
                         >
                           <div
-                            class="c39 c40 c41"
+                            class="c36 c37 c38"
                           >
                             <button
                               aria-expanded="false"
-                              class="c42"
+                              class="c39"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
                               <div
-                                class="c43"
+                                class="c40"
                               >
                                 <span
-                                  class="c44"
+                                  class="c41"
                                   data-testid="subject-picker-button-heading"
                                 >
                                   Subject
                                 </span>
                                 <p
-                                  class="c45"
+                                  class="c42"
                                 >
                                   Select
                                 </p>
@@ -1693,16 +1689,16 @@ exports[`CurriculumTab renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c46"
+                          class="c43"
                         >
                           <div
                             aria-hidden="true"
-                            class="c8"
+                            class="c5"
                             data-testid="brush-borders"
                           >
                             <svg
                               aria-hidden="true"
-                              class="c47"
+                              class="c44"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -1728,32 +1724,32 @@ exports[`CurriculumTab renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c48"
+                          class="c45"
                           style="width: 50%;"
                         >
                           <div
-                            class="c37 c49"
+                            class="c34 c46"
                           >
                             <div
-                              class="c50 c40 c41"
+                              class="c47 c37 c38"
                             >
                               <button
                                 aria-expanded="false"
-                                class="c42"
+                                class="c39"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
                                 <div
-                                  class="c51"
+                                  class="c48"
                                 >
                                   <span
-                                    class="c44"
+                                    class="c41"
                                     data-testid="phase-picker-button-heading"
                                   >
                                     School phase
                                   </span>
                                   <div
-                                    class="c52"
+                                    class="c49"
                                   >
                                     Select
                                   </div>
@@ -1761,35 +1757,35 @@ exports[`CurriculumTab renders 1`] = `
                               </button>
                             </div>
                             <div
-                              class="c53 c54"
+                              class="c50 c51"
                             >
                               <div
-                                class="c55 c56"
+                                class="c52 c53"
                               >
                                 <div
-                                  class="c57 grey-shadow"
+                                  class="c54 grey-shadow"
                                 />
                                 <div
-                                  class="c57 yellow-shadow"
+                                  class="c54 yellow-shadow"
                                 />
                                 <button
-                                  class="c58 c59 internal-button"
+                                  class="c55 c56 internal-button"
                                   data-testid="lot-picker-view-curriculum-button"
                                 >
                                   <div
-                                    class="c8 c60"
+                                    class="c5 c57"
                                   >
                                     <span
-                                      class="c61"
+                                      class="c58"
                                     >
                                       View
                                     </span>
                                     <span
-                                      class="c62"
+                                      class="c59"
                                     >
                                       <img
                                         alt=""
-                                        class="c63"
+                                        class="c60"
                                         data-nimg="fill"
                                         decoding="async"
                                         loading="lazy"
@@ -1810,14 +1806,14 @@ exports[`CurriculumTab renders 1`] = `
               </div>
             </div>
             <div
-              class="c64 c65"
+              class="c61 c62"
             >
               <div
-                class="c8 c66"
+                class="c5 c63"
               >
                 <img
                   alt=""
-                  class="c67"
+                  class="c64"
                   data-nimg="1"
                   decoding="async"
                   height="628"
@@ -1830,52 +1826,52 @@ exports[`CurriculumTab renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c65"
           >
             <nav
               aria-labelledby="choose-curriculum-label-small"
-              class="c31"
+              class="c28"
             >
               <div
-                class="c32"
+                class="c29"
                 id="choose-curriculum-label-small"
               >
                 Choose a curriculum
               </div>
               <div
-                class="c33"
+                class="c30"
                 data-testid="lot-picker"
               >
                 <div
-                  class="c34 c35"
+                  class="c31 c32"
                 >
                   <div
-                    class="c31 c36"
+                    class="c28 c33"
                   >
                     <div
-                      class="c37 c38"
+                      class="c34 c35"
                       style="width: 50%;"
                     >
                       <div
-                        class="c39 c40 c41"
+                        class="c36 c37 c38"
                       >
                         <button
                           aria-expanded="false"
-                          class="c42"
+                          class="c39"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
                           <div
-                            class="c43"
+                            class="c40"
                           >
                             <span
-                              class="c44"
+                              class="c41"
                               data-testid="subject-picker-button-heading"
                             >
                               Subject
                             </span>
                             <p
-                              class="c45"
+                              class="c42"
                             >
                               Select
                             </p>
@@ -1884,16 +1880,16 @@ exports[`CurriculumTab renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c46"
+                      class="c43"
                     >
                       <div
                         aria-hidden="true"
-                        class="c8"
+                        class="c5"
                         data-testid="brush-borders"
                       >
                         <svg
                           aria-hidden="true"
-                          class="c47"
+                          class="c44"
                           height="100%"
                           name="box-border-left"
                           style="width: 3px;"
@@ -1919,32 +1915,32 @@ exports[`CurriculumTab renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c48"
+                      class="c45"
                       style="width: 50%;"
                     >
                       <div
-                        class="c37 c49"
+                        class="c34 c46"
                       >
                         <div
-                          class="c50 c40 c41"
+                          class="c47 c37 c38"
                         >
                           <button
                             aria-expanded="false"
-                            class="c42"
+                            class="c39"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >
                             <div
-                              class="c51"
+                              class="c48"
                             >
                               <span
-                                class="c44"
+                                class="c41"
                                 data-testid="phase-picker-button-heading"
                               >
                                 School phase
                               </span>
                               <div
-                                class="c52"
+                                class="c49"
                               >
                                 Select
                               </div>
@@ -1952,35 +1948,35 @@ exports[`CurriculumTab renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c53 c54"
+                          class="c50 c51"
                         >
                           <div
-                            class="c55 c56"
+                            class="c52 c53"
                           >
                             <div
-                              class="c57 grey-shadow"
+                              class="c54 grey-shadow"
                             />
                             <div
-                              class="c57 yellow-shadow"
+                              class="c54 yellow-shadow"
                             />
                             <button
-                              class="c58 c59 internal-button"
+                              class="c55 c56 internal-button"
                               data-testid="lot-picker-view-curriculum-button"
                             >
                               <div
-                                class="c8 c60"
+                                class="c5 c57"
                               >
                                 <span
-                                  class="c61"
+                                  class="c58"
                                 >
                                   View
                                 </span>
                                 <span
-                                  class="c62"
+                                  class="c59"
                                 >
                                   <img
                                     alt=""
-                                    class="c63"
+                                    class="c60"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -2001,6 +1997,10 @@ exports[`CurriculumTab renders 1`] = `
           </div>
         </div>
       </div>
+      <div
+        aria-live="polite"
+        class="c66 c67 c68"
+      />
     </div>
     <div
       class="c69"
@@ -2027,7 +2027,7 @@ exports[`CurriculumTab renders 1`] = `
               Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
             </div>
             <div
-              class="c8 c76"
+              class="c5 c76"
             >
               <div
                 class="c77 c78"
@@ -2038,29 +2038,29 @@ exports[`CurriculumTab renders 1`] = `
                   type="button"
                 >
                   <span
-                    class="c22"
+                    class="c19"
                   >
                     Reject non-essential cookies
                   </span>
                 </button>
               </div>
               <div
-                class="c55 c56"
+                class="c52 c53"
               >
                 <div
-                  class="c57 grey-shadow"
+                  class="c54 grey-shadow"
                 />
                 <div
-                  class="c57 yellow-shadow"
+                  class="c54 yellow-shadow"
                 />
                 <button
                   class="c80 c81 internal-button"
                 >
                   <div
-                    class="c8 c60"
+                    class="c5 c57"
                   >
                     <span
-                      class="c61"
+                      class="c58"
                     >
                       Cookie settings
                     </span>
@@ -2068,23 +2068,23 @@ exports[`CurriculumTab renders 1`] = `
                 </button>
               </div>
               <div
-                class="c55 c56"
+                class="c52 c53"
               >
                 <div
-                  class="c57 grey-shadow"
+                  class="c54 grey-shadow"
                 />
                 <div
-                  class="c57 yellow-shadow"
+                  class="c54 yellow-shadow"
                 />
                 <button
-                  class="c58 c59 internal-button"
+                  class="c55 c56 internal-button"
                   data-testid="cookie-banner-accept"
                 >
                   <div
-                    class="c8 c60"
+                    class="c5 c57"
                   >
                     <span
-                      class="c61"
+                      class="c58"
                     >
                       Accept all cookies
                     </span>

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.stories.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.stories.tsx
@@ -6,7 +6,7 @@ import {
   OakThemeProvider,
 } from "@oaknational/oak-components";
 
-import HeaderNavFooter from "./HeaderNavFooter";
+import { HeaderNavFooter } from "./HeaderNavFooter";
 
 const meta: Meta<typeof HeaderNavFooter> = {
   component: HeaderNavFooter,

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.test.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/dom";
 
-import HeaderNavFooter, { HeaderNavFooterProps } from "./HeaderNavFooter";
+import { HeaderNavFooter, HeaderNavFooterProps } from "./HeaderNavFooter";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -15,9 +15,9 @@ export type HeaderNavFooterProps = {
   backgroundColorLevel: 1 | 3 | 4;
   type: "unit" | "lesson";
   viewHref: string;
-  title: string;
-  ref: Ref<HTMLDivElement>;
-  isStuck: boolean;
+  title?: string;
+  sentinelRef?: Ref<HTMLDivElement>;
+  isStuck?: boolean;
   prevHref?: string;
   nextHref?: string;
   actionButton?: React.ReactElement;
@@ -95,11 +95,11 @@ const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
 `;
 
 export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
-  const { ref, isStuck } = props;
+  const { sentinelRef, isStuck } = props;
   return (
     <>
       {/* Sentinel element, for checking when the user has scrolled past this point */}
-      <OakBox ref={ref} $height="spacing-0" />
+      <OakBox ref={sentinelRef} $height="spacing-0" />
       {/**
        * Most of the complexity here comes from having to pin to the bottom
        * of the screen on mobile viewports. position: sticky assumes you're

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -7,6 +7,7 @@ import {
   OakBox,
   OakTertiaryInvertedButton,
 } from "@oaknational/oak-components";
+import { useRef, useState, useEffect } from "react";
 
 export type HeaderNavFooterProps = {
   backgroundColorLevel: 1 | 3 | 4;
@@ -17,9 +18,37 @@ export type HeaderNavFooterProps = {
   viewHref: string;
 };
 
+function useDetectStuck() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [isStuck, setIsStuck] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([event]) => setIsStuck(event ? event.intersectionRatio < 1 : false),
+      { threshold: [1], rootMargin: "-1px 0px 0px 0px" },
+    );
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, isStuck };
+}
+
 const HeaderNavFooter = (props: HeaderNavFooterProps) => {
+  const { ref, isStuck } = useDetectStuck();
+  console.log(isStuck);
   return (
     <OakFlex
+      $zIndex={"in-front"}
+      ref={ref}
+      $position={"sticky"}
+      $top={"spacing-0"}
       $background={`bg-decorative${props.backgroundColorLevel}-subdued`}
       $width={"100%"}
       $pv={"spacing-24"}

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -5,6 +5,7 @@ import {
   OakSmallPrimaryInvertedButton,
   OakIcon,
   OakBox,
+  OakP,
 } from "@oaknational/oak-components";
 import { useRef, useState, useEffect } from "react";
 
@@ -15,6 +16,7 @@ export type HeaderNavFooterProps = {
   nextHref?: string;
   actionButton?: React.ReactElement;
   viewHref: string;
+  title: string;
 };
 
 function useDetectStuck() {
@@ -41,60 +43,81 @@ function useDetectStuck() {
 
 const HeaderNavFooter = (props: HeaderNavFooterProps) => {
   const { ref, isStuck } = useDetectStuck();
-  console.log(isStuck);
+
   return (
     <OakFlex
       $zIndex={"in-front"}
       ref={ref}
       $position={"sticky"}
       $top={"spacing-0"}
-      $background={`bg-decorative${props.backgroundColorLevel}-subdued`}
       $width={"100%"}
-      $pv={"spacing-24"}
-      $ph={["spacing-20", "spacing-40"]}
-      $flexDirection={["column", "row"]}
-      $gap={"spacing-24"}
-      $justifyContent="center"
+      $justifyContent={"center"}
     >
       <OakFlex
-        $justifyContent={"space-between"}
+        $background={
+          isStuck
+            ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
+            : `bg-decorative${props.backgroundColorLevel}-subdued`
+        }
+        $pv={"spacing-24"}
+        $ph={["spacing-20", "spacing-40"]}
+        $flexDirection={["column", "row"]}
+        $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
+        $mh={isStuck ? "spacing-40" : "auto"}
         $width={"100%"}
-        $gap={"spacing-16"}
-        $maxWidth="spacing-1280"
+        $gap={"spacing-24"}
+        $justifyContent="center"
+        $dropShadow={isStuck ? "drop-shadow-standard" : "drop-shadow-none"}
+        $bbr={isStuck ? "border-radius-l" : "border-radius-square"}
       >
-        {props.actionButton}
         <OakFlex
-          as="nav"
-          $display={["none", "flex"]}
-          $gap={"spacing-32"}
-          $alignItems={"center"}
+          $justifyContent={isStuck ? "start" : "space-between"}
+          $width={"100%"}
+          $gap={"spacing-16"}
+          $maxWidth="spacing-1280"
         >
-          <PrevNextButtons $display={"flex"} {...props} />
+          {props.actionButton}
           <OakBox
             $bl={"border-solid-m"}
-            $display={"flex"}
+            $display={isStuck ? ["none", "none", "block"] : "none"}
             $height={"spacing-24"}
             $borderColor={`border-decorative${props.backgroundColorLevel}`}
           />
+          <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
+            <OakP>{props.title}</OakP>
+          </OakBox>
+          <OakFlex
+            as="nav"
+            $display={isStuck ? "none" : ["none", "flex"]}
+            $gap={"spacing-32"}
+            $alignItems={"center"}
+          >
+            <PrevNextButtons $display={"flex"} {...props} />
+            <OakBox
+              $bl={"border-solid-m"}
+              $display={"flex"}
+              $height={"spacing-24"}
+              $borderColor={`border-decorative${props.backgroundColorLevel}`}
+            />
+          </OakFlex>
         </OakFlex>
+
+        <PrevNextButtons
+          $display={isStuck ? "none" : ["flex", "none"]}
+          {...props}
+        />
+        <OakSmallPrimaryInvertedButton
+          $display={isStuck ? "none" : "block"}
+          width={["100%", "auto"]}
+          iconName="list"
+          isTrailingIcon
+          $textWrap={"nowrap"}
+          element="a"
+          href={props.viewHref}
+        >
+          {`View ${props.type === "unit" ? "all units" : "unit"}`}
+        </OakSmallPrimaryInvertedButton>
       </OakFlex>
-      <OakBox
-        $display={["block", "none"]}
-        $bt={"border-solid-m"}
-        $borderColor={`border-decorative${props.backgroundColorLevel}`}
-        $width={"100%"}
-      />
-      <PrevNextButtons $display={["flex", "none"]} {...props} />
-      <OakSmallPrimaryInvertedButton
-        width={["100%", "auto"]}
-        iconName="list"
-        isTrailingIcon
-        $textWrap={"nowrap"}
-        element="a"
-        href={props.viewHref}
-      >
-        {`View ${props.type === "unit" ? "all units" : "unit"}`}
-      </OakSmallPrimaryInvertedButton>
     </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -7,43 +7,22 @@ import {
   OakBox,
   OakP,
 } from "@oaknational/oak-components";
-import { useRef, useState, useEffect } from "react";
+import { Ref } from "react";
 
 export type HeaderNavFooterProps = {
   backgroundColorLevel: 1 | 3 | 4;
   type: "unit" | "lesson";
+  viewHref: string;
+  title: string;
+  ref: Ref<HTMLDivElement>;
+  isStuck: boolean;
   prevHref?: string;
   nextHref?: string;
   actionButton?: React.ReactElement;
-  viewHref: string;
-  title: string;
 };
 
-function useDetectStuck() {
-  const ref = useRef<HTMLDivElement>(null);
-
-  const [isStuck, setIsStuck] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setIsStuck(entry ? !entry.isIntersecting : false),
-      { threshold: [0], rootMargin: "0px" },
-    );
-    observer.observe(ref.current);
-
-    return () => observer.disconnect();
-  }, []);
-
-  return { ref, isStuck };
-}
-
 const HeaderNavFooter = (props: HeaderNavFooterProps) => {
-  const { ref, isStuck } = useDetectStuck();
-
+  const { ref, isStuck } = props;
   return (
     <>
       <OakBox ref={ref} $height="spacing-0" />

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -5,7 +5,6 @@ import {
   OakSmallPrimaryInvertedButton,
   OakIcon,
   OakBox,
-  OakTertiaryInvertedButton,
 } from "@oaknational/oak-components";
 import { useRef, useState, useEffect } from "react";
 
@@ -63,23 +62,21 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
         $gap={"spacing-16"}
         $maxWidth="spacing-1280"
       >
-        <OakFlex as="nav" $gap={"spacing-32"} $alignItems={"center"}>
-          <OakTertiaryInvertedButton
-            iconName="list"
-            element="a"
-            href={props.viewHref}
-          >
-            {`View ${props.type === "unit" ? "all units" : "unit"}`}
-          </OakTertiaryInvertedButton>
+        {props.actionButton}
+        <OakFlex
+          as="nav"
+          $display={["none", "flex"]}
+          $gap={"spacing-32"}
+          $alignItems={"center"}
+        >
+          <PrevNextButtons $display={"flex"} {...props} />
           <OakBox
             $bl={"border-solid-m"}
-            $display={["none", "flex"]}
+            $display={"flex"}
             $height={"spacing-24"}
             $borderColor={`border-decorative${props.backgroundColorLevel}`}
           />
-          <PrevNextButtons $display={["none", "flex"]} {...props} />
         </OakFlex>
-        {props.actionButton}
       </OakFlex>
       <OakBox
         $display={["block", "none"]}
@@ -88,6 +85,16 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
         $width={"100%"}
       />
       <PrevNextButtons $display={["flex", "none"]} {...props} />
+      <OakSmallPrimaryInvertedButton
+        width={["100%", "auto"]}
+        iconName="list"
+        isTrailingIcon
+        $textWrap={"nowrap"}
+        element="a"
+        href={props.viewHref}
+      >
+        {`View ${props.type === "unit" ? "all units" : "unit"}`}
+      </OakSmallPrimaryInvertedButton>
     </OakFlex>
   );
 };
@@ -113,6 +120,7 @@ const PrevNextButtons = ({
     <OakFlex $display={$display} $gap={"spacing-16"}>
       {prevHref && (
         <OakSmallPrimaryInvertedButton
+          width={["100%", "auto"]}
           element="a"
           href={prevHref}
           iconOverride={
@@ -129,6 +137,7 @@ const PrevNextButtons = ({
       )}
       {nextHref && (
         <OakSmallPrimaryInvertedButton
+          width={["100%", "auto"]}
           element="a"
           href={nextHref}
           isTrailingIcon

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -6,8 +6,10 @@ import {
   OakIcon,
   OakBox,
   OakP,
+  OakTertiaryInvertedButton,
 } from "@oaknational/oak-components";
 import { Ref } from "react";
+import styled, { css, keyframes } from "styled-components";
 
 export type HeaderNavFooterProps = {
   backgroundColorLevel: 1 | 3 | 4;
@@ -21,10 +23,82 @@ export type HeaderNavFooterProps = {
   actionButton?: React.ReactElement;
 };
 
-const HeaderNavFooter = (props: HeaderNavFooterProps) => {
+export const HeaderNavFooter = (props: HeaderNavFooterProps) => {
+  return (
+    <OakFlex
+      $background={`bg-decorative${props.backgroundColorLevel}-subdued`}
+      $width={"100%"}
+      $pv={"spacing-24"}
+      $ph={["spacing-20", "spacing-40"]}
+      $flexDirection={["column", "row"]}
+      $gap={"spacing-24"}
+      $justifyContent="center"
+    >
+      <OakFlex
+        $justifyContent={"space-between"}
+        $width={"100%"}
+        $gap={"spacing-16"}
+        $maxWidth="spacing-1280"
+      >
+        <OakFlex as="nav" $gap={"spacing-32"} $alignItems={"center"}>
+          <OakTertiaryInvertedButton
+            iconName="list"
+            element="a"
+            href={props.viewHref}
+          >
+            {`View ${props.type === "unit" ? "all units" : "unit"}`}
+          </OakTertiaryInvertedButton>
+          <OakBox
+            $bl={"border-solid-m"}
+            $display={["none", "flex"]}
+            $height={"spacing-24"}
+            $borderColor={`border-decorative${props.backgroundColorLevel}`}
+          />
+          <PrevNextButtons $display={["none", "flex"]} {...props} />
+        </OakFlex>
+        {props.actionButton}
+      </OakFlex>
+      <OakBox
+        $display={["block", "none"]}
+        $bt={"border-solid-m"}
+        $borderColor={`border-decorative${props.backgroundColorLevel}`}
+        $width={"100%"}
+      />
+      <PrevNextButtons $display={["flex", "none"]} {...props} />
+    </OakFlex>
+  );
+};
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+/**
+ * Fades the bar in when it enters the stuck state. The animation only runs when
+ * $animateIn is true, so it plays on the transition into stuck and not on the
+ * way back out.
+ */
+const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
+  ${(props) =>
+    props.$animateIn &&
+    css`
+      animation: ${fadeIn} 300ms ease-in;
+      @media (prefers-reduced-motion) {
+        animation: none;
+      }
+    `}
+`;
+
+export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
   const { ref, isStuck } = props;
   return (
     <>
+      {/* Sentinel element, for checking when the user has scrolled past this point */}
       <OakBox ref={ref} $height="spacing-0" />
       {/**
        * Most of the complexity here comes from having to pin to the bottom
@@ -33,10 +107,10 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
        *
        * Positioning per breakpoint:
        *
-       * |          | not stuck | stuck            |
-       * | -------- | --------- | ---------------- |
-       * | mobile   | static    | fixed, bottom: 0 |
-       * | tablet+  |     sticky, top: 0           |
+       * |          | not stuck     | stuck            |
+       * | -------- | ---------     | ---------------- |
+       * | mobile   | static        | fixed, bottom: 0 |
+       * | tablet+  | sticky, top: 0| sticky, top: 0   |
        */}
       <OakFlex
         $zIndex={"in-front"}
@@ -47,7 +121,8 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
         $width={"100%"}
         $justifyContent={"center"}
       >
-        <OakFlex
+        <FadeInFlex
+          $animateIn={isStuck}
           $background={
             isStuck
               ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
@@ -111,7 +186,7 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
           >
             {`View ${props.type === "unit" ? "all units" : "unit"}`}
           </OakSmallPrimaryInvertedButton>
-        </OakFlex>
+        </FadeInFlex>
       </OakFlex>
     </>
   );
@@ -174,5 +249,3 @@ const PrevNextButtons = ({
     </OakFlex>
   );
 };
-
-export default HeaderNavFooter;

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooter.tsx
@@ -30,8 +30,8 @@ function useDetectStuck() {
     }
 
     const observer = new IntersectionObserver(
-      ([event]) => setIsStuck(event ? event.intersectionRatio < 1 : false),
-      { threshold: [1], rootMargin: "-1px 0px 0px 0px" },
+      ([entry]) => setIsStuck(entry ? !entry.isIntersecting : false),
+      { threshold: [0], rootMargin: "0px" },
     );
     observer.observe(ref.current);
 
@@ -45,80 +45,96 @@ const HeaderNavFooter = (props: HeaderNavFooterProps) => {
   const { ref, isStuck } = useDetectStuck();
 
   return (
-    <OakFlex
-      $zIndex={"in-front"}
-      ref={ref}
-      $position={"sticky"}
-      $top={"spacing-0"}
-      $width={"100%"}
-      $justifyContent={"center"}
-    >
+    <>
+      <OakBox ref={ref} $height="spacing-0" />
+      {/**
+       * Most of the complexity here comes from having to pin to the bottom
+       * of the screen on mobile viewports. position: sticky assumes you're
+       * pinning to the top.
+       *
+       * Positioning per breakpoint:
+       *
+       * |          | not stuck | stuck            |
+       * | -------- | --------- | ---------------- |
+       * | mobile   | static    | fixed, bottom: 0 |
+       * | tablet+  |     sticky, top: 0           |
+       */}
       <OakFlex
-        $background={
-          isStuck
-            ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
-            : `bg-decorative${props.backgroundColorLevel}-subdued`
-        }
-        $pv={"spacing-24"}
-        $ph={["spacing-20", "spacing-40"]}
-        $flexDirection={["column", "row"]}
-        $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
-        $mh={isStuck ? "spacing-40" : "auto"}
+        $zIndex={"in-front"}
+        $position={[isStuck ? "fixed" : "static", "sticky"]}
+        $bottom={[isStuck ? "spacing-0" : null, null]}
+        $top={[null, "spacing-0"]}
+        $left={[isStuck ? "spacing-0" : null, null]}
         $width={"100%"}
-        $gap={"spacing-24"}
-        $justifyContent="center"
-        $dropShadow={isStuck ? "drop-shadow-standard" : "drop-shadow-none"}
-        $bbr={isStuck ? "border-radius-l" : "border-radius-square"}
+        $justifyContent={"center"}
       >
         <OakFlex
-          $justifyContent={isStuck ? "start" : "space-between"}
+          $background={
+            isStuck
+              ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
+              : `bg-decorative${props.backgroundColorLevel}-subdued`
+          }
+          $pv={"spacing-24"}
+          $ph={["spacing-20", "spacing-40"]}
+          $flexDirection={["column", "row"]}
+          $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
+          $mh={isStuck ? "spacing-40" : "auto"}
           $width={"100%"}
-          $gap={"spacing-16"}
-          $maxWidth="spacing-1280"
+          $gap={"spacing-24"}
+          $justifyContent="center"
+          $dropShadow={isStuck ? "drop-shadow-standard" : "drop-shadow-none"}
+          $bbr={isStuck ? "border-radius-l" : "border-radius-square"}
         >
-          {props.actionButton}
-          <OakBox
-            $bl={"border-solid-m"}
-            $display={isStuck ? ["none", "none", "block"] : "none"}
-            $height={"spacing-24"}
-            $borderColor={`border-decorative${props.backgroundColorLevel}`}
-          />
-          <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
-            <OakP>{props.title}</OakP>
-          </OakBox>
           <OakFlex
-            as="nav"
-            $display={isStuck ? "none" : ["none", "flex"]}
-            $gap={"spacing-32"}
-            $alignItems={"center"}
+            $justifyContent={isStuck ? "start" : "space-between"}
+            $width={"100%"}
+            $gap={"spacing-16"}
+            $maxWidth="spacing-1280"
           >
-            <PrevNextButtons $display={"flex"} {...props} />
+            {props.actionButton}
             <OakBox
               $bl={"border-solid-m"}
-              $display={"flex"}
+              $display={isStuck ? ["none", "none", "block"] : "none"}
               $height={"spacing-24"}
               $borderColor={`border-decorative${props.backgroundColorLevel}`}
             />
+            <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
+              <OakP>{props.title}</OakP>
+            </OakBox>
+            <OakFlex
+              as="nav"
+              $display={isStuck ? "none" : ["none", "flex"]}
+              $gap={"spacing-32"}
+              $alignItems={"center"}
+            >
+              <PrevNextButtons $display={"flex"} {...props} />
+              <OakBox
+                $bl={"border-solid-m"}
+                $display={"flex"}
+                $height={"spacing-24"}
+                $borderColor={`border-decorative${props.backgroundColorLevel}`}
+              />
+            </OakFlex>
           </OakFlex>
-        </OakFlex>
 
-        <PrevNextButtons
-          $display={isStuck ? "none" : ["flex", "none"]}
-          {...props}
-        />
-        <OakSmallPrimaryInvertedButton
-          $display={isStuck ? "none" : "block"}
-          width={["100%", "auto"]}
-          iconName="list"
-          isTrailingIcon
-          $textWrap={"nowrap"}
-          element="a"
-          href={props.viewHref}
-        >
-          {`View ${props.type === "unit" ? "all units" : "unit"}`}
-        </OakSmallPrimaryInvertedButton>
+          <PrevNextButtons
+            $display={isStuck ? "none" : ["flex", "none"]}
+            {...props}
+          />
+          <OakSmallPrimaryInvertedButton
+            $display={isStuck ? "none" : "block"}
+            width={["100%", "auto"]}
+            iconName="list"
+            isTrailingIcon
+            $textWrap={"nowrap"}
+            element="a"
+            href={props.viewHref}
+          >
+            {`View ${props.type === "unit" ? "all units" : "unit"}`}
+          </OakSmallPrimaryInvertedButton>
+        </OakFlex>
       </OakFlex>
-    </OakFlex>
+    </>
   );
 };
 

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared.tsx
@@ -1,0 +1,74 @@
+import {
+  OakFlexProps,
+  OakUiRoleToken,
+  OakFlex,
+  OakSmallPrimaryInvertedButton,
+  OakIcon,
+} from "@oaknational/oak-components";
+
+export type BaseHeaderNavFooterProps = {
+  backgroundColorLevel: 1 | 3 | 4;
+  viewHref: string;
+  prevHref?: string;
+  nextHref?: string;
+  downloadButton?: React.ReactElement;
+};
+
+type PrevNextButtonsProps = {
+  type: "unit" | "lesson";
+  backgroundColorLevel: 1 | 3 | 4;
+  nextHref?: string;
+  prevHref?: string;
+  $display: OakFlexProps["$display"];
+};
+
+export const PrevNextButtons = ({
+  $display,
+  backgroundColorLevel,
+  nextHref,
+  prevHref,
+  type,
+}: PrevNextButtonsProps) => {
+  const iconColor =
+    `icon-decorative${backgroundColorLevel}` satisfies OakUiRoleToken;
+
+  return (
+    <OakFlex $display={$display} $gap={"spacing-16"}>
+      {prevHref && (
+        <OakSmallPrimaryInvertedButton
+          width={["100%", "auto"]}
+          element="a"
+          href={prevHref}
+          iconOverride={
+            <OakIcon
+              iconName="arrow-left"
+              $color={iconColor}
+              $width={"spacing-24"}
+              $height="spacing-24"
+            />
+          }
+        >
+          {"Previous " + type}
+        </OakSmallPrimaryInvertedButton>
+      )}
+      {nextHref && (
+        <OakSmallPrimaryInvertedButton
+          width={["100%", "auto"]}
+          element="a"
+          href={nextHref}
+          isTrailingIcon
+          iconOverride={
+            <OakIcon
+              iconName="arrow-right"
+              $color={iconColor}
+              $width={"spacing-24"}
+              $height="spacing-24"
+            />
+          }
+        >
+          {"Next " + type}
+        </OakSmallPrimaryInvertedButton>
+      )}
+    </OakFlex>
+  );
+};

--- a/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared.tsx
@@ -11,7 +11,7 @@ export type BaseHeaderNavFooterProps = {
   viewHref: string;
   prevHref?: string;
   nextHref?: string;
-  downloadButton?: React.ReactElement;
+  downloadButton?: (isStuck: boolean) => React.ReactElement;
 };
 
 type PrevNextButtonsProps = {

--- a/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.stories.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.stories.tsx
@@ -6,10 +6,10 @@ import {
   OakThemeProvider,
 } from "@oaknational/oak-components";
 
-import { HeaderNavFooter } from "./HeaderNavFooter";
+import { LessonHeaderNavFooter } from "./LessonHeaderNavFooter";
 
-const meta: Meta<typeof HeaderNavFooter> = {
-  component: HeaderNavFooter,
+const meta: Meta<typeof LessonHeaderNavFooter> = {
+  component: LessonHeaderNavFooter,
   tags: ["autodocs"],
   decorators: [
     (Story) => (
@@ -22,7 +22,7 @@ const meta: Meta<typeof HeaderNavFooter> = {
 
 export default meta;
 
-type Story = StoryObj<typeof HeaderNavFooter>;
+type Story = StoryObj<typeof LessonHeaderNavFooter>;
 
 export const Default: Story = {
   args: {
@@ -30,7 +30,6 @@ export const Default: Story = {
     prevHref: "www.google.com",
     nextHref: "www.google.com",
     viewHref: "www.google.com",
-    type: "lesson",
-    actionButton: <OakPrimaryButton>Action</OakPrimaryButton>,
+    downloadButton: <OakPrimaryButton>Action</OakPrimaryButton>,
   },
 };

--- a/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.test.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/dom";
+
+import {
+  LessonHeaderNavFooter,
+  LessonHeaderNavFooterProps,
+} from "./LessonHeaderNavFooter";
+
+import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
+
+const defaultProps: LessonHeaderNavFooterProps = {
+  backgroundColorLevel: 1,
+  viewHref: "testUrl",
+  downloadButton: <button>download</button>,
+};
+
+const render = renderWithTheme;
+
+describe("LessonHeaderNavFooter", () => {
+  it("Renders the correct text for the view href", () => {
+    render(<LessonHeaderNavFooter {...defaultProps} />);
+
+    const viewLink = screen.getByRole("link", { name: "View unit" });
+    expect(viewLink).toBeInTheDocument();
+  });
+  it("Renders previous and next links with correct text", () => {
+    render(
+      <LessonHeaderNavFooter
+        {...defaultProps}
+        prevHref="prevUrl"
+        nextHref="nextUrl"
+      />,
+    );
+
+    const prevLink = screen.getByRole("link", { name: "Previous lesson" });
+    expect(prevLink).toBeInTheDocument();
+
+    const nextLink = screen.getByRole("link", { name: "Next lesson" });
+    expect(nextLink).toBeInTheDocument();
+  });
+  it("renders an action button", () => {
+    render(
+      <LessonHeaderNavFooter
+        {...defaultProps}
+        downloadButton={<button>action button</button>}
+      />,
+    );
+
+    const actionButton = screen.getByRole("button");
+    expect(actionButton).toBeInTheDocument();
+    expect(actionButton).toHaveTextContent("action button");
+  });
+});

--- a/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.tsx
@@ -1,0 +1,64 @@
+import {
+  OakFlex,
+  OakBox,
+  OakTertiaryInvertedButton,
+} from "@oaknational/oak-components";
+
+import {
+  BaseHeaderNavFooterProps,
+  PrevNextButtons,
+} from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared";
+
+export type LessonHeaderNavFooterProps = BaseHeaderNavFooterProps & {
+  downloadButton: React.ReactElement;
+};
+
+export const LessonHeaderNavFooter = (props: LessonHeaderNavFooterProps) => {
+  return (
+    <OakFlex
+      $background={`bg-decorative${props.backgroundColorLevel}-subdued`}
+      $width={"100%"}
+      $pv={"spacing-24"}
+      $ph={["spacing-20", "spacing-40"]}
+      $flexDirection={["column", "row"]}
+      $gap={"spacing-24"}
+      $justifyContent="center"
+    >
+      <OakFlex
+        $justifyContent={"space-between"}
+        $width={"100%"}
+        $gap={"spacing-16"}
+        $maxWidth="spacing-1280"
+      >
+        <OakFlex as="nav" $gap={"spacing-32"} $alignItems={"center"}>
+          <OakTertiaryInvertedButton
+            iconName="list"
+            element="a"
+            href={props.viewHref}
+          >
+            View unit
+          </OakTertiaryInvertedButton>
+          <OakBox
+            $bl={"border-solid-m"}
+            $display={["none", "flex"]}
+            $height={"spacing-24"}
+            $borderColor={`border-decorative${props.backgroundColorLevel}`}
+          />
+          <PrevNextButtons
+            type="lesson"
+            $display={["none", "flex"]}
+            {...props}
+          />
+        </OakFlex>
+        {props.downloadButton}
+      </OakFlex>
+      <OakBox
+        $display={["block", "none"]}
+        $bt={"border-solid-m"}
+        $borderColor={`border-decorative${props.backgroundColorLevel}`}
+        $width={"100%"}
+      />
+      <PrevNextButtons type="lesson" $display={["flex", "none"]} {...props} />
+    </OakFlex>
+  );
+};

--- a/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/LessonHeaderNavFooter/LessonHeaderNavFooter.tsx
@@ -9,7 +9,10 @@ import {
   PrevNextButtons,
 } from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared";
 
-export type LessonHeaderNavFooterProps = BaseHeaderNavFooterProps & {
+export type LessonHeaderNavFooterProps = Omit<
+  BaseHeaderNavFooterProps,
+  "downloadButton"
+> & {
   downloadButton: React.ReactElement;
 };
 

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.stories.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+import {
+  oakDefaultTheme,
+  OakPrimaryButton,
+  OakThemeProvider,
+} from "@oaknational/oak-components";
+
+import { UnitHeaderNavFooter } from "./UnitHeaderNavFooter";
+
+const meta: Meta<typeof UnitHeaderNavFooter> = {
+  component: UnitHeaderNavFooter,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <Story />
+      </OakThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UnitHeaderNavFooter>;
+
+export const Default: Story = {
+  args: {
+    backgroundColorLevel: 3,
+    prevHref: "www.google.com",
+    nextHref: "www.google.com",
+    viewHref: "www.google.com",
+    title: "Unit title",
+    downloadButton: <OakPrimaryButton>Action</OakPrimaryButton>,
+  },
+};
+
+export const Stuck: Story = {
+  args: {
+    ...Default.args,
+    isStuck: true,
+  },
+};

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.stories.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = {
     nextHref: "www.google.com",
     viewHref: "www.google.com",
     title: "Unit title",
-    downloadButton: <OakPrimaryButton>Action</OakPrimaryButton>,
+    downloadButton: () => <OakPrimaryButton>Action</OakPrimaryButton>,
   },
 };
 

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
@@ -48,4 +48,52 @@ describe("UnitHeaderNavFooter", () => {
     expect(actionButton).toBeInTheDocument();
     expect(actionButton).toHaveTextContent("action button");
   });
+  it("renders the title when stuck", () => {
+    render(
+      <UnitHeaderNavFooter
+        {...defaultProps}
+        isStuck={true}
+        title="Unit title"
+      />,
+    );
+
+    expect(screen.getByText("Unit title")).toBeInTheDocument();
+  });
+  it("renders the view all units link when not stuck", () => {
+    render(
+      <UnitHeaderNavFooter
+        {...defaultProps}
+        isStuck={false}
+        title="Unit title"
+        prevHref="prevUrl"
+        nextHref="nextUrl"
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "View all units" }),
+    ).toBeInTheDocument();
+  });
+  it("renders in the stuck state with previous and next links", () => {
+    render(
+      <UnitHeaderNavFooter
+        {...defaultProps}
+        isStuck={true}
+        title="Unit title"
+        prevHref="prevUrl"
+        nextHref="nextUrl"
+        backgroundColorLevel={4}
+        downloadButton={<button>action button</button>}
+      />,
+    );
+
+    expect(screen.getByText("Unit title")).toBeInTheDocument();
+    expect(screen.getByText("action button")).toBeInTheDocument();
+  });
+  it("forwards the sentinel ref", () => {
+    const sentinelRef = jest.fn();
+    render(<UnitHeaderNavFooter {...defaultProps} sentinelRef={sentinelRef} />);
+
+    expect(sentinelRef).toHaveBeenCalled();
+  });
 });

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
@@ -14,6 +14,9 @@ const defaultProps: UnitHeaderNavFooterProps = {
 
 const render = renderWithTheme;
 
+const createDownloadButton = () =>
+  jest.fn(() => <button>action button</button>);
+
 describe("UnitHeaderNavFooter", () => {
   it("Renders the correct text for the view href", () => {
     render(<UnitHeaderNavFooter {...defaultProps} />);
@@ -36,17 +39,17 @@ describe("UnitHeaderNavFooter", () => {
     const nextLink = screen.getByRole("link", { name: "Next unit" });
     expect(nextLink).toBeInTheDocument();
   });
-  it("renders an action button", () => {
+  it("renders an action button and passes isStuck=false when not stuck", () => {
+    const downloadButton = createDownloadButton();
+
     render(
-      <UnitHeaderNavFooter
-        {...defaultProps}
-        downloadButton={<button>action button</button>}
-      />,
+      <UnitHeaderNavFooter {...defaultProps} downloadButton={downloadButton} />,
     );
 
     const actionButton = screen.getByRole("button");
     expect(actionButton).toBeInTheDocument();
     expect(actionButton).toHaveTextContent("action button");
+    expect(downloadButton).toHaveBeenCalledWith(false);
   });
   it("renders the title when stuck", () => {
     render(
@@ -74,7 +77,9 @@ describe("UnitHeaderNavFooter", () => {
       screen.getByRole("link", { name: "View all units" }),
     ).toBeInTheDocument();
   });
-  it("renders in the stuck state with previous and next links", () => {
+  it("renders in the stuck state with previous and next links and passes isStuck=true to downloadButton", () => {
+    const downloadButton = createDownloadButton();
+
     render(
       <UnitHeaderNavFooter
         {...defaultProps}
@@ -83,12 +88,12 @@ describe("UnitHeaderNavFooter", () => {
         prevHref="prevUrl"
         nextHref="nextUrl"
         backgroundColorLevel={4}
-        downloadButton={<button>action button</button>}
+        downloadButton={downloadButton}
       />,
     );
 
+    expect(downloadButton).toHaveBeenCalledWith(true);
     expect(screen.getByText("Unit title")).toBeInTheDocument();
-    expect(screen.getByText("action button")).toBeInTheDocument();
   });
   it("forwards the sentinel ref", () => {
     const sentinelRef = jest.fn();

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.test.tsx
@@ -1,33 +1,29 @@
 import { screen } from "@testing-library/dom";
 
-import { HeaderNavFooter, HeaderNavFooterProps } from "./HeaderNavFooter";
+import {
+  UnitHeaderNavFooter,
+  UnitHeaderNavFooterProps,
+} from "./UnitHeaderNavFooter";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
 
-const defaultProps: HeaderNavFooterProps = {
-  backgroundColorLevel: 1,
-  type: "unit",
+const defaultProps: UnitHeaderNavFooterProps = {
+  backgroundColorLevel: 3,
   viewHref: "testUrl",
 };
 
 const render = renderWithTheme;
 
-describe("HeaderNavFooter", () => {
-  it("Renders the correct text for view href when type is unit", () => {
-    render(<HeaderNavFooter {...defaultProps} />);
+describe("UnitHeaderNavFooter", () => {
+  it("Renders the correct text for the view href", () => {
+    render(<UnitHeaderNavFooter {...defaultProps} />);
 
     const viewLink = screen.getByRole("link", { name: "View all units" });
     expect(viewLink).toBeInTheDocument();
   });
-  it("Renders the correct text for view href when type is lesson", () => {
-    render(<HeaderNavFooter {...defaultProps} type="lesson" />);
-
-    const viewLink = screen.getByRole("link", { name: "View unit" });
-    expect(viewLink).toBeInTheDocument();
-  });
-  it("Renders previous and next links with correct text for unit", () => {
+  it("Renders previous and next links with correct text", () => {
     render(
-      <HeaderNavFooter
+      <UnitHeaderNavFooter
         {...defaultProps}
         prevHref="prevUrl"
         nextHref="nextUrl"
@@ -42,9 +38,9 @@ describe("HeaderNavFooter", () => {
   });
   it("renders an action button", () => {
     render(
-      <HeaderNavFooter
+      <UnitHeaderNavFooter
         {...defaultProps}
-        actionButton={<button>action button</button>}
+        downloadButton={<button>action button</button>}
       />,
     );
 

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -1,72 +1,21 @@
 import {
-  OakFlexProps,
-  OakUiRoleToken,
   OakFlex,
-  OakSmallPrimaryInvertedButton,
-  OakIcon,
   OakBox,
   OakP,
-  OakTertiaryInvertedButton,
+  OakSmallPrimaryInvertedButton,
 } from "@oaknational/oak-components";
 import { Ref } from "react";
 import styled, { css, keyframes } from "styled-components";
 
-export type HeaderNavFooterProps = {
-  backgroundColorLevel: 1 | 3 | 4;
-  type: "unit" | "lesson";
-  viewHref: string;
+import {
+  BaseHeaderNavFooterProps,
+  PrevNextButtons,
+} from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared";
+
+export type UnitHeaderNavFooterProps = BaseHeaderNavFooterProps & {
   title?: string;
   sentinelRef?: Ref<HTMLDivElement>;
   isStuck?: boolean;
-  prevHref?: string;
-  nextHref?: string;
-  actionButton?: React.ReactElement;
-};
-
-export const HeaderNavFooter = (props: HeaderNavFooterProps) => {
-  return (
-    <OakFlex
-      $background={`bg-decorative${props.backgroundColorLevel}-subdued`}
-      $width={"100%"}
-      $pv={"spacing-24"}
-      $ph={["spacing-20", "spacing-40"]}
-      $flexDirection={["column", "row"]}
-      $gap={"spacing-24"}
-      $justifyContent="center"
-    >
-      <OakFlex
-        $justifyContent={"space-between"}
-        $width={"100%"}
-        $gap={"spacing-16"}
-        $maxWidth="spacing-1280"
-      >
-        <OakFlex as="nav" $gap={"spacing-32"} $alignItems={"center"}>
-          <OakTertiaryInvertedButton
-            iconName="list"
-            element="a"
-            href={props.viewHref}
-          >
-            {`View ${props.type === "unit" ? "all units" : "unit"}`}
-          </OakTertiaryInvertedButton>
-          <OakBox
-            $bl={"border-solid-m"}
-            $display={["none", "flex"]}
-            $height={"spacing-24"}
-            $borderColor={`border-decorative${props.backgroundColorLevel}`}
-          />
-          <PrevNextButtons $display={["none", "flex"]} {...props} />
-        </OakFlex>
-        {props.actionButton}
-      </OakFlex>
-      <OakBox
-        $display={["block", "none"]}
-        $bt={"border-solid-m"}
-        $borderColor={`border-decorative${props.backgroundColorLevel}`}
-        $width={"100%"}
-      />
-      <PrevNextButtons $display={["flex", "none"]} {...props} />
-    </OakFlex>
-  );
 };
 
 const fadeIn = keyframes`
@@ -94,7 +43,7 @@ const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
     `}
 `;
 
-export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
+export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
   const { sentinelRef, isStuck } = props;
   return (
     <>
@@ -145,7 +94,7 @@ export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
             $gap={"spacing-16"}
             $maxWidth="spacing-1280"
           >
-            {props.actionButton}
+            {props.downloadButton}
             <OakBox
               $bl={"border-solid-m"}
               $display={isStuck ? ["none", "none", "block"] : "none"}
@@ -161,7 +110,7 @@ export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
               $gap={"spacing-32"}
               $alignItems={"center"}
             >
-              <PrevNextButtons $display={"flex"} {...props} />
+              <PrevNextButtons type="unit" $display={"flex"} {...props} />
               <OakBox
                 $bl={"border-solid-m"}
                 $display={"flex"}
@@ -172,6 +121,7 @@ export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
           </OakFlex>
 
           <PrevNextButtons
+            type="unit"
             $display={isStuck ? "none" : ["flex", "none"]}
             {...props}
           />
@@ -184,68 +134,10 @@ export const StickyHeaderNavFooter = (props: HeaderNavFooterProps) => {
             element="a"
             href={props.viewHref}
           >
-            {`View ${props.type === "unit" ? "all units" : "unit"}`}
+            View all units
           </OakSmallPrimaryInvertedButton>
         </FadeInFlex>
       </OakFlex>
     </>
-  );
-};
-
-type PrevNextButtonsProps = Pick<
-  HeaderNavFooterProps,
-  "backgroundColorLevel" | "type" | "nextHref" | "prevHref"
-> & {
-  $display: OakFlexProps["$display"];
-};
-
-const PrevNextButtons = ({
-  $display,
-  backgroundColorLevel,
-  nextHref,
-  prevHref,
-  type,
-}: PrevNextButtonsProps) => {
-  const iconColor =
-    `icon-decorative${backgroundColorLevel}` satisfies OakUiRoleToken;
-
-  return (
-    <OakFlex $display={$display} $gap={"spacing-16"}>
-      {prevHref && (
-        <OakSmallPrimaryInvertedButton
-          width={["100%", "auto"]}
-          element="a"
-          href={prevHref}
-          iconOverride={
-            <OakIcon
-              iconName="arrow-left"
-              $color={iconColor}
-              $width={"spacing-24"}
-              $height="spacing-24"
-            />
-          }
-        >
-          {"Previous " + type}
-        </OakSmallPrimaryInvertedButton>
-      )}
-      {nextHref && (
-        <OakSmallPrimaryInvertedButton
-          width={["100%", "auto"]}
-          element="a"
-          href={nextHref}
-          isTrailingIcon
-          iconOverride={
-            <OakIcon
-              iconName="arrow-right"
-              $color={iconColor}
-              $width={"spacing-24"}
-              $height="spacing-24"
-            />
-          }
-        >
-          {"Next " + type}
-        </OakSmallPrimaryInvertedButton>
-      )}
-    </OakFlex>
   );
 };

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -45,6 +45,7 @@ const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
 
 export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
   const { sentinelRef, isStuck } = props;
+
   return (
     <>
       {/* Sentinel element, for checking when the user has scrolled past this point */}
@@ -129,17 +130,18 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
               $display={isStuck ? "none" : ["flex", "none"]}
               {...props}
             />
-            <OakSmallPrimaryInvertedButton
-              $display={isStuck ? "none" : "block"}
-              width={["100%", "auto"]}
-              iconName="list"
-              isTrailingIcon
-              $textWrap={"nowrap"}
-              element="a"
-              href={props.viewHref}
-            >
-              View all units
-            </OakSmallPrimaryInvertedButton>
+            <OakBox $display={isStuck ? "none" : "block"}>
+              <OakSmallPrimaryInvertedButton
+                width={["100%", "auto"]}
+                iconName="list"
+                isTrailingIcon
+                $textWrap={"nowrap"}
+                element="a"
+                href={props.viewHref}
+              >
+                View all units
+              </OakSmallPrimaryInvertedButton>
+            </OakBox>
           </OakFlex>
         </FadeInFlex>
       </OakFlex>

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -87,7 +87,10 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
           $gap={"spacing-24"}
           $justifyContent="center"
           $dropShadow={isStuck ? "drop-shadow-standard" : "drop-shadow-none"}
-          $bbr={isStuck ? "border-radius-l" : "border-radius-square"}
+          $bbr={isStuck ? [null, "border-radius-l"] : undefined}
+          $btr={
+            isStuck ? ["border-radius-l", "border-radius-square"] : undefined
+          }
         >
           <OakFlex
             $width={"100%"}

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -1,8 +1,11 @@
 import {
   OakFlex,
   OakBox,
+  OakBoxProps,
   OakP,
   OakSmallPrimaryInvertedButton,
+  OakFlexProps,
+  OakUiRoleToken,
 } from "@oaknational/oak-components";
 import { Ref } from "react";
 import styled, { css, keyframes } from "styled-components";
@@ -11,6 +14,27 @@ import {
   BaseHeaderNavFooterProps,
   PrevNextButtons,
 } from "@/components/TeacherComponents/HeaderNavFooter/HeaderNavFooterShared";
+
+type DecorativeDividerProps = {
+  orientation: "vertical" | "horizontal";
+  borderColor: OakUiRoleToken;
+  $display?: OakBoxProps["$display"];
+};
+
+const DecorativeDivider = ({
+  orientation,
+  borderColor,
+  $display,
+}: DecorativeDividerProps) => (
+  <OakBox
+    $bl={orientation === "vertical" ? "border-solid-m" : undefined}
+    $bt={orientation === "horizontal" ? "border-solid-m" : undefined}
+    $display={$display}
+    $height={orientation === "vertical" ? "spacing-24" : undefined}
+    $width={orientation === "horizontal" ? "100%" : undefined}
+    $borderColor={borderColor}
+  />
+);
 
 export type UnitHeaderNavFooterProps = BaseHeaderNavFooterProps & {
   title?: string;
@@ -43,67 +67,145 @@ const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
     `}
 `;
 
+type BackgroundColorLevel = BaseHeaderNavFooterProps["backgroundColorLevel"];
+
+type UnitHeaderNavFooterAppearance = {
+  shell: OakFlexProps;
+  fadeIn: OakFlexProps;
+  content: Pick<OakFlexProps, "$gap" | "$justifyContent" | "$display">;
+  displays: {
+    stuckVerticalDivider: OakBoxProps["$display"];
+    horizontalDivider: OakBoxProps["$display"];
+    title: OakBoxProps["$display"];
+    desktopNav: OakFlexProps["$display"];
+    mobilePrevNext: OakFlexProps["$display"];
+    viewAllUnits: OakBoxProps["$display"];
+  };
+  borderColor: OakUiRoleToken;
+};
+
+/**
+ * Most of the complexity here comes from having to pin to the bottom of the
+ * screen on mobile viewports. position: sticky assumes you're pinning to the top.
+ *
+ * Positioning per breakpoint:
+ *
+ * |          | not stuck     | stuck            |
+ * | -------- | ---------     | ---------------- |
+ * | mobile   | static        | fixed, bottom: 0 |
+ * | tablet+  | sticky, top: 0| sticky, top: 0   |
+ */
+function getUnitHeaderNavFooterAppearance(
+  isStuck: boolean | undefined,
+  backgroundColorLevel: BackgroundColorLevel,
+): UnitHeaderNavFooterAppearance {
+  const borderColor =
+    `border-decorative${backgroundColorLevel}` satisfies OakUiRoleToken;
+  const bgSubdued =
+    `bg-decorative${backgroundColorLevel}-subdued` satisfies OakUiRoleToken;
+  const bgVerySubdued =
+    `bg-decorative${backgroundColorLevel}-very-subdued` satisfies OakUiRoleToken;
+
+  if (!isStuck) {
+    return {
+      shell: {
+        $position: ["static", "sticky"],
+        $bottom: [null, null],
+        $top: [null, "spacing-0"],
+        $left: [null, null],
+      },
+      fadeIn: {
+        $background: bgSubdued,
+        $pv: "spacing-24",
+        $ph: ["spacing-20", "spacing-40"],
+        $maxWidth: "auto",
+        $mh: "auto",
+        $dropShadow: "drop-shadow-none",
+        $bbr: undefined,
+        $btr: undefined,
+      },
+      content: {
+        $gap: ["spacing-24", "spacing-16"],
+        $justifyContent: "space-between",
+        $display: ["flex", "contents"],
+      },
+      displays: {
+        stuckVerticalDivider: "none",
+        horizontalDivider: ["block", "none"],
+        title: "none",
+        desktopNav: ["none", "flex"],
+        mobilePrevNext: ["flex", "none"],
+        viewAllUnits: "block",
+      },
+      borderColor,
+    };
+  }
+
+  return {
+    shell: {
+      $position: ["fixed", "sticky"],
+      $bottom: ["spacing-0", null],
+      $top: [null, "spacing-0"],
+      $left: ["spacing-0", null],
+    },
+    fadeIn: {
+      $background: bgVerySubdued,
+      $pv: ["spacing-16", "spacing-24"],
+      $ph: "spacing-16",
+      $maxWidth: ["spacing-1280"],
+      $mh: "spacing-40",
+      $dropShadow: "drop-shadow-standard",
+      $bbr: [null, "border-radius-l"],
+      $btr: ["border-radius-l", "border-radius-square"],
+    },
+    content: {
+      $gap: ["spacing-16", "spacing-24"],
+      $justifyContent: "start",
+      $display: "contents",
+    },
+    displays: {
+      stuckVerticalDivider: ["none", "none", "block"],
+      horizontalDivider: "none",
+      title: ["none", "none", "block"],
+      desktopNav: "none",
+      mobilePrevNext: "none",
+      viewAllUnits: "none",
+    },
+    borderColor,
+  };
+}
+
 export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
   const { sentinelRef, isStuck } = props;
+  const { shell, fadeIn, content, displays, borderColor } =
+    getUnitHeaderNavFooterAppearance(isStuck, props.backgroundColorLevel);
 
   return (
     <>
       {/* Sentinel element, for checking when the user has scrolled past this point */}
       <OakBox ref={sentinelRef} $height="spacing-0" />
-      {/**
-       * Most of the complexity here comes from having to pin to the bottom
-       * of the screen on mobile viewports. position: sticky assumes you're
-       * pinning to the top.
-       *
-       * Positioning per breakpoint:
-       *
-       * |          | not stuck     | stuck            |
-       * | -------- | ---------     | ---------------- |
-       * | mobile   | static        | fixed, bottom: 0 |
-       * | tablet+  | sticky, top: 0| sticky, top: 0   |
-       */}
       <OakFlex
         $zIndex={"in-front"}
-        $position={[isStuck ? "fixed" : "static", "sticky"]}
-        $bottom={[isStuck ? "spacing-0" : null, null]}
-        $top={[null, "spacing-0"]}
-        $left={[isStuck ? "spacing-0" : null, null]}
+        {...shell}
         $width={"100%"}
         $justifyContent={"center"}
       >
         <FadeInFlex
           $animateIn={isStuck}
-          $background={
-            isStuck
-              ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
-              : `bg-decorative${props.backgroundColorLevel}-subdued`
-          }
-          $pv={isStuck ? ["spacing-16", "spacing-24"] : "spacing-24"}
-          $ph={isStuck ? "spacing-16" : ["spacing-20", "spacing-40"]}
+          {...fadeIn}
           $flexDirection={["column", "row"]}
-          $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
-          $mh={isStuck ? "spacing-40" : "auto"}
           $width={"100%"}
           $gap={"spacing-24"}
           $justifyContent="center"
-          $dropShadow={isStuck ? "drop-shadow-standard" : "drop-shadow-none"}
-          $bbr={isStuck ? [null, "border-radius-l"] : undefined}
-          $btr={
-            isStuck ? ["border-radius-l", "border-radius-square"] : undefined
-          }
         >
           <OakFlex
             $width={"100%"}
             $maxWidth={"spacing-1280"}
-            $gap={
-              isStuck
-                ? ["spacing-16", "spacing-24"]
-                : ["spacing-24", "spacing-16"]
-            }
+            $gap={content.$gap}
             $flexDirection={["column", "row"]}
           >
             <OakFlex
-              $justifyContent={isStuck ? "start" : "space-between"}
+              $justifyContent={content.$justifyContent}
               $alignItems={"center"}
               $width={"100%"}
               $gap={"spacing-16"}
@@ -112,46 +214,43 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
                 $gap={"spacing-24"}
                 $flexDirection="column"
                 $width={"100%"}
-                $display={isStuck ? "contents" : ["flex", "contents"]}
+                $display={content.$display}
               >
                 {props.downloadButton?.(Boolean(isStuck))}
-                <OakBox
-                  $bl={"border-solid-m"}
-                  $display={isStuck ? ["none", "none", "block"] : "none"}
-                  $height={"spacing-24"}
-                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                <DecorativeDivider
+                  orientation="vertical"
+                  borderColor={borderColor}
+                  $display={displays.stuckVerticalDivider}
                 />
-                <OakBox
-                  $bt={"border-solid-m"}
-                  $display={isStuck ? "none" : ["block", "none"]}
-                  $width={"100%"}
-                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                <DecorativeDivider
+                  orientation="horizontal"
+                  borderColor={borderColor}
+                  $display={displays.horizontalDivider}
                 />
               </OakFlex>
-              <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
+              <OakBox $display={displays.title}>
                 <OakP $font="heading-7">{props.title}</OakP>
               </OakBox>
               <OakFlex
                 as="nav"
-                $display={isStuck ? "none" : ["none", "flex"]}
+                $display={displays.desktopNav}
                 $gap={"spacing-16"}
                 $alignItems={"center"}
               >
                 <PrevNextButtons type="unit" $display={"flex"} {...props} />
-                <OakBox
-                  $bl={"border-solid-m"}
-                  $height={"spacing-24"}
-                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                <DecorativeDivider
+                  orientation="vertical"
+                  borderColor={borderColor}
                 />
               </OakFlex>
             </OakFlex>
 
             <PrevNextButtons
               type="unit"
-              $display={isStuck ? "none" : ["flex", "none"]}
+              $display={displays.mobilePrevNext}
               {...props}
             />
-            <OakBox $display={isStuck ? "none" : "block"}>
+            <OakBox $display={displays.viewAllUnits}>
               <OakSmallPrimaryInvertedButton
                 width={["100%", "auto"]}
                 iconName="list"

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -89,53 +89,57 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
           $bbr={isStuck ? "border-radius-l" : "border-radius-square"}
         >
           <OakFlex
-            $justifyContent={isStuck ? "start" : "space-between"}
             $width={"100%"}
+            $maxWidth={"spacing-1280"}
             $gap={"spacing-16"}
-            $maxWidth="spacing-1280"
           >
-            {props.downloadButton}
-            <OakBox
-              $bl={"border-solid-m"}
-              $display={isStuck ? ["none", "none", "block"] : "none"}
-              $height={"spacing-24"}
-              $borderColor={`border-decorative${props.backgroundColorLevel}`}
-            />
-            <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
-              <OakP>{props.title}</OakP>
-            </OakBox>
             <OakFlex
-              as="nav"
-              $display={isStuck ? "none" : ["none", "flex"]}
-              $gap={"spacing-32"}
-              $alignItems={"center"}
+              $justifyContent={isStuck ? "start" : "space-between"}
+              $width={"100%"}
+              $gap={"spacing-16"}
             >
-              <PrevNextButtons type="unit" $display={"flex"} {...props} />
+              {props.downloadButton}
               <OakBox
                 $bl={"border-solid-m"}
-                $display={"flex"}
+                $display={isStuck ? ["none", "none", "block"] : "none"}
                 $height={"spacing-24"}
                 $borderColor={`border-decorative${props.backgroundColorLevel}`}
               />
+              <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
+                <OakP>{props.title}</OakP>
+              </OakBox>
+              <OakFlex
+                as="nav"
+                $display={isStuck ? "none" : ["none", "flex"]}
+                $gap={"spacing-16"}
+                $alignItems={"center"}
+              >
+                <PrevNextButtons type="unit" $display={"flex"} {...props} />
+                <OakBox
+                  $bl={"border-solid-m"}
+                  $height={"spacing-24"}
+                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                />
+              </OakFlex>
             </OakFlex>
-          </OakFlex>
 
-          <PrevNextButtons
-            type="unit"
-            $display={isStuck ? "none" : ["flex", "none"]}
-            {...props}
-          />
-          <OakSmallPrimaryInvertedButton
-            $display={isStuck ? "none" : "block"}
-            width={["100%", "auto"]}
-            iconName="list"
-            isTrailingIcon
-            $textWrap={"nowrap"}
-            element="a"
-            href={props.viewHref}
-          >
-            View all units
-          </OakSmallPrimaryInvertedButton>
+            <PrevNextButtons
+              type="unit"
+              $display={isStuck ? "none" : ["flex", "none"]}
+              {...props}
+            />
+            <OakSmallPrimaryInvertedButton
+              $display={isStuck ? "none" : "block"}
+              width={["100%", "auto"]}
+              iconName="list"
+              isTrailingIcon
+              $textWrap={"nowrap"}
+              element="a"
+              href={props.viewHref}
+            >
+              View all units
+            </OakSmallPrimaryInvertedButton>
+          </OakFlex>
         </FadeInFlex>
       </OakFlex>
     </>

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -78,7 +78,7 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
               ? `bg-decorative${props.backgroundColorLevel}-very-subdued`
               : `bg-decorative${props.backgroundColorLevel}-subdued`
           }
-          $pv={"spacing-24"}
+          $pv={isStuck ? ["spacing-16", "spacing-24"] : "spacing-24"}
           $ph={isStuck ? "spacing-16" : ["spacing-20", "spacing-40"]}
           $flexDirection={["column", "row"]}
           $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
@@ -95,7 +95,12 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
           <OakFlex
             $width={"100%"}
             $maxWidth={"spacing-1280"}
-            $gap={"spacing-16"}
+            $gap={
+              isStuck
+                ? ["spacing-16", "spacing-24"]
+                : ["spacing-24", "spacing-16"]
+            }
+            $flexDirection={["column", "row"]}
           >
             <OakFlex
               $justifyContent={isStuck ? "start" : "space-between"}
@@ -103,13 +108,26 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
               $width={"100%"}
               $gap={"spacing-16"}
             >
-              {props.downloadButton?.(Boolean(isStuck))}
-              <OakBox
-                $bl={"border-solid-m"}
-                $display={isStuck ? ["none", "none", "block"] : "none"}
-                $height={"spacing-24"}
-                $borderColor={`border-decorative${props.backgroundColorLevel}`}
-              />
+              <OakFlex
+                $gap={"spacing-24"}
+                $flexDirection="column"
+                $width={"100%"}
+                $display={isStuck ? "contents" : ["flex", "contents"]}
+              >
+                {props.downloadButton?.(Boolean(isStuck))}
+                <OakBox
+                  $bl={"border-solid-m"}
+                  $display={isStuck ? ["none", "none", "block"] : "none"}
+                  $height={"spacing-24"}
+                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                />
+                <OakBox
+                  $bt={"border-solid-m"}
+                  $display={isStuck ? "none" : ["block", "none"]}
+                  $width={"100%"}
+                  $borderColor={`border-decorative${props.backgroundColorLevel}`}
+                />
+              </OakFlex>
               <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
                 <OakP $font="heading-7">{props.title}</OakP>
               </OakBox>

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -78,7 +78,7 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
               : `bg-decorative${props.backgroundColorLevel}-subdued`
           }
           $pv={"spacing-24"}
-          $ph={["spacing-20", "spacing-40"]}
+          $ph={isStuck ? "spacing-16" : ["spacing-20", "spacing-40"]}
           $flexDirection={["column", "row"]}
           $maxWidth={isStuck ? ["spacing-1280"] : "auto"}
           $mh={isStuck ? "spacing-40" : "auto"}
@@ -95,10 +95,11 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
           >
             <OakFlex
               $justifyContent={isStuck ? "start" : "space-between"}
+              $alignItems={"center"}
               $width={"100%"}
               $gap={"spacing-16"}
             >
-              {props.downloadButton}
+              {props.downloadButton?.(Boolean(isStuck))}
               <OakBox
                 $bl={"border-solid-m"}
                 $display={isStuck ? ["none", "none", "block"] : "none"}
@@ -106,7 +107,7 @@ export const UnitHeaderNavFooter = (props: UnitHeaderNavFooterProps) => {
                 $borderColor={`border-decorative${props.backgroundColorLevel}`}
               />
               <OakBox $display={isStuck ? ["none", "none", "block"] : "none"}>
-                <OakP>{props.title}</OakP>
+                <OakP $font="heading-7">{props.title}</OakP>
               </OakBox>
               <OakFlex
                 as="nav"

--- a/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
+++ b/src/components/TeacherComponents/HeaderNavFooter/UnitHeaderNavFooter/UnitHeaderNavFooter.tsx
@@ -37,7 +37,7 @@ const FadeInFlex = styled(OakFlex)<{ $animateIn?: boolean }>`
     props.$animateIn &&
     css`
       animation: ${fadeIn} 300ms ease-in;
-      @media (prefers-reduced-motion) {
+      @media (prefers-reduced-motion: reduce) {
         animation: none;
       }
     `}

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
@@ -41,19 +41,12 @@ jest.mock("@oaknational/oak-components", () => ({
   useMediaQuery: jest.fn(),
 }));
 
-jest.mock("@/hooks/useMediaQuery.tsx", () => ({
-  __esModule: true,
-  default: () => ({
-    isMobile: false,
-  }),
-}));
-
 const mockedUseMediaQuery = jest.mocked(useMediaQuery);
 
 // Default: behave like a desktop viewport (matches the previous matchMedia mock)
 const setBreakpoint = ({
   isDesktop = true,
-  isMobile = true,
+  isMobile = false,
 }: {
   isDesktop?: boolean;
   isMobile?: boolean;

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useMediaQuery } from "@oaknational/oak-components";
 
 import UnitDownloadButton from "./UnitDownloadButton";
 
@@ -35,6 +36,11 @@ jest.mock(
   }),
 );
 
+jest.mock("@oaknational/oak-components", () => ({
+  ...jest.requireActual("@oaknational/oak-components"),
+  useMediaQuery: jest.fn(),
+}));
+
 jest.mock("@/hooks/useMediaQuery.tsx", () => ({
   __esModule: true,
   default: () => ({
@@ -42,9 +48,31 @@ jest.mock("@/hooks/useMediaQuery.tsx", () => ({
   }),
 }));
 
+const mockedUseMediaQuery = jest.mocked(useMediaQuery);
+
+// Default: behave like a desktop viewport (matches the previous matchMedia mock)
+const setBreakpoint = ({
+  isDesktop = true,
+  isMobile = true,
+}: {
+  isDesktop?: boolean;
+  isMobile?: boolean;
+} = {}) => {
+  mockedUseMediaQuery.mockImplementation((query) => {
+    if (query === "desktop") {
+      return isDesktop;
+    }
+    if (query === "mobile") {
+      return isMobile;
+    }
+    return false;
+  });
+};
+
 describe("UnitDownloadButton", () => {
   beforeEach(() => {
     setUseUserReturn(mockLoggedIn);
+    setBreakpoint();
   });
 
   it("should render a continue button when logged in but not onboarded", () => {
@@ -182,5 +210,109 @@ describe("UnitDownloadButton", () => {
     const user = userEvent.setup();
     await user.click(button);
     expect(onDownloadSuccess).toHaveBeenCalledTimes(1);
+  });
+  it("should set a download error when the download link request fails", async () => {
+    const { createUnitDownloadLink } = jest.requireMock(
+      "@/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink",
+    );
+    createUnitDownloadLink.mockRejectedValueOnce(new Error("network error"));
+    const setDownloadError = jest.fn();
+    const setShowDownloadMessage = jest.fn();
+    const setShowIncompleteMessage = jest.fn();
+
+    renderWithProviders()(
+      <UnitDownloadButton
+        setDownloadError={setDownloadError}
+        setDownloadInProgress={jest.fn()}
+        setShowDownloadMessage={setShowDownloadMessage}
+        setShowIncompleteMessage={setShowIncompleteMessage}
+        downloadInProgress={false}
+        onDownloadSuccess={jest.fn()}
+        unitFileId="mockSlug"
+        showNewTag
+        geoRestricted={false}
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Download (.zip 1.2MB)",
+    });
+    const user = userEvent.setup();
+    await user.click(button);
+
+    expect(setDownloadError).toHaveBeenCalledWith(true);
+    expect(setShowDownloadMessage).toHaveBeenCalledWith(false);
+    expect(setShowIncompleteMessage).toHaveBeenCalledWith(false);
+  });
+  it("should render the long label when stuck, regardless of breakpoint", () => {
+    setBreakpoint({ isDesktop: false, isMobile: false });
+    renderWithProviders()(
+      <UnitDownloadButton
+        setDownloadError={jest.fn()}
+        setDownloadInProgress={jest.fn()}
+        setShowDownloadMessage={jest.fn()}
+        setShowIncompleteMessage={jest.fn()}
+        downloadInProgress={false}
+        onDownloadSuccess={jest.fn()}
+        unitFileId="mockSlug"
+        showNewTag
+        geoRestricted={false}
+        isStuck
+      />,
+    );
+    expect(screen.getByText("Download (.zip 1.2MB)")).toBeInTheDocument();
+  });
+  it("should render the short label on tablet (not desktop, not mobile)", () => {
+    setBreakpoint({ isDesktop: false, isMobile: false });
+    renderWithProviders()(
+      <UnitDownloadButton
+        setDownloadError={jest.fn()}
+        setDownloadInProgress={jest.fn()}
+        setShowDownloadMessage={jest.fn()}
+        setShowIncompleteMessage={jest.fn()}
+        downloadInProgress={false}
+        onDownloadSuccess={jest.fn()}
+        unitFileId="mockSlug"
+        showNewTag
+        geoRestricted={false}
+      />,
+    );
+    expect(screen.getByText("Download")).toBeInTheDocument();
+    expect(screen.queryByText("Download (.zip 1.2MB)")).not.toBeInTheDocument();
+  });
+  it("should render the long label on mobile when longTextOnMobile is set", () => {
+    setBreakpoint({ isDesktop: false, isMobile: true });
+    renderWithProviders()(
+      <UnitDownloadButton
+        setDownloadError={jest.fn()}
+        setDownloadInProgress={jest.fn()}
+        setShowDownloadMessage={jest.fn()}
+        setShowIncompleteMessage={jest.fn()}
+        downloadInProgress={false}
+        onDownloadSuccess={jest.fn()}
+        unitFileId="mockSlug"
+        showNewTag
+        geoRestricted={false}
+        longTextOnMobile
+        fullWidthOnMobile
+      />,
+    );
+    expect(screen.getByText("Download (.zip 1.2MB)")).toBeInTheDocument();
+  });
+  it("should render the short label on mobile when longTextOnMobile is not set", () => {
+    setBreakpoint({ isDesktop: false, isMobile: true });
+    renderWithProviders()(
+      <UnitDownloadButton
+        setDownloadError={jest.fn()}
+        setDownloadInProgress={jest.fn()}
+        setShowDownloadMessage={jest.fn()}
+        setShowIncompleteMessage={jest.fn()}
+        downloadInProgress={false}
+        onDownloadSuccess={jest.fn()}
+        unitFileId="mockSlug"
+        showNewTag
+        geoRestricted={false}
+      />,
+    );
+    expect(screen.getByText("Download")).toBeInTheDocument();
   });
 });

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -162,7 +162,13 @@ const ButtonForSize = ({
         }
       : {};
 
-  return <ButtonComponent {...defaultPaddingProps} {...props} />;
+  return (
+    <ButtonComponent
+      {...defaultPaddingProps}
+      {...props}
+      width={["100%", "auto"]}
+    />
+  );
 };
 
 export const useUnitDownloadButtonState = () => {

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -18,22 +18,47 @@ import createAndClickHiddenDownloadLink from "@/components/SharedComponents/help
 import { createUnitDownloadLink } from "@/components/SharedComponents/helpers/downloadAndShareHelpers/createDownloadLink";
 import { resolveOakHref } from "@/common-lib/urls";
 
+const getLabel = ({
+  isStuck,
+  isDesktop,
+  isMobile,
+  longTextOnMobile,
+  longerText,
+}: {
+  isStuck: boolean | undefined;
+  isDesktop: boolean;
+  isMobile: boolean;
+  longTextOnMobile?: boolean;
+  longerText: string;
+}) => {
+  const label = "Download";
+  // Long text shows when stuck, on desktop, or - only where the caller opts in
+  // via longTextOnMobile (e.g. the full-width unit header button) - on mobile.
+  // This leaves tablet as the only breakpoint showing the short label.
+  if (isStuck || isDesktop || (longTextOnMobile && isMobile)) {
+    return label + " " + longerText;
+  }
+  return label;
+};
+
 // Used when a user is signed in but not onboarded
 const UnitDownloadOnboardButton = ({
   href,
   showNewTag,
   size,
   ariaLabel,
+  fullWidthOnMobile,
 }: {
   href: string;
   showNewTag: boolean;
   size?: "small";
   ariaLabel?: string;
+  fullWidthOnMobile?: boolean;
 }) => {
   return (
     <ButtonForSize
       size={size}
-      width="fit-content"
+      fullWidthOnMobile={fullWidthOnMobile}
       element="a"
       href={href}
       aria-label={ariaLabel}
@@ -58,19 +83,34 @@ const UnitDownloadSignInButton = ({
   redirectUrl,
   showNewTag,
   isDesktop,
+  isMobile,
+  longTextOnMobile,
+  fullWidthOnMobile,
   size,
   buttonLabel,
   ariaLabel,
+  isStuck,
 }: {
   redirectUrl: string;
   showNewTag: boolean;
   isDesktop: boolean;
+  isMobile: boolean;
+  longTextOnMobile?: boolean;
+  fullWidthOnMobile?: boolean;
   size?: "small";
   buttonLabel?: ReactNode;
   ariaLabel?: string;
+  isStuck?: boolean;
 }) => {
   const signInButtonLabel =
-    buttonLabel ?? `Download${isDesktop ? " complete unit" : ""}`;
+    buttonLabel ??
+    getLabel({
+      isStuck,
+      isDesktop,
+      isMobile,
+      longTextOnMobile,
+      longerText: "complete unit",
+    });
 
   return (
     <SignInButton
@@ -79,6 +119,7 @@ const UnitDownloadSignInButton = ({
     >
       <ButtonForSize
         size={size}
+        fullWidthOnMobile={fullWidthOnMobile}
         iconName={"download"}
         isTrailingIcon
         aria-label={ariaLabel}
@@ -106,20 +147,34 @@ const DownloadButton = ({
   fileSize,
   disabled,
   isDesktop,
+  isMobile,
+  longTextOnMobile,
+  fullWidthOnMobile,
   size,
   buttonLabel,
   ariaLabel,
+  isStuck,
 }: {
   onUnitDownloadClick: () => void;
   downloadInProgress: boolean;
   fileSize: string | undefined;
   disabled: boolean;
   isDesktop: boolean;
+  isMobile: boolean;
+  longTextOnMobile?: boolean;
+  fullWidthOnMobile?: boolean;
+  isStuck?: boolean;
   size?: "small";
   buttonLabel?: ReactNode;
   ariaLabel?: string;
 }) => {
-  const zipSizeText = isDesktop ? ` (.zip ${fileSize})` : "";
+  const zipSizeText = getLabel({
+    isStuck,
+    isDesktop,
+    isMobile,
+    longTextOnMobile,
+    longerText: `(.zip ${fileSize})`,
+  });
   const downloadButtonText: ReactNode = (
     <OakSpan>
       {buttonLabel ?? "Download"}
@@ -130,6 +185,7 @@ const DownloadButton = ({
   return (
     <ButtonForSize
       size={size}
+      fullWidthOnMobile={fullWidthOnMobile}
       iconName="download"
       isTrailingIcon
       onClick={onUnitDownloadClick}
@@ -148,8 +204,12 @@ const DownloadButton = ({
 
 const ButtonForSize = ({
   size,
+  fullWidthOnMobile,
   ...props
-}: React.ComponentProps<typeof OakPrimaryButton> & { size?: "small" }) => {
+}: React.ComponentProps<typeof OakPrimaryButton> & {
+  size?: "small";
+  fullWidthOnMobile?: boolean;
+}) => {
   const ButtonComponent =
     size === "small" ? OakSmallPrimaryButton : OakPrimaryButton;
 
@@ -166,7 +226,7 @@ const ButtonForSize = ({
     <ButtonComponent
       {...defaultPaddingProps}
       {...props}
-      width={["100%", "auto"]}
+      width={fullWidthOnMobile ? ["100%", "auto"] : "auto"}
     />
   );
 };
@@ -202,6 +262,9 @@ export type UnitDownloadButtonProps = {
   size?: "small";
   buttonLabel?: ReactNode;
   ariaLabel?: string;
+  isStuck?: boolean;
+  longTextOnMobile?: boolean;
+  fullWidthOnMobile?: boolean;
 };
 
 /**
@@ -217,6 +280,7 @@ export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
   const auth = useAuth();
   const pathname = usePathname();
   const isDesktop = useMediaQuery("desktop");
+  const isMobile = useMediaQuery("mobile");
 
   const {
     onDownloadSuccess,
@@ -225,6 +289,9 @@ export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
     setShowDownloadMessage,
     setShowIncompleteMessage,
     downloadInProgress,
+    isStuck,
+    longTextOnMobile,
+    fullWidthOnMobile,
   } = props;
 
   const { exists, fileSize, hasCheckedFiles } =
@@ -275,23 +342,32 @@ export default function UnitDownloadButton(props: UnitDownloadButtonProps) {
       showNewTag={props.showNewTag}
       size={props.size}
       ariaLabel={props.ariaLabel}
+      fullWidthOnMobile={fullWidthOnMobile}
     />
   ) : showSignInButton ? (
     <UnitDownloadSignInButton
+      isStuck={isStuck}
       redirectUrl={`/onboarding?returnTo=${pathname}`}
       showNewTag={props.showNewTag}
       isDesktop={isDesktop}
+      isMobile={isMobile}
+      longTextOnMobile={longTextOnMobile}
+      fullWidthOnMobile={fullWidthOnMobile}
       size={props.size}
       buttonLabel={props.buttonLabel}
       ariaLabel={props.ariaLabel}
     />
   ) : showDownloadButton ? (
     <DownloadButton
+      isStuck={isStuck}
       disabled={Boolean(isGeoBlocked)}
       onUnitDownloadClick={onUnitDownloadClick}
       downloadInProgress={downloadInProgress}
       fileSize={fileSize}
       isDesktop={isDesktop}
+      isMobile={isMobile}
+      longTextOnMobile={longTextOnMobile}
+      fullWidthOnMobile={fullWidthOnMobile}
       size={props.size}
       buttonLabel={props.buttonLabel}
       ariaLabel={props.ariaLabel}

--- a/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
+++ b/src/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton.tsx
@@ -176,10 +176,7 @@ const DownloadButton = ({
     longerText: `(.zip ${fileSize})`,
   });
   const downloadButtonText: ReactNode = (
-    <OakSpan>
-      {buttonLabel ?? "Download"}
-      {zipSizeText}
-    </OakSpan>
+    <OakSpan>{buttonLabel ?? zipSizeText}</OakSpan>
   );
 
   return (

--- a/src/context/OakNotifications/OakNotificationsProvider.tsx
+++ b/src/context/OakNotifications/OakNotificationsProvider.tsx
@@ -92,6 +92,7 @@ export const OakNotificationsProvider: FC<{
 
   return (
     <oakNotificationsContext.Provider value={contextValue}>
+      {children}
       <StyledOakNotificationsContainer
         $position="fixed"
         $zIndex="in-front"
@@ -120,7 +121,6 @@ export const OakNotificationsProvider: FC<{
           />
         )}
       </StyledOakNotificationsContainer>
-      {children}
     </oakNotificationsContext.Provider>
   );
 };


### PR DESCRIPTION
## Description

This PR adds a sticky header footer (lol) to the unit downloads page.:

- Replaced the generic HeaderNavFooter with LessonHeaderNavFooter and UnitHeaderNavFooter since their functionality has diverged a lot
- Moved previous/next navigation logic to a shared file.
- Updated the unit header footer to become sticky/fixed after scrolling, showing the unit title and download button in the stuck state
- Updated UnitDownloadButton labelling and width behaviour for mobile, tablet, desktop, and stuck states. This is getting annoyingly complex.
- Added tests for the above behaviour

## Issue(s)

[Fixes #LESQ-2041](https://www.notion.so/oaknationalacademy/I-want-a-sticky-unit-download-button-36726cc4e1b180b198fdf04492056e01)

## How to test

1. Go to [a unit view page](https://oak-web-application-website-git-feat-lesq-2041sticky-dow-ab7569.vercel.thenational.academy/teachers/programmes/art-primary-ks1/units/mark-making-using-drawing-tools-and-techniques/lessons)
2. Verify the layout matches the designs at each breakpoint
3. Scroll past the headerfooter
4. Verify the layout matches the designs at each breakpoint
5. Ensure there are no regressions on [the lesson page](https://oak-web-application-website-git-feat-lesq-2041sticky-dow-ab7569.vercel.thenational.academy/teachers/programmes/art-primary-ks1/units/mark-making-using-drawing-tools-and-techniques/lessons/how-artists-make-marks)
6. Ensure there are no regressions on the unit download button on the download success page

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
