### PR TITLE
Phases in hamburger menu  LESQ 2030

### DIFF
--- a/src/app/(core)/__snapshots__/layout.test.tsx.snap
+++ b/src/app/(core)/__snapshots__/layout.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`core layout renders correctly 1`] = `
             {
               "children": [],
               "description": "Early years foundation stage",
-              "slug": "eyfs",
+              "slug": "early-years-foundation-stage",
               "title": "EYFS",
               "type": "keystage",
             },

--- a/src/components/AppComponents/TopNav/ExamBoardPanel/ExamBoardPanel.test.tsx
+++ b/src/components/AppComponents/TopNav/ExamBoardPanel/ExamBoardPanel.test.tsx
@@ -229,6 +229,49 @@ describe("ExamBoardPanel", () => {
       expect(onLeave).not.toHaveBeenCalled();
     });
 
+    it("does not call onLeave when tabbing past the last exam board without focusManager", () => {
+      const onLeave = jest.fn();
+      render(
+        <ExamBoardPanel
+          examBoards={examBoards}
+          phaseSlug="secondary"
+          viewType="ks4"
+          selectedSubject={selectedSubject}
+          onClick={mockOnClick}
+          onLeave={onLeave}
+        />,
+      );
+
+      const lastLink = screen.getByRole("link", { name: "Edexcel" });
+      lastLink.focus();
+      fireEvent.keyDown(lastLink, { key: "Tab" });
+
+      expect(onLeave).not.toHaveBeenCalled();
+    });
+
+    it("calls onLeave when tabbing past the last exam board with focusManager", () => {
+      const focusManager = createFocusManagerMock();
+      const onLeave = jest.fn();
+      render(
+        <ExamBoardPanel
+          examBoards={examBoards}
+          phaseSlug="secondary"
+          viewType="ks4"
+          selectedSubject={selectedSubject}
+          focusManager={focusManager}
+          onClick={mockOnClick}
+          onLeave={onLeave}
+        />,
+      );
+
+      const lastLink = screen.getByRole("link", { name: "Edexcel" });
+      lastLink.focus();
+      fireEvent.keyDown(lastLink, { key: "Tab" });
+
+      expect(onLeave).toHaveBeenCalledTimes(1);
+      expect(focusManager.handleKeyDown).toHaveBeenCalledTimes(1);
+    });
+
     it("moves focus back to subject context on Shift+Tab from first exam board", async () => {
       const focusManager = new DropdownFocusManager<TeachersSubNavData>(
         [

--- a/src/components/AppComponents/TopNav/ExamBoardPanel/ExamBoardPanel.tsx
+++ b/src/components/AppComponents/TopNav/ExamBoardPanel/ExamBoardPanel.tsx
@@ -106,7 +106,7 @@ const ExamBoardPanel = ({
       (!e.shiftKey && index === sortedExamBoards.length - 1) ||
       (e.shiftKey && index === 0);
 
-    if (leavingPanel) {
+    if (leavingPanel && focusManager) {
       onLeave();
     }
 

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
@@ -19,6 +19,7 @@ import {
   TeachersSubNavData,
 } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
 import { resolveOakHref } from "@/common-lib/urls";
+import useAnalytics from "@/context/Analytics/useAnalytics";
 
 export function MainMenuContent(
   props: Readonly<TeachersSubNavData & { hamburgerMenu: HamburgerMenuHook }>,
@@ -66,6 +67,7 @@ function SubjectsSection(
   props: Readonly<TeachersBrowse & { hamburgerMenu: HamburgerMenuHook }>,
 ) {
   const { hamburgerMenu, ...browseData } = props;
+  const { track } = useAnalytics();
   const phaseSubjects = browseData.children.filter(
     (child) => child.type === "phase",
   );
@@ -108,7 +110,25 @@ function SubjectsSection(
         $pt="spacing-12"
       >
         {phaseSubjects.length > 0 && (
-          <MainMenuButton title={subjectsTitle} hamburgerMenu={hamburgerMenu} />
+          <MainMenuButton
+            title={subjectsTitle}
+            hamburgerMenu={hamburgerMenu}
+            track={() => {
+              track.browseRefined({
+                platform: "owa",
+                product: "teacher lesson resources",
+                engagementIntent: "refine",
+                componentType: "topnav-browse-button",
+                eventVersion: "2.0.0",
+                analyticsUseCase: "Teacher",
+                filterType: "Phase filter",
+                filterValue: browseData.slug,
+                activeFilters: {},
+                googleLoginHint: null,
+                clientEnvironment: null,
+              });
+            }}
+          />
         )}
         {keystages.length > 0 && (
           <MainMenuButton

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
@@ -8,6 +8,7 @@ import {
   OakSvg,
   OakUL,
   OakLeftAlignedButton,
+  OakLIProps,
 } from "@oaknational/oak-components";
 import Link from "next/link";
 
@@ -34,42 +35,30 @@ export function MainMenuContent(
   }, [submenuOpen, prevSubmenu]);
 
   return (
-    <OakUL
-      $display={"flex"}
-      $flexDirection={"column"}
-      $pa={"spacing-40"}
-      $gap={"spacing-40"}
-    >
+    <OakUL $display={"flex"} $flexDirection={"column"} $ph={"spacing-40"}>
       <SubjectsSection {...navData.primary} hamburgerMenu={hamburgerMenu} />
-      <MenuDivider />
       <SubjectsSection {...navData.secondary} hamburgerMenu={hamburgerMenu} />
-      <MenuDivider />
-      <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
-        <MainMenuButton title={"About us"} hamburgerMenu={hamburgerMenu} />
-        <MainMenuButton title={"Guidance"} hamburgerMenu={hamburgerMenu} />
-        <MainMenuLink
-          hamburgerMenu={hamburgerMenu}
-          href={resolveOakHref({
-            page: "labs",
-          })}
-          external={true}
-          title="AI Experiments"
-          iconName="external"
-          aria-label="AI Experiments (this will open in a new tab)"
-        />
-      </OakFlex>
+      <MainMenuButton
+        title={"About us"}
+        hamburgerMenu={hamburgerMenu}
+        $pb="spacing-16"
+      />
+      <MainMenuButton
+        title={"Guidance"}
+        hamburgerMenu={hamburgerMenu}
+        $pb="spacing-16"
+      />
+      <MainMenuLink
+        hamburgerMenu={hamburgerMenu}
+        href={resolveOakHref({
+          page: "labs",
+        })}
+        external={true}
+        title="AI Experiments"
+        iconName="external"
+        aria-label="AI Experiments (this will open in a new tab)"
+      />
     </OakUL>
-  );
-}
-
-function MenuDivider() {
-  return (
-    <OakBox
-      $width={"100%"}
-      $bt={"border-solid-s"}
-      $borderColor={"border-neutral-lighter"}
-      as="hr"
-    />
   );
 }
 
@@ -91,11 +80,12 @@ function SubjectsSection(
       : "Secondary key stages";
 
   return (
-    <OakBox>
+    <OakLI $listStyle={"none"} $pb="spacing-40">
       <OakFlex
         $flexDirection={"column"}
         $width={"fit-content"}
         $mb={"spacing-12"}
+        $pl="spacing-8"
       >
         <OakBox $position={"relative"}>
           <OakHeading tag="h2" $font={"heading-6"}>
@@ -110,7 +100,13 @@ function SubjectsSection(
           />
         </OakBox>
       </OakFlex>
-      <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
+      <OakFlex
+        as="ul"
+        $flexDirection={"column"}
+        $gap={"spacing-16"}
+        $ph="spacing-0"
+        $pt="spacing-12"
+      >
         {phaseSubjects.length > 0 && (
           <MainMenuButton title={subjectsTitle} hamburgerMenu={hamburgerMenu} />
         )}
@@ -121,7 +117,14 @@ function SubjectsSection(
           />
         )}
       </OakFlex>
-    </OakBox>
+      <OakBox
+        $mt="spacing-40"
+        $mh="spacing-8"
+        $bb={"border-solid-s"}
+        $borderColor={"border-neutral-lighter"}
+        aria-hidden={true}
+      />
+    </OakLI>
   );
 }
 
@@ -129,31 +132,31 @@ function MainMenuButton({
   title,
   hamburgerMenu,
   track,
+  $pb,
 }: Readonly<{
   title: SubmenuState;
   hamburgerMenu: HamburgerMenuHook;
   track?: () => void;
+  $pb?: OakLIProps["$pb"];
 }>) {
   const { setSubmenuOpen } = hamburgerMenu;
 
   return (
-    <OakBox $width={"100%"}>
-      <OakLI $listStyle={"none"}>
-        <OakLeftAlignedButton
-          aria-haspopup={true}
-          rightAlignIcon
-          iconName="chevron-right"
-          width={"100%"}
-          id={title + "button"}
-          onClick={() => {
-            track?.();
-            setSubmenuOpen(title);
-          }}
-        >
-          {title}
-        </OakLeftAlignedButton>
-      </OakLI>
-    </OakBox>
+    <OakLI $listStyle={"none"} $width={"100%"} $pb={$pb}>
+      <OakLeftAlignedButton
+        aria-haspopup={true}
+        rightAlignIcon
+        iconName="chevron-right"
+        width={"100%"}
+        id={title + "button"}
+        onClick={() => {
+          track?.();
+          setSubmenuOpen(title);
+        }}
+      >
+        {title}
+      </OakLeftAlignedButton>
+    </OakLI>
   );
 }
 

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
@@ -11,18 +11,13 @@ import {
 } from "@oaknational/oak-components";
 import Link from "next/link";
 
-import {
-  getEYFSAriaLabel,
-  SubmenuState,
-  HamburgerMenuHook,
-} from "./TeachersTopNavHamburger";
+import { SubmenuState, HamburgerMenuHook } from "./TeachersTopNavHamburger";
 
 import {
   TeachersBrowse,
   TeachersSubNavData,
 } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
 import { resolveOakHref } from "@/common-lib/urls";
-import useAnalytics from "@/context/Analytics/useAnalytics";
 
 export function MainMenuContent(
   props: Readonly<TeachersSubNavData & { hamburgerMenu: HamburgerMenuHook }>,
@@ -46,7 +41,9 @@ export function MainMenuContent(
       $gap={"spacing-40"}
     >
       <SubjectsSection {...navData.primary} hamburgerMenu={hamburgerMenu} />
+      <MenuDivider />
       <SubjectsSection {...navData.secondary} hamburgerMenu={hamburgerMenu} />
+      <MenuDivider />
       <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
         <MainMenuButton title={"About us"} hamburgerMenu={hamburgerMenu} />
         <MainMenuButton title={"Guidance"} hamburgerMenu={hamburgerMenu} />
@@ -65,11 +62,34 @@ export function MainMenuContent(
   );
 }
 
+function MenuDivider() {
+  return (
+    <OakBox
+      $width={"100%"}
+      $bt={"border-solid-s"}
+      $borderColor={"border-neutral-lighter"}
+      as="hr"
+    />
+  );
+}
+
 function SubjectsSection(
   props: Readonly<TeachersBrowse & { hamburgerMenu: HamburgerMenuHook }>,
 ) {
   const { hamburgerMenu, ...browseData } = props;
-  const { track } = useAnalytics();
+  const phaseSubjects = browseData.children.filter(
+    (child) => child.type === "phase",
+  );
+  const keystages = browseData.children.filter(
+    (child) => child.type === "keystage",
+  );
+  const subjectsTitle =
+    browseData.slug === "primary" ? "Primary subjects" : "Secondary subjects";
+  const keyStagesTitle =
+    browseData.slug === "primary"
+      ? "Primary key stages"
+      : "Secondary key stages";
+
   return (
     <OakBox>
       <OakFlex
@@ -91,29 +111,15 @@ function SubjectsSection(
         </OakBox>
       </OakFlex>
       <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
-        {browseData.children.map((keystage) => (
+        {phaseSubjects.length > 0 && (
+          <MainMenuButton title={subjectsTitle} hamburgerMenu={hamburgerMenu} />
+        )}
+        {keystages.length > 0 && (
           <MainMenuButton
-            key={keystage.slug + browseData.slug}
-            title={keystage.title as SubmenuState}
-            description={keystage.description}
+            title={keyStagesTitle}
             hamburgerMenu={hamburgerMenu}
-            track={() => {
-              track.browseRefined({
-                platform: "owa",
-                product: "teacher lesson resources",
-                engagementIntent: "refine",
-                componentType: "topnav-browse-button",
-                eventVersion: "2.0.0",
-                analyticsUseCase: "Teacher",
-                filterType: "Key stage filter",
-                filterValue: keystage.slug,
-                activeFilters: {},
-                googleLoginHint: null,
-                clientEnvironment: null,
-              });
-            }}
           />
-        ))}
+        )}
       </OakFlex>
     </OakBox>
   );
@@ -121,25 +127,20 @@ function SubjectsSection(
 
 function MainMenuButton({
   title,
-  description,
   hamburgerMenu,
   track,
 }: Readonly<{
   title: SubmenuState;
   hamburgerMenu: HamburgerMenuHook;
-  description?: string;
   track?: () => void;
 }>) {
   const { setSubmenuOpen } = hamburgerMenu;
-  const isEYFS = title === "EYFS";
-  const shouldShowDescription = !isEYFS && description;
 
   return (
     <OakBox $width={"100%"}>
       <OakLI $listStyle={"none"}>
         <OakLeftAlignedButton
           aria-haspopup={true}
-          aria-label={getEYFSAriaLabel(title)}
           rightAlignIcon
           iconName="chevron-right"
           width={"100%"}
@@ -149,7 +150,7 @@ function MainMenuButton({
             setSubmenuOpen(title);
           }}
         >
-          {shouldShowDescription ? description : title}
+          {title}
         </OakLeftAlignedButton>
       </OakLI>
     </OakBox>

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -98,21 +98,10 @@ export function SubmenuContainer({
   );
 }
 
-function SubjectsSubmenu({
-  title,
-  backButtonAriaLabel,
-  subjects,
-  keyStageSlug,
-  phase,
-  hamburgerMenu,
-  selectedExamBoardSubject,
-  setSelectedExamBoardSubject,
-  onBack,
-}: {
+type SubjectsSubmenuProps = {
   readonly title: string;
   readonly backButtonAriaLabel?: string;
   readonly subjects: SubjectsNavItem[];
-  readonly keyStageSlug: string;
   readonly phase: Phase;
   readonly hamburgerMenu: HamburgerMenuHook;
   readonly selectedExamBoardSubject: SubjectsNavItem | null;
@@ -120,14 +109,28 @@ function SubjectsSubmenu({
     subject: SubjectsNavItem | null,
   ) => void;
   readonly onBack?: () => void;
-}) {
+} & (
+  | { readonly viewType: "phase" }
+  | { readonly viewType: "keystage"; readonly keystageSlug: string }
+);
+
+function SubjectsSubmenu(props: SubjectsSubmenuProps) {
+  const {
+    title,
+    backButtonAriaLabel,
+    subjects,
+    phase,
+    hamburgerMenu,
+    selectedExamBoardSubject,
+    setSelectedExamBoardSubject,
+    onBack,
+  } = props;
   const { track } = useAnalytics();
   const { handleCloseHamburger } = hamburgerMenu;
+  const viewTypeSlug =
+    props.viewType === "keystage" ? props.keystageSlug : phase;
 
-  const handleSubjectBrowseClick = (
-    subjectSlug: string,
-    keystageSlug: string,
-  ) => {
+  const handleSubjectBrowseClick = (subjectSlug: string) => {
     track.browseRefined({
       platform: "owa",
       product: "teacher lesson resources",
@@ -137,7 +140,8 @@ function SubjectsSubmenu({
       analyticsUseCase: "Teacher",
       filterType: "Subject filter",
       filterValue: subjectSlug,
-      activeFilters: { keystages: [keystageSlug] },
+      activeFilters:
+        props.viewType === "keystage" ? { keyStage: [props.keystageSlug] } : {},
       googleLoginHint: null,
       clientEnvironment: null,
     });
@@ -145,16 +149,21 @@ function SubjectsSubmenu({
   };
 
   if (selectedExamBoardSubject?.examBoards?.length) {
+    const examBoardMenuTitle =
+      props.viewType === "keystage"
+        ? `KS4, ${selectedExamBoardSubject.title}`
+        : `Secondary, ${selectedExamBoardSubject.title}`;
+
     return (
       <SubmenuContainer
-        title={`${title}, ${selectedExamBoardSubject.title}`}
+        title={examBoardMenuTitle}
         hamburgerMenu={hamburgerMenu}
         onBack={() => setSelectedExamBoardSubject(null)}
       >
         <ExamBoardPanel
           examBoards={selectedExamBoardSubject.examBoards}
           phaseSlug={phase}
-          viewType={keyStageSlug}
+          viewType={viewTypeSlug}
           selectedSubject={selectedExamBoardSubject}
           onClick={handleSubjectBrowseClick}
           onLeave={() => setSelectedExamBoardSubject(null)}
@@ -175,7 +184,7 @@ function SubjectsSubmenu({
         selectedMenu={phase}
         subjects={subjects}
         selectedSubject={selectedExamBoardSubject}
-        viewTypeSlug={keyStageSlug}
+        viewTypeSlug={viewTypeSlug}
         phase={phase}
         onExamBoardPanelOpen={setSelectedExamBoardSubject}
         closeExamBoardPanel={() => setSelectedExamBoardSubject(null)}
@@ -257,7 +266,7 @@ export function SubmenuContent(
         <SubjectsSubmenu
           title={submenuOpen}
           subjects={phaseItem.children}
-          keyStageSlug={phase}
+          viewType="phase"
           phase={phase}
           hamburgerMenu={hamburgerMenu}
           selectedExamBoardSubject={selectedExamBoardSubject}
@@ -281,7 +290,8 @@ export function SubmenuContent(
             title={getKeystageListLabel(selectedKeystage)}
             backButtonAriaLabel={getKeystageListAriaLabel(selectedKeystage)}
             subjects={selectedKeystage.children}
-            keyStageSlug={selectedKeystage.slug}
+            viewType="keystage"
+            keystageSlug={selectedKeystage.slug}
             phase={phase}
             hamburgerMenu={hamburgerMenu}
             selectedExamBoardSubject={selectedExamBoardSubject}

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -6,6 +6,7 @@ import {
   OakFlex,
   OakHeading,
   OakLI,
+  OakBox,
 } from "@oaknational/oak-components";
 import Link from "next/link";
 
@@ -79,6 +80,7 @@ export function SubmenuContainer({
         iconName="chevron-left"
         aria-label={ariaLabel}
         selected={true}
+        $pl="spacing-0"
         onClick={() => {
           if (onBack) {
             onBack();
@@ -221,7 +223,7 @@ export function SubmenuContent(
           <OakUL
             $display={"flex"}
             $flexDirection={"column"}
-            $pl="spacing-40"
+            $pa="spacing-0"
             $gap={"spacing-16"}
           >
             {links.children.map((link) => (
@@ -306,6 +308,7 @@ export function SubmenuContent(
             $display={"flex"}
             $flexDirection={"column"}
             $gap={"spacing-16"}
+            $pa="spacing-0"
           >
             {keystages.map((keystage) => (
               <OakLI key={keystage.slug} $listStyle={"none"} $width={"100%"}>

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -6,7 +6,6 @@ import {
   OakFlex,
   OakHeading,
   OakLI,
-  OakBox,
 } from "@oaknational/oak-components";
 import Link from "next/link";
 
@@ -125,6 +124,26 @@ function SubjectsSubmenu({
   const { track } = useAnalytics();
   const { handleCloseHamburger } = hamburgerMenu;
 
+  const handleSubjectBrowseClick = (
+    subjectSlug: string,
+    keystageSlug: string,
+  ) => {
+    track.browseRefined({
+      platform: "owa",
+      product: "teacher lesson resources",
+      engagementIntent: "refine",
+      componentType: "topnav-browse-button",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Teacher",
+      filterType: "Subject filter",
+      filterValue: subjectSlug,
+      activeFilters: { keystages: [keystageSlug] },
+      googleLoginHint: null,
+      clientEnvironment: null,
+    });
+    handleCloseHamburger();
+  };
+
   if (selectedExamBoardSubject?.examBoards?.length) {
     return (
       <SubmenuContainer
@@ -137,22 +156,7 @@ function SubjectsSubmenu({
           phaseSlug={phase}
           viewType={keyStageSlug}
           selectedSubject={selectedExamBoardSubject}
-          onClick={(subjectSlug, keystageSlug) => {
-            track.browseRefined({
-              platform: "owa",
-              product: "teacher lesson resources",
-              engagementIntent: "refine",
-              componentType: "topnav-browse-button",
-              eventVersion: "2.0.0",
-              analyticsUseCase: "Teacher",
-              filterType: "Subject filter",
-              filterValue: subjectSlug,
-              activeFilters: { keystages: [keystageSlug] },
-              googleLoginHint: null,
-              clientEnvironment: null,
-            });
-            handleCloseHamburger();
-          }}
+          onClick={handleSubjectBrowseClick}
           onLeave={() => setSelectedExamBoardSubject(null)}
         />
       </SubmenuContainer>
@@ -167,22 +171,7 @@ function SubjectsSubmenu({
       onBack={onBack}
     >
       <TopNavSubjectButtons
-        handleClick={(subjectSlug, keystageSlug) => {
-          track.browseRefined({
-            platform: "owa",
-            product: "teacher lesson resources",
-            engagementIntent: "refine",
-            componentType: "topnav-browse-button",
-            eventVersion: "2.0.0",
-            analyticsUseCase: "Teacher",
-            filterType: "Subject filter",
-            filterValue: subjectSlug,
-            activeFilters: { keystages: [keystageSlug] },
-            googleLoginHint: null,
-            clientEnvironment: null,
-          });
-          handleCloseHamburger();
-        }}
+        handleClick={handleSubjectBrowseClick}
         selectedMenu={phase}
         subjects={subjects}
         selectedSubject={selectedExamBoardSubject}

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -141,7 +141,7 @@ function SubjectsSubmenu(props: SubjectsSubmenuProps) {
       filterType: "Subject filter",
       filterValue: subjectSlug,
       activeFilters:
-        props.viewType === "keystage" ? { keyStage: [props.keystageSlug] } : {},
+        props.viewType === "keystage" ? { keystage: [props.keystageSlug] } : {},
       googleLoginHint: null,
       clientEnvironment: null,
     });

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -1,25 +1,23 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
 import {
-  OakBox,
   OakPrimaryInvertedButton,
   OakUL,
   OakLeftAlignedButton,
   OakFlex,
   OakHeading,
+  OakLI,
 } from "@oaknational/oak-components";
 import Link from "next/link";
 
 import TopNavSubjectButtons from "../TopNavDropdown/TopNavSubjectButtons";
 import ExamBoardPanel from "../ExamBoardPanel/ExamBoardPanel";
 
-import {
-  getEYFSAriaLabel,
-  HamburgerMenuHook,
-  SubmenuState,
-} from "./TeachersTopNavHamburger";
+import { HamburgerMenuHook } from "./TeachersTopNavHamburger";
 
 import {
+  Phase,
   SubjectsNavItem,
+  TeachersBrowseChildItem,
   TeachersSubNavData,
 } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
 import {
@@ -28,15 +26,24 @@ import {
 } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 
+const isEyfsKeystage = (keystage: TeachersBrowseChildItem) =>
+  keystage.slug === "early-years-foundation-stage";
+
+const getKeystageListLabel = (keystage: TeachersBrowseChildItem) =>
+  isEyfsKeystage(keystage) ? keystage.title : keystage.description;
+
+const getKeystageListAriaLabel = (keystage: TeachersBrowseChildItem) =>
+  isEyfsKeystage(keystage) ? keystage.description : undefined;
+
 export function SubmenuContainer({
   title,
-  description,
+  ariaLabel,
   children,
   hamburgerMenu,
   onBack,
 }: {
-  readonly title: SubmenuState;
-  readonly description?: string;
+  readonly title: string;
+  readonly ariaLabel?: string;
   readonly children: ReactNode;
   readonly hamburgerMenu: HamburgerMenuHook;
   readonly onBack?: () => void;
@@ -70,7 +77,7 @@ export function SubmenuContainer({
     >
       <OakPrimaryInvertedButton
         iconName="chevron-left"
-        aria-label={getEYFSAriaLabel(title)}
+        aria-label={ariaLabel}
         selected={true}
         onClick={() => {
           if (onBack) {
@@ -81,12 +88,108 @@ export function SubmenuContainer({
         }}
       >
         <OakHeading $font="heading-6" tag="h3">
-          {description || title}
+          {title}
         </OakHeading>
       </OakPrimaryInvertedButton>
 
       {children}
     </OakFlex>
+  );
+}
+
+function SubjectsSubmenu({
+  title,
+  backButtonAriaLabel,
+  subjects,
+  keyStageSlug,
+  phase,
+  hamburgerMenu,
+  selectedExamBoardSubject,
+  setSelectedExamBoardSubject,
+  onBack,
+}: {
+  readonly title: string;
+  readonly backButtonAriaLabel?: string;
+  readonly subjects: SubjectsNavItem[];
+  readonly keyStageSlug: string;
+  readonly phase: Phase;
+  readonly hamburgerMenu: HamburgerMenuHook;
+  readonly selectedExamBoardSubject: SubjectsNavItem | null;
+  readonly setSelectedExamBoardSubject: (
+    subject: SubjectsNavItem | null,
+  ) => void;
+  readonly onBack?: () => void;
+}) {
+  const { track } = useAnalytics();
+  const { handleCloseHamburger } = hamburgerMenu;
+
+  if (selectedExamBoardSubject?.examBoards?.length) {
+    return (
+      <SubmenuContainer
+        title={`${title}, ${selectedExamBoardSubject.title}`}
+        hamburgerMenu={hamburgerMenu}
+        onBack={() => setSelectedExamBoardSubject(null)}
+      >
+        <ExamBoardPanel
+          examBoards={selectedExamBoardSubject.examBoards}
+          phaseSlug={phase}
+          viewType={keyStageSlug}
+          selectedSubject={selectedExamBoardSubject}
+          onClick={(subjectSlug, keystageSlug) => {
+            track.browseRefined({
+              platform: "owa",
+              product: "teacher lesson resources",
+              engagementIntent: "refine",
+              componentType: "topnav-browse-button",
+              eventVersion: "2.0.0",
+              analyticsUseCase: "Teacher",
+              filterType: "Subject filter",
+              filterValue: subjectSlug,
+              activeFilters: { keystages: [keystageSlug] },
+              googleLoginHint: null,
+              clientEnvironment: null,
+            });
+            handleCloseHamburger();
+          }}
+          onLeave={() => setSelectedExamBoardSubject(null)}
+        />
+      </SubmenuContainer>
+    );
+  }
+
+  return (
+    <SubmenuContainer
+      ariaLabel={backButtonAriaLabel}
+      title={title}
+      hamburgerMenu={hamburgerMenu}
+      onBack={onBack}
+    >
+      <TopNavSubjectButtons
+        handleClick={(subjectSlug, keystageSlug) => {
+          track.browseRefined({
+            platform: "owa",
+            product: "teacher lesson resources",
+            engagementIntent: "refine",
+            componentType: "topnav-browse-button",
+            eventVersion: "2.0.0",
+            analyticsUseCase: "Teacher",
+            filterType: "Subject filter",
+            filterValue: subjectSlug,
+            activeFilters: { keystages: [keystageSlug] },
+            googleLoginHint: null,
+            clientEnvironment: null,
+          });
+          handleCloseHamburger();
+        }}
+        selectedMenu={phase}
+        subjects={subjects}
+        selectedSubject={selectedExamBoardSubject}
+        viewTypeSlug={keyStageSlug}
+        phase={phase}
+        onExamBoardPanelOpen={setSelectedExamBoardSubject}
+        closeExamBoardPanel={() => setSelectedExamBoardSubject(null)}
+      />
+    </SubmenuContainer>
   );
 }
 
@@ -98,9 +201,12 @@ export function SubmenuContent(
   const { submenuOpen, handleCloseHamburger } = hamburgerMenu;
   const [selectedExamBoardSubject, setSelectedExamBoardSubject] =
     useState<SubjectsNavItem | null>(null);
+  const [selectedKeystage, setSelectedKeystage] =
+    useState<TeachersBrowseChildItem | null>(null);
 
   useEffect(() => {
     setSelectedExamBoardSubject(null);
+    setSelectedKeystage(null);
   }, [submenuOpen]);
 
   if (!submenuOpen) return null;
@@ -119,7 +225,7 @@ export function SubmenuContent(
             $gap={"spacing-16"}
           >
             {links.children.map((link) => (
-              <OakBox key={link.slug}>
+              <OakLI key={link.slug} $listStyle={"none"}>
                 <OakLeftAlignedButton
                   onClick={() => {
                     handleCloseHamburger();
@@ -139,93 +245,103 @@ export function SubmenuContent(
                 >
                   {link.title}
                 </OakLeftAlignedButton>
-              </OakBox>
+              </OakLI>
             ))}
           </OakUL>
         </SubmenuContainer>
       );
     }
 
-    default: {
-      const phase = ["KS1", "KS2", "EYFS"].includes(submenuOpen)
-        ? "primary"
-        : "secondary";
+    case "Primary subjects":
+    case "Secondary subjects": {
+      const phase: Phase =
+        submenuOpen === "Primary subjects" ? "primary" : "secondary";
       const phaseData = navData[phase];
-      const keystage = phaseData.children.find(
-        (ks) => ks.title === submenuOpen,
+      const phaseItem = phaseData.children.find(
+        (child) => child.type === "phase",
       );
-      if (!keystage) return null;
-      const subjects = keystage.children;
+      if (!phaseItem) return null;
 
-      if (selectedExamBoardSubject?.examBoards?.length) {
+      return (
+        <SubjectsSubmenu
+          title={submenuOpen}
+          subjects={phaseItem.children}
+          keyStageSlug={phase}
+          phase={phase}
+          hamburgerMenu={hamburgerMenu}
+          selectedExamBoardSubject={selectedExamBoardSubject}
+          setSelectedExamBoardSubject={setSelectedExamBoardSubject}
+        />
+      );
+    }
+
+    case "Primary key stages":
+    case "Secondary key stages": {
+      const phase: Phase =
+        submenuOpen === "Primary key stages" ? "primary" : "secondary";
+      const phaseData = navData[phase];
+      const keystages = phaseData.children.filter(
+        (child) => child.type === "keystage",
+      );
+
+      if (selectedKeystage) {
         return (
-          <SubmenuContainer
-            title={
-              `${keystage.title}, ${selectedExamBoardSubject.title}` as SubmenuState
-            }
+          <SubjectsSubmenu
+            title={getKeystageListLabel(selectedKeystage)}
+            backButtonAriaLabel={getKeystageListAriaLabel(selectedKeystage)}
+            subjects={selectedKeystage.children}
+            keyStageSlug={selectedKeystage.slug}
+            phase={phase}
             hamburgerMenu={hamburgerMenu}
-            onBack={() => setSelectedExamBoardSubject(null)}
-          >
-            <ExamBoardPanel
-              examBoards={selectedExamBoardSubject.examBoards}
-              phaseSlug={phase}
-              viewType={keystage.slug}
-              selectedSubject={selectedExamBoardSubject}
-              onClick={(subjectSlug, keystageSlug) => {
-                track.browseRefined({
-                  platform: "owa",
-                  product: "teacher lesson resources",
-                  engagementIntent: "refine",
-                  componentType: "topnav-browse-button",
-                  eventVersion: "2.0.0",
-                  analyticsUseCase: "Teacher",
-                  filterType: "Subject filter",
-                  filterValue: subjectSlug,
-                  activeFilters: { keystages: [keystageSlug] },
-                  googleLoginHint: null,
-                  clientEnvironment: null,
-                });
-                handleCloseHamburger();
-              }}
-              onLeave={() => setSelectedExamBoardSubject(null)}
-            />
-          </SubmenuContainer>
+            selectedExamBoardSubject={selectedExamBoardSubject}
+            setSelectedExamBoardSubject={setSelectedExamBoardSubject}
+            onBack={() => setSelectedKeystage(null)}
+          />
         );
       }
 
       return (
-        <SubmenuContainer
-          description={keystage.description}
-          title={submenuOpen}
-          hamburgerMenu={hamburgerMenu}
-        >
-          <TopNavSubjectButtons
-            handleClick={(subjectSlug, keystageSlug) => {
-              track.browseRefined({
-                platform: "owa",
-                product: "teacher lesson resources",
-                engagementIntent: "refine",
-                componentType: "topnav-browse-button",
-                eventVersion: "2.0.0",
-                analyticsUseCase: "Teacher",
-                filterType: "Subject filter",
-                filterValue: subjectSlug,
-                activeFilters: { keystages: [keystageSlug] },
-                googleLoginHint: null,
-                clientEnvironment: null,
-              });
-              handleCloseHamburger();
-            }}
-            selectedMenu={phase}
-            subjects={subjects}
-            selectedSubject={selectedExamBoardSubject}
-            viewTypeSlug={keystage.slug}
-            phase={phase}
-            onExamBoardPanelOpen={setSelectedExamBoardSubject}
-            closeExamBoardPanel={() => setSelectedExamBoardSubject(null)}
-          />
+        <SubmenuContainer title={submenuOpen} hamburgerMenu={hamburgerMenu}>
+          <OakUL
+            $display={"flex"}
+            $flexDirection={"column"}
+            $gap={"spacing-16"}
+          >
+            {keystages.map((keystage) => (
+              <OakLI key={keystage.slug} $listStyle={"none"} $width={"100%"}>
+                <OakLeftAlignedButton
+                  aria-haspopup={true}
+                  aria-label={getKeystageListAriaLabel(keystage)}
+                  rightAlignIcon
+                  iconName="chevron-right"
+                  width={"100%"}
+                  onClick={() => {
+                    track.browseRefined({
+                      platform: "owa",
+                      product: "teacher lesson resources",
+                      engagementIntent: "refine",
+                      componentType: "topnav-browse-button",
+                      eventVersion: "2.0.0",
+                      analyticsUseCase: "Teacher",
+                      filterType: "Key stage filter",
+                      filterValue: keystage.slug,
+                      activeFilters: {},
+                      googleLoginHint: null,
+                      clientEnvironment: null,
+                    });
+                    setSelectedKeystage(keystage);
+                  }}
+                >
+                  {getKeystageListLabel(keystage)}
+                </OakLeftAlignedButton>
+              </OakLI>
+            ))}
+          </OakUL>
         </SubmenuContainer>
       );
     }
+
+    default:
+      return null;
   }
 }

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
@@ -188,6 +188,58 @@ describe("TeachersTopNavHamburger", () => {
     expect(getByText("Primary")).toBeInTheDocument();
   });
 
+  it("should track subject click with keyStage activeFilter when browsing by keystage", async () => {
+    const { getByTestId, getByText, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 1",
+    });
+
+    const englishButton = getByRole("link", { name: /English/i });
+    await user.click(englishButton);
+
+    expect(mockBrowseRefined).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterType: "Subject filter",
+        filterValue: "english",
+        activeFilters: { keyStage: ["ks1"] },
+      }),
+    );
+  });
+
+  it("should track subject click without keyStage activeFilter when browsing by phase", async () => {
+    const { getByTestId, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    const secondarySubjectsButton = getByRole("button", {
+      name: "Secondary subjects",
+    });
+    await user.click(secondarySubjectsButton);
+
+    const computerScienceButton = getByRole("link", {
+      name: /Computer science/i,
+    });
+    await user.click(computerScienceButton);
+
+    expect(mockBrowseRefined).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterType: "Subject filter",
+        filterValue: "computer-science",
+        activeFilters: {},
+      }),
+    );
+  });
+
   it("should track browse refined when a keystage is selected", async () => {
     const { getByTestId, getByText, getByRole } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
@@ -336,7 +388,7 @@ describe("TeachersTopNavHamburger", () => {
       getByRole("heading", { name: "Choose tier for KS4 Geography" }),
     ).toBeInTheDocument();
 
-    const backButton = getByRole("button", { name: "Key stage 4, Geography" });
+    const backButton = getByRole("button", { name: "KS4, Geography" });
     await user.click(backButton);
 
     expect(

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
@@ -2,10 +2,7 @@ import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
 
-import {
-  getEYFSAriaLabel,
-  TeachersTopNavHamburger,
-} from "./TeachersTopNavHamburger";
+import { TeachersTopNavHamburger } from "./TeachersTopNavHamburger";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
@@ -31,6 +28,27 @@ jest.mock("@/context/Analytics/useAnalytics", () => ({
   }),
 }));
 
+async function openKeystageSubjects(
+  user: ReturnType<typeof userEvent.setup>,
+  getByRole: ReturnType<typeof render>["getByRole"],
+  getByText: ReturnType<typeof render>["getByText"],
+  {
+    phaseKeyStagesLabel,
+    keystageLabel,
+  }: {
+    phaseKeyStagesLabel: string;
+    keystageLabel: string;
+  },
+) {
+  const phaseKeyStagesButton = getByRole("button", {
+    name: phaseKeyStagesLabel,
+  });
+  await user.click(phaseKeyStagesButton);
+
+  const keystageButton = getByText(keystageLabel);
+  await user.click(keystageButton);
+}
+
 describe("TeachersTopNavHamburger", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -47,47 +65,6 @@ describe("TeachersTopNavHamburger", () => {
   });
 
   it("should display main menu content when no submenu is open", async () => {
-    const { getByTestId, getByText } = render(
-      <TeachersTopNavHamburger {...mockTopNavProps} />,
-    );
-    const user = userEvent.setup();
-    const button = getByTestId("top-nav-hamburger-button");
-    await user.click(button);
-
-    expect(getByText("Primary")).toBeInTheDocument();
-  });
-
-  it("should display submenu content when a submenu is opened", async () => {
-    const { getByTestId, getByText } = render(
-      <TeachersTopNavHamburger {...mockTopNavProps} />,
-    );
-
-    const user = userEvent.setup();
-    const button = getByTestId("top-nav-hamburger-button");
-    await user.click(button);
-
-    const keyStageItem = getByText("Key stage 1");
-    await user.click(keyStageItem);
-    expect(getByText("English")).toBeInTheDocument();
-  });
-
-  it("should focus the first list item when submenu is opened", async () => {
-    const { getByTestId, getByText } = render(
-      <TeachersTopNavHamburger {...mockTopNavProps} />,
-    );
-    const user = userEvent.setup();
-    const button = getByTestId("top-nav-hamburger-button");
-    await user.click(button);
-
-    const keyStageItem = getByText("Key stage 1");
-    await user.click(keyStageItem);
-    const firstListItem = getByTestId("topnav-subject-button-english");
-    expect(document?.activeElement?.textContent).toBe(
-      firstListItem.textContent,
-    );
-  });
-
-  it("should close submenu and return to main menu when back button is triggered", async () => {
     const { getByTestId, getByText, queryByText } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
     );
@@ -95,18 +72,71 @@ describe("TeachersTopNavHamburger", () => {
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const keyStageItem = getByText("Key stage 1");
-    await user.click(keyStageItem);
+    expect(getByText("Primary")).toBeInTheDocument();
+    expect(getByText("Primary key stages")).toBeInTheDocument();
+    expect(getByText("Secondary subjects")).toBeInTheDocument();
+    expect(getByText("Secondary key stages")).toBeInTheDocument();
+    expect(queryByText("Primary subjects")).not.toBeInTheDocument();
+    expect(queryByText("Primary years")).not.toBeInTheDocument();
+    expect(queryByText("Secondary years")).not.toBeInTheDocument();
+  });
 
-    const backButton = getByText("Key stage 1");
+  it("should display submenu content when a submenu is opened", async () => {
+    const { getByTestId, getByText, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 1",
+    });
+    expect(getByText("English")).toBeInTheDocument();
+  });
+
+  it("should focus the first list item when submenu is opened", async () => {
+    const { getByTestId, getByText, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 1",
+    });
+    const firstListItem = getByTestId("topnav-subject-button-english");
+    expect(document?.activeElement?.textContent).toBe(
+      firstListItem.textContent,
+    );
+  });
+
+  it("should close submenu and return to key stages list when back button is triggered", async () => {
+    const { getByTestId, getByText, queryByText, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 1",
+    });
+
+    const backButton = getByRole("button", { name: "Key stage 1" });
     await user.click(backButton);
 
     expect(queryByText("English")).not.toBeInTheDocument();
-    expect(getByText("Primary")).toBeInTheDocument();
+    expect(getByText("Key stage 2")).toBeInTheDocument();
   });
 
   it("should focus the triggering element when returning to main menu from submenu", async () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, getByRole } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
     );
     const user = userEvent.setup();
@@ -114,25 +144,38 @@ describe("TeachersTopNavHamburger", () => {
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const keyStageItem = getByText("Key stage 3");
-    await user.click(keyStageItem);
+    const phaseKeyStagesButton = getByRole("button", {
+      name: "Secondary key stages",
+    });
+    await user.click(phaseKeyStagesButton);
 
-    const backButton = getByText("Key stage 3");
-    await user.click(backButton);
+    const keystageItem = getByText("Key stage 3");
+    await user.click(keystageItem);
 
-    expect(document?.activeElement?.textContent).toBe(keyStageItem.textContent);
+    const backToKeyStages = getByRole("button", { name: "Key stage 3" });
+    await user.click(backToKeyStages);
+
+    const backToMainMenu = getByRole("button", {
+      name: "Secondary key stages",
+    });
+    await user.click(backToMainMenu);
+
+    expect(document?.activeElement?.textContent).toBe(
+      phaseKeyStagesButton.textContent,
+    );
   });
 
   it("should reset all states when modal closes", async () => {
-    const { getByTestId, getByText, queryByText, getByLabelText } = render(
-      <TeachersTopNavHamburger {...mockTopNavProps} />,
-    );
+    const { getByTestId, getByText, queryByText, getByLabelText, getByRole } =
+      render(<TeachersTopNavHamburger {...mockTopNavProps} />);
     const user = userEvent.setup();
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const keyStageItem = getByText("Key stage 2");
-    await user.click(keyStageItem);
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 2",
+    });
 
     const closeButton = getByLabelText("Close");
     await user.click(closeButton);
@@ -145,23 +188,18 @@ describe("TeachersTopNavHamburger", () => {
     expect(getByText("Primary")).toBeInTheDocument();
   });
 
-  it('should only return "Early years foundation stage" for EYFS title', () => {
-    const EYFS = getEYFSAriaLabel("EYFS");
-    const Ks1 = getEYFSAriaLabel("KS1");
-    expect(EYFS).toBe("Early years foundation stage");
-    expect(Ks1).toBeUndefined();
-  });
-
   it("should track browse refined when a keystage is selected", async () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, getByRole } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
     );
     const user = userEvent.setup();
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const keyStageItem = getByText("Key stage 1");
-    await user.click(keyStageItem);
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Primary key stages",
+      keystageLabel: "Key stage 1",
+    });
 
     expect(mockBrowseRefined).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -170,6 +208,53 @@ describe("TeachersTopNavHamburger", () => {
       }),
     );
   });
+
+  it("should show EYFS with full accessible label in primary key stages list and back button", async () => {
+    const { getByTestId, getByRole, getByText, queryByText } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    const primaryKeyStagesButton = getByRole("button", {
+      name: "Primary key stages",
+    });
+    await user.click(primaryKeyStagesButton);
+
+    expect(getByText("EYFS")).toBeInTheDocument();
+    expect(queryByText("Early years foundation stage")).not.toBeInTheDocument();
+    expect(
+      getByRole("button", { name: "Early years foundation stage" }),
+    ).toBeInTheDocument();
+
+    const eyfsButton = getByRole("button", {
+      name: "Early years foundation stage",
+    });
+    await user.click(eyfsButton);
+
+    expect(getByRole("heading", { name: "EYFS" })).toBeInTheDocument();
+    expect(
+      getByRole("button", { name: "Early years foundation stage" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should display phase subjects when a phase subjects submenu is opened", async () => {
+    const { getByTestId, getByText, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    const secondarySubjectsButton = getByRole("button", {
+      name: "Secondary subjects",
+    });
+    await user.click(secondarySubjectsButton);
+
+    expect(getByText("Computer science")).toBeInTheDocument();
+  });
+
   it("should render an aria label for external links in the main nav", async () => {
     const { getByTestId, getByRole } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
@@ -183,6 +268,7 @@ describe("TeachersTopNavHamburger", () => {
     });
     expect(aiExperimentsLink).toHaveTextContent("AI Experiments");
   });
+
   it("renders the submenu correctly", async () => {
     const { getByTestId, getByRole, queryByTestId } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
@@ -193,16 +279,17 @@ describe("TeachersTopNavHamburger", () => {
 
     expect(queryByTestId("submenu-container")).not.toBeInTheDocument();
 
-    const menuButton = getByRole("button", { name: "Key stage 1" });
+    const menuButton = getByRole("button", { name: "Primary key stages" });
     await user.click(menuButton);
 
     expect(getByTestId("submenu-container")).toBeInTheDocument();
 
-    const backButton = getByRole("button", { name: "Key stage 1" });
+    const backButton = getByRole("button", { name: "Primary key stages" });
     await user.click(backButton);
 
     expect(queryByTestId("submenu-container")).not.toBeInTheDocument();
   });
+
   it("should render an aria label for external links in the sub menu", async () => {
     const { getByTestId, getByRole, getByText } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
@@ -237,8 +324,10 @@ describe("TeachersTopNavHamburger", () => {
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const keyStage4Item = getByText("Key stage 4");
-    await user.click(keyStage4Item);
+    await openKeystageSubjects(user, getByRole, getByText, {
+      phaseKeyStagesLabel: "Secondary key stages",
+      keystageLabel: "Key stage 4",
+    });
 
     const geographySubject = getByRole("button", { name: "Geography" });
     await user.click(geographySubject);
@@ -247,7 +336,7 @@ describe("TeachersTopNavHamburger", () => {
       getByRole("heading", { name: "Choose tier for KS4 Geography" }),
     ).toBeInTheDocument();
 
-    const backButton = getByRole("button", { name: "KS4, Geography" });
+    const backButton = getByRole("button", { name: "Key stage 4, Geography" });
     await user.click(backButton);
 
     expect(

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
@@ -208,7 +208,7 @@ describe("TeachersTopNavHamburger", () => {
       expect.objectContaining({
         filterType: "Subject filter",
         filterValue: "english",
-        activeFilters: { keyStage: ["ks1"] },
+        activeFilters: { keystage: ["ks1"] },
       }),
     );
   });
@@ -257,6 +257,27 @@ describe("TeachersTopNavHamburger", () => {
       expect.objectContaining({
         filterType: "Key stage filter",
         filterValue: "ks1",
+      }),
+    );
+  });
+
+  it("should track browse refined when phase subjects submenu is opened", async () => {
+    const { getByTestId, getByRole } = render(
+      <TeachersTopNavHamburger {...mockTopNavProps} />,
+    );
+    const user = userEvent.setup();
+    const button = getByTestId("top-nav-hamburger-button");
+    await user.click(button);
+
+    const secondarySubjectsButton = getByRole("button", {
+      name: "Secondary subjects",
+    });
+    await user.click(secondarySubjectsButton);
+
+    expect(mockBrowseRefined).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterType: "Phase filter",
+        filterValue: "secondary",
       }),
     );
   });

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.tsx
@@ -12,11 +12,10 @@ import { SubmenuContent } from "./HamburgerSubMenu";
 import { TeachersSubNavData } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
 
 export type SubmenuState =
-  | "KS1"
-  | "KS2"
-  | "EYFS"
-  | "KS3"
-  | "KS4"
+  | "Primary subjects"
+  | "Secondary subjects"
+  | "Primary key stages"
+  | "Secondary key stages"
   | "About us"
   | "Guidance"
   | null;
@@ -29,11 +28,6 @@ export type HamburgerMenuHook = {
   handleOpen: () => void;
   handleCloseHamburger: () => void;
   handleCloseSubmenu: () => void;
-};
-
-export const getEYFSAriaLabel = (title: SubmenuState) => {
-  const isEYFS = title === "EYFS";
-  return isEYFS ? "Early years foundation stage" : undefined;
 };
 
 export const useHamburgerMenuState = (): HamburgerMenuHook => {

--- a/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
@@ -56,7 +56,7 @@ export const topNavFixture: TopNavProps = {
         },
         {
           type: "keystage",
-          slug: "eyfs",
+          slug: "early-years-foundation-stage",
           title: "EYFS",
           description: "Early years foundation stage",
           children: [],


### PR DESCRIPTION
## Description

Music year: 1975

## Description

- Restructure the teachers hamburger menu into Primary/Secondary sections with separate **subjects** and **key stages** sub-menus, aligned with the desktop top nav phase model
- Add a keystage drill-down: key stages list → subjects for that keystage, with back navigation at each level
- Reuse `TopNavSubjectButtons` and `ExamBoardPanel` in hamburger sub-menus (including KS4 exam board/tier selection)
- Show **EYFS** as the visible label with full **Early years foundation stage** accessible name on list and back button
- Align hamburger layout with latest designs (spacing, dividers)
- Extract shared subject browse tracking callback in `SubjectsSubmenu`
- Refactor teachers nav data and desktop dropdown to use `viewType`/`viewTypeSlug` instead of keystage-specific naming

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-2030phases-in-62267f.vercel.thenational.academy/teachers at a **mobile viewport** (≤768px wide, or use device toolbar)
2. Tap the hamburger icon (top right) to open the navigation modal
3. You should see **Primary** and **Secondary** headings, each with **Primary/Secondary subjects** and **Primary/Secondary key stages** chevron buttons, followed by **About us**, **Guidance**, and **AI Experiments**

**Also verify the key stages drill-down:**

4. Tap **Primary key stages**
5. You should see a back button labelled **Primary key stages** and a list including **EYFS**, **Key stage 1**, and **Key stage 2**
6. Tap **Key stage 1**
7. You should see a back button labelled **Key stage 1** and subject buttons including **English** and **Maths**; focus should land on the first subject button
8. Tap the **Key stage 1** back button
9. You should return to the key stages list (**Key stage 2** visible, **English** no longer visible)
10. Tap the **Primary key stages** back button
11. You should return to the main hamburger menu

**Also verify EYFS accessibility labelling:**

12. From **Primary key stages**, tap the row labelled **EYFS**
13. You should see heading **EYFS** and a back button with accessible name **Early years foundation stage** (not the long label as visible list text)

**Also verify phase subjects and KS4 exam boards:**

14. Return to the main menu and tap **Secondary subjects**
15. You should see phase-level subjects including **Computer science**
16. Go back, tap **Secondary key stages** → **Key stage 4** → **Geography**
17. You should see **Choose tier for KS4 Geography** with exam board/tier options
18. Tap the **Key stage 4, Geography** back button
19. You should return to the KS4 subject list with **Geography** still visible and the tier picker closed

**And verify no regression for desktop top nav and modal reset:**

20. Widen the viewport to desktop (≥1024px) and open the **Primary** or **Secondary** dropdown in the top nav
21. You should see the same phase/keystage browse structure and subject links working as before
22. On mobile again, open **Primary key stages** → **Key stage 2**, then close the modal with **Close**
23. Reopen the hamburger menu — you should land on the main menu (not stuck on **Key stage 2** subjects)

## Screenshots

How it used to look

<img width="478" height="1048" alt="Screenshot 2026-06-11 at 12 24 50" src="https://github.com/user-attachments/assets/f56fe4b3-1695-4798-a11a-f7b178616b21" />

<img width="482" height="1048" alt="Screenshot 2026-06-11 at 12 25 08" src="https://github.com/user-attachments/assets/76a0de26-382b-4171-a0bd-1b20c81db2fd" />

<img width="481" height="1049" alt="Screenshot 2026-06-11 at 12 25 19" src="https://github.com/user-attachments/assets/ab99624d-2d0f-4a67-a4d8-3011563bf5c7" />


How it should now look:

<img width="480" height="1050" alt="Screenshot 2026-06-11 at 12 26 31" src="https://github.com/user-attachments/assets/5a2bde4d-71aa-465c-acf2-cbe675598b80" />

<img width="480" height="1048" alt="Screenshot 2026-06-11 at 12 26 42" src="https://github.com/user-attachments/assets/c6d4f27a-f9c0-446d-9d0a-47dcd07782d4" />

<img width="482" height="1048" alt="Screenshot 2026-06-11 at 12 26 50" src="https://github.com/user-attachments/assets/22c27fa9-a075-470e-a1ad-66d343de2bbd" />

<img width="482" height="1049" alt="Screenshot 2026-06-11 at 13 13 44" src="https://github.com/user-attachments/assets/25085b97-8e14-483e-b304-42355d97f87a" />

<img width="480" height="1048" alt="Screenshot 2026-06-11 at 13 14 11" src="https://github.com/user-attachments/assets/ad6ba8b9-ca71-4b40-a13c-ac2c2541a0f7" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
