### PR TITLE
DEMO: Spike/lesq 2109/cache variants [LESQ-2109]

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitView.tsx
@@ -12,10 +12,13 @@ import { SubjectIcon } from "@/components/TeacherComponents/Header/Header";
 import { useUnitDownloadButtonState } from "@/components/TeacherComponents/UnitDownloadButton/UnitDownloadButton";
 import { getUnitDownloadFileId } from "@/utils/getUnitDownloadFileId";
 import ComplexCopyrightRestrictionBanner from "@/components/TeacherComponents/ComplexCopyrightRestrictionBanner/ComplexCopyrightRestrictionBanner";
+import { useCaptureFeatureFlag } from "@/utils/posthogExperiments/useCaptureFeatureFlag";
 
 export type UnitPageProps = TeachersUnitOverviewData & { isEnabled: boolean };
 
 export const UnitView = (props: UnitPageProps) => {
+  useCaptureFeatureFlag("test-flag");
+
   const subjectIconName = `subject-${props.subjectSlug}` as SubjectIcon;
 
   const subjectPhaseSlug = getTeacherSubjectPhaseSlug({

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitView.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/Components/UnitView.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { OakBox } from "@oaknational/oak-components";
+import { OakBox, OakPrimaryButton } from "@oaknational/oak-components";
 
 import UnitHeader from "./UnitHeader/UnitHeader";
 import { Breadcrumbs } from "./Breadcrumbs/Breadcrumbs";
@@ -13,7 +13,7 @@ import { useUnitDownloadButtonState } from "@/components/TeacherComponents/UnitD
 import { getUnitDownloadFileId } from "@/utils/getUnitDownloadFileId";
 import ComplexCopyrightRestrictionBanner from "@/components/TeacherComponents/ComplexCopyrightRestrictionBanner/ComplexCopyrightRestrictionBanner";
 
-export type UnitPageProps = TeachersUnitOverviewData;
+export type UnitPageProps = TeachersUnitOverviewData & { isEnabled: boolean };
 
 export const UnitView = (props: UnitPageProps) => {
   const subjectIconName = `subject-${props.subjectSlug}` as SubjectIcon;
@@ -60,6 +60,7 @@ export const UnitView = (props: UnitPageProps) => {
         }
         downloadButtonState={downloadButtonState}
       />
+      {props.isEnabled && <OakPrimaryButton>TEST BUTTON</OakPrimaryButton>}
       <OakBox $ph="spacing-40">
         <OakBox $mh="auto" $width={"100%"} $maxWidth={"spacing-1280"}>
           <ComplexCopyrightRestrictionBanner

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/generateMetadata.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/generateMetadata.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from "next";
+
+import { getCachedUnitData } from "./getCachedUnitData";
+
+import { getOpenGraphMetadata, getTwitterMetadata } from "@/app/metadata";
+import { AppPageProps } from "@/hocs/withPageErrorHandling";
+
+type LessonsPageParams = { slug: string; unitSlug: string };
+
+export const dynamic = "force-static";
+
+export async function generateMetadata(
+  props: AppPageProps<LessonsPageParams>,
+): Promise<Metadata> {
+  const { slug: programmeSlug, unitSlug } = await props.params;
+
+  try {
+    const data = await getCachedUnitData(programmeSlug, unitSlug);
+    const {
+      unitTitle,
+      keyStageSlug,
+      year,
+      subjectTitle,
+      examBoardTitle,
+      tierTitle,
+    } = data;
+
+    const tierSegment = tierTitle ? ` ${tierTitle}` : "";
+    const examboardSegment = examBoardTitle ? ` ${examBoardTitle}` : "";
+
+    const title = `${unitTitle} ${keyStageSlug.toUpperCase()} | Y${year} ${subjectTitle}${tierSegment}${examboardSegment} | Lesson Resources`;
+    const description = `Free lessons and teaching resources about ${unitTitle.toLowerCase()}`;
+
+    return {
+      title,
+      description,
+      openGraph: getOpenGraphMetadata({ title, description }),
+      twitter: getTwitterMetadata({ title, description }),
+    };
+  } catch {
+    return {};
+  }
+}

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
@@ -1,0 +1,32 @@
+import { UnitView } from "../Components/UnitView";
+import {
+  getCachedUnitData,
+  redirectUnitPageIfNeeded,
+} from "../getCachedUnitData";
+
+import withPageErrorHandling, {
+  AppPageProps,
+} from "@/hocs/withPageErrorHandling";
+import { getFeatureFlagValue } from "@/utils/featureFlags";
+
+type LessonsPageParams = { slug: string; unitSlug: string };
+
+export const dynamic = "force-dynamic";
+
+export { generateMetadata } from "../generateMetadata";
+
+const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
+  const { slug: programmeSlug, unitSlug } = await props.params;
+
+  await redirectUnitPageIfNeeded({ programmeSlug, unitSlug });
+
+  const isEnabled = await getFeatureFlagValue("test-flag", "string");
+
+  const data = await getCachedUnitData(programmeSlug, unitSlug);
+
+  return <UnitView {...data} isEnabled={isEnabled === "test"} />;
+};
+
+const UnitPage = withPageErrorHandling(InnerUnitPage, "unit-page::app");
+
+export default UnitPage;

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
@@ -1,5 +1,3 @@
-import { cookies } from "next/headers";
-
 import { UnitView } from "../Components/UnitView";
 import {
   getCachedUnitData,
@@ -10,7 +8,6 @@ import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
 import { getFeatureFlagValue } from "@/utils/featureFlags";
-import { EXPERIMENT_COOKIE } from "@/middleware";
 
 type LessonsPageParams = { slug: string; unitSlug: string };
 
@@ -23,21 +20,11 @@ const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
 
   await redirectUnitPageIfNeeded({ programmeSlug, unitSlug });
 
-  const cookieStore = await cookies();
-  const experimentCookie = cookieStore.get(EXPERIMENT_COOKIE);
-  let isEnabled = experimentCookie?.value === "test";
-
-  if (!experimentCookie) {
-    const featureFlag = await getFeatureFlagValue("test-flag", "string");
-    if (featureFlag) {
-      cookieStore.set(EXPERIMENT_COOKIE, featureFlag);
-      isEnabled = featureFlag === "test";
-    }
-  }
+  const featureFlag = await getFeatureFlagValue("test-flag", "string");
 
   const data = await getCachedUnitData(programmeSlug, unitSlug);
 
-  return <UnitView {...data} isEnabled={isEnabled} />;
+  return <UnitView {...data} isEnabled={featureFlag === "test"} />;
 };
 
 const UnitPage = withPageErrorHandling(InnerUnitPage, "unit-page::app");

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/ssr/page.tsx
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 import { UnitView } from "../Components/UnitView";
 import {
   getCachedUnitData,
@@ -8,6 +10,7 @@ import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
 import { getFeatureFlagValue } from "@/utils/featureFlags";
+import { EXPERIMENT_COOKIE } from "@/middleware";
 
 type LessonsPageParams = { slug: string; unitSlug: string };
 
@@ -20,11 +23,21 @@ const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
 
   await redirectUnitPageIfNeeded({ programmeSlug, unitSlug });
 
-  const isEnabled = await getFeatureFlagValue("test-flag", "string");
+  const cookieStore = await cookies();
+  const experimentCookie = cookieStore.get(EXPERIMENT_COOKIE);
+  let isEnabled = experimentCookie?.value === "test";
+
+  if (!experimentCookie) {
+    const featureFlag = await getFeatureFlagValue("test-flag", "string");
+    if (featureFlag) {
+      cookieStore.set(EXPERIMENT_COOKIE, featureFlag);
+      isEnabled = featureFlag === "test";
+    }
+  }
 
   const data = await getCachedUnitData(programmeSlug, unitSlug);
 
-  return <UnitView {...data} isEnabled={isEnabled === "test"} />;
+  return <UnitView {...data} isEnabled={isEnabled} />;
 };
 
 const UnitPage = withPageErrorHandling(InnerUnitPage, "unit-page::app");

--- a/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/variant/page.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/units/[unitSlug]/lessons/variant/page.tsx
@@ -1,17 +1,18 @@
-import { UnitView } from "./Components/UnitView";
+import { UnitView } from "../Components/UnitView";
 import {
   getCachedUnitData,
   redirectUnitPageIfNeeded,
-} from "./getCachedUnitData";
+} from "../getCachedUnitData";
 
 import withPageErrorHandling, {
   AppPageProps,
 } from "@/hocs/withPageErrorHandling";
+
 type LessonsPageParams = { slug: string; unitSlug: string };
 
 export const dynamic = "force-static";
 
-export { generateMetadata } from "./generateMetadata";
+export { generateMetadata } from "../generateMetadata";
 
 const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
   const { slug: programmeSlug, unitSlug } = await props.params;
@@ -20,7 +21,7 @@ const InnerUnitPage = async (props: AppPageProps<LessonsPageParams>) => {
 
   const data = await getCachedUnitData(programmeSlug, unitSlug);
 
-  return <UnitView {...data} isEnabled={false} />;
+  return <UnitView {...data} isEnabled={true} />;
 };
 
 const UnitPage = withPageErrorHandling(InnerUnitPage, "unit-page::app");

--- a/src/browser-lib/posthog/posthog.ts
+++ b/src/browser-lib/posthog/posthog.ts
@@ -54,6 +54,9 @@ export const posthogToAnalyticsServiceWithoutQueue = (
   page: () => {
     client.capture("$pageview");
   },
+  trackFeatureFlag: (properties) => {
+    client.capture("$feature_flag_called", properties);
+  },
   track: (name, properties) => {
     const m = window.location.search.match(/update_tracking_profile=true/);
 

--- a/src/context/Analytics/AnalyticsProvider.tsx
+++ b/src/context/Analytics/AnalyticsProvider.tsx
@@ -40,6 +40,10 @@ export type EventFn = (
 export type PageProperties = {
   path: string;
 };
+export type TrackFeatureFlagFunction = (properties: {
+  $feature_flag: string;
+  $feature_flag_response: string;
+}) => void;
 export type PageFn = (properties: PageProperties) => void;
 export type IdentifyProperties = { email?: string };
 export type IdentifyFn = (
@@ -75,6 +79,7 @@ export type AnalyticsContext = {
   track: TrackFns;
   identify: IdentifyFn;
   alias?: AliasFn;
+  trackFeatureFlag?: TrackFeatureFlagFunction;
   posthogDistinctId: PosthogDistinctId | null;
 };
 
@@ -85,6 +90,7 @@ export type AnalyticsService<ServiceConfig> = {
   track: EventFn;
   page: PageFn;
   identify: IdentifyFn;
+  trackFeatureFlag?: TrackFeatureFlagFunction;
   alias?: AliasFn;
   optOut: () => void;
   optIn: () => void;
@@ -234,6 +240,12 @@ const AnalyticsProvider: FC<AnalyticsProviderProps> = (props) => {
     },
     [posthog],
   );
+  const trackFeatureFlag: TrackFeatureFlagFunction = useCallback(
+    (properties) => {
+      posthog.trackFeatureFlag?.(properties);
+    },
+    [posthog],
+  );
   /**
    * Event tracking
    * Object containing Track functions as defined in the Avo tracking plan.
@@ -254,9 +266,10 @@ const AnalyticsProvider: FC<AnalyticsProviderProps> = (props) => {
       track,
       identify,
       alias,
+      trackFeatureFlag,
       posthogDistinctId,
     };
-  }, [track, identify, posthogDistinctId, alias]);
+  }, [track, identify, posthogDistinctId, alias, trackFeatureFlag]);
 
   return (
     <analyticsContext.Provider value={analytics}>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { MiddlewareConfig, NextResponse } from "next/server";
 
 import getServerConfig from "./node-lib/getServerConfig";
 
-export const EXPERIMENT_COOKIE = "__experiments=cta-experiment:test";
+export const EXPERIMENT_COOKIE = "__experiments:test-flag";
 const posthogApiKey = getServerConfig("posthogApiKey");
 
 export default clerkMiddleware(async (_, req) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,67 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
-import { MiddlewareConfig } from "next/server";
+import { MiddlewareConfig, NextResponse } from "next/server";
 
-export default clerkMiddleware();
+import getServerConfig from "./node-lib/getServerConfig";
+
+export const EXPERIMENT_COOKIE = "__experiments=cta-experiment:test";
+const posthogApiKey = getServerConfig("posthogApiKey");
+
+export default clerkMiddleware(async (_, req) => {
+  if (
+    req.nextUrl.pathname.match(/\/teachers\/programmes\/.*\/units\/.*\/lessons/)
+  ) {
+    const existing = req.cookies.get(EXPERIMENT_COOKIE)?.value;
+
+    if (existing === "test") {
+      return NextResponse.rewrite(new URL("/variant", req.url));
+    }
+
+    if (existing === "control") {
+      return NextResponse.next();
+    }
+
+    // No cookie yet — evaluate the flag
+    const posthogCookie = req.cookies.get(`ph_${posthogApiKey}_posthog`);
+    const cookieValue = posthogCookie ? JSON.parse(posthogCookie.value) : {};
+    const distinctId = cookieValue["distinct_id"];
+
+    if (distinctId) {
+      const phRes = await fetch(
+        `${getServerConfig("posthogApiHost")}/decide?v=3`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            api_key: posthogApiKey,
+            distinct_id: distinctId,
+          }),
+        },
+      );
+
+      if (!phRes.ok) return null;
+
+      const data = await phRes.json();
+      const variant = data?.featureFlags?.["test-flag"] ?? null;
+
+      const isTest = variant === "test";
+      const res = isTest
+        ? NextResponse.rewrite(
+            new URL(req.nextUrl.pathname + "/variant", req.url),
+          )
+        : NextResponse.next();
+
+      res.cookies.set(EXPERIMENT_COOKIE, isTest ? "test" : "control", {
+        maxAge: 60 * 60 * 24 * 30,
+        sameSite: "lax",
+        path: "/",
+      });
+      return res;
+    }
+  }
+
+  // For all other routes, just fall through to Clerk's default behavior
+});
+
 /**
  * Clerk middleware causes page latency, we're only enabling it for API routes or pages where
  * we need to access the user session in the backend
@@ -10,8 +70,10 @@ export default clerkMiddleware();
 export const config: MiddlewareConfig = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    // "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    //"/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     // API routes except /api/classroom/* which is used for Google Classroom Add-on
     "/(api|trpc)((?!/classroom))(.*)",
+    // Experiment route
+    "/teachers/programmes/:programmeSlug/units/:unitSlug/lessons",
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,9 +11,9 @@ export default clerkMiddleware(async (_, req) => {
     req.nextUrl.pathname.match(/\/teachers\/programmes\/.*\/units\/.*\/lessons/)
   ) {
     const existing = req.cookies.get(EXPERIMENT_COOKIE)?.value;
-
+    const rewriteUrl = new URL(req.nextUrl.pathname + "/variant", req.url);
     if (existing === "test") {
-      return NextResponse.rewrite(new URL("/variant", req.url));
+      return NextResponse.rewrite(rewriteUrl);
     }
 
     if (existing === "control") {
@@ -45,9 +45,7 @@ export default clerkMiddleware(async (_, req) => {
 
       const isTest = variant === "test";
       const res = isTest
-        ? NextResponse.rewrite(
-            new URL(req.nextUrl.pathname + "/variant", req.url),
-          )
+        ? NextResponse.rewrite(rewriteUrl)
         : NextResponse.next();
 
       res.cookies.set(EXPERIMENT_COOKIE, isTest ? "test" : "control", {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -55,9 +55,12 @@ export default clerkMiddleware(async (_, req) => {
       });
       return res;
     }
+
+    return NextResponse.next();
   }
 
   // For all other routes, just fall through to Clerk's default behavior
+  console.log("Running clerk middleware on route: ", req.url);
 });
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,20 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
-import { MiddlewareConfig, NextResponse } from "next/server";
+import {
+  MiddlewareConfig,
+  NextFetchEvent,
+  NextRequest,
+  NextResponse,
+} from "next/server";
 
 import getServerConfig from "./node-lib/getServerConfig";
 
 export const EXPERIMENT_COOKIE = "__experiments:test-flag";
 const posthogApiKey = getServerConfig("posthogApiKey");
 
-export default clerkMiddleware(async (_, req) => {
+export default async function middleware(
+  req: NextRequest,
+  event: NextFetchEvent,
+) {
   if (
     req.nextUrl.pathname.match(/\/teachers\/programmes\/.*\/units\/.*\/lessons/)
   ) {
@@ -57,11 +65,11 @@ export default clerkMiddleware(async (_, req) => {
     }
 
     return NextResponse.next();
+  } else {
+    // Fall through to default clerk middleware on all other routes (/api)
+    return clerkMiddleware()(req, event);
   }
-
-  // For all other routes, just fall through to Clerk's default behavior
-  console.log("Running clerk middleware on route: ", req.url);
-});
+}
 
 /**
  * Clerk middleware causes page latency, we're only enabling it for API routes or pages where

--- a/src/utils/posthogExperiments/getExperimentCookieKey.ts
+++ b/src/utils/posthogExperiments/getExperimentCookieKey.ts
@@ -1,0 +1,3 @@
+export const getExperimentCookieKey = (flagKey: string) => {
+  return `__experiments:${flagKey}`;
+};

--- a/src/utils/posthogExperiments/useCaptureFeatureFlag.tsx
+++ b/src/utils/posthogExperiments/useCaptureFeatureFlag.tsx
@@ -1,0 +1,21 @@
+import Cookies from "js-cookie";
+import { useEffect } from "react";
+
+import { getExperimentCookieKey } from "./getExperimentCookieKey";
+
+import useAnalytics from "@/context/Analytics/useAnalytics";
+
+export const useCaptureFeatureFlag = (flagKey: string) => {
+  const { trackFeatureFlag } = useAnalytics();
+  useEffect(() => {
+    // Track call to feature flag when cookie has been set
+    const cookieKey = getExperimentCookieKey(flagKey);
+    const variant = Cookies.get(cookieKey);
+    if (!variant || !trackFeatureFlag) return;
+
+    trackFeatureFlag({
+      $feature_flag: flagKey,
+      $feature_flag_response: variant,
+    });
+  }, [trackFeatureFlag, flagKey]);
+};


### PR DESCRIPTION
## Description

Music year: 1971

*Do not merge*

A demonstration of two approaches to handle posthog experiments in app router. See the full write up[ in the ticket.](https://app.notion.com/p/oaknationalacademy/SPIKE-caching-experiment-variants-37c26cc4e1b180d989cdc7243b63b9be?source=copy_link)

## Testing

Option A (SSR)
1. Go to any unit overview page
2. Append `/ssr` to the URL
3. Check your cookies for `__experiment: test-flag`, if the value is `test` you should see a test button on the page
4. If the value is `control` you should not see the button

Option B (Middleware)
1. Clear your cookies
2. Go to any unit overview page
3. Check your cookies for `__experiment: test-flag`, if the value is `test` you should see a test button on the page
4. If the value is `control` you should not see the button
5. The URL should be the same regardless of which experiment group you are in

