### PR TITLE
fix(LESQ-2073): only show download started toast after a real downloa…

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/downloads/success/Components/DownloadSuccessView.tsx
@@ -8,7 +8,6 @@ import {
   OakIcon,
   OakSpan,
 } from "@oaknational/oak-components";
-import { useEffect } from "react";
 import styled from "styled-components";
 
 import { LessonList } from "@/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/LessonList";
@@ -20,7 +19,6 @@ import { resolveOakHref } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import type { LessonListSchema } from "@/node-lib/curriculum-api-2023/shared.schema";
 import { KeyStageTitleValueType } from "@/browser-lib/avo/Avo";
-import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
 import { getUnitDownloadFileId } from "@/utils/getUnitDownloadFileId";
 
 type DownloadSuccessViewLesson = {
@@ -73,8 +71,6 @@ export function DownloadSuccessView({
   const { track } = useAnalytics();
   const { onwardContentSelected, unitDownloadInitiated } = track;
 
-  const { setCurrentToastProps } = useOakNotificationsContext();
-
   const {
     setShowDownloadMessage,
     setDownloadError,
@@ -86,17 +82,6 @@ export function DownloadSuccessView({
   const isGeorestrictedUnit = lessons.some(
     (l) => "geoRestricted" in l && l.geoRestricted,
   );
-
-  useEffect(() => {
-    setCurrentToastProps({
-      message: "Download started. This may take a few minutes",
-      variant: "success",
-      autoDismiss: true,
-      showClose: true,
-      showIcon: true,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <>

--- a/src/components/TeacherViews/LessonDownloads.view.tsx
+++ b/src/components/TeacherViews/LessonDownloads.view.tsx
@@ -235,7 +235,16 @@ export function LessonDownloads(props: LessonDownloadsProps) {
       });
 
       if (props.successRedirect) {
-        waitForLinkCallback(() => router.replace(props.successRedirect!));
+        waitForLinkCallback(() => {
+          setCurrentToastProps({
+            message: "Download started. This may take a few minutes",
+            variant: "success",
+            autoDismiss: true,
+            showClose: true,
+            showIcon: true,
+          });
+          router.replace(props.successRedirect!);
+        });
       } else {
         setIsDownloadSuccessful(true);
       }


### PR DESCRIPTION
## Description

Music year: 1956

## Description

- Fire the "Download started" toast from `waitForLinkCallback` in `LessonDownloads.view.tsx` after the hidden download link is confirmed clicked
- Remove toast logic from `DownloadSuccessView` (no mount-time toast)
- Redirect to the success page after showing the toast; toast state persists via `OakNotificationsProvider` in the root layout

## How to test

1. Go to https://oak-web-application-website-git-feat-lesq-2073only-show-70603e.vercel.thenational.academy/teachers/programmes/science-secondary-ks3/units/forces/lessons/what-forces-do/downloads/success
2. Load the page directly (no prior download)
3. You should see the success page ("Thanks for downloading!") with **no** "Download started. This may take a few minutes" toast

**Also verify refresh does not show the toast:**

4. Refresh the success page
5. You should still see **no** toast

**And verify a real download does show the toast:**

6. Go to https://oak-web-application-website-git-feat-lesq-2073only-show-70603e.vercel.thenational.academy/teachers/programmes/science-secondary-ks3/units/forces/lessons/what-forces-do/downloads
7. Complete the download flow (select resources, submit)
8. You should be redirected to the success page and see the "Download started. This may take a few minutes" success toast

**Also verify browser back does not show the toast:**

9. From the success page, click into another lesson in the unit list, then use the browser back button
10. You should return to the success page with **no** toast

**And verify auth redirect does not show the toast prematurely:**

11. Go to https://oak-web-application-website-git-feat-lesq-2073only-show-70603e.vercel.thenational.academy/teachers/programmes/music-secondary-ks3/units/the-role-of-improvision-harmony-and-rhythm-in-blues-composition/lessons/the-use-of-the-drum-kit-in-grunge/downloads
12. Sign in / complete onboarding when prompted, then land back on the downloads page
13. You should see **no** "Download started" toast until you actually submit a download; after submitting, the toast should appear on the success page

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
