### PR TITLE
fix(PUPIL-1770): persist video result on completion for shared lessons

### DIFF
--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
@@ -134,7 +134,6 @@ describe("video page", () => {
     const { getByTestId } = renderPage();
     fireEvent.click(getByTestId("proceed-to-next-section"));
     const video = usePupilLessonProgress.getState().sectionResults.video;
-    // Required by the attempt schema; missing fields break copy-link (PUPIL-1770).
     expect(video?.isComplete).toBe(true);
     expect(video?.played).toBe(false);
     expect(video?.duration).toBe(0);

--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.test.tsx
@@ -130,6 +130,17 @@ describe("video page", () => {
     expect(video?.duration).toBe(60);
   });
 
+  it("persists a complete video result when proceeding without playing the video", () => {
+    const { getByTestId } = renderPage();
+    fireEvent.click(getByTestId("proceed-to-next-section"));
+    const video = usePupilLessonProgress.getState().sectionResults.video;
+    // Required by the attempt schema; missing fields break copy-link (PUPIL-1770).
+    expect(video?.isComplete).toBe(true);
+    expect(video?.played).toBe(false);
+    expect(video?.duration).toBe(0);
+    expect(video?.timeElapsed).toBe(0);
+  });
+
   it("returns notFound from getStaticProps when the variant is invalid", async () => {
     expect(
       await getStaticProps({ params: { variant: "no" } } as never),

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -185,8 +185,6 @@ const VideoPageContent = ({
       if (!lessonStarted) {
         trackLessonStarted();
       }
-      // Persist the video result before completing so it satisfies the
-      // attempt schema even when no player event fired (PUPIL-1770).
       updateSectionInProgressResult("video", videoResultRef.current);
       completeSection("video");
       const nextSectionResults = getSectionResultsAfterComplete();

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/video.tsx
@@ -185,6 +185,9 @@ const VideoPageContent = ({
       if (!lessonStarted) {
         trackLessonStarted();
       }
+      // Persist the video result before completing so it satisfies the
+      // attempt schema even when no player event fired (PUPIL-1770).
+      updateSectionInProgressResult("video", videoResultRef.current);
       completeSection("video");
       const nextSectionResults = getSectionResultsAfterComplete();
       trackVideoCompleted({


### PR DESCRIPTION
## Description

- Persist the gathered video result to the lesson-progress store when the video section is completed, before marking it complete.
- Previously, completing the video only stored `isComplete`, leaving the attempt schema's required video fields (`played`/`duration`/`timeElapsed`) undefined when no player event had fired. This threw a `ZodError` in `logAttempt` on the review page, so **Copy link** did nothing for Video + Quiz shared lessons.
- Added a regression test covering completion without any player interaction.

## Issue(s)

[Fixes PUPIL-1770 (Notion: Copy Link - Non functional for Video + Quiz shared lessons)
](https://www.notion.so/oaknationalacademy/Shared-Quiz-Copy-Link-Non-functional-when-Video-not-played-38126cc4e1b180e48af3fda18714e63b?source=copy_link)
## How to test

1. Go to https://oak-web-application-website-git-fix-pupil-1770-copy-link-1bd477.vercel.thenational.academy/pupils/lessons/explain-that-items-can-be-compared-using-length-and-height/shared/video-exit-quiz/overview
2. Complete the video section by clicking "I've finished the video" **without playing the video**, then complete the quiz.
3. On the Review page, click **Copy link**.
4. You should see the link copied (share state becomes "shared") with no `ZodError` in the console. Repeat with the `starter-quiz-video` variant.

## Screenshots

How it should now look:
<img width="1510" height="824" alt="Screenshot 2026-06-16 at 16 26 39" src="https://github.com/user-attachments/assets/02672d08-c8af-4832-9401-35dc0bc0a34d" />


## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

Made with [Cursor](https://cursor.com)