### PR TITLE
chore(PUPIL-1753): bump oak-components to 2.41.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@mux/mux-player": "^3.10.2",
     "@mux/mux-player-react": "3.10.2",
     "@oaknational/google-classroom-addon": "^1.33.0",
-    "@oaknational/oak-components": "^2.40.0",
+    "@oaknational/oak-components": "^2.41.1",
     "@oaknational/oak-consent-client": "2.4.0",
     "@oaknational/oak-curriculum-schema": "2.4.0-beta.2",
     "@ooxml-tools/units": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: 3.10.2(@types/react-dom@18.3.0)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@oaknational/google-classroom-addon':
         specifier: ^1.33.0
-        version: 1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))
+        version: 1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.41.1(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))
       '@oaknational/oak-components':
-        specifier: ^2.40.0
-        version: 2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
+        specifier: ^2.41.1
+        version: 2.41.1(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
       '@oaknational/oak-consent-client':
         specifier: 2.4.0
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)
@@ -3108,8 +3108,8 @@ packages:
       zod: '>=3.25.76'
       zustand: '>=5.0.9'
 
-  '@oaknational/oak-components@2.40.0':
-    resolution: {integrity: sha512-8Qz1Kgx1IdG+u9mmRSr5QNvTe9J+fz5cZUaGztirbKkak8LtSrvXKotmaWERcaA6uO7JsjJ1RNptqQ1WPcveUQ==}
+  '@oaknational/oak-components@2.41.1':
+    resolution: {integrity: sha512-Ub2Vu8xmr1LcZyUpEtdBBIu8eb4NjRtqdiBjO3Zl5hJVlLUfGEVNVvHbZdWkNrFNHCzL6KL3jfDTR1S23qdTiw==}
     engines: {node: '24', pnpm: '>=11'}
     peerDependencies:
       next: '>=14.2.12'
@@ -17034,11 +17034,11 @@ snapshots:
   '@npmcli/redact@4.0.0':
     optional: true
 
-  '@oaknational/google-classroom-addon@1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))':
+  '@oaknational/google-classroom-addon@1.33.0(@google-cloud/firestore@7.11.6)(@googleapis/classroom@4.9.0)(@oaknational/oak-components@2.41.1(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)))(google-auth-library@9.15.1)(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)(zustand@5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)))':
     dependencies:
       '@google-cloud/firestore': 7.11.6
       '@googleapis/classroom': 4.9.0
-      '@oaknational/oak-components': 2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
+      '@oaknational/oak-components': 2.41.1(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
       google-auth-library: 9.15.1
       iron-session: 8.0.4
       lodash: 4.18.1
@@ -17048,7 +17048,7 @@ snapshots:
       zod: 4.3.6
       zustand: 5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
 
-  '@oaknational/oak-components@2.40.0(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))':
+  '@oaknational/oak-components@2.41.1(next-cloudinary@6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))':
     dependencies:
       next: 15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0)
       next-cloudinary: 6.16.0(next@15.5.15(@babel/core@7.28.3(supports-color@5.5.0))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1)


### PR DESCRIPTION
## Description

Music year: n/a

- Bump `@oaknational/oak-components` from `^2.40.0` to `^2.41.1`
- Surgical lockfile update only (16 lines) — consumes upstream accessibility fix from [oak-components #719](https://github.com/oaknational/oak-components/pull/719)
- No OWA code changes; fix lives in shared components (`OakPupilLessonReviewQuiz` / `InternalReviewAccordion`)

## Issue(s)

Fixes [PUPIL-1753](https://www.notion.so/oaknationalacademy/Associate-results-button-to-section-programmatically-37526cc4e1b180569be5fd994489fd09?source=copy_link)

Replaces closed [OWA #4300](https://github.com/oaknational/Oak-Web-Application/pull/4300) (DOM patching approach rejected in review).

## How to test

1. Go to OWA preview → pupil lesson review page with starter and exit quizzes
2. Open browser accessibility tree or screen reader (VoiceOver/NVDA)
3. Focus each **Results** toggle button
4. You should hear section-specific names: **"Starter quiz results"** / **"Exit quiz results"** (not generic "Results button")
5. Confirm `aria-expanded` still toggles correctly when opening/closing results

## Screenshots

<img width="1459" height="738" alt="Screenshot 2026-06-17 at 14 12 29" src="https://github.com/user-attachments/assets/1034d24c-c409-4b32-bb28-2a993f780242" />
<img width="1459" height="738" alt="Screenshot 2026-06-17 at 14 12 35" src="https://github.com/user-attachments/assets/0e369693-0848-473b-915b-1cccabd47c53" />
<img width="1459" height="738" alt="Screenshot 2026-06-17 at 14 12 41" src="https://github.com/user-attachments/assets/fd115a14-36b2-4064-aa6b-2bcb77995100" />
<img width="1459" height="738" alt="Screenshot 2026-06-17 at 14 12 48" src="https://github.com/user-attachments/assets/61f249f4-f1a3-424b-9290-6c9429d93752" />

## Checklist

- [x] Added or updated tests where appropriate (covered in oak-components #719)
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility (this PR delivers the a11y fix)
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change (no — patch release only)


Made with [Cursor](https://cursor.com)