### PR TITLE
fix(PUPIL-1769): prevent shared quiz crash from stale store state

### DIFF
--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -27,6 +27,8 @@ type ProgressState = {
 };
 
 type QuizState = {
+  lessonSlug: string | null;
+  section: "starter-quiz" | "exit-quiz" | null;
   currentQuestionIndex: number;
   questionState: QuestionState[];
   numQuestions: number;
@@ -87,6 +89,9 @@ const baseQuestionState: QuestionState = {
 const mcqQuestion = quizQuestions[0];
 if (!mcqQuestion) throw new Error("mcq fixture missing");
 
+const orderQuestion = quizQuestions.find((q) => q.questionType === "order");
+if (!orderQuestion) throw new Error("order fixture missing");
+
 const buildProgressState = (
   overrides: Partial<ProgressState> = {},
 ): ProgressState => ({
@@ -100,6 +105,8 @@ const buildProgressState = (
 });
 
 const buildQuizState = (overrides: Partial<QuizState> = {}): QuizState => ({
+  lessonSlug: "test-lesson",
+  section: "starter-quiz",
   currentQuestionIndex: 0,
   questionState: [baseQuestionState],
   numQuestions: 1,
@@ -186,7 +193,10 @@ describe("QuizPageContent", () => {
   });
 
   it("redirects to review when the exit quiz is already hydrated complete", () => {
-    quizState = buildQuizState({ isHydratedComplete: true });
+    quizState = buildQuizState({
+      section: "exit-quiz",
+      isHydratedComplete: true,
+    });
     quizHookMock.mockImplementation((selector) => selector(quizState));
 
     renderWithTheme(
@@ -291,6 +301,7 @@ describe("QuizPageContent", () => {
     });
     progressHookMock.mockImplementation((selector) => selector(progressState));
     quizState = buildQuizState({
+      section: "exit-quiz",
       questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
       currentQuestionIndex: 0,
       numQuestions: 1,
@@ -384,5 +395,45 @@ describe("QuizPageContent", () => {
 
     const { getByText } = renderPage();
     expect(getByText("Well done!")).toBeInTheDocument();
+  });
+
+  // Regression: the quiz store is a singleton shared across the starter-quiz
+  // and exit-quiz pages. On a client-side navigation into the exit quiz, the
+  // store can still hold the previous section's state for one render before
+  // initialiseQuiz runs. Pairing the new section's questions with the old
+  // question state (e.g. a short-answer's single-string feedback landing on an
+  // order question) used to throw and crash the lesson with the error page.
+  it("does not crash when entering the exit quiz before its state initialises", () => {
+    quizState = buildQuizState({
+      section: "starter-quiz",
+      questionState: [
+        {
+          ...baseQuestionState,
+          mode: "feedback",
+          grade: 0,
+          feedback: "incorrect",
+        },
+      ],
+      currentQuestionIndex: 0,
+      numQuestions: 1,
+      numInteractiveQuestions: 1,
+    });
+    quizHookMock.mockImplementation((selector) => selector(quizState));
+    quizGetStateMock.mockReturnValue(quizState);
+
+    const renderStaleExitQuiz = () =>
+      renderWithTheme(
+        <QuizPageContent
+          section="exit-quiz"
+          questionsArray={[orderQuestion]}
+          lessonSlug="test-lesson"
+          phase="primary"
+        />,
+      );
+
+    expect(renderStaleExitQuiz).not.toThrow();
+    expect(
+      renderStaleExitQuiz().container.querySelector("#quiz-form"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -397,12 +397,6 @@ describe("QuizPageContent", () => {
     expect(getByText("Well done!")).toBeInTheDocument();
   });
 
-  // Regression: the quiz store is a singleton shared across the starter-quiz
-  // and exit-quiz pages. On a client-side navigation into the exit quiz, the
-  // store can still hold the previous section's state for one render before
-  // initialiseQuiz runs. Pairing the new section's questions with the old
-  // question state (e.g. a short-answer's single-string feedback landing on an
-  // order question) used to throw and crash the lesson with the error page.
   it("does not crash when entering the exit quiz before its state initialises", () => {
     quizState = buildQuizState({
       section: "starter-quiz",

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -431,9 +431,12 @@ describe("QuizPageContent", () => {
         />,
       );
 
-    expect(renderStaleExitQuiz).not.toThrow();
+    let rendered: ReturnType<typeof renderStaleExitQuiz> | undefined;
+    expect(() => {
+      rendered = renderStaleExitQuiz();
+    }).not.toThrow();
     expect(
-      renderStaleExitQuiz().container.querySelector("#quiz-form"),
+      rendered?.container.querySelector("#quiz-form"),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -83,6 +83,8 @@ export const QuizPageContent = ({
     })),
   );
   const {
+    storeLessonSlug,
+    storeSection,
     currentQuestionIndex,
     questionState,
     numQuestions,
@@ -95,6 +97,8 @@ export const QuizPageContent = ({
     handleNextQuestion,
   } = usePupilLessonQuiz(
     useShallow((state) => ({
+      storeLessonSlug: state.lessonSlug,
+      storeSection: state.section,
       currentQuestionIndex: state.currentQuestionIndex,
       questionState: state.questionState,
       numQuestions: state.numQuestions,
@@ -107,6 +111,13 @@ export const QuizPageContent = ({
       handleNextQuestion: state.handleNextQuestion,
     })),
   );
+  // The quiz store is a module-level singleton that survives client-side
+  // navigation between the starter and exit quizzes. Until `initialiseQuiz`
+  // re-runs for this page, the store can still describe the previous section,
+  // pairing this section's questions with the wrong question state. Treat the
+  // store as ready only once it matches the section we are rendering.
+  const isStoreReadyForSection =
+    storeLessonSlug === lessonSlug && storeSection === section;
   const {
     trackSectionStarted,
     trackQuizQuestionAttempt,
@@ -143,7 +154,7 @@ export const QuizPageContent = ({
   }, [initialiseQuiz, lessonSlug, questionsArray, section, sectionResults]);
 
   useEffect(() => {
-    if (!isHydratedComplete) return;
+    if (!isStoreReadyForSection || !isHydratedComplete) return;
 
     void router.push(
       getNewLessonSectionHref({
@@ -152,7 +163,14 @@ export const QuizPageContent = ({
         searchParams: currentSearchParams,
       }),
     );
-  }, [currentSearchParams, isHydratedComplete, lessonSlug, router, section]);
+  }, [
+    currentSearchParams,
+    isStoreReadyForSection,
+    isHydratedComplete,
+    lessonSlug,
+    router,
+    section,
+  ]);
 
   useEffect(() => {
     const handleKeyDownTabToInput = (event: KeyboardEvent): void => {
@@ -348,6 +366,14 @@ export const QuizPageContent = ({
       </MathJaxWrap>
     );
   };
+
+  // Avoid rendering the quiz with mismatched question/question-state data while
+  // the store is still re-initialising for this section after a client-side
+  // navigation. `initialiseQuiz` runs in an effect on mount, so this guard only
+  // skips the first render before the store is realigned.
+  if (!isStoreReadyForSection) {
+    return null;
+  }
 
   return (
     <OakCloudinaryConfigProvider

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -111,11 +111,6 @@ export const QuizPageContent = ({
       handleNextQuestion: state.handleNextQuestion,
     })),
   );
-  // The quiz store is a module-level singleton that survives client-side
-  // navigation between the starter and exit quizzes. Until `initialiseQuiz`
-  // re-runs for this page, the store can still describe the previous section,
-  // pairing this section's questions with the wrong question state. Treat the
-  // store as ready only once it matches the section we are rendering.
   const isStoreReadyForSection =
     storeLessonSlug === lessonSlug && storeSection === section;
   const {
@@ -374,10 +369,6 @@ export const QuizPageContent = ({
     );
   };
 
-  // Avoid rendering the quiz with mismatched question/question-state data while
-  // the store is still re-initialising for this section after a client-side
-  // navigation. `initialiseQuiz` runs in an effect on mount, so this guard only
-  // skips the first render before the store is realigned.
   if (!isStoreReadyForSection) {
     return null;
   }

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -173,6 +173,8 @@ export const QuizPageContent = ({
   ]);
 
   useEffect(() => {
+    if (!isStoreReadyForSection) return;
+
     const handleKeyDownTabToInput = (event: KeyboardEvent): void => {
       if (event.key !== "Tab" || firstTabPressed.pressed) return;
 
@@ -198,7 +200,12 @@ export const QuizPageContent = ({
     return () => {
       globalThis.removeEventListener("keydown", handleKeyDownTabToInput);
     };
-  }, [currentQuestionData, currentQuestionIndex, firstTabPressed]);
+  }, [
+    currentQuestionData,
+    currentQuestionIndex,
+    firstTabPressed,
+    isStoreReadyForSection,
+  ]);
 
   const navigateToSection = (nextSection: "overview" | "review") => {
     void router.push(


### PR DESCRIPTION
## Description

Music year: n/a

The pupil quiz store (`usePupilLessonQuiz`) is a module-level singleton that survives client-side navigation between the starter and exit quizzes. On entering the exit quiz, the store could still describe the **previous** section for one render — `initialiseQuiz` only re-runs in a mount effect. That pairs the new section's `questionsArray` with the old section's `questionState` at the same index. When the feedback shapes differ (e.g. a starter-quiz `short-answer`'s single-string feedback landing on an exit-quiz `order` question, which expects array feedback), an `invariant` throws `OakError("misc/unexpected-type")` and the lesson crashes to the error page.

This is why it reproduced on some lessons (e.g. `making-simple-sushi`, where index 3 is `short-answer` in the starter quiz and `order` in the exit quiz) but not others, and only via client-side navigation (a hard reload clears the in-memory store).

- Derive `isStoreReadyForSection` from the store's own `lessonSlug`/`section` and gate rendering until the store is initialised for the current section (returns `null` for the single pre-init render).
- Guard the hydration-complete redirect effect with the same flag so stale `isHydratedComplete` can't trigger a wrong redirect.
- Add a regression test reproducing the stale-state render (verified RED without the guard).

## Issue(s)

Fixes [PUPIL-1769](https://www.notion.so/oaknationalacademy/Shared-lesson-Quizzes-only-Exit-quiz-displays-error-page-unexpected-type-38126cc4e1b18057bec5cda8928d6b3d?source=copy_link)

## How to test

1. Go to https://oak-web-application-website-git-fix-pupil-1769-shared-qu-cad98c.vercel.thenational.academy/pupils/lessons/making-simple-sushi/shared/quizzes-only/overview
2. Complete (or start) the starter quiz, then return to the overview and click **Exit quiz** (client-side navigation, no page reload)
3. You should see the exit quiz render normally — previously this crashed to the "unexpected type" error page

## Screenshots

How it used to look (delete if n/a):
<img width="1510" height="824" alt="Screenshot 2026-06-16 at 12 38 24" src="https://github.com/user-attachments/assets/7399fffb-6cc9-4f6e-8182-0cfd400f9a02" />


How it should now look:
Exit quiz renders its first question as expected.
<img width="1510" height="824" alt="Screenshot 2026-06-16 at 15 37 26" src="https://github.com/user-attachments/assets/2ecee765-fe43-48bb-b597-e0f72c9d7ca9" />



## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)