### PR TITLE
chore: reduce prepush ci check strain

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 
 git diff-index --quiet HEAD -- || (echo "Error: You have uncommitted changes. Please commit or stash them before pushing." && exit 1)
 pnpm run check-types
-pnpm run test:ci
+pnpm run test:prepush

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test": "jest --watch --collectCoverage=false",
     "test:coverage": "jest --watch",
     "test:ci": "jest",
+    "test:prepush": "jest --collectCoverage=false --workerIdleMemoryLimit=1GB --maxWorkers=50%",
     "test:pages": "jest -c ./jest.pages.config.cjs ./src/__tests__",
     "test:components": "jest -c ./jest.components.config.cjs ./src/components",
     "test:storybook": "jest --config=jest.storybook.config.cjs",


### PR DESCRIPTION
## Description

Music year: 1956

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
