### PR TITLE
Highlight optionality units not highlighted in threads LESQ 2078

### DIFF
--- a/src/__tests__/__helpers__/getOakUiColor.ts
+++ b/src/__tests__/__helpers__/getOakUiColor.ts
@@ -1,0 +1,11 @@
+import { oakDefaultTheme } from "@oaknational/oak-components";
+
+import theme from "@/styles/theme";
+import type { OakColorName } from "@/styles/theme/types";
+
+export type OakUiColorToken = keyof typeof oakDefaultTheme.uiColors;
+
+export function getOakUiColor(token: OakUiColorToken): string {
+  const colorName = oakDefaultTheme.uiColors[token] as OakColorName;
+  return theme.colors[colorName];
+}

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/UnitSequence/UnitList.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/UnitSequence/UnitList.test.tsx
@@ -3,8 +3,11 @@ import { act, screen } from "@testing-library/react";
 import { ProgrammeUnitList } from "./UnitList";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { getOakUiColor } from "@/__tests__/__helpers__/getOakUiColor";
 import { createFilter } from "@/fixtures/curriculum/filters";
+import { createThread } from "@/fixtures/curriculum/thread";
 import { createUnit } from "@/fixtures/curriculum/unit";
+import { createUnitOption } from "@/fixtures/curriculum/unitOption";
 import { createYearData } from "@/fixtures/curriculum/yearData";
 import { getKeyStageTitle } from "@/utils/curriculum/formatting";
 
@@ -95,6 +98,107 @@ describe("ProgrammeUnitList", () => {
         componentType: "unit_info_button",
       }),
     );
+  });
+
+  describe("thread highlighting", () => {
+    const thread = createThread({
+      slug: "invasion-migration-and-settlement",
+      title: "Invasion, migration and settlement",
+    });
+
+    const optionalityUnit = createUnit({
+      slug: "optionality-unit",
+      title: "Historical options",
+      threads: [thread],
+      unit_options: [
+        createUnitOption({
+          slug: "medicine-in-britain",
+          title: "Medicine in Britain, c1250–present",
+        }),
+        createUnitOption({
+          slug: "another-option",
+          title: "Another historical option",
+        }),
+      ],
+    });
+
+    it("highlights optionality child cards when the unit matches the selected thread", () => {
+      render(
+        <ProgrammeUnitList
+          {...defaultProps}
+          units={[optionalityUnit]}
+          filters={createFilter({ threads: [thread.slug] })}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("card-listing-container");
+      expect(cards).toHaveLength(3);
+      expect(cards[0]).toHaveStyle({ background: getOakUiColor("bg-primary") });
+      expect(cards[1]).toHaveStyle({
+        background: getOakUiColor("bg-inverted"),
+      });
+      expect(cards[2]).toHaveStyle({
+        background: getOakUiColor("bg-inverted"),
+      });
+    });
+
+    it("does not highlight optionality child cards when the unit does not match the selected thread", () => {
+      render(
+        <ProgrammeUnitList
+          {...defaultProps}
+          units={[optionalityUnit]}
+          filters={createFilter({ threads: ["other-thread"] })}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("card-listing-container");
+      cards.forEach((card) => {
+        expect(card).toHaveStyle({ background: getOakUiColor("bg-primary") });
+      });
+    });
+
+    it("highlights a normal unit card when it matches the selected thread", () => {
+      const normalUnit = createUnit({
+        slug: "normal-unit",
+        title: "Normal Unit",
+        threads: [thread],
+      });
+
+      render(
+        <ProgrammeUnitList
+          {...defaultProps}
+          units={[normalUnit]}
+          filters={createFilter({ threads: [thread.slug] })}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("card-listing-container");
+      expect(cards).toHaveLength(1);
+      expect(cards[0]).toHaveStyle({
+        background: getOakUiColor("bg-inverted"),
+      });
+    });
+
+    it("does not highlight any cards when no thread filter is active", () => {
+      const normalUnit = createUnit({
+        slug: "normal-unit",
+        title: "Normal Unit",
+        threads: [thread],
+      });
+
+      render(
+        <ProgrammeUnitList
+          {...defaultProps}
+          units={[normalUnit, optionalityUnit]}
+          filters={createFilter({ threads: [] })}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("card-listing-container");
+      cards.forEach((card) => {
+        expect(card).toHaveStyle({ background: getOakUiColor("bg-primary") });
+      });
+    });
   });
 });
 

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/UnitSequence/UnitList.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/UnitSequence/UnitList.tsx
@@ -75,28 +75,31 @@ export function ProgrammeUnitList({
       }
     };
 
-    const childCards: CardProps[] | undefined = isOptionalityUnitCard
-      ? unit.unit_options.map((option) => ({
-          isHighlighted,
-          title: option.title,
-          saveProps: getSavePropsForUnitCard({
-            slug: option.slug ?? unit.slug,
-            title: option.title,
-            programmeSlug,
-            subject: unit.subject,
-            subjectSlug: unit.subject_slug,
-            keystageSlug: unit.keystage_slug,
-            isOptionalityUnit: false,
-          }),
-          href: resolveOakHref({
-            page: "integrated-unit-overview",
-            unitSlug: option.slug ?? unit.slug,
-            programmeSlug,
-          }),
-          showBorder: true,
-          onClickLink: () => onClick(unit, isHighlighted),
-          lessonCount: option.lessons.length,
-        }))
+    const childCards = isOptionalityUnitCard
+      ? unit.unit_options.map(
+          (option) =>
+            ({
+              highlightColorVariant: isHighlighted ? "secondary" : undefined,
+              title: option.title,
+              saveProps: getSavePropsForUnitCard({
+                slug: option.slug ?? unit.slug,
+                title: option.title,
+                programmeSlug,
+                subject: unit.subject,
+                subjectSlug: unit.subject_slug,
+                keystageSlug: unit.keystage_slug,
+                isOptionalityUnit: false,
+              }),
+              href: resolveOakHref({
+                page: "integrated-unit-overview",
+                unitSlug: option.slug ?? unit.slug,
+                programmeSlug,
+              }),
+              showBorder: true,
+              onClickLink: () => onClick(unit, isHighlighted),
+              lessonCount: option.lessons.length,
+            }) satisfies CardProps,
+        )
       : undefined;
 
     return (

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonInformationBox/LessonInformationBox.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/[lessonSlug]/Components/LessonInformationBox/LessonInformationBox.test.tsx
@@ -1,19 +1,11 @@
 import { screen } from "@testing-library/dom";
-import { oakDefaultTheme } from "@oaknational/oak-components";
 
 import LessonInformationBox from "./LessonInformationBox";
 
 import renderWithTheme from "@/__tests__/__helpers__/renderWithTheme";
-import theme from "@/styles/theme";
-import type { OakColorName } from "@/styles/theme/types";
+import { getOakUiColor } from "@/__tests__/__helpers__/getOakUiColor";
 
 const render = renderWithTheme;
-const getOakBackgroundColor = (
-  token: "bg-decorative2-subdued" | "bg-neutral",
-): string => {
-  const colorName = oakDefaultTheme.uiColors[token] as OakColorName;
-  return theme.colors[colorName];
-};
 
 describe("LessonInformationBox", () => {
   it("renders teacher tip", () => {
@@ -37,7 +29,7 @@ describe("LessonInformationBox", () => {
     expect(teacherTipHeading).toBeInTheDocument();
     expect(teacherTipText).toBeInTheDocument();
     expect(lessonInformationContainer).toHaveStyle({
-      background: getOakBackgroundColor("bg-decorative2-subdued"),
+      background: getOakUiColor("bg-decorative2-subdued"),
     });
   });
 
@@ -57,7 +49,7 @@ describe("LessonInformationBox", () => {
     expect(equipmentHeading).toBeInTheDocument();
     expect(equipmentText).toBeInTheDocument();
     expect(lessonInformationContainer).toHaveStyle({
-      background: getOakBackgroundColor("bg-neutral"),
+      background: getOakUiColor("bg-neutral"),
     });
   });
 
@@ -77,7 +69,7 @@ describe("LessonInformationBox", () => {
     expect(contentGuidanceHeading).toBeInTheDocument();
     expect(contentGuidanceText).toBeInTheDocument();
     expect(lessonInformationContainer).toHaveStyle({
-      background: getOakBackgroundColor("bg-neutral"),
+      background: getOakUiColor("bg-neutral"),
     });
   });
 
@@ -93,7 +85,7 @@ describe("LessonInformationBox", () => {
     expect(supervisionHeading).toBeInTheDocument();
     expect(supervisionText).toBeInTheDocument();
     expect(lessonInformationContainer).toHaveStyle({
-      background: getOakBackgroundColor("bg-neutral"),
+      background: getOakUiColor("bg-neutral"),
     });
   });
 
@@ -128,7 +120,7 @@ describe("LessonInformationBox", () => {
     expect(downloadInstructionText).toBeInTheDocument();
     expect(buttonText).toBeInTheDocument();
     expect(lessonInformationContainer).toHaveStyle({
-      background: getOakBackgroundColor("bg-neutral"),
+      background: getOakUiColor("bg-neutral"),
     });
   });
 

--- a/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.test.tsx
+++ b/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.test.tsx
@@ -9,15 +9,9 @@ import { buildFocusTree } from "@/components/AppComponents/TopNav/DropdownFocusM
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import { TeachersSubNavData } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
-import theme from "@/styles/theme/default.theme";
-import { oakDefaultTheme } from "@/styles/oakThemeApp";
-import { OakColorName } from "@/styles/theme/types";
+import { getOakUiColor } from "@/__tests__/__helpers__/getOakUiColor";
 
 const render = renderWithProviders();
-const getOakBackgroundColor = (token: "bg-decorative1-very-subdued") => {
-  const colorName = oakDefaultTheme.uiColors[token] as OakColorName;
-  return theme.colors[colorName];
-};
 
 const mockBrowseRefined = jest.fn();
 jest.mock("@/context/Analytics/useAnalytics", () => ({
@@ -165,7 +159,7 @@ describe("TopNavDropdown", () => {
 
         expect(subjectButtons[2]).toHaveTextContent("Financial education");
         expect(subjectButtons[2]).toHaveStyle({
-          background: getOakBackgroundColor("bg-decorative1-very-subdued"),
+          background: getOakUiColor("bg-decorative1-very-subdued"),
         });
       });
 

--- a/src/components/TeacherComponents/CardListing/CardListing.test.tsx
+++ b/src/components/TeacherComponents/CardListing/CardListing.test.tsx
@@ -3,6 +3,7 @@ import { screen } from "@testing-library/dom";
 import CardListing from "./CardListing";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+import { getOakUiColor } from "@/__tests__/__helpers__/getOakUiColor";
 
 const render = renderWithProviders();
 
@@ -116,17 +117,21 @@ describe("CardListing", () => {
     );
 
     const card = screen.getByTestId("card-listing-container");
-    expect(card).toHaveStyle({ background: "#222222" });
+    expect(card).toHaveStyle({ background: getOakUiColor("bg-inverted") });
 
     const saveButton = screen.getByRole("button", {
       name: "Save this unit: Unit title",
     });
-    expect(saveButton).toHaveStyle({ background: "#222222" });
+    expect(saveButton).toHaveStyle({
+      background: getOakUiColor("bg-inverted"),
+    });
 
     rerender(<CardListing {...defaultProps} saveProps={saveProps} />);
 
     const rerenderedCard = screen.getByTestId("card-listing-container");
-    expect(rerenderedCard).toHaveStyle({ background: "#ffffff" });
+    expect(rerenderedCard).toHaveStyle({
+      background: getOakUiColor("bg-primary"),
+    });
 
     const rerenderedSaveButton = screen.getByRole("button", {
       name: "Save this unit: Unit title",
@@ -200,5 +205,47 @@ describe("CardListing", () => {
       name: "Save this unit: Unit title",
     });
     expect(saveButton).toBeInTheDocument();
+  });
+  it("renders highlighted child cards when highlightColorVariant is set on children", () => {
+    render(
+      <CardListing
+        {...defaultProps}
+        childCards={[
+          {
+            ...childCardProps,
+            title: "Optionality 1",
+            highlightColorVariant: "secondary",
+          },
+          {
+            ...childCardProps,
+            title: "Optionality 2",
+            highlightColorVariant: "secondary",
+          },
+        ]}
+      />,
+    );
+
+    const cards = screen.getAllByTestId("card-listing-container");
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toHaveStyle({ background: getOakUiColor("bg-primary") });
+    expect(cards[1]).toHaveStyle({ background: getOakUiColor("bg-inverted") });
+    expect(cards[2]).toHaveStyle({ background: getOakUiColor("bg-inverted") });
+  });
+  it("renders unhighlighted child cards when highlightColorVariant is not set on children", () => {
+    render(
+      <CardListing
+        {...defaultProps}
+        childCards={[
+          { ...childCardProps, title: "Optionality 1" },
+          { ...childCardProps, title: "Optionality 2" },
+        ]}
+      />,
+    );
+
+    const cards = screen.getAllByTestId("card-listing-container");
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toHaveStyle({ background: getOakUiColor("bg-primary") });
+    expect(cards[1]).toHaveStyle({ background: getOakUiColor("bg-primary") });
+    expect(cards[2]).toHaveStyle({ background: getOakUiColor("bg-primary") });
   });
 });

--- a/src/components/TeacherComponents/CardListing/CardListing.tsx
+++ b/src/components/TeacherComponents/CardListing/CardListing.tsx
@@ -23,6 +23,7 @@ import {
 import { TrackingProgrammeData } from "@/node-lib/educator-api/helpers/saveUnits/utils";
 
 export type CardProps = {
+  /** Ignored on parent CardListing when `childCards` is present; use on child cards instead. */
   highlightColorVariant?: HighlightColorVariant;
   title: string;
   lessonCount?: number;


### PR DESCRIPTION
## Description

Music year: 1957

- Pass `highlightColorVariant: "secondary"` to optionality child cards in `UnitList` instead of the invalid `isHighlighted` prop
- Document on `CardProps.highlightColorVariant` that it is ignored on parent `CardListing` when `childCards` is present
- Add `CardListing` and `UnitList` tests for thread-selected highlighting of optionality units
- Add shared `getOakUiColor` test helper and use theme tokens instead of hardcoded hex values in affected tests

## How to test

1. Go to https://oak-web-application-website-git-fix-lesq-2078optionality-a1470f.vercel.thenational.academy/teachers/programmes/history-secondary-edexcel/units?threads=invasion-migration-and-settlement
2. Find the optionality unit group containing **Medicine in Britain, c1250–present**
3. You should see the **Medicine in Britain, c1250–present** child option card with a dark highlighted background; the parent optionality wrapper around it should stay white/neutral

**Also verify non-optionality units still highlight:**

4. On the same page, find a normal (non-optionality) unit that belongs to the **Invasion, migration and settlement** thread
5. You should see that unit card also has the same dark highlighted background as the optionality child cards

**And verify no regression for non-thread and non-matching thread states:**

6. Go to https://oak-web-application-website-git-fix-lesq-2078optionality-a1470f.vercel.thenational.academy/teachers/programmes/history-secondary-edexcel/units (no `threads` query param)
7. You should see no unit cards with the dark highlight styling — optionality child cards and normal unit cards should both use the default white background
8. Go to https://oak-web-application-website-git-fix-lesq-2078optionality-a1470f.vercel.thenational.academy/teachers/programmes/history-secondary-edexcel/units?threads=some-other-thread-slug (a thread that does not match the optionality unit)
9. You should see **Medicine in Britain, c1250–present** and other optionality child cards without the dark highlight

## Screenshots

How it used to look

<img width="1074" height="947" alt="Screenshot 2026-06-22 at 17 44 23" src="https://github.com/user-attachments/assets/df02f552-ffbb-4ae1-b73f-c70b5b72aa07" />


How it should now look:

<img width="1066" height="951" alt="Screenshot 2026-06-22 at 17 44 12" src="https://github.com/user-attachments/assets/dcffb0e6-dd98-4a38-8fba-e9aea209ffc9" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
