### PR TITLE
fix(PUPIL-1754): announce copy-link confirmation to screen readers

### DIFF
--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareMessaging.ts
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareMessaging.ts
@@ -1,0 +1,5 @@
+export const SHARE_COPY_SUCCESS_MESSAGE =
+  "Link copied to clipboard! You can share this with your teacher.";
+
+export const SHARE_COPY_FAILED_MESSAGE =
+  "Failed to share results. Please try again.";

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
@@ -1,11 +1,11 @@
 import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/react";
 
+import { PupilLessonReviewShareOptions } from "./PupilLessonReviewShareOptions";
 import {
-  PupilLessonReviewShareOptions,
   SHARE_COPY_FAILED_MESSAGE,
   SHARE_COPY_SUCCESS_MESSAGE,
-} from "./PupilLessonReviewShareOptions";
+} from "./PupilLessonReviewShareMessaging";
 
 import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
 

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
@@ -68,6 +68,9 @@ describe("PupilLessonReviewShareOptions", () => {
     expect(announcement).toHaveAttribute("aria-live", "polite");
     expect(announcement).toHaveAttribute("aria-atomic", "true");
     expect(announcement).toHaveTextContent(SHARE_COPY_SUCCESS_MESSAGE);
+    expect(
+      screen.getByRole("heading", { name: SHARE_COPY_SUCCESS_MESSAGE }),
+    ).toBeInTheDocument();
   });
 
   it("announces copy failure to screen readers via a live region", () => {
@@ -83,5 +86,8 @@ describe("PupilLessonReviewShareOptions", () => {
     expect(announcement).toHaveAttribute("aria-live", "assertive");
     expect(announcement).toHaveAttribute("aria-atomic", "true");
     expect(announcement).toHaveTextContent(SHARE_COPY_FAILED_MESSAGE);
+    expect(
+      screen.getByRole("heading", { name: SHARE_COPY_FAILED_MESSAGE }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.test.tsx
@@ -1,6 +1,11 @@
 import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/react";
 
-import { PupilLessonReviewShareOptions } from "./PupilLessonReviewShareOptions";
+import {
+  PupilLessonReviewShareOptions,
+  SHARE_COPY_FAILED_MESSAGE,
+  SHARE_COPY_SUCCESS_MESSAGE,
+} from "./PupilLessonReviewShareOptions";
 
 import { renderWithProvidersByName } from "@/__tests__/__helpers__/renderWithProviders";
 
@@ -42,5 +47,41 @@ describe("PupilLessonReviewShareOptions", () => {
     expect(document.body).toHaveTextContent(
       "Failed to share results. Please try again.",
     );
+  });
+
+  it("keeps a screen reader live region mounted before copy succeeds", () => {
+    render(<PupilLessonReviewShareOptions onCopyLink={() => undefined} />);
+
+    expect(screen.getByTestId("share-copy-announcement")).toBeEmptyDOMElement();
+  });
+
+  it("announces copy success to screen readers via a live region", () => {
+    render(
+      <PupilLessonReviewShareOptions
+        onCopyLink={() => undefined}
+        shareState="shared"
+      />,
+    );
+
+    const announcement = screen.getByTestId("share-copy-announcement");
+
+    expect(announcement).toHaveAttribute("aria-live", "polite");
+    expect(announcement).toHaveAttribute("aria-atomic", "true");
+    expect(announcement).toHaveTextContent(SHARE_COPY_SUCCESS_MESSAGE);
+  });
+
+  it("announces copy failure to screen readers via a live region", () => {
+    render(
+      <PupilLessonReviewShareOptions
+        onCopyLink={() => undefined}
+        shareState="failed"
+      />,
+    );
+
+    const announcement = screen.getByTestId("share-copy-error-announcement");
+
+    expect(announcement).toHaveAttribute("aria-live", "assertive");
+    expect(announcement).toHaveAttribute("aria-atomic", "true");
+    expect(announcement).toHaveTextContent(SHARE_COPY_FAILED_MESSAGE);
   });
 });

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
@@ -6,6 +6,14 @@ import {
   OakSecondaryButton,
 } from "@oaknational/oak-components";
 
+import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
+
+export const SHARE_COPY_SUCCESS_MESSAGE =
+  "Link copied to clipboard! You can share this with your teacher.";
+
+export const SHARE_COPY_FAILED_MESSAGE =
+  "Failed to share results. Please try again.";
+
 export type PupilLessonReviewShareOptionsProps = {
   showPrintable?: boolean;
   printableHref?: string;
@@ -57,11 +65,27 @@ export const PupilLessonReviewShareOptions = ({
         </OakSecondaryButton>
       </OakFlex>
 
+      <ScreenReaderOnly
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="share-copy-announcement"
+      >
+        {shareState === "shared" ? SHARE_COPY_SUCCESS_MESSAGE : ""}
+      </ScreenReaderOnly>
+
+      <ScreenReaderOnly
+        aria-live="assertive"
+        aria-atomic="true"
+        data-testid="share-copy-error-announcement"
+      >
+        {shareState === "failed" ? SHARE_COPY_FAILED_MESSAGE : ""}
+      </ScreenReaderOnly>
+
       {shareState === "shared" && (
         <OakFlex $gap="spacing-4" $alignItems="center">
           <OakIcon iconName="tick" $colorFilter="text-success" />
           <OakHeading tag="h2" $font="heading-light-7" $color="text-success">
-            Link copied to clipboard! You can share this with your teacher.
+            {SHARE_COPY_SUCCESS_MESSAGE}
           </OakHeading>
         </OakFlex>
       )}
@@ -70,7 +94,7 @@ export const PupilLessonReviewShareOptions = ({
         <OakFlex $gap="spacing-4" $alignItems="center">
           <OakIcon iconName="cross" $colorFilter="text-error" />
           <OakHeading tag="h2" $font="heading-light-7" $color="text-error">
-            Failed to share results. Please try again.
+            {SHARE_COPY_FAILED_MESSAGE}
           </OakHeading>
         </OakFlex>
       )}

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
@@ -13,7 +13,6 @@ import {
 
 import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
 
-
 export type PupilLessonReviewShareOptionsProps = {
   showPrintable?: boolean;
   printableHref?: string;

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions.tsx
@@ -6,13 +6,13 @@ import {
   OakSecondaryButton,
 } from "@oaknational/oak-components";
 
+import {
+  SHARE_COPY_FAILED_MESSAGE,
+  SHARE_COPY_SUCCESS_MESSAGE,
+} from "./PupilLessonReviewShareMessaging";
+
 import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
 
-export const SHARE_COPY_SUCCESS_MESSAGE =
-  "Link copied to clipboard! You can share this with your teacher.";
-
-export const SHARE_COPY_FAILED_MESSAGE =
-  "Failed to share results. Please try again.";
 
 export type PupilLessonReviewShareOptionsProps = {
   showPrintable?: boolean;

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -9,7 +9,7 @@ import { PupilViewsReview } from "./PupilReview.view";
 import {
   SHARE_COPY_FAILED_MESSAGE,
   SHARE_COPY_SUCCESS_MESSAGE,
-} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions";
+} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareMessaging";
 import { useOakPupil } from "@/hooks/useOakPupil";
 import { OakPupilClientProvider } from "@/context/Pupil/OakPupilClientProvider";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -6,6 +6,10 @@ import { screen, waitFor } from "@testing-library/react";
 
 import { PupilViewsReview } from "./PupilReview.view";
 
+import {
+  SHARE_COPY_FAILED_MESSAGE,
+  SHARE_COPY_SUCCESS_MESSAGE,
+} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions";
 import { useOakPupil } from "@/hooks/useOakPupil";
 import { OakPupilClientProvider } from "@/context/Pupil/OakPupilClientProvider";
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
@@ -663,9 +667,10 @@ describe("PupilReview", () => {
 
       const announcement = screen.getByTestId("share-copy-announcement");
       expect(announcement).toHaveAttribute("aria-live", "polite");
-      expect(announcement).toHaveTextContent(
-        "Link copied to clipboard! You can share this with your teacher.",
-      );
+      expect(announcement).toHaveTextContent(SHARE_COPY_SUCCESS_MESSAGE);
+      expect(
+        screen.getByRole("heading", { name: SHARE_COPY_SUCCESS_MESSAGE }),
+      ).toBeInTheDocument();
     });
 
     it("shows 'Failed to share results' when the share promise rejects", async () => {
@@ -703,11 +708,14 @@ describe("PupilReview", () => {
       await waitFor(() => {
         expect(
           screen.getByTestId("share-copy-error-announcement"),
-        ).toHaveTextContent("Failed to share results. Please try again.");
+        ).toHaveTextContent(SHARE_COPY_FAILED_MESSAGE);
       });
 
       const announcement = screen.getByTestId("share-copy-error-announcement");
       expect(announcement).toHaveAttribute("aria-live", "assertive");
+      expect(
+        screen.getByRole("heading", { name: SHARE_COPY_FAILED_MESSAGE }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "@testing-library/jest-dom";
 import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
 import userEvent from "@testing-library/user-event";
-import { waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import { PupilViewsReview } from "./PupilReview.view";
 
@@ -661,11 +661,11 @@ describe("PupilReview", () => {
 
       await userEvent.click(getByText("Copy link"));
 
-      expect(
-        getByText(
-          "Link copied to clipboard! You can share this with your teacher.",
-        ),
-      ).toBeInTheDocument();
+      const announcement = screen.getByTestId("share-copy-announcement");
+      expect(announcement).toHaveAttribute("aria-live", "polite");
+      expect(announcement).toHaveTextContent(
+        "Link copied to clipboard! You can share this with your teacher.",
+      );
     });
 
     it("shows 'Failed to share results' when the share promise rejects", async () => {
@@ -700,11 +700,14 @@ describe("PupilReview", () => {
 
       await userEvent.click(getByText("Copy link"));
 
-      await waitFor(() =>
+      await waitFor(() => {
         expect(
-          getByText("Failed to share results. Please try again."),
-        ).toBeInTheDocument(),
-      );
+          screen.getByTestId("share-copy-error-announcement"),
+        ).toHaveTextContent("Failed to share results. Please try again.");
+      });
+
+      const announcement = screen.getByTestId("share-copy-error-announcement");
+      expect(announcement).toHaveAttribute("aria-live", "assertive");
     });
   });
 });

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -23,6 +23,11 @@ import { PupilExperienceViewProps } from "../PupilExperience";
 import { useLessonReviewFeedback } from "./useLessonReviewFeedback";
 import { CourseWorkHandInButton } from "./CourseWorkHandInButton";
 
+import {
+  SHARE_COPY_FAILED_MESSAGE,
+  SHARE_COPY_SUCCESS_MESSAGE,
+} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions";
+import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
 import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 import { useGetSectionLinkProps } from "@/components/PupilComponents/pupilUtils/lessonNavigation";
 import { QuizResults } from "@/components/PupilComponents/QuizQuestions/QuizResults";
@@ -335,6 +340,24 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
                           Copy link
                         </OakSecondaryButton>
                       </OakFlex>
+                      <ScreenReaderOnly
+                        aria-live="polite"
+                        aria-atomic="true"
+                        data-testid="share-copy-announcement"
+                      >
+                        {isAttemptingShare === "shared"
+                          ? SHARE_COPY_SUCCESS_MESSAGE
+                          : ""}
+                      </ScreenReaderOnly>
+                      <ScreenReaderOnly
+                        aria-live="assertive"
+                        aria-atomic="true"
+                        data-testid="share-copy-error-announcement"
+                      >
+                        {isAttemptingShare === "failed"
+                          ? SHARE_COPY_FAILED_MESSAGE
+                          : ""}
+                      </ScreenReaderOnly>
                       {isAttemptingShare === "shared" && (
                         <OakFlex $gap={"spacing-4"} $alignItems={"center"}>
                           <OakIcon
@@ -346,8 +369,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
                             $font={"heading-light-7"}
                             $color={"text-success"}
                           >
-                            Link copied to clipboard! You can share this with
-                            your teacher.
+                            {SHARE_COPY_SUCCESS_MESSAGE}
                           </OakHeading>
                         </OakFlex>
                       )}
@@ -362,7 +384,7 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
                             $font={"heading-light-7"}
                             $color={"text-error"}
                           >
-                            Failed to share results. Please try again.
+                            {SHARE_COPY_FAILED_MESSAGE}
                           </OakHeading>
                         </OakFlex>
                       )}

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -26,7 +26,7 @@ import { CourseWorkHandInButton } from "./CourseWorkHandInButton";
 import {
   SHARE_COPY_FAILED_MESSAGE,
   SHARE_COPY_SUCCESS_MESSAGE,
-} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareOptions";
+} from "@/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewShareOptions/PupilLessonReviewShareMessaging";
 import ScreenReaderOnly from "@/components/SharedComponents/ScreenReaderOnly";
 import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 import { useGetSectionLinkProps } from "@/components/PupilComponents/pupilUtils/lessonNavigation";


### PR DESCRIPTION
## Description

On the pupil lesson review page, clicking **Copy link** shows a visual confirmation (“Link copied to clipboard! You can share this with your teacher.”) but screen readers were not notified when the message appeared.

Music year: 1984

- Add persistent `ScreenReaderOnly` live regions for copy success (`aria-live="polite"`) and failure (`aria-live="assertive"`)
- Keep visual tick + heading feedback separate from the SR announcement (VoiceOver does not reliably announce newly mounted live regions)
- Wire the same pattern on `PupilLessonReviewShareOptions` and the legacy `PupilReview` view

## Issue(s)

Fixes [PUPIL-1754](https://www.notion.so/oaknationalacademy/Announce-dynamic-confirmation-message-to-screen-reader-users-37526cc4e1b18029b0cfd9060e2a9976?source=copy_link)

## How to test

1. Open the Vercel preview URL from the bot comment below
2. Complete a pupil lesson with quizzes and reach the **Lesson review** page (or use `/pupils/lessons/{lessonSlug}/shared/{variant}/review` with a lesson that has share options)
3. Turn on VoiceOver (or NVDA)
4. Click **Copy link**
5. Confirm VoiceOver announces “Link copied to clipboard! You can share this with your teacher.” without moving focus
6. Confirm the visual success message still appears below the button

## Screenshots

# Complete Lesson
<img width="1450" height="784" alt="Screenshot 2026-06-16 at 08 20 06" src="https://github.com/user-attachments/assets/fbe9eb23-d7ca-4f40-8eb4-df806a05947d" />

# Shared single component (/shared/)
<img width="1450" height="748" alt="Screenshot 2026-06-16 at 08 23 21" src="https://github.com/user-attachments/assets/a8c8b9ac-4e6d-46cc-916d-f6cabf4ce7c4" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)