### PR TITLE
fix(PUPIL-1753): label lesson review results buttons

### DIFF
--- a/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
@@ -1,7 +1,8 @@
+import type { ComponentProps } from "react";
 import { useEffect, useRef } from "react";
 import { OakLessonReviewQuiz } from "@oaknational/oak-components";
 
-export type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
+export type LessonReviewQuizWithAriaLabelProps = ComponentProps<
   typeof OakLessonReviewQuiz
 > & {
   resultsButtonAriaLabel: string;

--- a/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
@@ -43,7 +43,12 @@ const LessonReviewQuizWithAriaLabel = (
       if (applyLabel()) observer.disconnect();
     });
 
-    observer.observe(root, { childList: true, subtree: true });
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-expanded"],
+    });
 
     return () => observer.disconnect();
   }, [resultsButtonAriaLabel]);

--- a/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
@@ -24,12 +24,27 @@ const LessonReviewQuizWithAriaLabel = (
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const button = containerRef.current?.querySelector<HTMLButtonElement>(
-      "button[aria-expanded]",
-    );
-    if (button) {
+    const root = containerRef.current;
+    if (!root) return;
+
+    const applyLabel = () => {
+      const button = root.querySelector<HTMLButtonElement>(
+        "button[aria-expanded]",
+      );
+      if (!button) return false;
       button.setAttribute("aria-label", resultsButtonAriaLabel);
-    }
+      return true;
+    };
+
+    if (applyLabel()) return;
+
+    const observer = new MutationObserver(() => {
+      if (applyLabel()) observer.disconnect();
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
   }, [resultsButtonAriaLabel]);
 
   return (

--- a/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/LessonReviewQuizWithAriaLabel.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import { OakLessonReviewQuiz } from "@oaknational/oak-components";
+
+export type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
+  typeof OakLessonReviewQuiz
+> & {
+  resultsButtonAriaLabel: string;
+};
+
+/**
+ * `OakLessonReviewQuiz` renders a generic "Results" toggle.
+ * We need that toggle’s accessible name to include the section context.
+ *
+ * We do this (without changing the UI label) by setting `aria-label` on the
+ * internal `button[aria-expanded]` once the component has rendered.
+ *
+ * The wrapper uses `display: contents` to preserve layout (i.e. this wrapper
+ * does not become a flex/grid item).
+ */
+const LessonReviewQuizWithAriaLabel = (
+  props: LessonReviewQuizWithAriaLabelProps,
+) => {
+  const { resultsButtonAriaLabel, ...quizProps } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const button = containerRef.current?.querySelector<HTMLButtonElement>(
+      "button[aria-expanded]",
+    );
+    if (button) {
+      button.setAttribute("aria-label", resultsButtonAriaLabel);
+    }
+  }, [resultsButtonAriaLabel]);
+
+  return (
+    <div ref={containerRef} style={{ display: "contents" }}>
+      <OakLessonReviewQuiz {...quizProps} />
+    </div>
+  );
+};
+
+export default LessonReviewQuizWithAriaLabel;

--- a/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/index.ts
+++ b/src/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./LessonReviewQuizWithAriaLabel";
+export type { LessonReviewQuizWithAriaLabelProps } from "./LessonReviewQuizWithAriaLabel";

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.test.tsx
@@ -28,8 +28,8 @@ describe("PupilLessonReviewSections", () => {
     expect(document.body).toHaveTextContent("Starter quiz results");
   });
 
-  it("gives the results button an accessible name including the section", () => {
-    const { getByRole } = render(
+  it("gives the results button an accessible name including the section", async () => {
+    const { findByRole } = render(
       <PupilLessonReviewSections
         items={[
           {
@@ -45,7 +45,7 @@ describe("PupilLessonReviewSections", () => {
 
     // The visible label is "Results" but screen readers should hear which section.
     expect(
-      getByRole("button", { name: "Starter quiz results" }),
+      await findByRole("button", { name: "Starter quiz results" }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.test.tsx
@@ -27,4 +27,25 @@ describe("PupilLessonReviewSections", () => {
     expect(document.body).toHaveTextContent("Starter quiz");
     expect(document.body).toHaveTextContent("Starter quiz results");
   });
+
+  it("gives the results button an accessible name including the section", () => {
+    const { getByRole } = render(
+      <PupilLessonReviewSections
+        items={[
+          {
+            section: "starter-quiz",
+            completed: true,
+            grade: 3,
+            numQuestions: 4,
+            resultsSlot: <div>Starter quiz results</div>,
+          },
+        ]}
+      />,
+    );
+
+    // The visible label is "Results" but screen readers should hear which section.
+    expect(
+      getByRole("button", { name: "Starter quiz results" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.tsx
@@ -1,46 +1,13 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import {
   OakFlex,
   OakLessonReviewIntroVideo,
-  OakLessonReviewQuiz,
 } from "@oaknational/oak-components";
+
+import LessonReviewQuizWithAriaLabel from "@/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel";
 
 const getResultsButtonAriaLabel = (section: "starter-quiz" | "exit-quiz") =>
   section === "starter-quiz" ? "Starter quiz results" : "Exit quiz results";
-
-type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
-  typeof OakLessonReviewQuiz
-> & {
-  resultsButtonAriaLabel: string;
-};
-
-/**
- * `OakLessonReviewQuiz` renders a generic "Results" button.
- * For screen readers, we need that button's accessible name to include the section.
- * We do this here (without changing the UI label) by setting `aria-label` on the
- * expand/collapse button once the component has rendered.
- */
-const LessonReviewQuizWithAriaLabel = (
-  props: LessonReviewQuizWithAriaLabelProps,
-) => {
-  const { resultsButtonAriaLabel, ...quizProps } = props;
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const button = containerRef.current?.querySelector<HTMLButtonElement>(
-      "button[aria-expanded]",
-    );
-    if (button) {
-      button.setAttribute("aria-label", resultsButtonAriaLabel);
-    }
-  }, [resultsButtonAriaLabel]);
-
-  return (
-    <div ref={containerRef}>
-      <OakLessonReviewQuiz {...quizProps} />
-    </div>
-  );
-};
 
 export type PupilLessonReviewSectionItem =
   | {

--- a/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonReview/PupilLessonReviewSections/PupilLessonReviewSections.tsx
@@ -1,9 +1,46 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import {
   OakFlex,
   OakLessonReviewIntroVideo,
   OakLessonReviewQuiz,
 } from "@oaknational/oak-components";
+
+const getResultsButtonAriaLabel = (section: "starter-quiz" | "exit-quiz") =>
+  section === "starter-quiz" ? "Starter quiz results" : "Exit quiz results";
+
+type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
+  typeof OakLessonReviewQuiz
+> & {
+  resultsButtonAriaLabel: string;
+};
+
+/**
+ * `OakLessonReviewQuiz` renders a generic "Results" button.
+ * For screen readers, we need that button's accessible name to include the section.
+ * We do this here (without changing the UI label) by setting `aria-label` on the
+ * expand/collapse button once the component has rendered.
+ */
+const LessonReviewQuizWithAriaLabel = (
+  props: LessonReviewQuizWithAriaLabelProps,
+) => {
+  const { resultsButtonAriaLabel, ...quizProps } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const button = containerRef.current?.querySelector<HTMLButtonElement>(
+      "button[aria-expanded]",
+    );
+    if (button) {
+      button.setAttribute("aria-label", resultsButtonAriaLabel);
+    }
+  }, [resultsButtonAriaLabel]);
+
+  return (
+    <div ref={containerRef}>
+      <OakLessonReviewQuiz {...quizProps} />
+    </div>
+  );
+};
 
 export type PupilLessonReviewSectionItem =
   | {
@@ -57,13 +94,14 @@ export const PupilLessonReviewSections = ({
         }
 
         return (
-          <OakLessonReviewQuiz
+          <LessonReviewQuizWithAriaLabel
             key={item.section}
             lessonSectionName={item.section}
             completed={item.completed}
             grade={item.grade}
             numQuestions={item.numQuestions}
             resultsSlot={item.resultsSlot}
+            resultsButtonAriaLabel={getResultsButtonAriaLabel(item.section)}
           />
         );
       })}

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -237,6 +237,37 @@ describe("PupilReview", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps aria-expanded toggling on the results buttons", async () => {
+    const { findByRole } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider
+          value={createLessonEngineContext({
+            sectionResults: sectionResultsFixture,
+          })}
+        >
+          <OakPupilClientProvider>
+            <PupilViewsReview
+              lessonTitle="Lesson title"
+              exitQuizQuestionsArray={[]}
+              starterQuizQuestionsArray={[]}
+              programmeSlug="programme-slug"
+              unitSlug="unit-slug"
+              browseData={mockBroweData}
+              pageType="browse"
+            />
+          </OakPupilClientProvider>
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    const button = await findByRole("button", { name: "Starter quiz results" });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    await userEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
   describe("Copy link button", () => {
     it("should display the print button", () => {
       const { queryByText } = renderWithTheme(

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -206,6 +206,37 @@ describe("PupilReview", () => {
     expect(getByText("Great effort!")).toBeInTheDocument();
   });
 
+  it("gives quiz results buttons accessible names including the section", () => {
+    const { getByRole } = renderWithTheme(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <LessonEngineContext.Provider
+          value={createLessonEngineContext({
+            sectionResults: sectionResultsFixture,
+          })}
+        >
+          <OakPupilClientProvider>
+            <PupilViewsReview
+              lessonTitle="Lesson title"
+              exitQuizQuestionsArray={[]}
+              starterQuizQuestionsArray={[]}
+              programmeSlug="programme-slug"
+              unitSlug="unit-slug"
+              browseData={mockBroweData}
+              pageType="browse"
+            />
+          </OakPupilClientProvider>
+        </LessonEngineContext.Provider>
+      </OakThemeProvider>,
+    );
+
+    expect(
+      getByRole("button", { name: "Starter quiz results" }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole("button", { name: "Exit quiz results" }),
+    ).toBeInTheDocument();
+  });
+
   describe("Copy link button", () => {
     it("should display the print button", () => {
       const { queryByText } = renderWithTheme(

--- a/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.test.tsx
@@ -206,8 +206,8 @@ describe("PupilReview", () => {
     expect(getByText("Great effort!")).toBeInTheDocument();
   });
 
-  it("gives quiz results buttons accessible names including the section", () => {
-    const { getByRole } = renderWithTheme(
+  it("gives quiz results buttons accessible names including the section", async () => {
+    const { findByRole } = renderWithTheme(
       <OakThemeProvider theme={oakDefaultTheme}>
         <LessonEngineContext.Provider
           value={createLessonEngineContext({
@@ -230,10 +230,10 @@ describe("PupilReview", () => {
     );
 
     expect(
-      getByRole("button", { name: "Starter quiz results" }),
+      await findByRole("button", { name: "Starter quiz results" }),
     ).toBeInTheDocument();
     expect(
-      getByRole("button", { name: "Exit quiz results" }),
+      await findByRole("button", { name: "Exit quiz results" }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   OakFlex,
@@ -11,7 +11,6 @@ import {
   OakLessonBottomNav,
   OakLessonLayout,
   OakLessonReviewIntroVideo,
-  OakLessonReviewQuiz,
   OakPrimaryButton,
   OakTertiaryButton,
   OakSecondaryButton,
@@ -23,6 +22,7 @@ import { PupilExperienceViewProps } from "../PupilExperience";
 import { useLessonReviewFeedback } from "./useLessonReviewFeedback";
 import { CourseWorkHandInButton } from "./CourseWorkHandInButton";
 
+import LessonReviewQuizWithAriaLabel from "@/components/PupilComponents/Views/PupilLessonReview/LessonReviewQuizWithAriaLabel";
 import { useLessonEngineContext } from "@/components/PupilComponents/LessonEngineProvider";
 import { useGetSectionLinkProps } from "@/components/PupilComponents/pupilUtils/lessonNavigation";
 import { QuizResults } from "@/components/PupilComponents/QuizQuestions/QuizResults";
@@ -49,34 +49,6 @@ type PupilViewsReviewProps = {
   pageType: PupilExperienceViewProps["pageType"];
   isHandedIn?: boolean;
   onHandInSuccess?: () => void;
-};
-
-type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
-  typeof OakLessonReviewQuiz
-> & {
-  resultsButtonAriaLabel: string;
-};
-
-const LessonReviewQuizWithAriaLabel = (
-  props: LessonReviewQuizWithAriaLabelProps,
-) => {
-  const { resultsButtonAriaLabel, ...quizProps } = props;
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const button = containerRef.current?.querySelector<HTMLButtonElement>(
-      "button[aria-expanded]",
-    );
-    if (button) {
-      button.setAttribute("aria-label", resultsButtonAriaLabel);
-    }
-  }, [resultsButtonAriaLabel]);
-
-  return (
-    <div ref={containerRef}>
-      <OakLessonReviewQuiz {...quizProps} />
-    </div>
-  );
 };
 
 export const PupilViewsReview = (props: PupilViewsReviewProps) => {

--- a/src/components/PupilViews/PupilReview/PupilReview.view.tsx
+++ b/src/components/PupilViews/PupilReview/PupilReview.view.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   OakFlex,
@@ -49,6 +49,34 @@ type PupilViewsReviewProps = {
   pageType: PupilExperienceViewProps["pageType"];
   isHandedIn?: boolean;
   onHandInSuccess?: () => void;
+};
+
+type LessonReviewQuizWithAriaLabelProps = React.ComponentProps<
+  typeof OakLessonReviewQuiz
+> & {
+  resultsButtonAriaLabel: string;
+};
+
+const LessonReviewQuizWithAriaLabel = (
+  props: LessonReviewQuizWithAriaLabelProps,
+) => {
+  const { resultsButtonAriaLabel, ...quizProps } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const button = containerRef.current?.querySelector<HTMLButtonElement>(
+      "button[aria-expanded]",
+    );
+    if (button) {
+      button.setAttribute("aria-label", resultsButtonAriaLabel);
+    }
+  }, [resultsButtonAriaLabel]);
+
+  return (
+    <div ref={containerRef}>
+      <OakLessonReviewQuiz {...quizProps} />
+    </div>
+  );
 };
 
 export const PupilViewsReview = (props: PupilViewsReviewProps) => {
@@ -407,13 +435,18 @@ export const PupilViewsReview = (props: PupilViewsReviewProps) => {
                     ? exitQuizQuestionsArray
                     : starterQuizQuestionsArray;
                 return (
-                  <OakLessonReviewQuiz
+                  <LessonReviewQuizWithAriaLabel
                     key={lessonSection}
                     lessonSectionName={lessonSection}
                     completed={!!sectionResults[lessonSection]?.isComplete}
                     grade={sectionResults[lessonSection]?.grade ?? 0}
                     numQuestions={
                       sectionResults[lessonSection]?.numQuestions ?? 0
+                    }
+                    resultsButtonAriaLabel={
+                      lessonSection === "starter-quiz"
+                        ? "Starter quiz results"
+                        : "Exit quiz results"
                     }
                     resultsSlot={
                       <QuizResults


### PR DESCRIPTION
## Description

Music year: 1988

- Give lesson review quiz “Results” toggle buttons section-specific accessible names (e.g. “Starter quiz results”, “Exit quiz results”) so screen readers announce which results are collapsed/expanded.
- Extracted a shared `LessonReviewQuizWithAriaLabel` wrapper (used by both review flows) and set the wrapper to `display: contents` to preserve layout.
- Ensure the aria-label is still applied if the internal results toggle mounts after the initial render (MutationObserver).

## Issue(s)

Fixes [PUPIL-1753](https://www.notion.so/oaknationalacademy/Associate-results-button-to-section-programmatically-37526cc4e1b180569be5fd994489fd09?source=copy_link)

## How to test

1. Go to the OWA Preview URL from the Vercel bot comment
2. Navigate to a pupil **Lesson review** page with quiz sections
3. With a screen reader (VoiceOver/NVDA), move through the buttons labelled “Results”
4. Confirm they are announced as “Starter quiz results, button, collapsed/expanded” and “Exit quiz results, button, collapsed/expanded” (and that `aria-expanded` continues to be announced)

## Screenshots

<img width="1425" height="690" alt="Screenshot 2026-06-16 at 09 29 13" src="https://github.com/user-attachments/assets/25e383cd-19e5-40d1-9292-bc35a4734fc8" />
<img width="1425" height="690" alt="Screenshot 2026-06-16 at 09 29 19" src="https://github.com/user-attachments/assets/32213707-d82f-4bd6-8eec-59c6dbe2a1b2" />
<img width="1425" height="690" alt="Screenshot 2026-06-16 at 09 29 31" src="https://github.com/user-attachments/assets/eeddee44-6bf7-490c-9f40-589c6c7d01ad" />
<img width="1425" height="690" alt="Screenshot 2026-06-16 at 09 29 42" src="https://github.com/user-attachments/assets/e2ae9a8a-0006-44e2-9dab-1e948e9944dc" />

## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)