### PR TITLE
Bump oak-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@mux/mux-player": "^3.10.2",
     "@mux/mux-player-react": "3.10.2",
     "@oaknational/google-classroom-addon": "^1.33.0",
-    "@oaknational/oak-components": "^2.31.0",
+    "@oaknational/oak-components": "^2.40.0",
     "@oaknational/oak-consent-client": "2.4.0",
     "@oaknational/oak-curriculum-schema": "2.4.0-beta.2",
     "@ooxml-tools/units": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 8.9.0(@bugsnag/core@8.9.0)
       '@clerk/nextjs':
         specifier: ^6.37.3
-        version: 6.38.2(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.38.2(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@eslint/compat':
         specifier: ^2.0.1
-        version: 2.0.5(eslint@9.39.2(jiti@2.6.1))
+        version: 2.0.5(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       '@google-cloud/dlp':
         specifier: ^6.5.0
         version: 6.5.0
@@ -52,10 +52,10 @@ importers:
         version: 3.10.2(@types/react-dom@18.3.0)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@oaknational/google-classroom-addon':
         specifier: ^1.33.0
-        version: 1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.31.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))
+        version: 1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))
       '@oaknational/oak-components':
-        specifier: ^2.31.0
-        version: 2.31.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
+        specifier: ^2.40.0
+        version: 2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
       '@oaknational/oak-consent-client':
         specifier: 2.4.0
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)
@@ -103,16 +103,16 @@ importers:
         version: 1.1.0
       '@sentry/nextjs':
         specifier: ^10.48.0
-        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
+        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)(supports-color@5.5.0)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@sentry/webpack-plugin':
         specifier: ^3.2.1
         version: 3.5.0(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: ^4.0.1
-        version: 4.0.3(@swc/helpers@0.5.19)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
+        version: 4.0.3(@swc/helpers@0.5.19)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@storybook/react':
         specifier: ^9.1.8
-        version: 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)
+        version: 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -169,7 +169,7 @@ importers:
         version: 3.4.0
       eslint-plugin-compat:
         specifier: ^6.2.0
-        version: 6.2.0(eslint@9.39.2(jiti@2.6.1))
+        version: 6.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       favicons:
         specifier: ^7.1.5
         version: 7.2.0
@@ -205,13 +205,13 @@ importers:
         version: 5.0.9
       next:
         specifier: ^15.5.12
-        version: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+        version: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       next-cloudinary:
         specifier: ^6.16.0
-        version: 6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
+        version: 6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
       next-seo:
         specifier: ^6.6.0
-        version: 6.6.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.6.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0
@@ -274,7 +274,7 @@ importers:
         version: 3.2.0
       styled-components:
         specifier: ^5.3.6
-        version: 5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
+        version: 5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
       svix:
         specifier: ^1.67.0
         version: 1.67.0
@@ -323,7 +323,7 @@ importers:
         version: 4.10.2
       '@babel/core':
         specifier: ^7.28.3
-        version: 7.28.3
+        version: 7.28.3(supports-color@5.5.0)
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@22.19.17)(typescript@5.9.3)
@@ -347,7 +347,7 @@ importers:
         version: 6.0.1
       '@graphql-codegen/cli':
         specifier: ^5.0.6
-        version: 5.0.7(@types/node@22.19.17)(graphql@16.10.0)(typescript@5.9.3)
+        version: 5.0.7(@types/node@22.19.17)(graphql@16.10.0)(supports-color@5.5.0)(typescript@5.9.3)
       '@graphql-codegen/typescript':
         specifier: ^4.1.6
         version: 4.1.6(graphql@16.10.0)
@@ -374,7 +374,7 @@ importers:
         version: 15.3.2
       '@percy/cli':
         specifier: ^1.30.11
-        version: 1.30.11(typescript@5.9.3)
+        version: 1.30.11(supports-color@5.5.0)(typescript@5.9.3)
       '@prettier/plugin-xml':
         specifier: 3.2.2
         version: 3.2.2(prettier@3.3.3)
@@ -383,13 +383,13 @@ importers:
         version: 7.21.0
       '@semantic-release/changelog':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@24.2.4(typescript@5.9.3))
+        version: 6.0.3(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))
       '@semantic-release/exec':
         specifier: ^7.1.0
-        version: 7.1.0(semantic-release@24.2.4(typescript@5.9.3))
+        version: 7.1.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@24.2.4(typescript@5.9.3))
+        version: 10.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)
       '@slack/bolt':
         specifier: ^3.22.0
         version: 3.22.0
@@ -398,22 +398,22 @@ importers:
         version: 5.28.3(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@storybook/addon-a11y':
         specifier: ^9.1.8
-        version: 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+        version: 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       '@storybook/addon-docs':
         specifier: ^9.1.8
-        version: 9.1.8(@types/react@18.2.79)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+        version: 9.1.8(@types/react@18.2.79)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       '@storybook/addon-links':
         specifier: ^9.1.8
-        version: 9.1.8(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+        version: 9.1.8(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       '@storybook/addon-onboarding':
         specifier: ^9.1.8
-        version: 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+        version: 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       '@storybook/cli':
         specifier: ^9.1.8
-        version: 9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3))(@testing-library/dom@10.2.0)(prettier@3.3.3)
+        version: 9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))(@testing-library/dom@10.2.0)(prettier@3.3.3)
       '@storybook/nextjs':
         specifier: ^9.1.8
-        version: 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/webpack@5.28.5(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))(esbuild@0.19.12)(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
+        version: 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/webpack@5.28.5(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))(esbuild@0.19.12)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(supports-color@5.5.0)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@testing-library/dom':
         specifier: ^10.2.0
         version: 10.2.0
@@ -473,10 +473,10 @@ importers:
         version: 17.0.35
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.52.0
-        version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.52.0
-        version: 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       browserslist-useragent-regexp:
         specifier: ^4.1.3
         version: 4.1.4(browserslist@4.28.1)
@@ -488,7 +488,7 @@ importers:
         version: 5.6.2
       chromedriver:
         specifier: ^130.0.4
-        version: 130.0.4
+        version: 130.0.4(supports-color@5.5.0)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -509,34 +509,34 @@ importers:
         version: 1.0.3
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-config-next:
         specifier: ^15.3.0
-        version: 15.3.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 15.3.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
-        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+        version: 7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+        version: 7.0.1(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       eslint-plugin-storybook:
         specifier: ^9.1.8
-        version: 9.1.8(eslint@9.39.2(jiti@2.6.1))(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)
+        version: 9.1.8(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)
       express:
         specifier: ^5.1.0
-        version: 5.2.1
+        version: 5.2.1(supports-color@5.5.0)
       firebase-tools:
         specifier: ^14.18.0
-        version: 14.27.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3)
+        version: 14.27.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(supports-color@5.5.0)(typescript@5.9.3)
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -569,7 +569,7 @@ importers:
         version: 3.0.3
       jest-styled-components:
         specifier: ^7.2.0
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
+        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
       json-diff:
         specifier: ^1.0.6
         version: 1.0.6
@@ -578,7 +578,7 @@ importers:
         version: 6.3.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.9.2)
       lint-staged:
         specifier: ^15.2.10
-        version: 15.5.2
+        version: 15.5.2(supports-color@5.5.0)
       microdiff:
         specifier: ^1.5.0
         version: 1.5.0
@@ -587,10 +587,10 @@ importers:
         version: 4.0.8
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
+        version: 0.9.13(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))
+        version: 4.2.3(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))
       node-mocks-http:
         specifier: ^1.16.1
         version: 1.16.2(@types/express@5.0.6)(@types/node@22.19.17)
@@ -626,22 +626,22 @@ importers:
         version: 6.0.1
       semantic-release:
         specifier: ^24.2.4
-        version: 24.2.4(typescript@5.9.3)
+        version: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
       sharp:
         specifier: ^0.34.2
         version: 0.34.5
       storybook:
         specifier: ^9.1.8
-        version: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+        version: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       storybook-css-modules-preset:
         specifier: ^1.1.1
         version: 1.1.1
       stylelint:
         specifier: ^16.20.0
-        version: 16.21.0(typescript@5.9.3)
+        version: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
       stylelint-config-standard-scss:
         specifier: ^13.1.0
-        version: 13.1.0(postcss@8.5.9)(stylelint@16.21.0(typescript@5.9.3))
+        version: 13.1.0(postcss@8.5.9)(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-styled-components:
         specifier: ^0.1.1
         version: 0.1.1
@@ -662,7 +662,7 @@ importers:
         version: 5.9.3
       typescript-plugin-css-modules:
         specifier: ^5.2.0
-        version: 5.2.0(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)
+        version: 5.2.0(supports-color@5.5.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)
       webpack:
         specifier: ^5.105.1
         version: 5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)
@@ -3108,8 +3108,9 @@ packages:
       zod: '>=3.25.76'
       zustand: '>=5.0.9'
 
-  '@oaknational/oak-components@2.31.0':
-    resolution: {integrity: sha512-AdPsXnNFWakw3IpoeI5VSFG5HU0i6iP1gXrYWpA2w+iA/8sYSMlkAGIVXjVgGwVSiIKHcvibMG9+EqZDc+3Dsg==}
+  '@oaknational/oak-components@2.40.0':
+    resolution: {integrity: sha512-8Qz1Kgx1IdG+u9mmRSr5QNvTe9J+fz5cZUaGztirbKkak8LtSrvXKotmaWERcaA6uO7JsjJ1RNptqQ1WPcveUQ==}
+    engines: {node: '24', pnpm: '>=11'}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'
@@ -14280,13 +14281,13 @@ snapshots:
 
   '@babel/compat-data@7.28.0': {}
 
-  '@babel/core@7.28.3':
+  '@babel/core@7.28.3(supports-color@5.5.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helpers': 7.28.3
       '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
@@ -14324,29 +14325,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.28.3)':
+  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.7
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.28.3)':
+  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.28.3)':
+  '@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.3(supports-color@5.5.0)
@@ -14381,9 +14382,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.3(supports-color@5.5.0)
@@ -14396,16 +14397,16 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.28.3)':
+  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.22.20
 
-  '@babel/helper-replace-supers@7.24.1(@babel/core@7.28.3)':
+  '@babel/helper-replace-supers@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -14446,633 +14447,633 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.4(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.28.3)':
+  '@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.28.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.28.3)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-block-scoping@7.24.4(@babel/core@7.28.3)':
+  '@babel/plugin-transform-block-scoping@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-static-block@7.24.4(@babel/core@7.28.3)':
+  '@babel/plugin-transform-class-static-block@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-classes@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-classes@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
 
-  '@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
-  '@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-for-of@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-for-of@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-function-name@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-function-name@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-literals@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-literals@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
-
-  '@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+
+  '@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
+    dependencies:
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
+    dependencies:
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.28.3)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-new-target@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-new-target@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-object-super@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-object-super@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-parameters@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-parameters@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3)
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-constant-elements@7.24.1(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-react-constant-elements@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.28.3)':
+  '@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.28.3(supports-color@5.5.0))':
+    dependencies:
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.28.3)':
+  '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-runtime@7.24.3(@babel/core@7.28.3)':
+  '@babel/plugin-transform-runtime@7.24.3(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.28.3)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.28.3)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.28.3)
+      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.28.3(supports-color@5.5.0))
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-spread@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typescript@7.24.4(@babel/core@7.28.3)':
+  '@babel/plugin-transform-typescript@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3)
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/preset-env@7.24.4(@babel/core@7.28.3)':
+  '@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.4(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.3)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-async-generator-functions': 7.24.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-block-scoping': 7.24.4(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.28.3)
-      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.28.3)
-      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.28.3)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.3)
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.28.3)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.28.3)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.28.3)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-async-generator-functions': 7.24.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-block-scoping': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.28.3(supports-color@5.5.0))
       core-js-compat: 3.37.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-flow@7.27.1(@babel/core@7.28.3)':
+  '@babel/preset-flow@7.27.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.28.3(supports-color@5.5.0))
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.3)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.2
       esutils: 2.0.3
 
-  '@babel/preset-react@7.24.1(@babel/core@7.28.3)':
+  '@babel/preset-react@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.3)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.28.3)
-      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.24.1(@babel/core@7.28.3)':
+  '@babel/preset-typescript@7.24.1(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.28.6(@babel/core@7.28.3)':
+  '@babel/register@7.28.6(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -15169,13 +15170,13 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.38.2(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@6.38.2(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 2.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.61.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 3.47.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.101.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       server-only: 0.0.1
@@ -15567,20 +15568,20 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.0.5(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint/compat@2.0.5(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.1(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -15786,7 +15787,7 @@ snapshots:
       graphql: 16.10.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.7(@types/node@22.19.17)(graphql@16.10.0)(typescript@5.9.3)':
+  '@graphql-codegen/cli@5.0.7(@types/node@22.19.17)(graphql@16.10.0)(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/template': 7.27.2
@@ -15801,7 +15802,7 @@ snapshots:
       '@graphql-tools/graphql-file-loader': 8.0.2(graphql@16.10.0)
       '@graphql-tools/json-file-loader': 8.0.2(graphql@16.10.0)
       '@graphql-tools/load': 8.1.0(graphql@16.10.0)
-      '@graphql-tools/prisma-loader': 8.0.3(@types/node@22.19.17)(graphql@16.10.0)
+      '@graphql-tools/prisma-loader': 8.0.3(@types/node@22.19.17)(graphql@16.10.0)(supports-color@5.5.0)
       '@graphql-tools/url-loader': 8.0.2(@types/node@22.19.17)(graphql@16.10.0)
       '@graphql-tools/utils': 10.8.6(graphql@16.10.0)
       '@whatwg-node/fetch': 0.10.3
@@ -16090,9 +16091,9 @@ snapshots:
 
   '@graphql-tools/graphql-tag-pluck@8.3.0(graphql@16.10.0)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/parser': 7.28.3
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/traverse': 7.28.3(supports-color@5.5.0)
       '@babel/types': 7.28.2
       '@graphql-tools/utils': 10.8.6(graphql@16.10.0)
@@ -16135,7 +16136,7 @@ snapshots:
       graphql: 16.10.0
       tslib: 2.8.1
 
-  '@graphql-tools/prisma-loader@8.0.3(@types/node@22.19.17)(graphql@16.10.0)':
+  '@graphql-tools/prisma-loader@8.0.3(@types/node@22.19.17)(graphql@16.10.0)(supports-color@5.5.0)':
     dependencies:
       '@graphql-tools/url-loader': 8.0.2(@types/node@22.19.17)(graphql@16.10.0)
       '@graphql-tools/utils': 10.8.6(graphql@16.10.0)
@@ -16755,7 +16756,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.30
       babel-plugin-istanbul: 6.1.1
@@ -16873,7 +16874,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-rate-limit: 8.3.2(express@5.2.1)
       hono: 4.12.14
       jose: 6.2.2
@@ -17033,27 +17034,27 @@ snapshots:
   '@npmcli/redact@4.0.0':
     optional: true
 
-  '@oaknational/google-classroom-addon@1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.31.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))':
+  '@oaknational/google-classroom-addon@1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))':
     dependencies:
       '@google-cloud/firestore': 7.11.6
       '@googleapis/classroom': 4.9.0
-      '@oaknational/oak-components': 2.31.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
+      '@oaknational/oak-components': 2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
       google-auth-library: 9.15.1
       iron-session: 8.0.4
       lodash: 4.18.1
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
 
-  '@oaknational/oak-components@2.31.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))':
+  '@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))':
     dependencies:
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
-      next-cloudinary: 6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next-cloudinary: 6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-components: 5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
 
   '@oaknational/oak-consent-client@2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)':
     dependencies:
@@ -17247,7 +17248,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17256,7 +17257,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
@@ -17265,7 +17266,7 @@ snapshots:
   '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17273,21 +17274,21 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17295,7 +17296,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17304,7 +17305,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
@@ -17313,7 +17314,7 @@ snapshots:
   '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17321,7 +17322,7 @@ snapshots:
   '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17330,7 +17331,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17338,14 +17339,14 @@ snapshots:
   '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17354,7 +17355,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -17362,7 +17363,7 @@ snapshots:
   '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
@@ -17371,7 +17372,7 @@ snapshots:
   '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/mysql': 2.15.27
     transitivePeerDependencies:
@@ -17381,7 +17382,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
       '@types/pg': 8.15.6
@@ -17392,7 +17393,7 @@ snapshots:
   '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
@@ -17403,7 +17404,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.207.0
       import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17412,16 +17413,16 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.212.0
       import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17704,7 +17705,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli@1.30.11(typescript@5.9.3)':
+  '@percy/cli@1.30.11(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@percy/cli-app': 1.30.11(typescript@5.9.3)
       '@percy/cli-build': 1.30.11(typescript@5.9.3)
@@ -17713,7 +17714,7 @@ snapshots:
       '@percy/cli-exec': 1.30.11(typescript@5.9.3)
       '@percy/cli-snapshot': 1.30.11(typescript@5.9.3)
       '@percy/cli-upload': 1.30.11(typescript@5.9.3)
-      '@percy/client': 1.30.11
+      '@percy/client': 1.30.11(supports-color@5.5.0)
       '@percy/logger': 1.30.11
     transitivePeerDependencies:
       - bufferutil
@@ -17721,11 +17722,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.30.11':
+  '@percy/client@1.30.11(supports-color@5.5.0)':
     dependencies:
       '@percy/env': 1.30.11
       '@percy/logger': 1.30.11
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@5.5.0)
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -17741,7 +17742,7 @@ snapshots:
 
   '@percy/core@1.30.11(typescript@5.9.3)':
     dependencies:
-      '@percy/client': 1.30.11
+      '@percy/client': 1.30.11(supports-color@5.5.0)
       '@percy/config': 1.30.11(typescript@5.9.3)
       '@percy/dom': 1.30.11
       '@percy/logger': 1.30.11
@@ -17887,7 +17888,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       extract-zip: 2.0.1
       progress: 2.0.3
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@5.5.0)
       semver: 7.7.4
       tar-fs: 3.1.2
       yargs: 17.7.2
@@ -18959,25 +18960,25 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/changelog@6.0.3(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.2.0
       lodash: 4.18.1
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
 
-  '@semantic-release/commit-analyzer@13.0.0(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@13.0.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)':
     dependencies:
       conventional-changelog-angular: 8.0.0
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
       debug: 4.4.3(supports-color@5.5.0)
-      import-from-esm: 1.3.4
+      import-from-esm: 1.3.4(supports-color@5.5.0)
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -18985,7 +18986,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/exec@7.1.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -18993,11 +18994,11 @@ snapshots:
       execa: 9.5.3
       lodash-es: 4.18.1
       parse-json: 8.3.0
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/git@10.0.1(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -19007,11 +19008,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@11.0.0(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/github@11.0.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)':
     dependencies:
       '@octokit/core': 6.1.2
       '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.2)
@@ -19028,12 +19029,12 @@ snapshots:
       lodash-es: 4.18.1
       mime: 4.0.4
       p-filter: 4.1.0
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@12.0.1(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/npm@12.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
@@ -19046,11 +19047,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 9.0.1
       registry-auth-token: 5.0.2
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
       semver: 7.7.4
       tempy: 3.1.0
 
-  '@semantic-release/release-notes-generator@14.0.1(semantic-release@24.2.4(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@14.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)':
     dependencies:
       conventional-changelog-angular: 8.0.0
       conventional-changelog-writer: 8.0.0
@@ -19058,11 +19059,11 @@ snapshots:
       conventional-commits-parser: 6.0.0
       debug: 4.4.3(supports-color@5.5.0)
       get-stream: 7.0.1
-      import-from-esm: 1.3.4
+      import-from-esm: 1.3.4(supports-color@5.5.0)
       into-stream: 7.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 24.2.4(typescript@5.9.3)
+      semantic-release: 24.2.4(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -19098,7 +19099,7 @@ snapshots:
 
   '@sentry/bundler-plugin-core@3.5.0':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@sentry/babel-plugin-component-annotate': 3.5.0
       '@sentry/cli': 2.42.2
       dotenv: 16.4.5
@@ -19112,7 +19113,7 @@ snapshots:
 
   '@sentry/bundler-plugin-core@5.3.0':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@sentry/babel-plugin-component-annotate': 5.3.0
       '@sentry/cli': 2.58.5
       dotenv: 16.4.5
@@ -19209,7 +19210,7 @@ snapshots:
 
   '@sentry/core@10.52.0': {}
 
-  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)(supports-color@5.5.0)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -19217,12 +19218,12 @@ snapshots:
       '@sentry-internal/browser-utils': 10.52.0
       '@sentry/bundler-plugin-core': 5.3.0
       '@sentry/core': 10.52.0
-      '@sentry/node': 10.52.0
+      '@sentry/node': 10.52.0(supports-color@5.5.0)
       '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/react': 10.52.0(react@18.3.1)
       '@sentry/vercel-edge': 10.52.0
       '@sentry/webpack-plugin': 5.3.0(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       rollup: 4.60.3
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -19234,7 +19235,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/node-core@10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node-core@10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@sentry/core': 10.52.0
       '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
@@ -19242,16 +19243,16 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@sentry/node@10.52.0':
+  '@sentry/node@10.52.0(supports-color@5.5.0)':
     dependencies:
       '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
@@ -19274,7 +19275,7 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
       '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.52.0
-      '@sentry/node-core': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/node-core': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -19542,48 +19543,48 @@ snapshots:
       '@statoscope/types': 5.28.1
       '@types/md5': 2.3.5
 
-  '@storybook/addon-a11y@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/addon-a11y@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
 
-  '@storybook/addon-docs@9.1.8(@types/react@18.2.79)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/addon-docs@9.1.8(@types/react@18.2.79)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@18.2.79)(react@18.3.1)
-      '@storybook/csf-plugin': 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+      '@storybook/csf-plugin': 9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 9.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+      '@storybook/react-dom-shim': 9.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-links@9.1.8(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/addon-links@9.1.8(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/addon-onboarding@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/addon-onboarding@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
 
-  '@storybook/addon-webpack5-compiler-swc@4.0.3(@swc/helpers@0.5.19)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@storybook/addon-webpack5-compiler-swc@4.0.3(@swc/helpers@0.5.19)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
       '@swc/core': 1.15.18(@swc/helpers@0.5.19)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       swc-loader: 0.2.6(@swc/core@1.15.18(@swc/helpers@0.5.19))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
 
-  '@storybook/builder-webpack5@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       css-loader: 6.11.0(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
@@ -19591,7 +19592,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       html-webpack-plugin: 5.6.6(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       magic-string: 0.30.17
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       style-loader: 3.3.4(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       terser-webpack-plugin: 5.4.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       ts-dedent: 2.2.0
@@ -19608,15 +19609,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/cli@9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3))(@testing-library/dom@10.2.0)(prettier@3.3.3)':
+  '@storybook/cli@9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))(@testing-library/dom@10.2.0)(prettier@3.3.3)':
     dependencies:
-      '@storybook/codemod': 9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3))(@testing-library/dom@10.2.0)
+      '@storybook/codemod': 9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))(@testing-library/dom@10.2.0)
       '@types/semver': 7.5.8
       commander: 12.1.0
       create-storybook: 9.1.20
       giget: 1.2.5
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3))
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -19628,13 +19629,13 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/codemod@9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3))(@testing-library/dom@10.2.0)':
+  '@storybook/codemod@9.1.20(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))(@testing-library/dom@10.2.0)':
     dependencies:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
       es-toolkit: 1.45.1
       globby: 14.1.0
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3))
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0)))
       prettier: 3.8.3
       storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.8.3)
       tiny-invariant: 1.3.3
@@ -19647,14 +19648,14 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/core-webpack@9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/core-webpack@9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/csf-plugin@9.1.8(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -19664,31 +19665,31 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/nextjs@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/webpack@5.28.5(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))(esbuild@0.19.12)(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@storybook/nextjs@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/webpack@5.28.5(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))(esbuild@0.19.12)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(supports-color@5.5.0)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-runtime': 7.24.3(@babel/core@7.28.3)
-      '@babel/preset-env': 7.24.4(@babel/core@7.28.3)
-      '@babel/preset-react': 7.24.1(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-runtime': 7.24.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-env': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-react': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/runtime': 7.29.2
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
-      '@storybook/builder-webpack5': 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)
-      '@storybook/react': 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@storybook/react': 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)
       '@types/semver': 7.5.8
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
+      babel-loader: 9.2.1(@babel/core@7.28.3(supports-color@5.5.0))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       css-loader: 6.11.0(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       image-size: 2.0.2
       loader-utils: 3.2.1
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       postcss: 8.5.9
       postcss-loader: 8.1.1(postcss@8.5.9)(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
@@ -19698,9 +19699,9 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.5(sass@1.75.0)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       semver: 7.7.4
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       style-loader: 3.3.4(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
-      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.3(supports-color@5.5.0))(react@18.3.1)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
     optionalDependencies:
@@ -19724,10 +19725,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@9.1.20(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
+      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(supports-color@5.5.0)(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@types/semver': 7.5.8
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -19736,7 +19737,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.7.4
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
       tsconfig-paths: 4.2.0
       webpack: 5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)
     optionalDependencies:
@@ -19748,7 +19749,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(supports-color@5.5.0)(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       endent: 2.1.0
@@ -19762,76 +19763,76 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/react-dom-shim@9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
 
-  '@storybook/react-dom-shim@9.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))':
+  '@storybook/react-dom-shim@9.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
 
-  '@storybook/react@9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3)':
+  '@storybook/react@9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.28.3)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.28.3)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.28.3(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.3)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.3(supports-color@5.5.0))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.3(supports-color@5.5.0))
 
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3(supports-color@5.5.0))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -19846,8 +19847,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3(supports-color@5.5.0))
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -19865,11 +19866,11 @@ snapshots:
 
   '@svgr/webpack@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-transform-react-constant-elements': 7.24.1(@babel/core@7.28.3)
-      '@babel/preset-env': 7.24.4(@babel/core@7.28.3)
-      '@babel/preset-react': 7.24.1(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/plugin-transform-react-constant-elements': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-env': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-react': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
@@ -20549,15 +20550,15 @@ snapshots:
       '@types/node': 22.19.17
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -20565,19 +20566,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.2(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
@@ -20595,13 +20596,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20609,9 +20610,9 @@ snapshots:
 
   '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.2(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.58.2(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
@@ -20624,13 +20625,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.58.2(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -21225,26 +21226,26 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-core@7.0.0-bridge.0(@babel/core@7.28.3):
+  babel-core@7.0.0-bridge.0(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  babel-jest@29.7.0(@babel/core@7.28.3):
+  babel-jest@29.7.0(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.28.3)
+      babel-preset-jest: 29.6.3(@babel/core@7.28.3(supports-color@5.5.0))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)):
+  babel-loader@9.2.1(@babel/core@7.28.3(supports-color@5.5.0))(webpack@5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.105.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.19.12)
@@ -21266,63 +21267,63 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
 
-  babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.28.3):
+  babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3(supports-color@5.5.0))
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.28.3):
+  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3(supports-color@5.5.0))
       core-js-compat: 3.37.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.28.3):
+  babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.3)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))(supports-color@5.5.0):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.28.3(supports-color@5.5.0))(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       lodash: 4.18.1
       picomatch: 2.3.2
-      styled-components: 5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.28.3):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3)
+      '@babel/core': 7.28.3(supports-color@5.5.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3(supports-color@5.5.0))
 
-  babel-preset-jest@29.6.3(@babel/core@7.28.3):
+  babel-preset-jest@29.6.3(@babel/core@7.28.3(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.3)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.3(supports-color@5.5.0))
 
   bail@2.0.2: {}
 
@@ -21434,7 +21435,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -21790,13 +21791,13 @@ snapshots:
 
   chrome-trace-event@1.0.3: {}
 
-  chromedriver@130.0.4:
+  chromedriver@130.0.4(supports-color@5.5.0):
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.15.0
       compare-versions: 6.1.0
       extract-zip: 2.0.1
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@5.5.0)
       proxy-from-env: 1.1.0
       tcp-port-used: 1.0.2
     transitivePeerDependencies:
@@ -22900,7 +22901,7 @@ snapshots:
 
   es6-promise@4.2.8: {}
 
-  esbuild-register@3.6.0(esbuild@0.25.1):
+  esbuild-register@3.6.0(esbuild@0.25.1)(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.1
@@ -22983,19 +22984,19 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@15.3.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@15.3.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.3.0
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -23003,9 +23004,9 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -23022,25 +23023,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
@@ -23048,45 +23049,45 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-compat@6.2.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-compat@6.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       '@mdn/browser-compat-data': 6.1.5
       ast-metadata-inferer: 0.8.1
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001769
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       find-up: 5.0.0
       globals: 15.15.0
       lodash.memoize: 4.1.2
       semver: 7.7.4
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23095,9 +23096,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -23109,13 +23110,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23124,9 +23125,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -23138,13 +23139,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -23154,7 +23155,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -23163,22 +23164,22 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/parser': 7.28.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -23186,7 +23187,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -23200,11 +23201,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@9.1.8(eslint@9.39.2(jiti@2.6.1))(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3))(typescript@5.9.3):
+  eslint-plugin-storybook@9.1.8(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@5.5.0)
+      storybook: 9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23225,11 +23226,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.1(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
       '@eslint/eslintrc': 3.3.3
@@ -23436,7 +23437,7 @@ snapshots:
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.1.0
 
   express@4.22.2:
@@ -23475,10 +23476,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -23488,7 +23489,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -23499,8 +23500,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -23672,7 +23673,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -23744,7 +23745,7 @@ snapshots:
 
   finity@0.5.4: {}
 
-  firebase-tools@14.27.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3):
+  firebase-tools@14.27.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@apphosting/build': 0.1.6(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3)
       '@apphosting/common': 0.0.8
@@ -23802,7 +23803,7 @@ snapshots:
       pglite-2: '@electric-sql/pglite@0.2.17'
       portfinder: 1.0.32
       progress: 2.0.3
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@5.5.0)
       retry: 0.13.1
       semver: 7.7.4
       sql-formatter: 15.6.10
@@ -23813,7 +23814,7 @@ snapshots:
       tcp-port-used: 1.0.2
       tmp: 0.2.5
       triple-beam: 1.4.1
-      universal-analytics: 0.5.3
+      universal-analytics: 0.5.3(supports-color@5.5.0)
       update-notifier-cjs: 5.1.7
       uuid: 8.3.2
       winston: 3.13.0
@@ -24090,7 +24091,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.3:
+  get-uri@6.0.3(supports-color@5.5.0):
     dependencies:
       basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
@@ -24738,14 +24739,14 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-from-esm@1.3.4:
+  import-from-esm@1.3.4(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
-  import-from-esm@2.0.0:
+  import-from-esm@2.0.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       import-meta-resolve: 4.1.0
@@ -25191,7 +25192,7 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -25201,7 +25202,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.2:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -25309,10 +25310,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.19.17)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
+      babel-jest: 29.7.0(@babel/core@7.28.3(supports-color@5.5.0))
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -25516,15 +25517,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/generator': 7.28.3
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
       '@babel/types': 7.28.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.3)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.3(supports-color@5.5.0))
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -25539,10 +25540,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)):
+  jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)):
     dependencies:
       '@adobe/css-tools': 4.4.4
-      styled-components: 5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
 
   jest-util@29.7.0:
     dependencies:
@@ -25633,19 +25634,19 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3)):
+  jscodeshift@0.15.2(@babel/preset-env@7.24.4(@babel/core@7.28.3(supports-color@5.5.0))):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/parser': 7.28.3
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.28.3)
-      '@babel/preset-flow': 7.27.1(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3)
-      '@babel/register': 7.28.6(@babel/core@7.28.3)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.28.3)
+      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-flow': 7.27.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.28.3(supports-color@5.5.0))
+      '@babel/register': 7.28.6(@babel/core@7.28.3(supports-color@5.5.0))
+      babel-core: 7.0.0-bridge.0(@babel/core@7.28.3(supports-color@5.5.0))
       chalk: 4.1.2
       flow-parser: 0.309.0
       graceful-fs: 4.2.11
@@ -25656,7 +25657,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.24.4(@babel/core@7.28.3)
+      '@babel/preset-env': 7.24.4(@babel/core@7.28.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -25904,7 +25905,7 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
-  lint-staged@15.5.2:
+  lint-staged@15.5.2(supports-color@5.5.0):
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
@@ -26807,34 +26808,34 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1):
+  next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1):
     dependencies:
       '@cloudinary-util/types': 1.5.10
       '@cloudinary-util/url-loader': 5.10.4
       '@cloudinary-util/util': 4.0.0
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       react: 18.3.1
 
-  next-router-mock@0.9.13(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1):
+  next-router-mock@0.9.13(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1):
     dependencies:
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       react: 18.3.1
 
-  next-seo@6.6.0(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-seo@6.6.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next-sitemap@4.2.3(next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)):
+  next-sitemap@4.2.3(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
+      next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
 
-  next@15.5.15(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0):
+  next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -26842,7 +26843,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.3(supports-color@5.5.0))(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.15
       '@next/swc-darwin-x64': 15.5.15
@@ -27359,12 +27360,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@7.2.0(supports-color@5.5.0):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
-      get-uri: 6.0.3
+      get-uri: 6.0.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
@@ -28013,14 +28014,14 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0:
+  proxy-agent@6.5.0(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@5.5.0)
       proxy-from-env: 1.1.0
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -28217,7 +28218,7 @@ snapshots:
 
   react-docgen@7.1.1:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
       '@babel/traverse': 7.28.3(supports-color@5.5.0)
       '@babel/types': 7.28.2
       '@types/babel__core': 7.20.5
@@ -28528,7 +28529,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -28661,7 +28662,7 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -28778,13 +28779,13 @@ snapshots:
 
   secure-compare@3.0.1: {}
 
-  semantic-release@24.2.4(typescript@5.9.3):
+  semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.0(semantic-release@24.2.4(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 13.0.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.0(semantic-release@24.2.4(typescript@5.9.3))
-      '@semantic-release/npm': 12.0.1(semantic-release@24.2.4(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.0.1(semantic-release@24.2.4(typescript@5.9.3))
+      '@semantic-release/github': 11.0.0(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)
+      '@semantic-release/npm': 12.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 14.0.1(semantic-release@24.2.4(supports-color@5.5.0)(typescript@5.9.3))(supports-color@5.5.0)
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
@@ -28796,7 +28797,7 @@ snapshots:
       git-log-parser: 1.2.0
       hook-std: 3.0.0
       hosted-git-info: 8.1.0
-      import-from-esm: 2.0.0
+      import-from-esm: 2.0.0(supports-color@5.5.0)
       lodash-es: 4.18.1
       marked: 15.0.12
       marked-terminal: 7.1.0(marked@15.0.12)
@@ -28847,7 +28848,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -28887,7 +28888,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29216,7 +29217,7 @@ snapshots:
 
   storybook-css-modules-preset@1.1.1: {}
 
-  storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3):
+  storybook@9.1.20(@testing-library/dom@10.2.0)(prettier@3.3.3)(supports-color@5.5.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.8.0
@@ -29226,7 +29227,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.1
-      esbuild-register: 3.6.0(esbuild@0.25.1)
+      esbuild-register: 3.6.0(esbuild@0.25.1)(supports-color@5.5.0)
       recast: 0.23.11
       semver: 7.7.4
       ws: 8.20.0
@@ -29250,7 +29251,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.1
-      esbuild-register: 3.6.0(esbuild@0.25.1)
+      esbuild-register: 3.6.0(esbuild@0.25.1)(supports-color@5.5.0)
       recast: 0.23.11
       semver: 7.7.4
       ws: 8.20.0
@@ -29448,14 +29449,14 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1):
+  styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1):
     dependencies:
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/traverse': 7.28.3(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.28.3)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))(supports-color@5.5.0)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.28.3(supports-color@5.5.0))(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))(supports-color@5.5.0)
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
@@ -29466,38 +29467,38 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  styled-jsx@5.1.6(@babel/core@7.28.3)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.28.3(supports-color@5.5.0))(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.3(supports-color@5.5.0)
 
-  stylelint-config-recommended-scss@14.1.0(postcss@8.5.9)(stylelint@16.21.0(typescript@5.9.3)):
+  stylelint-config-recommended-scss@14.1.0(postcss@8.5.9)(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.9)
-      stylelint: 16.21.0(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.21.0(typescript@5.9.3))
-      stylelint-scss: 6.8.1(stylelint@16.21.0(typescript@5.9.3))
+      stylelint: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-scss: 6.8.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.9
 
-  stylelint-config-recommended@14.0.1(stylelint@16.21.0(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.21.0(typescript@5.9.3)
+      stylelint: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-standard-scss@13.1.0(postcss@8.5.9)(stylelint@16.21.0(typescript@5.9.3)):
+  stylelint-config-standard-scss@13.1.0(postcss@8.5.9)(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.21.0(typescript@5.9.3)
-      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.9)(stylelint@16.21.0(typescript@5.9.3))
-      stylelint-config-standard: 36.0.1(stylelint@16.21.0(typescript@5.9.3))
+      stylelint: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.9)(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-config-standard: 36.0.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.9
 
-  stylelint-config-standard@36.0.1(stylelint@16.21.0(typescript@5.9.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.21.0(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.21.0(typescript@5.9.3))
+      stylelint: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3))
 
   stylelint-config-styled-components@0.1.1: {}
 
@@ -29510,7 +29511,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  stylelint-scss@6.8.1(stylelint@16.21.0(typescript@5.9.3)):
+  stylelint-scss@6.8.1(stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       css-tree: 3.1.0
       is-plain-object: 5.0.0
@@ -29520,9 +29521,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 16.21.0(typescript@5.9.3)
+      stylelint: 16.21.0(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint@16.21.0(typescript@5.9.3):
+  stylelint@16.21.0(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -29566,7 +29567,7 @@ snapshots:
       - supports-color
       - typescript
 
-  stylus@0.62.0:
+  stylus@0.62.0(supports-color@5.5.0):
     dependencies:
       '@adobe/css-tools': 4.3.3
       debug: 4.4.3(supports-color@5.5.0)
@@ -29599,7 +29600,7 @@ snapshots:
       on-finished: 2.4.1
       on-headers: 1.1.0
       path-to-regexp: 1.9.0
-      router: 2.2.0
+      router: 2.2.0(supports-color@5.5.0)
       update-notifier-cjs: 5.1.7
     optionalDependencies:
       re2: 1.24.0
@@ -30104,7 +30105,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-plugin-css-modules@5.2.0(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3):
+  typescript-plugin-css-modules@5.2.0(supports-color@5.5.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/postcss-modules-local-by-default': 4.0.2
       '@types/postcss-modules-scope': 3.0.4
@@ -30123,7 +30124,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       typescript: 5.9.3
     optionalDependencies:
-      stylus: 0.62.0
+      stylus: 0.62.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -30230,7 +30231,7 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  universal-analytics@0.5.3:
+  universal-analytics@0.5.3(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       uuid: 8.3.2

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -499,7 +499,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c185 {
+.c184 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c188 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -508,7 +514,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c186 {
+.c189 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -516,7 +522,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c193 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -527,7 +533,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c194 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -538,7 +544,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c196 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -546,12 +552,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c198 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c202 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -569,7 +575,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c201 {
+.c204 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -587,7 +593,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c203 {
+.c206 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -595,7 +601,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c204 {
+.c207 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -603,13 +609,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c205 {
+.c208 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c209 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -617,7 +623,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c208 {
+.c211 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -628,15 +634,8 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c214 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -1057,7 +1056,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c184 {
+.c187 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1068,7 +1067,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c187 {
+.c190 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1084,7 +1083,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c194 {
+.c197 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1102,7 +1101,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c196 {
+.c199 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1115,7 +1114,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c207 {
+.c210 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1130,7 +1129,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c210 {
+.c213 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1232,7 +1231,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c209 {
+.c212 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1500,7 +1499,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c212 {
+.c216 {
   background: none;
   color: inherit;
   border: none;
@@ -1523,7 +1522,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c212:disabled {
+.c216:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1544,13 +1543,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c200 {
+.c203 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c202 {
+.c205 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1819,27 +1818,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   background: #222222;
 }
 
-.c188 > :first-child:focus-visible .shadow {
+.c191 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c188 > :first-child:hover .shadow {
+.c191 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c188 > :first-child:active .shadow {
+.c191 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c188 > :first-child:disabled .icon-container {
+.c191 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c188 > :first-child:hover .icon-container {
+.c191 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c188 > :first-child:active .icon-container {
+.c191 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
@@ -1982,7 +1981,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c197 {
+.c200 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1993,7 +1992,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c198 {
+.c201 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2036,6 +2035,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
+.c186 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c28 {
   display: inline;
   -webkit-align-items: center;
@@ -2060,6 +2066,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c28 .c185 {
+  -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c28:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2068,13 +2081,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #081676;
 }
 
+.c28:visited .c185 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+}
+
 .c28:active {
   color: #081676;
+  outline: 1px solid #081676;
+}
+
+.c28:active .c185 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
 .c28[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c28[disabled] .c185 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c182 {
@@ -2101,6 +2130,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c182 .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c182:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2109,13 +2145,102 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
+.c182:visited .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c182:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c182:active .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c182[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c182[disabled] .c185 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c215 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c215 .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c215:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c215:visited {
+  color: #222222;
+}
+
+.c215:visited .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c215:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c215:active .c185 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c215[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c215[disabled] .c185 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c46 {
@@ -2306,7 +2431,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   top: 82px;
 }
 
-.c189 .icon-container > *:first-child {
+.c192 .icon-container > *:first-child {
   border: 0;
 }
 
@@ -2410,7 +2535,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c192 {
+.c195 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -3007,19 +3132,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c186 {
+  .c189 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c196 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c195 {
+  .c198 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3028,13 +3153,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c202 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c202 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3042,7 +3167,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c199 {
+  .c202 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3050,55 +3175,55 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c204 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c209 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c209 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c209 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c209 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3242,7 +3367,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c184 {
+  .c187 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3251,13 +3376,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c187 {
+  .c190 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3265,7 +3390,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3274,7 +3399,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3283,7 +3408,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c199 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3292,7 +3417,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3300,7 +3425,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3308,7 +3433,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3317,7 +3442,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3326,19 +3451,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3346,7 +3471,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3354,7 +3479,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c210 {
+  .c213 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3362,7 +3487,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     gap: 2rem;
   }
 }
@@ -3422,25 +3547,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3781,6 +3906,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c28:hover .c185,
+  .c28:visited:hover .c185 {
+    -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
+    filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
@@ -3790,6 +3923,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c182:hover .c185,
+  .c182:visited:hover .c185 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c215:hover,
+  .c215:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c215:hover .c185,
+  .c215:visited:hover .c185 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
@@ -6171,19 +6329,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c184"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c80 c185 c186"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6305,19 +6467,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             Careers
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c184"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c80 c185 c186"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6348,19 +6514,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             Help
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c184"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c80 c185 c186"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6391,19 +6561,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             Status
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c184"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c80 c185 c186"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                     </ul>
@@ -6574,13 +6748,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c11 c49 c176"
               >
                 <div
-                  class="c177 c184"
+                  class="c177 c187"
                 >
                   <div
                     class="c42"
                   >
                     <span
-                      class="c185"
+                      class="c188"
                     >
                       <img
                         alt=""
@@ -6594,10 +6768,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c186 c187"
+                    class="c189 c190"
                   >
                     <div
-                      class="c48 c49 c188 c189"
+                      class="c48 c49 c191 c192"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6608,10 +6782,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c190 c55 icon-container"
+                            class="c193 c55 icon-container"
                           >
                             <div
-                              class="c191 shadow"
+                              class="c194 shadow"
                             />
                             <span
                               class="c24"
@@ -6635,7 +6809,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c188 c189"
+                      class="c48 c49 c191 c192"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6646,10 +6820,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c190 c55 icon-container"
+                            class="c193 c55 icon-container"
                           >
                             <div
-                              class="c191 shadow"
+                              class="c194 shadow"
                             />
                             <span
                               class="c24"
@@ -6673,7 +6847,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c188 c189"
+                      class="c48 c49 c191 c192"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6684,10 +6858,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c190 c55 icon-container"
+                            class="c193 c55 icon-container"
                           >
                             <div
-                              class="c191 shadow"
+                              class="c194 shadow"
                             />
                             <span
                               class="c24"
@@ -6715,7 +6889,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c91 c192"
+              class="c91 c195"
               data-percy-hide="contents"
             >
               <img
@@ -6731,13 +6905,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c193 c194"
+              class="c196 c197"
             >
               <div
-                class="c195 c196"
+                class="c198 c199"
               >
                 <div
-                  class="c48 c49 c188 c189"
+                  class="c48 c49 c191 c192"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6748,10 +6922,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c190 c55 icon-container"
+                        class="c193 c55 icon-container"
                       >
                         <div
-                          class="c191 shadow"
+                          class="c194 shadow"
                         />
                         <span
                           class="c24"
@@ -6775,7 +6949,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c188 c189"
+                  class="c48 c49 c191 c192"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6786,10 +6960,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c190 c55 icon-container"
+                        class="c193 c55 icon-container"
                       >
                         <div
-                          class="c191 shadow"
+                          class="c194 shadow"
                         />
                         <span
                           class="c24"
@@ -6813,7 +6987,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c188 c189"
+                  class="c48 c49 c191 c192"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6824,10 +6998,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c190 c55 icon-container"
+                        class="c193 c55 icon-container"
                       >
                         <div
-                          class="c191 shadow"
+                          class="c194 shadow"
                         />
                         <span
                           class="c24"
@@ -6855,7 +7029,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c59"
               >
                 <span
-                  class="c185"
+                  class="c188"
                 >
                   <img
                     alt=""
@@ -6872,12 +7046,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c177 c84"
               >
                 <p
-                  class="c197"
+                  class="c200"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c198"
+                  class="c201"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6886,11 +7060,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c199"
+          class="c202"
         >
           <img
             alt=""
-            class="c200"
+            class="c203"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6899,11 +7073,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c201"
+          class="c204"
         >
           <img
             alt=""
-            class="c202"
+            class="c205"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6915,23 +7089,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     </div>
   </div>
   <div
-    class="c203"
+    class="c206"
   >
     <div
-      class="c204"
+      class="c207"
       data-testid="cookie-banner"
     >
       <div
-        class="c205"
+        class="c208"
       >
         <div
-          class="c206 c207"
+          class="c209 c210"
         >
           <div
-            class="c208"
+            class="c211"
           >
             <strong
-              class="c209"
+              class="c212"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6939,13 +7113,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c210"
+            class="c11 c213"
           >
             <div
-              class="c211 c44"
+              class="c214 c44"
             >
               <button
-                class="c182 "
+                class="c215"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6989,7 +7163,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c8 yellow-shadow"
               />
               <button
-                class="c212 c23 internal-button"
+                class="c216 c23 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c109 {
+.c110 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -333,20 +333,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c111 {
+.c112 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c112 {
+.c113 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c113 {
+.c114 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -361,26 +361,26 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c114 {
+.c115 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c119 {
+.c120 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -390,7 +390,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -401,7 +401,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c127 {
+.c128 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -411,14 +411,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c129 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -430,12 +430,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c134 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c136 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -449,7 +449,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c138 {
+.c139 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -528,7 +528,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c183 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c187 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -537,7 +543,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c185 {
+.c188 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -545,7 +551,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c192 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -556,7 +562,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c193 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -567,14 +573,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c194 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c196 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -582,12 +588,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c198 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c202 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -605,7 +611,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c201 {
+.c204 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -623,7 +629,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c203 {
+.c206 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -631,7 +637,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c204 {
+.c207 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -639,13 +645,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c205 {
+.c208 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c209 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -653,7 +659,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c208 {
+.c211 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -664,15 +670,8 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c214 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -993,7 +992,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c115 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1004,7 +1003,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c122 {
+.c123 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1019,7 +1018,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c126 {
+.c127 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1030,7 +1029,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c134 {
+.c135 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1062,7 +1061,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c183 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1073,7 +1072,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c186 {
+.c189 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1089,7 +1088,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c194 {
+.c197 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1107,7 +1106,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c196 {
+.c199 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1120,7 +1119,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c207 {
+.c210 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1135,7 +1134,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c210 {
+.c213 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1227,7 +1226,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c149 {
+.c109 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1249,7 +1248,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c209 {
+.c212 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1517,7 +1516,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c212 {
+.c216 {
   background: none;
   color: inherit;
   border: none;
@@ -1540,7 +1539,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c212:disabled {
+.c216:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1561,13 +1560,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c200 {
+.c203 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c202 {
+.c205 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1827,27 +1826,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   background: #222222;
 }
 
-.c187 > :first-child:focus-visible .shadow {
+.c190 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c187 > :first-child:hover .shadow {
+.c190 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c187 > :first-child:active .shadow {
+.c190 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c187 > :first-child:disabled .icon-container {
+.c190 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c187 > :first-child:hover .icon-container {
+.c190 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c187 > :first-child:active .icon-container {
+.c190 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
@@ -1884,7 +1883,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c116 {
+.c117 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1896,7 +1895,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: center;
 }
 
-.c136 {
+.c137 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1961,9 +1960,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 
 .c107 {
   font-family: --var(google-font),Lexend,sans-serif;
+  color: #222222;
 }
 
-.c137 {
+.c138 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
@@ -1994,7 +1994,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c197 {
+.c200 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2005,7 +2005,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c198 {
+.c201 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2016,7 +2016,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c110 {
+.c111 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2079,6 +2079,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
+.c185 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c28 {
   display: inline;
   -webkit-align-items: center;
@@ -2103,6 +2110,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c28 .c184 {
+  -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c28:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2111,13 +2125,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #081676;
 }
 
+.c28:visited .c184 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+}
+
 .c28:active {
   color: #081676;
+  outline: 1px solid #081676;
+}
+
+.c28:active .c184 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
 .c28[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c28[disabled] .c184 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c181 {
@@ -2144,6 +2174,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c181 .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c181:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2152,13 +2189,102 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
+.c181:visited .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c181:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c181:active .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c181[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c181[disabled] .c184 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c215 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c215 .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c215:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c215:visited {
+  color: #222222;
+}
+
+.c215:visited .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c215:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c215:active .c184 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c215[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c215[disabled] .c184 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c46 {
@@ -2229,13 +2355,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(auto-fit,minmax(200px,1fr));
 }
 
-.c131 {
+.c132 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c132 {
+.c133 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2276,25 +2402,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c120 {
+.c121 {
   box-shadow: none;
 }
 
-.c120:has(a:hover,button:hover) {
+.c121:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c120:has( a, button) {
+.c121:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c120:has( a, button)  a,
-.c120:has( a, button) button {
+.c121:has( a, button)  a,
+.c121:has( a, button) button {
   outline: none;
 }
 
-.c120:has(a:active,button:active) {
+.c121:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
@@ -2306,9 +2432,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c103:hover h3 {
+.c103:hover h1,
+.c103:hover h2,
+.c103:hover h3,
+.c103:hover h4,
+.c103:hover h5,
+.c103:hover h6,
+.c103:hover span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c103:hover span {
+  -webkit-text-decoration-thickness: 18%;
+  text-decoration-thickness: 18%;
 }
 
 .c61:hover .oak-save-count {
@@ -2394,7 +2531,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   top: 82px;
 }
 
-.c188 .icon-container > *:first-child {
+.c191 .icon-container > *:first-child {
   border: 0;
 }
 
@@ -2404,7 +2541,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c141 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2415,23 +2552,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c140::-webkit-scrollbar-track {
+.c141::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar {
+.c141::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar-thumb {
+.c141::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c143 {
+.c144 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2440,23 +2577,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c143::-webkit-scrollbar-track {
+.c144::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c143::-webkit-scrollbar {
+.c144::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c143::-webkit-scrollbar-thumb {
+.c144::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c145 {
+.c146 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2464,18 +2601,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c145::-webkit-scrollbar-track {
+.c146::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c145::-webkit-scrollbar {
+.c146::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c145::-webkit-scrollbar-thumb {
+.c146::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
@@ -2491,14 +2628,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c141 {
+.c142 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c192 {
+.c195 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -2509,16 +2646,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   width: auto;
 }
 
-.c123:hover {
+.c124:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c118 {
+.c119 {
   padding: 0;
   margin: 0;
 }
 
-.c117 {
+.c118 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2530,7 +2667,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c144 {
+.c145 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2578,7 +2715,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   appearance: none;
 }
 
-.c147 {
+.c148 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2601,7 +2738,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c148 {
+.c149 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2612,12 +2749,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c142:focus-within .c146 {
+.c143:focus-within .c147 {
   background: #374cf1;
   color: #fff;
 }
 
-.c142:focus-within .c153 {
+.c143:focus-within .c153 {
   display: inline;
 }
 
@@ -2697,7 +2834,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: none;
 }
 
-.c157:focus-within .c146 {
+.c157:focus-within .c147 {
   background: #374cf1;
   color: #fff;
 }
@@ -2740,12 +2877,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c139 {
+.c140 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c130 {
   max-width: 100%;
   justify-self: center;
 }
@@ -2964,43 +3101,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3009,7 +3146,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3018,13 +3155,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3032,7 +3169,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3040,37 +3177,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c115 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c115 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     padding-bottom: 2.5rem;
   }
 }
@@ -3100,19 +3237,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c185 {
+  .c188 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c196 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c195 {
+  .c198 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3121,13 +3258,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c202 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c202 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3135,7 +3272,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c199 {
+  .c202 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3143,55 +3280,55 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c204 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c209 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c209 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c209 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c209 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c211 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3298,19 +3435,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c115 {
+  .c116 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c115 {
+  .c116 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c183 {
+  .c186 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3319,13 +3456,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c186 {
+  .c189 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3333,7 +3470,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3342,7 +3479,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3351,7 +3488,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c199 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3360,7 +3497,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3368,7 +3505,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3376,7 +3513,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3385,7 +3522,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3394,19 +3531,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3414,7 +3551,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3422,7 +3559,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c210 {
+  .c213 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3430,7 +3567,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c213 {
     gap: 2rem;
   }
 }
@@ -3490,25 +3627,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3649,43 +3786,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3694,7 +3831,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3757,49 +3894,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3808,7 +3945,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3822,6 +3959,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c28:hover .c184,
+  .c28:visited:hover .c184 {
+    -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
+    filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
@@ -3831,6 +3976,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c181:hover .c184,
+  .c181:visited:hover .c184 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c215:hover,
+  .c215:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c215:hover .c184,
+  .c215:visited:hover .c184 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
@@ -3848,7 +4018,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     grid-column: span 6;
   }
 }
@@ -3948,7 +4118,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (max-width:800px) {
-  .c117 {
+  .c118 {
     grid-template-columns: repeat(1,1fr);
   }
 }
@@ -3960,7 +4130,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c130 {
     max-width: 870px;
   }
 }
@@ -4810,7 +4980,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   class="c11 c44"
                                 >
                                   <span
-                                    class="c29"
+                                    class="c109"
                                   >
                                     See bio
                                   </span>
@@ -4894,7 +5064,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   class="c11 c44"
                                 >
                                   <span
-                                    class="c29"
+                                    class="c109"
                                   >
                                     See bio
                                   </span>
@@ -4929,7 +5099,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     Governance
                   </h2>
                   <div
-                    class="c109 c110"
+                    class="c110 c111"
                   >
                     <p>
                       Test governance text
@@ -4940,14 +5110,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c111"
+            class="c112"
             style="margin-top: -72px;"
           >
             <div
-              class="c112"
+              class="c113"
             >
               <span
-                class="c113"
+                class="c114"
                 style="pointer-events: none;"
               >
                 <img
@@ -4964,10 +5134,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c72"
               >
                 <div
-                  class="c114 c115"
+                  class="c115 c116"
                 >
                   <h2
-                    class="c116"
+                    class="c117"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -4976,27 +5146,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c117"
+                      class="c118"
                     >
                       <li
-                        class="c118"
+                        class="c119"
                       >
                         <div
-                          class="c119 c120"
+                          class="c120 c121"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c121 c122 c123"
+                              class="c122 c123 c124"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
@@ -5010,7 +5180,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c125 c126"
+                                class="c126 c127"
                               >
                                 About Oak
                               </div>
@@ -5018,7 +5188,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c127"
+                                  class="c128"
                                 >
                                   <img
                                     alt=""
@@ -5036,24 +5206,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c118"
+                        class="c119"
                       >
                         <div
-                          class="c119 c120"
+                          class="c120 c121"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c121 c122 c123"
+                              class="c122 c123 c124"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
@@ -5067,7 +5237,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c125 c126"
+                                class="c126 c127"
                               >
                                 Oak's curricula
                               </div>
@@ -5075,7 +5245,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c127"
+                                  class="c128"
                                 >
                                   <img
                                     alt=""
@@ -5093,24 +5263,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c118"
+                        class="c119"
                       >
                         <div
-                          class="c119 c120"
+                          class="c120 c121"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c121 c122 c123"
+                              class="c122 c123 c124"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
@@ -5124,7 +5294,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c125 c126"
+                                class="c126 c127"
                               >
                                 Meet the team
                               </div>
@@ -5132,7 +5302,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c127"
+                                  class="c128"
                                 >
                                   <img
                                     alt=""
@@ -5150,24 +5320,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c118"
+                        class="c119"
                       >
                         <div
-                          class="c119 c120"
+                          class="c120 c121"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c121 c122 c123"
+                              class="c122 c123 c124"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
@@ -5181,7 +5351,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c125 c126"
+                                class="c126 c127"
                               >
                                 Get involved
                               </div>
@@ -5189,7 +5359,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c11 c49"
                               >
                                 <span
-                                  class="c127"
+                                  class="c128"
                                 >
                                   <img
                                     alt=""
@@ -5213,29 +5383,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c128"
+            class="c129"
             id="newsletter-signup"
           >
             <div
               class="c72"
             >
               <div
-                class="c11 c49 c129"
+                class="c11 c49 c130"
               >
                 <div
-                  class="c130 c4"
+                  class="c131 c4"
                 >
                   <div
-                    class="c11 c131"
+                    class="c11 c132"
                   >
                     <div
-                      class="c11 c49 c132"
+                      class="c11 c49 c133"
                     >
                       <div
-                        class="c133 c134"
+                        class="c134 c135"
                       >
                         <span
-                          class="c135"
+                          class="c136"
                         >
                           <img
                             alt=""
@@ -5248,13 +5418,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c136"
+                          class="c137"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c137"
+                        class="c138"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5274,18 +5444,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c138 c49 c132"
+                      class="c139 c49 c133"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c139"
+                        class="c140"
                         novalidate=""
                       >
                         <div
-                          class="c140 c141 c142"
+                          class="c141 c142 c143"
                         >
                           <div
-                            class="c143 "
+                            class="c144 "
                           >
                             <div
                               aria-hidden="true"
@@ -5294,7 +5464,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5319,7 +5489,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5344,7 +5514,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5369,7 +5539,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5394,11 +5564,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c145 "
+                              class="c146 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c146 c147 c148"
+                                class="c147 c148 c149"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5410,7 +5580,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c149"
+                                    class="c109"
                                   >
                                     (required)
                                   </span>
@@ -5442,10 +5612,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c140 c141 c142"
+                          class="c141 c142 c143"
                         >
                           <div
-                            class="c143 "
+                            class="c144 "
                           >
                             <div
                               aria-hidden="true"
@@ -5454,7 +5624,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5479,7 +5649,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5504,7 +5674,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5529,7 +5699,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c144"
+                                class="c145"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5554,11 +5724,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c145 "
+                              class="c146 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c146 c147 c148"
+                                class="c147 c148 c149"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5570,7 +5740,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c149"
+                                    class="c109"
                                   >
                                     (required)
                                   </span>
@@ -5611,7 +5781,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c144"
+                              class="c145"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5636,7 +5806,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c144"
+                              class="c145"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5661,7 +5831,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c144"
+                              class="c145"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5686,7 +5856,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c144"
+                              class="c145"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5726,7 +5896,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             class="c159 c49"
                           >
                             <label
-                              class="c146 c147 c148"
+                              class="c147 c148 c149"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5845,7 +6015,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             class="c173 c174"
           >
             <div
-              class="c11 c131"
+              class="c11 c132"
             >
               <div
                 class="c11 c49 c175"
@@ -5939,19 +6109,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c183"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c128 c184 c185"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6073,19 +6247,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             Careers
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c183"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c128 c184 c185"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6116,19 +6294,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             Help
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c183"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c128 c184 c185"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6159,19 +6341,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             Status
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c183"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c128 c184 c185"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                     </ul>
@@ -6342,13 +6528,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c11 c49 c175"
               >
                 <div
-                  class="c176 c183"
+                  class="c176 c186"
                 >
                   <div
                     class="c42"
                   >
                     <span
-                      class="c184"
+                      class="c187"
                     >
                       <img
                         alt=""
@@ -6362,10 +6548,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c185 c186"
+                    class="c188 c189"
                   >
                     <div
-                      class="c48 c49 c187 c188"
+                      class="c48 c49 c190 c191"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6376,10 +6562,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c189 c55 icon-container"
+                            class="c192 c55 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c193 shadow"
                             />
                             <span
                               class="c24"
@@ -6403,7 +6589,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c187 c188"
+                      class="c48 c49 c190 c191"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6414,10 +6600,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c189 c55 icon-container"
+                            class="c192 c55 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c193 shadow"
                             />
                             <span
                               class="c24"
@@ -6441,7 +6627,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c187 c188"
+                      class="c48 c49 c190 c191"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6452,10 +6638,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c189 c55 icon-container"
+                            class="c192 c55 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c193 shadow"
                             />
                             <span
                               class="c24"
@@ -6483,7 +6669,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c191 c192"
+              class="c194 c195"
               data-percy-hide="contents"
             >
               <img
@@ -6499,13 +6685,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c193 c194"
+              class="c196 c197"
             >
               <div
-                class="c195 c196"
+                class="c198 c199"
               >
                 <div
-                  class="c48 c49 c187 c188"
+                  class="c48 c49 c190 c191"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6516,10 +6702,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c189 c55 icon-container"
+                        class="c192 c55 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c193 shadow"
                         />
                         <span
                           class="c24"
@@ -6543,7 +6729,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c187 c188"
+                  class="c48 c49 c190 c191"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6554,10 +6740,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c189 c55 icon-container"
+                        class="c192 c55 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c193 shadow"
                         />
                         <span
                           class="c24"
@@ -6581,7 +6767,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c187 c188"
+                  class="c48 c49 c190 c191"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6592,10 +6778,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c189 c55 icon-container"
+                        class="c192 c55 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c193 shadow"
                         />
                         <span
                           class="c24"
@@ -6623,7 +6809,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c59"
               >
                 <span
-                  class="c184"
+                  class="c187"
                 >
                   <img
                     alt=""
@@ -6640,12 +6826,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c176 c156"
               >
                 <p
-                  class="c197"
+                  class="c200"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c198"
+                  class="c201"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6654,11 +6840,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c199"
+          class="c202"
         >
           <img
             alt=""
-            class="c200"
+            class="c203"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6667,11 +6853,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c201"
+          class="c204"
         >
           <img
             alt=""
-            class="c202"
+            class="c205"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6683,23 +6869,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     </div>
   </div>
   <div
-    class="c203"
+    class="c206"
   >
     <div
-      class="c204"
+      class="c207"
       data-testid="cookie-banner"
     >
       <div
-        class="c205"
+        class="c208"
       >
         <div
-          class="c206 c207"
+          class="c209 c210"
         >
           <div
-            class="c208"
+            class="c211"
           >
             <strong
-              class="c209"
+              class="c212"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6707,13 +6893,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c210"
+            class="c11 c213"
           >
             <div
-              class="c211 c44"
+              class="c214 c44"
             >
               <button
-                class="c181 "
+                class="c215"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6757,7 +6943,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c8 yellow-shadow"
               />
               <button
-                class="c212 c23 internal-button"
+                class="c216 c23 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -694,7 +694,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c216 {
+.c215 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c219 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -703,7 +709,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c217 {
+.c220 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -711,7 +717,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c221 {
+.c224 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -722,7 +728,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c222 {
+.c225 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -733,14 +739,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c223 {
+.c226 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c225 {
+.c228 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -748,12 +754,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c227 {
+.c230 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c231 {
+.c234 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -771,7 +777,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c233 {
+.c236 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -789,7 +795,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c235 {
+.c238 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -797,7 +803,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c236 {
+.c239 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -805,13 +811,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c237 {
+.c240 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c238 {
+.c241 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -819,7 +825,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c240 {
+.c243 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -830,15 +836,8 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c243 {
+.c246 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -1343,7 +1342,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c215 {
+.c218 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1354,7 +1353,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c218 {
+.c221 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1370,7 +1369,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c226 {
+.c229 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1388,7 +1387,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c228 {
+.c231 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1401,7 +1400,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c239 {
+.c242 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1416,7 +1415,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c242 {
+.c245 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1531,7 +1530,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c241 {
+.c244 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1843,13 +1842,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c232 {
+.c235 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c234 {
+.c237 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -2109,27 +2108,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   background: #222222;
 }
 
-.c219 > :first-child:focus-visible .shadow {
+.c222 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c219 > :first-child:hover .shadow {
+.c222 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c219 > :first-child:active .shadow {
+.c222 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c219 > :first-child:disabled .icon-container {
+.c222 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c219 > :first-child:hover .icon-container {
+.c222 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c219 > :first-child:active .icon-container {
+.c222 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
@@ -2361,7 +2360,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c229 {
+.c232 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2372,7 +2371,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c230 {
+.c233 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2415,6 +2414,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
+.c217 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c28 {
   display: inline;
   -webkit-align-items: center;
@@ -2439,6 +2445,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c28 .c216 {
+  -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c28:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2447,13 +2460,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #081676;
 }
 
+.c28:visited .c216 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+}
+
 .c28:active {
   color: #081676;
+  outline: 1px solid #081676;
+}
+
+.c28:active .c216 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
 .c28[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c28[disabled] .c216 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c213 {
@@ -2480,6 +2509,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c213 .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c213:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2488,13 +2524,102 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
+.c213:visited .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c213:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c213:active .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c213[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c213[disabled] .c216 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c247 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c247 .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c247:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c247:visited {
+  color: #222222;
+}
+
+.c247:visited .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c247:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c247:active .c216 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c247[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c247[disabled] .c216 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c46 {
@@ -2644,7 +2769,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   top: 82px;
 }
 
-.c220 .icon-container > *:first-child {
+.c223 .icon-container > *:first-child {
   border: 0;
 }
 
@@ -2748,7 +2873,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c224 {
+.c227 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -3424,19 +3549,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c220 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c225 {
+  .c228 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c227 {
+  .c230 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3445,13 +3570,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c231 {
+  .c234 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c231 {
+  .c234 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3459,7 +3584,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c231 {
+  .c234 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3467,55 +3592,55 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c233 {
+  .c236 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c238 {
+  .c241 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c238 {
+  .c241 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c238 {
+  .c241 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c238 {
+  .c241 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c243 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c243 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c243 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c243 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3676,7 +3801,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c218 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3685,13 +3810,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c221 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c226 {
+  .c229 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3699,7 +3824,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c226 {
+  .c229 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3708,7 +3833,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c226 {
+  .c229 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3717,7 +3842,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c228 {
+  .c231 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3726,7 +3851,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c239 {
+  .c242 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3734,7 +3859,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c239 {
+  .c242 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3742,7 +3867,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c239 {
+  .c242 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3751,7 +3876,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c239 {
+  .c242 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3760,19 +3885,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c239 {
+  .c242 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c239 {
+  .c242 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c245 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3780,7 +3905,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c245 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3788,7 +3913,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c242 {
+  .c245 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3796,7 +3921,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c245 {
     gap: 2rem;
   }
 }
@@ -3856,25 +3981,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c244 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c244 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c244 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c244 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4242,6 +4367,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c28:hover .c216,
+  .c28:visited:hover .c216 {
+    -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
+    filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
@@ -4251,6 +4384,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c213:hover .c216,
+  .c213:visited:hover .c216 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c247:hover,
+  .c247:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c247:hover .c216,
+  .c247:visited:hover .c216 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
@@ -6495,19 +6653,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c215"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c161 c216 c217"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6629,19 +6791,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             Careers
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c215"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c161 c216 c217"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6672,19 +6838,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             Help
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c215"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c161 c216 c217"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6715,19 +6885,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             Status
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c215"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c161 c216 c217"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                     </ul>
@@ -6898,13 +7072,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c11 c49 c208"
               >
                 <div
-                  class="c209 c215"
+                  class="c209 c218"
                 >
                   <div
                     class="c42"
                   >
                     <span
-                      class="c216"
+                      class="c219"
                     >
                       <img
                         alt=""
@@ -6918,10 +7092,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c217 c218"
+                    class="c220 c221"
                   >
                     <div
-                      class="c48 c49 c219 c220"
+                      class="c48 c49 c222 c223"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6932,10 +7106,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c221 c55 icon-container"
+                            class="c224 c55 icon-container"
                           >
                             <div
-                              class="c222 shadow"
+                              class="c225 shadow"
                             />
                             <span
                               class="c24"
@@ -6959,7 +7133,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c219 c220"
+                      class="c48 c49 c222 c223"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6970,10 +7144,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c221 c55 icon-container"
+                            class="c224 c55 icon-container"
                           >
                             <div
-                              class="c222 shadow"
+                              class="c225 shadow"
                             />
                             <span
                               class="c24"
@@ -6997,7 +7171,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c219 c220"
+                      class="c48 c49 c222 c223"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -7008,10 +7182,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c221 c55 icon-container"
+                            class="c224 c55 icon-container"
                           >
                             <div
-                              class="c222 shadow"
+                              class="c225 shadow"
                             />
                             <span
                               class="c24"
@@ -7039,7 +7213,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c223 c224"
+              class="c226 c227"
               data-percy-hide="contents"
             >
               <img
@@ -7055,13 +7229,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c225 c226"
+              class="c228 c229"
             >
               <div
-                class="c227 c228"
+                class="c230 c231"
               >
                 <div
-                  class="c48 c49 c219 c220"
+                  class="c48 c49 c222 c223"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -7072,10 +7246,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c221 c55 icon-container"
+                        class="c224 c55 icon-container"
                       >
                         <div
-                          class="c222 shadow"
+                          class="c225 shadow"
                         />
                         <span
                           class="c24"
@@ -7099,7 +7273,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c219 c220"
+                  class="c48 c49 c222 c223"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -7110,10 +7284,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c221 c55 icon-container"
+                        class="c224 c55 icon-container"
                       >
                         <div
-                          class="c222 shadow"
+                          class="c225 shadow"
                         />
                         <span
                           class="c24"
@@ -7137,7 +7311,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c219 c220"
+                  class="c48 c49 c222 c223"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -7148,10 +7322,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c221 c55 icon-container"
+                        class="c224 c55 icon-container"
                       >
                         <div
-                          class="c222 shadow"
+                          class="c225 shadow"
                         />
                         <span
                           class="c24"
@@ -7179,7 +7353,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c59"
               >
                 <span
-                  class="c216"
+                  class="c219"
                 >
                   <img
                     alt=""
@@ -7196,12 +7370,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c209 c98"
               >
                 <p
-                  class="c229"
+                  class="c232"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c230"
+                  class="c233"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7210,11 +7384,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c231"
+          class="c234"
         >
           <img
             alt=""
-            class="c232"
+            class="c235"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7223,11 +7397,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c233"
+          class="c236"
         >
           <img
             alt=""
-            class="c234"
+            class="c237"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7239,23 +7413,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     </div>
   </div>
   <div
-    class="c235"
+    class="c238"
   >
     <div
-      class="c236"
+      class="c239"
       data-testid="cookie-banner"
     >
       <div
-        class="c237"
+        class="c240"
       >
         <div
-          class="c238 c239"
+          class="c241 c242"
         >
           <div
-            class="c240"
+            class="c243"
           >
             <strong
-              class="c241"
+              class="c244"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -7263,13 +7437,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c242"
+            class="c11 c245"
           >
             <div
-              class="c243 c44"
+              class="c246 c44"
             >
               <button
-                class="c213 "
+                class="c247"
                 data-testid="cookie-banner-reject"
                 type="button"
               >

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -565,7 +565,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c191 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c195 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -574,7 +580,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c196 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -582,7 +588,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c197 {
+.c200 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -593,7 +599,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c201 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -604,14 +610,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c202 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c201 {
+.c204 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -619,12 +625,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c203 {
+.c206 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c207 {
+.c210 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -642,7 +648,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c209 {
+.c212 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -660,7 +666,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c211 {
+.c214 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -668,7 +674,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c212 {
+.c215 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -676,13 +682,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c213 {
+.c216 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c214 {
+.c217 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -690,7 +696,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c216 {
+.c219 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -701,15 +707,8 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c219 {
+.c222 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -1092,7 +1091,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c191 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1103,7 +1102,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c194 {
+.c197 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1119,7 +1118,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c202 {
+.c205 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1137,7 +1136,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c204 {
+.c207 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1150,7 +1149,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c215 {
+.c218 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1165,7 +1164,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c218 {
+.c221 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1267,7 +1266,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c217 {
+.c220 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1535,7 +1534,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c220 {
+.c224 {
   background: none;
   color: inherit;
   border: none;
@@ -1558,7 +1557,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c220:disabled {
+.c224:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1579,13 +1578,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c208 {
+.c211 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c210 {
+.c213 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1845,27 +1844,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   background: #222222;
 }
 
-.c195 > :first-child:focus-visible .shadow {
+.c198 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c195 > :first-child:hover .shadow {
+.c198 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c195 > :first-child:active .shadow {
+.c198 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c195 > :first-child:disabled .icon-container {
+.c198 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c195 > :first-child:hover .icon-container {
+.c198 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c195 > :first-child:active .icon-container {
+.c198 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
@@ -2054,7 +2053,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c205 {
+.c208 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2065,7 +2064,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c206 {
+.c209 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2108,6 +2107,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
+.c193 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c28 {
   display: inline;
   -webkit-align-items: center;
@@ -2132,6 +2138,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c28 .c192 {
+  -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c28:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2140,13 +2153,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #081676;
 }
 
+.c28:visited .c192 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+}
+
 .c28:active {
   color: #081676;
+  outline: 1px solid #081676;
+}
+
+.c28:active .c192 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
 .c28[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c28[disabled] .c192 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c189 {
@@ -2173,6 +2202,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c189 .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c189:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -2181,13 +2217,102 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
+.c189:visited .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c189:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c189:active .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c189[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c189[disabled] .c192 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c223 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c223 .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c223:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c223:visited {
+  color: #222222;
+}
+
+.c223:visited .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c223:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c223:active .c192 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c223[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c223[disabled] .c192 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c46 {
@@ -2757,11 +2882,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-self: center;
 }
 
-.c196 .icon-container > *:first-child {
+.c199 .icon-container > *:first-child {
   border: 0;
 }
 
-.c200 {
+.c203 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -3179,19 +3304,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c196 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c204 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c203 {
+  .c206 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3200,13 +3325,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c210 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3214,7 +3339,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c210 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3222,55 +3347,55 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c212 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c214 {
+  .c217 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c214 {
+  .c217 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c214 {
+  .c217 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c214 {
+  .c217 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c219 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c219 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c219 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c219 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3356,7 +3481,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c194 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3365,13 +3490,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c197 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c205 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3379,7 +3504,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c205 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3388,7 +3513,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c205 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3397,7 +3522,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c204 {
+  .c207 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3406,7 +3531,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c218 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3414,7 +3539,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c215 {
+  .c218 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3422,7 +3547,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c218 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3431,7 +3556,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c215 {
+  .c218 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3440,19 +3565,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c218 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c215 {
+  .c218 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c221 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3460,7 +3585,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c221 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3468,7 +3593,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c218 {
+  .c221 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3476,7 +3601,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c221 {
     gap: 2rem;
   }
 }
@@ -3536,25 +3661,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c220 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c220 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c220 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c220 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4021,6 +4146,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c28:hover .c192,
+  .c28:visited:hover .c192 {
+    -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
+    filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
@@ -4030,6 +4163,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c189:hover .c192,
+  .c189:visited:hover .c192 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c223:hover,
+  .c223:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c223:hover .c192,
+  .c223:visited:hover .c192 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
@@ -5998,19 +6156,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c191"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c136 c192 c193"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6132,19 +6294,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             Careers
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c191"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c136 c192 c193"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6175,19 +6341,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             Help
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c191"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c136 c192 c193"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -6218,19 +6388,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             Status
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c191"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c136 c192 c193"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                     </ul>
@@ -6401,13 +6575,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c11 c49 c183"
               >
                 <div
-                  class="c184 c191"
+                  class="c184 c194"
                 >
                   <div
                     class="c42"
                   >
                     <span
-                      class="c192"
+                      class="c195"
                     >
                       <img
                         alt=""
@@ -6421,10 +6595,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c193 c194"
+                    class="c196 c197"
                   >
                     <div
-                      class="c48 c49 c195 c196"
+                      class="c48 c49 c198 c199"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6435,10 +6609,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c197 c55 icon-container"
+                            class="c200 c55 icon-container"
                           >
                             <div
-                              class="c198 shadow"
+                              class="c201 shadow"
                             />
                             <span
                               class="c24"
@@ -6462,7 +6636,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c195 c196"
+                      class="c48 c49 c198 c199"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6473,10 +6647,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c197 c55 icon-container"
+                            class="c200 c55 icon-container"
                           >
                             <div
-                              class="c198 shadow"
+                              class="c201 shadow"
                             />
                             <span
                               class="c24"
@@ -6500,7 +6674,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c195 c196"
+                      class="c48 c49 c198 c199"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6511,10 +6685,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c197 c55 icon-container"
+                            class="c200 c55 icon-container"
                           >
                             <div
-                              class="c198 shadow"
+                              class="c201 shadow"
                             />
                             <span
                               class="c24"
@@ -6542,7 +6716,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c199 c200"
+              class="c202 c203"
               data-percy-hide="contents"
             >
               <img
@@ -6558,13 +6732,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c201 c202"
+              class="c204 c205"
             >
               <div
-                class="c203 c204"
+                class="c206 c207"
               >
                 <div
-                  class="c48 c49 c195 c196"
+                  class="c48 c49 c198 c199"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6575,10 +6749,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c197 c55 icon-container"
+                        class="c200 c55 icon-container"
                       >
                         <div
-                          class="c198 shadow"
+                          class="c201 shadow"
                         />
                         <span
                           class="c24"
@@ -6602,7 +6776,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c195 c196"
+                  class="c48 c49 c198 c199"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6613,10 +6787,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c197 c55 icon-container"
+                        class="c200 c55 icon-container"
                       >
                         <div
-                          class="c198 shadow"
+                          class="c201 shadow"
                         />
                         <span
                           class="c24"
@@ -6640,7 +6814,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c195 c196"
+                  class="c48 c49 c198 c199"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6651,10 +6825,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c197 c55 icon-container"
+                        class="c200 c55 icon-container"
                       >
                         <div
-                          class="c198 shadow"
+                          class="c201 shadow"
                         />
                         <span
                           class="c24"
@@ -6682,7 +6856,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c59"
               >
                 <span
-                  class="c192"
+                  class="c195"
                 >
                   <img
                     alt=""
@@ -6699,12 +6873,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c184 c98"
               >
                 <p
-                  class="c205"
+                  class="c208"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c206"
+                  class="c209"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6713,11 +6887,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c207"
+          class="c210"
         >
           <img
             alt=""
-            class="c208"
+            class="c211"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6726,11 +6900,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c209"
+          class="c212"
         >
           <img
             alt=""
-            class="c210"
+            class="c213"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6742,23 +6916,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     </div>
   </div>
   <div
-    class="c211"
+    class="c214"
   >
     <div
-      class="c212"
+      class="c215"
       data-testid="cookie-banner"
     >
       <div
-        class="c213"
+        class="c216"
       >
         <div
-          class="c214 c215"
+          class="c217 c218"
         >
           <div
-            class="c216"
+            class="c219"
           >
             <strong
-              class="c217"
+              class="c220"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6766,13 +6940,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c218"
+            class="c11 c221"
           >
             <div
-              class="c219 c44"
+              class="c222 c44"
             >
               <button
-                class="c189 "
+                class="c223"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6816,7 +6990,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c8 yellow-shadow"
               />
               <button
-                class="c220 c23 internal-button"
+                class="c224 c23 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -373,7 +373,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
+.c114 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
 .c115 {
+  position: relative;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c119 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -382,7 +398,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c120 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -390,7 +406,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c124 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -401,7 +417,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c125 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -412,14 +428,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c126 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c128 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -427,12 +443,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c130 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c134 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -450,7 +466,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c132 {
+.c136 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -468,7 +484,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c134 {
+.c138 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -476,7 +492,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 299;
 }
 
-.c135 {
+.c139 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -484,13 +500,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c136 {
+.c140 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c141 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -498,7 +514,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c143 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -509,15 +525,8 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c142 {
+.c146 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -786,7 +795,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c114 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -797,7 +806,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: left;
 }
 
-.c117 {
+.c121 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -813,7 +822,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c125 {
+.c129 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -831,7 +840,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c127 {
+.c131 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -844,7 +853,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c138 {
+.c142 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -859,7 +868,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c141 {
+.c145 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -932,7 +941,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c140 {
+.c144 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1199,7 +1208,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c143 {
+.c148 {
   background: none;
   color: inherit;
   border: none;
@@ -1222,7 +1231,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c143:disabled {
+.c148:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1243,13 +1252,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c131 {
+.c135 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c133 {
+.c137 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1547,27 +1556,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   background: #222222;
 }
 
-.c118 > :first-child:focus-visible .shadow {
+.c122 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:hover .shadow {
+.c122 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c118 > :first-child:active .shadow {
+.c122 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:disabled .icon-container {
+.c122 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c118 > :first-child:hover .icon-container {
+.c122 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c118 > :first-child:active .icon-container {
+.c122 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
@@ -1624,7 +1633,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c128 {
+.c132 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1635,7 +1644,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c129 {
+.c133 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1700,6 +1709,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
+.c117 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c28 {
   display: inline;
   -webkit-align-items: center;
@@ -1724,6 +1740,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c28 .c116 {
+  -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c28:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -1732,13 +1755,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #081676;
 }
 
+.c28:visited .c116 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+}
+
 .c28:active {
   color: #081676;
+  outline: 1px solid #081676;
+}
+
+.c28:active .c116 {
+  -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
+  filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
 
 .c28[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c28[disabled] .c116 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c76 {
@@ -1765,6 +1804,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c76 .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c76:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -1773,13 +1819,102 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
+.c76:visited .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c76:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c76:active .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c76[disabled] {
   cursor: not-allowed;
   color: #808080;
+}
+
+.c76[disabled] .c116 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c147 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c147 .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c147:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c147:visited {
+  color: #222222;
+}
+
+.c147:visited .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c147:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c147:active .c116 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c147[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c147[disabled] .c116 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
 .c46 {
@@ -1936,11 +2071,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   top: 82px;
 }
 
-.c119 .icon-container > *:first-child {
+.c123 .icon-container > *:first-child {
   border: 0;
 }
 
-.c123 {
+.c127 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -2247,19 +2382,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c120 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c128 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c130 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2268,13 +2403,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c134 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c134 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -2282,7 +2417,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c130 {
+  .c134 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -2290,55 +2425,55 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c136 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c141 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c137 {
+  .c141 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c141 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c137 {
+  .c141 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c143 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c143 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c143 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c143 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2400,7 +2535,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c118 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -2409,13 +2544,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c121 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c129 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2423,7 +2558,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c129 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2432,7 +2567,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c129 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -2441,7 +2576,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c131 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2450,7 +2585,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c142 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -2458,7 +2593,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c138 {
+  .c142 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2466,7 +2601,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c142 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2475,7 +2610,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c138 {
+  .c142 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2484,19 +2619,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c142 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c138 {
+  .c142 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c145 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2504,7 +2639,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c145 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -2512,7 +2647,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c145 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -2520,7 +2655,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c145 {
     gap: 2rem;
   }
 }
@@ -2580,25 +2715,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c144 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c144 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c144 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c144 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2750,6 +2885,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c28:hover .c116,
+  .c28:visited:hover .c116 {
+    -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
+    filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
@@ -2759,6 +2902,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c76:hover .c116,
+  .c76:visited:hover .c116 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c147:hover,
+  .c147:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c147:hover .c116,
+  .c147:visited:hover .c116 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
@@ -3440,7 +3608,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   class="c75"
                 >
                   <a
-                    class="c76 "
+                    class="c76"
                     href="/"
                     style="overflow: hidden;"
                   >
@@ -3472,7 +3640,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <a
-                    class="c76 "
+                    class="c76"
                     href="/about-us/meet-the-team"
                     style="overflow: hidden;"
                   >
@@ -3773,19 +3941,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             Aila, Oak’s AI lesson assistant
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c114"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c115 c116 c117"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -3907,19 +4079,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             Careers
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c114"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c115 c116 c117"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -3950,19 +4126,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             Help
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c114"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c115 c116 c117"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                       <li
@@ -3993,19 +4173,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             Status
                           </span>
-                          <span
-                            class="c24 "
+                          <div
+                            class="c114"
                           >
-                            <img
-                              alt=""
-                              class="c25"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
-                          </span>
+                            <span
+                              class="c115 c116 c117"
+                            >
+                              <img
+                                alt=""
+                                class="c25"
+                                data-nimg="fill"
+                                decoding="async"
+                                loading="lazy"
+                                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
+                                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                              />
+                            </span>
+                          </div>
                         </a>
                       </li>
                     </ul>
@@ -4176,13 +4360,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c11 c49 c106"
               >
                 <div
-                  class="c107 c114"
+                  class="c107 c118"
                 >
                   <div
                     class="c42"
                   >
                     <span
-                      class="c115"
+                      class="c119"
                     >
                       <img
                         alt=""
@@ -4196,10 +4380,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c116 c117"
+                    class="c120 c121"
                   >
                     <div
-                      class="c48 c49 c118 c119"
+                      class="c48 c49 c122 c123"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -4210,10 +4394,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c120 c55 icon-container"
+                            class="c124 c55 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c125 shadow"
                             />
                             <span
                               class="c24"
@@ -4237,7 +4421,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c118 c119"
+                      class="c48 c49 c122 c123"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -4248,10 +4432,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c120 c55 icon-container"
+                            class="c124 c55 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c125 shadow"
                             />
                             <span
                               class="c24"
@@ -4275,7 +4459,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c48 c49 c118 c119"
+                      class="c48 c49 c122 c123"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -4286,10 +4470,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c11 c53"
                         >
                           <div
-                            class="c120 c55 icon-container"
+                            class="c124 c55 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c125 shadow"
                             />
                             <span
                               class="c24"
@@ -4317,7 +4501,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c122 c123"
+              class="c126 c127"
               data-percy-hide="contents"
             >
               <img
@@ -4333,13 +4517,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               />
             </span>
             <div
-              class="c124 c125"
+              class="c128 c129"
             >
               <div
-                class="c126 c127"
+                class="c130 c131"
               >
                 <div
-                  class="c48 c49 c118 c119"
+                  class="c48 c49 c122 c123"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -4350,10 +4534,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c120 c55 icon-container"
+                        class="c124 c55 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c125 shadow"
                         />
                         <span
                           class="c24"
@@ -4377,7 +4561,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c118 c119"
+                  class="c48 c49 c122 c123"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -4388,10 +4572,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c120 c55 icon-container"
+                        class="c124 c55 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c125 shadow"
                         />
                         <span
                           class="c24"
@@ -4415,7 +4599,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c48 c49 c118 c119"
+                  class="c48 c49 c122 c123"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -4426,10 +4610,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c11 c53"
                     >
                       <div
-                        class="c120 c55 icon-container"
+                        class="c124 c55 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c125 shadow"
                         />
                         <span
                           class="c24"
@@ -4457,7 +4641,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c59"
               >
                 <span
-                  class="c115"
+                  class="c119"
                 >
                   <img
                     alt=""
@@ -4474,12 +4658,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c107 c108"
               >
                 <p
-                  class="c128"
+                  class="c132"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c129"
+                  class="c133"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -4488,11 +4672,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c130"
+          class="c134"
         >
           <img
             alt=""
-            class="c131"
+            class="c135"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4501,11 +4685,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           />
         </span>
         <span
-          class="c132"
+          class="c136"
         >
           <img
             alt=""
-            class="c133"
+            class="c137"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4517,23 +4701,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     </div>
   </div>
   <div
-    class="c134"
+    class="c138"
   >
     <div
-      class="c135"
+      class="c139"
       data-testid="cookie-banner"
     >
       <div
-        class="c136"
+        class="c140"
       >
         <div
-          class="c137 c138"
+          class="c141 c142"
         >
           <div
-            class="c139"
+            class="c143"
           >
             <strong
-              class="c140"
+              class="c144"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -4541,13 +4725,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c11 c141"
+            class="c11 c145"
           >
             <div
-              class="c142 c44"
+              class="c146 c44"
             >
               <button
-                class="c76 "
+                class="c147"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -4591,7 +4775,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c8 yellow-shadow"
               />
               <button
-                class="c143 c23 internal-button"
+                class="c148 c23 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeHeader/getSubjectHeroImageUrl.ts
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeHeader/getSubjectHeroImageUrl.ts
@@ -64,6 +64,7 @@ export const subjectHeroImages: Record<SubjectName, string | null> = {
   "cooking-nutrition": subjectHeroAssets["independent-living"],
   "creative-arts": subjectHeroAssets["art-and-design"],
   "design-technology": subjectHeroAssets["design-and-technology"],
+  "digital-literacy": subjectHeroAssets["computing"],
   drama: subjectHeroAssets["drama"],
   english: subjectHeroAssets["english"],
   "english-language": subjectHeroAssets["english"],

--- a/src/components/AppComponents/TopNav/TopNav.tsx
+++ b/src/components/AppComponents/TopNav/TopNav.tsx
@@ -157,7 +157,7 @@ const TopNav = (props: TopNavProps) => {
       as="header"
       $position="relative"
       data-testid="app-topnav"
-      onKeyDown={(event) =>
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) =>
         focusManager?.handleEscapeKey({
           event,
           elementId: document.activeElement?.id || "",

--- a/src/components/CurriculumComponents/CurricTimetablingFilters/__snapshots__/CurricTimetablingFilters.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricTimetablingFilters/__snapshots__/CurricTimetablingFilters.test.tsx.snap
@@ -170,11 +170,11 @@ exports[`CurricTimetablingFilters basic usage 1`] = `
         </div>
       </div>
       <div
-        class="sc-aXZVg sc-gEvEer sc-bDpDS cUjhPB iDBIXi"
+        class="sc-aXZVg sc-gEvEer sc-bVHCgj cUjhPB iDBIXi"
         focusable="false"
       >
         <svg
-          class="sc-brPLxw jwxDvw"
+          class="sc-gFVvzn gBPbQe"
           height="100%"
           preserveAspectRatio="none"
           viewBox="0 0 866 8"

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`CurricTimetablingUnits snapshot (mode=debug) 1`] = `
     </div>
   </div>
   <div
-    class="sc-aXZVg sc-gEvEer sc-gFVvzn gqmiXn fUxOFh"
+    class="sc-aXZVg sc-gEvEer sc-kAkpmW gqmiXn fUxOFh"
   >
     <div
       class="sc-aXZVg sc-gEvEer jPvJsJ fjNQtm"
@@ -292,11 +292,11 @@ exports[`CurricTimetablingUnits snapshot (mode=debug) 1`] = `
             </div>
           </div>
           <div
-            class="sc-aXZVg sc-gEvEer sc-bDpDS cUjhPB iDBIXi"
+            class="sc-aXZVg sc-gEvEer sc-bVHCgj cUjhPB iDBIXi"
             focusable="false"
           >
             <svg
-              class="sc-brPLxw jwxDvw"
+              class="sc-gFVvzn gBPbQe"
               height="100%"
               preserveAspectRatio="none"
               viewBox="0 0 866 8"
@@ -695,7 +695,7 @@ exports[`CurricTimetablingUnits snapshot (mode=normal) 1`] = `
     </div>
   </div>
   <div
-    class="sc-aXZVg sc-gEvEer sc-gFVvzn gqmiXn fUxOFh"
+    class="sc-aXZVg sc-gEvEer sc-kAkpmW gqmiXn fUxOFh"
   >
     <div
       class="sc-aXZVg sc-gEvEer jPvJsJ fjNQtm"
@@ -840,11 +840,11 @@ exports[`CurricTimetablingUnits snapshot (mode=normal) 1`] = `
             </div>
           </div>
           <div
-            class="sc-aXZVg sc-gEvEer sc-bDpDS cUjhPB iDBIXi"
+            class="sc-aXZVg sc-gEvEer sc-bVHCgj cUjhPB iDBIXi"
             focusable="false"
           >
             <svg
-              class="sc-brPLxw jwxDvw"
+              class="sc-gFVvzn gBPbQe"
               height="100%"
               preserveAspectRatio="none"
               viewBox="0 0 866 8"
@@ -1033,7 +1033,7 @@ exports[`CurricTimetablingUnits snapshot (mode=normal) 1`] = `
                       class="sc-f456e885-1 bqYjse"
                     >
                       <div
-                        class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+                        class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
                       >
                         <a
                           class="sc-a6022ff2-0 ejmuOd"
@@ -1096,7 +1096,7 @@ exports[`CurricTimetablingUnits snapshot (mode=normal) 1`] = `
                       class="sc-f456e885-1 bqYjse"
                     >
                       <div
-                        class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+                        class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
                       >
                         <a
                           class="sc-a6022ff2-0 ejmuOd"

--- a/src/components/CurriculumComponents/CurricUnitCard/__snapshots__/CurricUnitCard.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricUnitCard/__snapshots__/CurricUnitCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CurricUnitCard changes color when highlighed 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+      class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
     >
       <a
         class="sc-a6022ff2-0 ejmuOd"
@@ -81,7 +81,7 @@ exports[`CurricUnitCard highlighted state 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+      class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
     >
       <a
         class="sc-a6022ff2-0 QTKhP"
@@ -163,7 +163,7 @@ exports[`CurricUnitCard index is correct 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+      class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
     >
       <a
         class="sc-a6022ff2-0 ejmuOd"
@@ -240,7 +240,7 @@ exports[`CurricUnitCard render 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg sc-fTFjTM jJROoH dDtfAW"
+      class="sc-aXZVg sc-hZDyAQ jJROoH bXvWdu"
     >
       <a
         class="sc-a6022ff2-0 ejmuOd"

--- a/src/components/CurriculumComponents/OakComponentsKitchen/YourDetails/index.tsx
+++ b/src/components/CurriculumComponents/OakComponentsKitchen/YourDetails/index.tsx
@@ -206,8 +206,6 @@ export default function YourDetails({
               target="_blank"
               iconName="external"
               isTrailingIcon
-              iconHeight="spacing-20"
-              iconWidth="spacing-20"
             >
               privacy policy
             </OakLink>

--- a/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
+++ b/src/components/GenericPagesComponents/CurriculumTab/__snapshots__/CurriculumTab.test.tsx.snap
@@ -82,27 +82,33 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 .c25 {
+  padding-left: 0.25rem;
+  display: inline-block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c26 {
   position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c30 {
   max-width: 40rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c28 {
+.c31 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c29 {
+.c32 {
   position: relative;
   top: 0.5rem;
   left: 0.5rem;
@@ -130,7 +136,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 298;
 }
 
-.c30 {
+.c33 {
   position: relative;
   border: 0.125rem solid;
   border-color: #222222;
@@ -139,7 +145,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 150;
 }
 
-.c31 {
+.c34 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -147,12 +153,12 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c37 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c36 {
+.c39 {
   width: 100%;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0rem;
@@ -161,7 +167,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c43 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -169,7 +175,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c43 {
+.c46 {
   position: relative;
   width: 0.125rem;
   height: 3rem;
@@ -177,12 +183,12 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c48 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c47 {
+.c50 {
   width: 100%;
   border-top-left-radius: 0rem;
   border-top-right-radius: 0.25rem;
@@ -191,14 +197,14 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c48 {
+.c51 {
   padding-left: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c49 {
+.c52 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -210,7 +216,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c50 {
+.c53 {
   position: absolute;
   right: 0rem;
   width: -webkit-fit-content;
@@ -224,7 +230,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 3;
 }
 
-.c52 {
+.c55 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -233,7 +239,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c57 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -242,19 +248,29 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c60 {
-  display: none;
+.c62 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c64 {
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c68 {
   max-width: 60rem;
   padding-top: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c69 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -262,7 +278,7 @@ exports[`CurriculumTab renders 1`] = `
   z-index: 299;
 }
 
-.c66 {
+.c70 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -270,13 +286,13 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c71 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c72 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -284,7 +300,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c70 {
+.c74 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -295,15 +311,8 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c73 {
+.c77 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -375,7 +384,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 1.5rem;
 }
 
-.c32 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -394,7 +403,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0rem;
 }
 
-.c33 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -412,7 +421,7 @@ exports[`CurriculumTab renders 1`] = `
   justify-content: flex-start;
 }
 
-.c35 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -422,7 +431,7 @@ exports[`CurriculumTab renders 1`] = `
   align-self: stretch;
 }
 
-.c46 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -433,14 +442,14 @@ exports[`CurriculumTab renders 1`] = `
   gap: 1rem;
 }
 
-.c51 {
+.c54 {
   display: none;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.c57 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -459,7 +468,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0.5rem;
 }
 
-.c61 {
+.c65 {
   display: none;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
@@ -478,7 +487,7 @@ exports[`CurriculumTab renders 1`] = `
   flex-grow: 1;
 }
 
-.c62 {
+.c66 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -489,7 +498,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0.5rem;
 }
 
-.c69 {
+.c73 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -504,7 +513,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 1.5rem;
 }
 
-.c72 {
+.c76 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -526,7 +535,7 @@ exports[`CurriculumTab renders 1`] = `
   gap: 0.75rem;
 }
 
-.c74 {
+.c78 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -541,7 +550,7 @@ exports[`CurriculumTab renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c41 {
+.c44 {
   color: #222222;
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -554,7 +563,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c58 {
+.c61 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -566,7 +575,7 @@ exports[`CurriculumTab renders 1`] = `
   text-align: left;
 }
 
-.c71 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -577,7 +586,7 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c55 {
+.c58 {
   background: none;
   color: inherit;
   border: none;
@@ -600,12 +609,12 @@ exports[`CurriculumTab renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c55:disabled {
+.c58:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c75 {
+.c80 {
   background: none;
   color: inherit;
   border: none;
@@ -628,7 +637,7 @@ exports[`CurriculumTab renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c75:disabled {
+.c80:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -639,23 +648,23 @@ exports[`CurriculumTab renders 1`] = `
   object-fit: contain;
 }
 
-.c26 {
+.c29 {
   object-fit: contain;
 }
 
-.c59 {
+.c63 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c56 {
+.c59 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c56:hover {
+.c59:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -663,37 +672,37 @@ exports[`CurriculumTab renders 1`] = `
   border-color: #575757;
 }
 
-.c56:hover [data-state="selected"] {
+.c59:hover [data-state="selected"] {
   display: none;
 }
 
-.c56:active {
+.c59:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c56:active [data-state="selected"] {
+.c59:active [data-state="selected"] {
   display: none;
 }
 
-.c56:disabled {
+.c59:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c56:disabled [data-state="selected"] {
+.c59:disabled [data-state="selected"] {
   display: none;
 }
 
-.c76 {
+.c81 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c76:hover {
+.c81:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -701,52 +710,52 @@ exports[`CurriculumTab renders 1`] = `
   border-color: #222222;
 }
 
-.c76:hover [data-state="selected"] {
+.c81:hover [data-state="selected"] {
   display: none;
 }
 
-.c76:active {
+.c81:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c76:active [data-state="selected"] {
+.c81:active [data-state="selected"] {
   display: none;
 }
 
-.c76:disabled {
+.c81:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c76:disabled [data-state="selected"] {
+.c81:disabled [data-state="selected"] {
   display: none;
 }
 
-.c53 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c56 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c53 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c56 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c53 .yellow-shadow:has(+ .internal-button:hover),
-.c53 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c56 .yellow-shadow:has(+ .internal-button:hover),
+.c56 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c53 .grey-shadow:has(+ * + .internal-button:hover) {
+.c56 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c53 .grey-shadow:has(+ * + .internal-button:active) {
+.c56 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c53 .yellow-shadow:has(+ .internal-button:active) {
+.c56 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
@@ -782,7 +791,7 @@ exports[`CurriculumTab renders 1`] = `
   display: revert;
 }
 
-.c42 {
+.c45 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -829,6 +838,13 @@ exports[`CurriculumTab renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
+.c28 {
+  width: 1.25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  min-height: 1.25em;
+}
+
 .c21 {
   display: inline;
   -webkit-align-items: center;
@@ -853,6 +869,13 @@ exports[`CurriculumTab renders 1`] = `
   overflow-wrap: break-word;
 }
 
+.c21 .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
 .c21:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -861,8 +884,19 @@ exports[`CurriculumTab renders 1`] = `
   color: #222222;
 }
 
+.c21:visited .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
 .c21:active {
   color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c21:active .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c21[disabled] {
@@ -870,28 +904,106 @@ exports[`CurriculumTab renders 1`] = `
   color: #808080;
 }
 
-.c37 {
+.c21[disabled] .c27 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c79 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  color: #222222;
+  overflow-wrap: break-word;
+}
+
+.c79 .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  display: inline-block;
+  vertical-align: text-top;
+}
+
+.c79:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c79:visited {
+  color: #222222;
+}
+
+.c79:visited .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c79:active {
+  color: #222222;
+  outline: 1px solid #222222;
+}
+
+.c79:active .c27 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c79[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+.c79[disabled] .c27 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c40 {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c37:has(a:hover,button:hover) {
+.c40:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c37:has( a, button) {
+.c40:has( a, button) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c37:has( a, button)  a,
-.c37:has( a, button) button {
+.c40:has( a, button)  a,
+.c40:has( a, button) button {
   outline: none;
 }
 
-.c37:has(a:active,button:active) {
+.c40:has(a:active,button:active) {
   box-shadow: none;
 }
 
-.c63 {
+.c67 {
   object-fit: contain;
   width: 100%;
   height: auto;
@@ -902,23 +1014,23 @@ exports[`CurriculumTab renders 1`] = `
   transform: none;
 }
 
-.c63::-webkit-scrollbar-track {
+.c67::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c63::-webkit-scrollbar {
+.c67::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c63::-webkit-scrollbar-thumb {
+.c67::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c44 {
+.c47 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -935,11 +1047,11 @@ exports[`CurriculumTab renders 1`] = `
   top: 82px;
 }
 
-.c38 {
+.c41 {
   box-shadow: none;
 }
 
-.c39 {
+.c42 {
   background: none;
   width: 100%;
   border: none;
@@ -1010,79 +1122,79 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c27 {
+  .c30 {
     display: none;
   }
 }
 
 @media (min-width:1280px) {
-  .c27 {
+  .c30 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c39 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c39 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c39 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c36 {
-    border-bottom-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c47 {
-    border-top-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c47 {
-    border-top-right-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c47 {
-    border-bottom-left-radius: 0.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c47 {
+  .c39 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
   .c50 {
+    border-top-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c50 {
+    border-top-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c50 {
+    border-bottom-left-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c50 {
+    border-bottom-right-radius: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c53 {
     max-width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c50 {
+  .c53 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c64 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1091,7 +1203,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c60 {
+  .c64 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1100,61 +1212,61 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c68 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c68 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c72 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c72 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c72 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c68 {
+  .c72 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c74 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c74 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c74 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c74 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -1172,7 +1284,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c32 {
+  .c35 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1180,13 +1292,13 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c51 {
+  .c54 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c65 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1195,7 +1307,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c61 {
+  .c65 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1204,7 +1316,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c73 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -1212,7 +1324,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c69 {
+  .c73 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1220,7 +1332,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c73 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -1229,7 +1341,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c69 {
+  .c73 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -1238,19 +1350,19 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c73 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c69 {
+  .c73 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c76 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1258,7 +1370,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c76 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -1266,7 +1378,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c76 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -1274,31 +1386,31 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c76 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c75 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c75 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c75 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c71 {
+  .c75 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -1366,11 +1478,36 @@ exports[`CurriculumTab renders 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c21:hover .c27,
+  .c21:visited:hover .c27 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  }
+}
+
+@media (hover:hover) {
+  .c79:hover,
+  .c79:visited:hover {
+    color: #222222;
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
+  }
+
+  .c79:hover .c27,
+  .c79:visited:hover .c27 {
+    -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+    filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (min-width:750px) {
-  .c63 {
+  .c67 {
     -webkit-transform: none;
     -ms-transform: none;
     transform: none;
@@ -1378,7 +1515,7 @@ exports[`CurriculumTab renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c63 {
+  .c67 {
     -webkit-transform: rotate(-2deg);
     -ms-transform: rotate(-2deg);
     transform: rotate(-2deg);
@@ -1482,68 +1619,72 @@ exports[`CurriculumTab renders 1`] = `
                       Our curriculum planning approach
                     </span>
                   </span>
-                  <span
-                    class="c25 "
+                  <div
+                    class="c25"
                   >
-                    <img
-                      alt=""
-                      class="c26"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="c26 c27 c28"
+                    >
+                      <img
+                        alt=""
+                        class="c29"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                 </a>
               </div>
               <div
-                class="c27"
+                class="c30"
               >
                 <nav
                   aria-labelledby="choose-curriculum-label-large"
-                  class="c28"
+                  class="c31"
                 >
                   <div
-                    class="c29"
+                    class="c32"
                     id="choose-curriculum-label-large"
                   >
                     Choose a curriculum
                   </div>
                   <div
-                    class="c30"
+                    class="c33"
                     data-testid="lot-picker"
                   >
                     <div
-                      class="c31 c32"
+                      class="c34 c35"
                     >
                       <div
-                        class="c28 c33"
+                        class="c31 c36"
                       >
                         <div
-                          class="c34 c35"
+                          class="c37 c38"
                           style="width: 50%;"
                         >
                           <div
-                            class="c36 c37 c38"
+                            class="c39 c40 c41"
                           >
                             <button
                               aria-expanded="false"
-                              class="c39"
+                              class="c42"
                               data-testid="subject-picker-button"
                               title="Subject"
                             >
                               <div
-                                class="c40"
+                                class="c43"
                               >
                                 <span
-                                  class="c41"
+                                  class="c44"
                                   data-testid="subject-picker-button-heading"
                                 >
                                   Subject
                                 </span>
                                 <p
-                                  class="c42"
+                                  class="c45"
                                 >
                                   Select
                                 </p>
@@ -1552,7 +1693,7 @@ exports[`CurriculumTab renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c43"
+                          class="c46"
                         >
                           <div
                             aria-hidden="true"
@@ -1561,7 +1702,7 @@ exports[`CurriculumTab renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c44"
+                              class="c47"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -1587,32 +1728,32 @@ exports[`CurriculumTab renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c45"
+                          class="c48"
                           style="width: 50%;"
                         >
                           <div
-                            class="c34 c46"
+                            class="c37 c49"
                           >
                             <div
-                              class="c47 c37 c38"
+                              class="c50 c40 c41"
                             >
                               <button
                                 aria-expanded="false"
-                                class="c39"
+                                class="c42"
                                 data-testid="phase-picker-button"
                                 title="Phase"
                               >
                                 <div
-                                  class="c48"
+                                  class="c51"
                                 >
                                   <span
-                                    class="c41"
+                                    class="c44"
                                     data-testid="phase-picker-button-heading"
                                   >
                                     School phase
                                   </span>
                                   <div
-                                    class="c49"
+                                    class="c52"
                                   >
                                     Select
                                   </div>
@@ -1620,35 +1761,35 @@ exports[`CurriculumTab renders 1`] = `
                               </button>
                             </div>
                             <div
-                              class="c50 c51"
+                              class="c53 c54"
                             >
                               <div
-                                class="c52 c53"
+                                class="c55 c56"
                               >
                                 <div
-                                  class="c54 grey-shadow"
+                                  class="c57 grey-shadow"
                                 />
                                 <div
-                                  class="c54 yellow-shadow"
+                                  class="c57 yellow-shadow"
                                 />
                                 <button
-                                  class="c55 c56 internal-button"
+                                  class="c58 c59 internal-button"
                                   data-testid="lot-picker-view-curriculum-button"
                                 >
                                   <div
-                                    class="c8 c57"
+                                    class="c8 c60"
                                   >
                                     <span
-                                      class="c58"
+                                      class="c61"
                                     >
                                       View
                                     </span>
                                     <span
-                                      class="c25"
+                                      class="c62"
                                     >
                                       <img
                                         alt=""
-                                        class="c59"
+                                        class="c63"
                                         data-nimg="fill"
                                         decoding="async"
                                         loading="lazy"
@@ -1669,14 +1810,14 @@ exports[`CurriculumTab renders 1`] = `
               </div>
             </div>
             <div
-              class="c60 c61"
+              class="c64 c65"
             >
               <div
-                class="c8 c62"
+                class="c8 c66"
               >
                 <img
                   alt=""
-                  class="c63"
+                  class="c67"
                   data-nimg="1"
                   decoding="async"
                   height="628"
@@ -1689,52 +1830,52 @@ exports[`CurriculumTab renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c68"
           >
             <nav
               aria-labelledby="choose-curriculum-label-small"
-              class="c28"
+              class="c31"
             >
               <div
-                class="c29"
+                class="c32"
                 id="choose-curriculum-label-small"
               >
                 Choose a curriculum
               </div>
               <div
-                class="c30"
+                class="c33"
                 data-testid="lot-picker"
               >
                 <div
-                  class="c31 c32"
+                  class="c34 c35"
                 >
                   <div
-                    class="c28 c33"
+                    class="c31 c36"
                   >
                     <div
-                      class="c34 c35"
+                      class="c37 c38"
                       style="width: 50%;"
                     >
                       <div
-                        class="c36 c37 c38"
+                        class="c39 c40 c41"
                       >
                         <button
                           aria-expanded="false"
-                          class="c39"
+                          class="c42"
                           data-testid="subject-picker-button"
                           title="Subject"
                         >
                           <div
-                            class="c40"
+                            class="c43"
                           >
                             <span
-                              class="c41"
+                              class="c44"
                               data-testid="subject-picker-button-heading"
                             >
                               Subject
                             </span>
                             <p
-                              class="c42"
+                              class="c45"
                             >
                               Select
                             </p>
@@ -1743,7 +1884,7 @@ exports[`CurriculumTab renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c43"
+                      class="c46"
                     >
                       <div
                         aria-hidden="true"
@@ -1752,7 +1893,7 @@ exports[`CurriculumTab renders 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="c44"
+                          class="c47"
                           height="100%"
                           name="box-border-left"
                           style="width: 3px;"
@@ -1778,32 +1919,32 @@ exports[`CurriculumTab renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c45"
+                      class="c48"
                       style="width: 50%;"
                     >
                       <div
-                        class="c34 c46"
+                        class="c37 c49"
                       >
                         <div
-                          class="c47 c37 c38"
+                          class="c50 c40 c41"
                         >
                           <button
                             aria-expanded="false"
-                            class="c39"
+                            class="c42"
                             data-testid="phase-picker-button"
                             title="Phase"
                           >
                             <div
-                              class="c48"
+                              class="c51"
                             >
                               <span
-                                class="c41"
+                                class="c44"
                                 data-testid="phase-picker-button-heading"
                               >
                                 School phase
                               </span>
                               <div
-                                class="c49"
+                                class="c52"
                               >
                                 Select
                               </div>
@@ -1811,35 +1952,35 @@ exports[`CurriculumTab renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c50 c51"
+                          class="c53 c54"
                         >
                           <div
-                            class="c52 c53"
+                            class="c55 c56"
                           >
                             <div
-                              class="c54 grey-shadow"
+                              class="c57 grey-shadow"
                             />
                             <div
-                              class="c54 yellow-shadow"
+                              class="c57 yellow-shadow"
                             />
                             <button
-                              class="c55 c56 internal-button"
+                              class="c58 c59 internal-button"
                               data-testid="lot-picker-view-curriculum-button"
                             >
                               <div
-                                class="c8 c57"
+                                class="c8 c60"
                               >
                                 <span
-                                  class="c58"
+                                  class="c61"
                                 >
                                   View
                                 </span>
                                 <span
-                                  class="c25"
+                                  class="c62"
                                 >
                                   <img
                                     alt=""
-                                    class="c59"
+                                    class="c63"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -1862,23 +2003,23 @@ exports[`CurriculumTab renders 1`] = `
       </div>
     </div>
     <div
-      class="c65"
+      class="c69"
     >
       <div
-        class="c66"
+        class="c70"
         data-testid="cookie-banner"
       >
         <div
-          class="c67"
+          class="c71"
         >
           <div
-            class="c68 c69"
+            class="c72 c73"
           >
             <div
-              class="c70"
+              class="c74"
             >
               <strong
-                class="c71"
+                class="c75"
               >
                 This site uses cookies to store information on your computer.
               </strong>
@@ -1886,13 +2027,13 @@ exports[`CurriculumTab renders 1`] = `
               Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
             </div>
             <div
-              class="c8 c72"
+              class="c8 c76"
             >
               <div
-                class="c73 c74"
+                class="c77 c78"
               >
                 <button
-                  class="c21 "
+                  class="c79"
                   data-testid="cookie-banner-reject"
                   type="button"
                 >
@@ -1904,22 +2045,22 @@ exports[`CurriculumTab renders 1`] = `
                 </button>
               </div>
               <div
-                class="c52 c53"
+                class="c55 c56"
               >
                 <div
-                  class="c54 grey-shadow"
+                  class="c57 grey-shadow"
                 />
                 <div
-                  class="c54 yellow-shadow"
+                  class="c57 yellow-shadow"
                 />
                 <button
-                  class="c75 c76 internal-button"
+                  class="c80 c81 internal-button"
                 >
                   <div
-                    class="c8 c57"
+                    class="c8 c60"
                   >
                     <span
-                      class="c58"
+                      class="c61"
                     >
                       Cookie settings
                     </span>
@@ -1927,23 +2068,23 @@ exports[`CurriculumTab renders 1`] = `
                 </button>
               </div>
               <div
-                class="c52 c53"
+                class="c55 c56"
               >
                 <div
-                  class="c54 grey-shadow"
+                  class="c57 grey-shadow"
                 />
                 <div
-                  class="c54 yellow-shadow"
+                  class="c57 yellow-shadow"
                 />
                 <button
-                  class="c55 c56 internal-button"
+                  class="c58 c59 internal-button"
                   data-testid="cookie-banner-accept"
                 >
                   <div
-                    class="c8 c57"
+                    class="c8 c60"
                   >
                     <span
-                      class="c58"
+                      class="c61"
                     >
                       Accept all cookies
                     </span>

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                 class="sc-ea54c430-1 duAgam"
               >
                 <div
-                  class="sc-aXZVg sc-fTFjTM kBnJtM fTpqJb"
+                  class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
                 >
                   <a
                     href="#item_one"
@@ -99,7 +99,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                 class="sc-ea54c430-1 duAgam"
               >
                 <div
-                  class="sc-aXZVg sc-fTFjTM kBnJtM fTpqJb"
+                  class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
                 >
                   <a
                     href="#item_two"
@@ -156,7 +156,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                 class="sc-ea54c430-1 duAgam"
               >
                 <div
-                  class="sc-aXZVg sc-fTFjTM kBnJtM fTpqJb"
+                  class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
                 >
                   <a
                     href="#item_three"

--- a/src/components/GenericPagesComponents/WhoAreWeTimeline/__snapshots__/WhoAreWeTimeline.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeTimeline/__snapshots__/WhoAreWeTimeline.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`WhoAreWeTimeline renders correctly 1`] = `
                       >
                         ITEM_TEXT_3
                         <a
-                          class="sc-hzhJZQ jgULhJ"
+                          class="sc-fHjqPf bwIJQB"
                           href="#newsletter-signup"
                         >
                           <span
@@ -180,7 +180,7 @@ exports[`WhoAreWeTimeline renders correctly 1`] = `
                           </span>
                         </a>
                         <a
-                          class="sc-hzhJZQ jgULhJ"
+                          class="sc-fHjqPf bwIJQB"
                           href="#"
                         >
                           <span

--- a/src/components/SharedComponents/Banners/__snapshots__/Banners.test.tsx.snap
+++ b/src/components/SharedComponents/Banners/__snapshots__/Banners.test.tsx.snap
@@ -111,11 +111,11 @@ exports[`Banners shows mythbusting banner 1`] = `
       class="sc-aXZVg cZwvRV"
     >
       <div
-        class="sc-aXZVg sc-gEvEer sc-bDpDS dDGJCM iDBIXi"
+        class="sc-aXZVg sc-gEvEer sc-bVHCgj dDGJCM iDBIXi"
         focusable="false"
       >
         <svg
-          class="sc-brPLxw hcmShC"
+          class="sc-gFVvzn bbsfFI"
           height="100%"
           preserveAspectRatio="none"
           viewBox="0 0 866 8"

--- a/src/components/TeacherComponents/CopyrightLicence/CopyrightLicence.tsx
+++ b/src/components/TeacherComponents/CopyrightLicence/CopyrightLicence.tsx
@@ -17,8 +17,6 @@ const CopyrightLicence = (
           target={"_blank"}
           iconName="external"
           isTrailingIcon
-          iconHeight="spacing-20"
-          iconWidth="spacing-20"
           data-testid="external-link-icon"
           aria-label="Open Government Licence version 3.0 (opens in a new tab)"
         >
@@ -44,8 +42,6 @@ const CopyrightLicence = (
           aria-label="Oak's terms & conditions (opens in a new tab)"
           iconName="external"
           isTrailingIcon
-          iconHeight="spacing-20"
-          iconWidth="spacing-20"
           data-testid="external-link-icon"
         >
           Oak's terms & conditions

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -226,8 +226,6 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
               }
               iconName={"external"}
               isTrailingIcon={true}
-              iconHeight={"spacing-24"}
-              iconWidth={"spacing-24"}
             >
               install the Google Fonts ‘Lexend’ and ‘Kalam’
             </OakLink>

--- a/src/components/TeacherComponents/OglCopyrightNotice/OglCopyrightNotice.tsx
+++ b/src/components/TeacherComponents/OglCopyrightNotice/OglCopyrightNotice.tsx
@@ -29,8 +29,6 @@ const PreAlbCopyright = (
         aria-label="Terms and conditions (opens in a new tab)"
         iconName="external"
         isTrailingIcon
-        iconHeight="spacing-20"
-        iconWidth="spacing-20"
         data-testid="external-link-icon"
       >
         terms &amp; conditions

--- a/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
+++ b/src/components/TeacherComponents/OnboardingForm/OnboardingForm.tsx
@@ -218,7 +218,7 @@ const OnboardingForm = ({
         as="form"
         noValidate
         onSubmit={
-          (event) => {
+          (event: React.FormEvent<HTMLFormElement>) => {
             if (props.canSubmit) {
               props.handleSubmit(onFormSubmit)(event);
             } else {

--- a/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
+++ b/src/components/TeacherComponents/PreviousNextNav/PreviousNextItem.tsx
@@ -7,6 +7,7 @@ import {
   OakIconName,
   OakTypography,
   parseColor,
+  type OakColorToken,
 } from "@oaknational/oak-components";
 import styled from "styled-components";
 import Link from "next/link";
@@ -42,9 +43,13 @@ const StyledFlexContainer = styled(OakFlex)<
 >`
   &:hover {
     background: ${(props) =>
-      parseColor(`bg-decorative${props.$backgroundColorLevel}-very-subdued`)};
+      parseColor(
+        `bg-decorative${props.$backgroundColorLevel}-very-subdued` as OakColorToken,
+      )};
     border-color: ${(props) =>
-      parseColor(`border-decorative${props.$backgroundColorLevel}-stronger`)};
+      parseColor(
+        `border-decorative${props.$backgroundColorLevel}-stronger` as OakColorToken,
+      )};
     .previous-next-item-link {
       color: ${parseColor("text-subdued")};
       text-decoration: underline;

--- a/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
+++ b/src/components/TeacherComponents/ResourcePageTermsAndConditionsCheckbox/ResourcePageTermsAndConditionsCheckbox.tsx
@@ -67,8 +67,6 @@ const ResourcePageTermsAndConditionsCheckbox: FC<
           aria-label="Oak's terms & conditions (opens in a new tab)"
           iconName="external"
           isTrailingIcon
-          iconHeight="spacing-20"
-          iconWidth="spacing-20"
           data-testid="external-link-icon"
         >
           Oak's terms & conditions

--- a/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
+++ b/src/components/TeacherComponents/TermsAgreementForm/TermsAgreementForm.tsx
@@ -186,8 +186,6 @@ const TermsAgreementForm: FC<TermsAgreementFormProps> = ({
                   target="_blank"
                   iconName="external"
                   isTrailingIcon
-                  iconHeight="spacing-20"
-                  iconWidth="spacing-20"
                 >
                   privacy policy
                 </OakLink>


### PR DESCRIPTION
## Description
Bumps oak-components and fixes the following issues

 - Remove `iconHeight`/`iconWidth` because no longer supported on `<OakLink/>` — https://github.com/oaknational/oak-components/pull/710
 - Fix for missing or invalid types — unsure why this was triggering only in my build

## Issue(s)
None

## How to test
Verify that the various terms and conditions around the app (where the links with icons would have slightly changed size) still look ok

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
