### PR TITLE
Change colour icons from `<OakIcon/>` to `<OakImage/>`

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.test.tsx.snap
@@ -157,11 +157,11 @@ exports[`Teachers Page Page component renders 1`] = `
                     pupils
                   </span>
                   <span
-                    class="sc-aXZVg jJQFnr"
+                    class="sc-aXZVg jZQmlG"
                   >
                     <img
                       alt=""
-                      class="sc-iGgWBj cMzyFO"
+                      class="sc-iGgWBj dZvqhO"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -60,9 +60,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 .c20 {
   position: relative;
   width: 1.5rem;
-  min-width: 1.5rem;
   height: 1.5rem;
-  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -84,6 +82,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   width: 2rem;
   height: 2.5rem;
   padding: 0rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c34 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -194,28 +202,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -224,7 +232,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -232,7 +240,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -242,41 +250,41 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c78 {
+.c79 {
   background: #e3e9fb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   height: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c87 {
+.c88 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c90 {
+.c91 {
   background: #ffffff;
   border-radius: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c92 {
   padding: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c101 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -287,33 +295,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c106 {
+.c107 {
   width: 100%;
   aspect-ratio: 16/9;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c111 {
+.c112 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c112 {
+.c113 {
   position: absolute;
   top: 0rem;
   left: 0rem;
   width: 100%;
-  min-width: 100%;
   height: 100%;
-  min-height: 100%;
   display: none;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
@@ -321,26 +327,26 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c113 {
+.c114 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c123 {
+.c124 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -350,7 +356,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -361,14 +367,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c126 {
+.c127 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c129 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -380,12 +386,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c132 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c134 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -399,36 +405,36 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c136 {
+.c137 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c153 {
+.c154 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c156 {
+.c157 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c159 {
+.c160 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c164 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c168 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -438,13 +444,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c168 {
+.c169 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c171 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -456,12 +462,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c173 {
+.c174 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c175 {
+.c176 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -473,18 +479,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c179 {
+.c180 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c180 {
+.c181 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c185 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -493,7 +499,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c185 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -501,7 +507,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c190 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -512,7 +518,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c191 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -523,7 +529,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c193 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -531,12 +537,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c194 {
+.c195 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c199 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -554,7 +560,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c200 {
+.c201 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -572,7 +578,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c202 {
+.c203 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -582,7 +588,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c205 {
+.c206 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -590,7 +596,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c206 {
+.c207 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -598,13 +604,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c207 {
+.c208 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c208 {
+.c209 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -612,7 +618,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c210 {
+.c211 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -623,7 +629,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c213 {
+.c214 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -685,7 +691,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,7 +710,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -803,7 +809,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c80 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -813,7 +819,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -829,7 +835,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -840,7 +846,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c86 {
+.c87 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -851,7 +857,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: flex-end;
 }
 
-.c92 {
+.c93 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -862,7 +868,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -873,7 +879,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c96 {
+.c97 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -884,7 +890,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c98 {
+.c99 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -895,7 +901,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c101 {
+.c102 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -906,7 +912,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.25rem;
 }
 
-.c102 {
+.c103 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -920,7 +926,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c103 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -931,7 +937,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c105 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -942,7 +948,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c108 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -961,7 +967,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   row-gap: 1.5rem;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -972,7 +978,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c121 {
+.c122 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -987,7 +993,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c125 {
+.c126 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -998,7 +1004,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c132 {
+.c133 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1012,7 +1018,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c171 {
+.c172 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1030,7 +1036,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c183 {
+.c184 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1041,7 +1047,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c186 {
+.c187 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1057,7 +1063,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c193 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1075,7 +1081,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c195 {
+.c196 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1088,7 +1094,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c203 {
+.c204 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1103,7 +1109,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c209 {
+.c210 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1118,7 +1124,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c212 {
+.c213 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1168,7 +1174,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1191,14 +1197,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #a0b6f2;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c147 {
+.c148 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1209,7 +1215,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c161 {
+.c162 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1220,7 +1226,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c212 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1231,7 +1237,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c169 {
+.c170 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1330,7 +1336,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c30 {
   background: none;
   color: inherit;
   border: none;
@@ -1353,7 +1359,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c30:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1395,7 +1401,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1425,12 +1431,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1454,12 +1460,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c164 {
+.c165 {
   background: none;
   color: inherit;
   border: none;
@@ -1483,12 +1489,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c164:disabled {
+.c165:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c215 {
+.c216 {
   background: none;
   color: inherit;
   border: none;
@@ -1511,12 +1517,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c215:disabled {
+.c216:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c61 {
   object-fit: contain;
 }
 
@@ -1532,19 +1538,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c199 {
+.c200 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c201 {
+.c202 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c27 {
+.c21 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1553,7 +1559,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c107 {
+.c108 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1638,13 +1644,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1652,37 +1658,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c31:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c31:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c31:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c31:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c31:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1690,27 +1696,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1807,31 +1813,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   background: #222222;
 }
 
-.c187 > :first-child:focus-visible .shadow {
+.c188 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c187 > :first-child:hover .shadow {
+.c188 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c187 > :first-child:active .shadow {
+.c188 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c187 > :first-child:disabled .icon-container {
+.c188 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c187 > :first-child:hover .icon-container {
+.c188 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c187 > :first-child:active .icon-container {
+.c188 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1842,7 +1848,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c83 {
+.c84 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1853,7 +1859,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c94 {
+.c95 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1864,7 +1870,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c115 {
+.c116 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1876,7 +1882,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: center;
 }
 
-.c134 {
+.c135 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1887,7 +1893,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c174 {
+.c175 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1900,7 +1906,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c29 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1908,7 +1914,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c177 {
+.c178 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1917,7 +1923,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1928,7 +1934,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c95 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1939,13 +1945,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c135 {
+.c136 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c165 {
+.c166 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1958,7 +1964,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c166 {
+.c167 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1970,7 +1976,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c196 {
+.c197 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1981,7 +1987,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c197 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1992,7 +1998,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c176 {
+.c177 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2003,7 +2009,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c28 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2024,7 +2030,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c182 {
+.c183 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2055,7 +2061,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c181 {
+.c24 .c182 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2070,7 +2076,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c181 {
+.c24:visited .c182 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2080,7 +2086,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c181 {
+.c24:active .c182 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2090,12 +2096,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c181 {
+.c24[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c178 {
+.c179 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2119,47 +2125,47 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c178 .c181 {
+.c179 .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c178:focus-visible {
+.c179:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c178:visited {
+.c179:visited {
   color: #222222;
 }
 
-.c178:visited .c181 {
+.c179:visited .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c178:active {
+.c179:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c178:active .c181 {
+.c179:active .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c178[disabled] {
+.c179[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c178[disabled] .c181 {
+.c179[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c214 {
+.c215 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2192,42 +2198,42 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c214 .c181 {
+.c215 .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c214:focus-visible {
+.c215:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c214:visited {
+.c215:visited {
   color: #222222;
 }
 
-.c214:visited .c181 {
+.c215:visited .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c214:active {
+.c215:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c214:active .c181 {
+.c215:active .c182 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c214[disabled] {
+.c215[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c214[disabled] .c181 {
+.c215[disabled] .c182 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2290,7 +2296,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   background: #ffffff;
 }
 
-.c81 {
+.c82 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2300,7 +2306,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(4,1fr);
 }
 
-.c97 {
+.c98 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2309,13 +2315,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c129 {
+.c130 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c82 {
+.c83 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2326,7 +2332,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 1;
 }
 
-.c84 {
+.c85 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2337,7 +2343,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 3;
 }
 
-.c89 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2348,7 +2354,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 2;
 }
 
-.c99 {
+.c100 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2358,7 +2364,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c104 {
+.c105 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2368,7 +2374,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c130 {
+.c131 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2377,7 +2383,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c172 {
+.c173 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2386,25 +2392,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c119 {
+.c120 {
   box-shadow: none;
 }
 
-.c119:has(a:hover,button:hover) {
+.c120:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c119:has( a, button) {
+.c120:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c119:has( a, button)  a,
-.c119:has( a, button) button {
+.c120:has( a, button)  a,
+.c120:has( a, button) button {
   outline: none;
 }
 
-.c119:has(a:active,button:active) {
+.c120:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
@@ -2416,27 +2422,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c204 {
+.c205 {
   top: 152px;
 }
 
-.c188 .icon-container > *:first-child {
+.c189 .icon-container > *:first-child {
   border: 0;
 }
 
-.c191 {
+.c192 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c150 {
+.c151 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c138 {
+.c139 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2447,23 +2453,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c138::-webkit-scrollbar-track {
+.c139::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c138::-webkit-scrollbar {
+.c139::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c138::-webkit-scrollbar-thumb {
+.c139::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c141 {
+.c142 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2472,23 +2478,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c141::-webkit-scrollbar-track {
+.c142::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c141::-webkit-scrollbar {
+.c142::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c141::-webkit-scrollbar-thumb {
+.c142::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c143 {
+.c144 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2496,39 +2502,39 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c143::-webkit-scrollbar-track {
+.c144::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c143::-webkit-scrollbar {
+.c144::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c143::-webkit-scrollbar-thumb {
+.c144::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c139 {
+.c140 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c122:hover {
+.c123:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c117 {
+.c118 {
   padding: 0;
   margin: 0;
 }
 
-.c116 {
+.c117 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2540,7 +2546,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c142 {
+.c143 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2552,7 +2558,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c148 {
+.c149 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2563,32 +2569,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c148::-webkit-input-placeholder {
+.c149::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c148::-moz-placeholder {
+.c149::-moz-placeholder {
   color: #575757;
 }
 
-.c148:-ms-input-placeholder {
+.c149:-ms-input-placeholder {
   color: #575757;
 }
 
-.c148::placeholder {
+.c149::placeholder {
   color: #575757;
 }
 
-.c148::-webkit-search-decoration,
-.c148::-webkit-search-cancel-button,
-.c148::-webkit-search-results-button,
-.c148::-webkit-search-results-decoration {
+.c149::-webkit-search-decoration,
+.c149::-webkit-search-cancel-button,
+.c149::-webkit-search-results-button,
+.c149::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c145 {
+.c146 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2598,7 +2604,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c152 {
+.c153 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2611,7 +2617,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c146 {
+.c147 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2622,16 +2628,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c140:focus-within .c144 {
+.c141:focus-within .c145 {
   background: #374cf1;
   color: #fff;
 }
 
-.c140:focus-within .c151 {
+.c141:focus-within .c152 {
   display: inline;
 }
 
-.c149 {
+.c150 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2647,7 +2653,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: none;
 }
 
-.c149::-webkit-input-placeholder {
+.c150::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2655,7 +2661,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c149::-moz-placeholder {
+.c150::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2663,7 +2669,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c149:-ms-input-placeholder {
+.c150:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2671,7 +2677,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c149::placeholder {
+.c150::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2679,31 +2685,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c149:valid:not([value=""]) {
+.c150:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c149:valid:not([value=""])::-webkit-input-placeholder {
+.c150:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c149:valid:not([value=""])::-moz-placeholder {
+.c150:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c149:valid:not([value=""]):-ms-input-placeholder {
+.c150:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c149:valid:not([value=""])::placeholder {
+.c150:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c157 {
+.c158 {
   background: none;
   color: inherit;
   border: none;
@@ -2714,16 +2720,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c155 {
+.c156 {
   display: none;
 }
 
-.c154:focus-within .c144 {
+.c155:focus-within .c145 {
   background: #374cf1;
   color: #fff;
 }
 
-.c158 {
+.c159 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2750,43 +2756,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #575757;
 }
 
-.c160 {
+.c161 {
   max-width: calc(100% - 20px);
 }
 
-.c162 {
+.c163 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c137 {
+.c138 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c128 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c77 {
+.c78 {
   height: 125%;
   -webkit-filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
   filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
 }
 
-.c88 {
+.c89 {
   height: 260px;
 }
 
-.c109 {
+.c110 {
   max-height: 40px;
   height: auto;
   width: auto;
@@ -2897,19 +2903,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -2923,79 +2929,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3004,7 +3010,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3013,13 +3019,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3027,7 +3033,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3035,79 +3041,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c170 {
+  .c171 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c170 {
+  .c171 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c173 {
+  .c174 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c179 {
+  .c180 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c185 {
+  .c186 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c195 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3116,13 +3122,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c199 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c199 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3130,7 +3136,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c198 {
+  .c199 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3138,19 +3144,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3158,61 +3164,61 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3259,31 +3265,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3292,7 +3298,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3301,25 +3307,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c102 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c109 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3327,7 +3333,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c109 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3335,19 +3341,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c183 {
+  .c184 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3356,13 +3362,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c186 {
+  .c187 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3370,7 +3376,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3379,7 +3385,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3388,7 +3394,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c195 {
+  .c196 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3397,7 +3403,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c203 {
+  .c204 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3406,7 +3412,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3414,7 +3420,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3422,7 +3428,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3431,7 +3437,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3440,19 +3446,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3460,7 +3466,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3468,7 +3474,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c212 {
+  .c213 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3476,7 +3482,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     gap: 2rem;
   }
 }
@@ -3536,25 +3542,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3587,43 +3593,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3632,7 +3638,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3641,43 +3647,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3686,169 +3692,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c83 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    font-weight: 400;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    font-weight: 400;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    font-size: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    font-size: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3858,24 +3702,186 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c95 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    font-weight: 400;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    font-weight: 400;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    font-size: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    font-size: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c96 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3884,7 +3890,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     margin-right: 1.5rem;
   }
 }
@@ -3899,16 +3905,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c181,
-  .c24:visited:hover .c181 {
+  .c24:hover .c182,
+  .c24:visited:hover .c182 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c178:hover,
-  .c178:visited:hover {
+  .c179:hover,
+  .c179:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3916,16 +3922,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c178:hover .c181,
-  .c178:visited:hover .c181 {
+  .c179:hover .c182,
+  .c179:visited:hover .c182 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c214:hover,
-  .c214:visited:hover {
+  .c215:hover,
+  .c215:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3933,8 +3939,8 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c214:hover .c181,
-  .c214:visited:hover .c181 {
+  .c215:hover .c182,
+  .c215:visited:hover .c182 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -3954,267 +3960,267 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c81 {
+  .c82 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     grid-template-columns: repeat(8,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c81 {
+  .c82 {
     grid-template-columns: repeat(12,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     -webkit-column-gap: 2.5rem;
     column-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-column: 2 / span 3;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-column: 3 / span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column: 5 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column-start: 5;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c99 {
+  .c100 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c99 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c105 {
     grid-column: 6 / span 7;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c105 {
     grid-column-start: 6;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c172 {
+  .c173 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c116 {
+  .c117 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c149 {
+  .c150 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c77 {
+  .c78 {
     min-width: 400px;
   }
 }
 
 @media (min-width:921px) and (max-width:1050px) {
-  .c77 {
+  .c78 {
     display: block;
     -webkit-translate: 14% -35%;
     translate: 14% -35%;
@@ -4225,7 +4231,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1051px) and (max-width:1180px) {
-  .c77 {
+  .c78 {
     -webkit-translate: 21% -33%;
     translate: 21% -33%;
     -webkit-transform: scale(1.6) rotate(-9deg);
@@ -4235,7 +4241,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1181px) and (max-width:1279px) {
-  .c77 {
+  .c78 {
     -webkit-transform: scale(1.55) rotate(-8.5deg);
     -ms-transform: scale(1.55) rotate(-8.5deg);
     transform: scale(1.55) rotate(-8.5deg);
@@ -4245,7 +4251,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c77 {
+  .c78 {
     -webkit-translate: 20% -41%;
     translate: 20% -41%;
     -webkit-transform: scale(1.7) rotate(-8deg);
@@ -4255,25 +4261,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     height: 380px;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c89 {
     height: 430px;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     max-height: 56px;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     max-height: 64px;
   }
 }
@@ -4465,7 +4471,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               >
                 <img
                   alt=""
-                  class="c27"
+                  class="c21"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4476,7 +4482,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c27"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4484,10 +4490,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c28"
               >
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4501,15 +4507,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Primary
                         </span>
@@ -4518,7 +4524,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4532,15 +4538,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Secondary
                         </span>
@@ -4549,7 +4555,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4563,15 +4569,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Guidance
                         </span>
@@ -4580,7 +4586,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4594,15 +4600,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           About us
                         </span>
@@ -4611,7 +4617,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4624,21 +4630,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -4702,7 +4708,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             class="c52 shadow"
                           />
                           <span
-                            class="c20"
+                            class="c34"
                             data-icon-for="button"
                           >
                             <img
@@ -4745,7 +4751,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c52 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4780,7 +4786,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4789,7 +4795,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4805,13 +4811,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c32"
                   >
                     <span
-                      class="c34"
+                      class="c33"
                     >
                       Sign in
                     </span>
@@ -4821,7 +4827,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4835,14 +4841,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
                   class="c9 c49"
                 >
                   <span
-                    class="c20"
+                    class="c34"
                   >
                     <img
                       alt=""
@@ -4864,46 +4870,46 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Get involved
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   We need your help to understand what's needed in the classroom. Want to get involved? We can't wait to hear from you.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76 c77"
+                  class="c77 c78"
                   data-testid="about-shared-loop"
                 >
                   <img
                     alt=""
-                    class="c21"
+                    class="c61"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4915,38 +4921,38 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c78"
+            class="c79"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c79 c80"
+                class="c80 c81"
               >
                 <div
-                  class="c9 c81"
+                  class="c9 c82"
                 >
                   <div
-                    class="c9 c45 c82"
+                    class="c9 c45 c83"
                   >
                     <h2
-                      class="c83"
+                      class="c84"
                     >
                       Collaborate with us
                     </h2>
                   </div>
                   <div
-                    class="c9 c45 c84"
+                    class="c9 c45 c85"
                   >
                     <div
-                      class="c85 c86"
+                      class="c86 c87"
                     >
                       <span
-                        class="c87 c88"
+                        class="c88 c89"
                       >
                         <img
                           alt=""
-                          class="c27"
+                          class="c21"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -4957,33 +4963,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9 c45 c89"
+                    class="c9 c45 c90"
                   >
                     <div
-                      class="c9 c71"
+                      class="c9 c72"
                     >
                       <div
-                        class="c90"
+                        class="c91"
                       >
                         <div
-                          class="c91 c92"
+                          class="c92 c93"
                         >
                           <div
-                            class="c9 c93"
+                            class="c9 c94"
                           >
                             <h3
-                              class="c94"
+                              class="c95"
                             >
                               Join our teacher research panel
                             </h3>
                             <p
-                              class="c95"
+                              class="c96"
                             >
                               Share your story and we'll send you a gift voucher as a thanks for your time. Whether you've planned more efficiently, strengthened your subject knowledge or refreshed your curriculum design, your experience can inspire other teachers.
                             </p>
                           </div>
                           <div
-                            class="c9 c96"
+                            class="c9 c97"
                           >
                             <div
                               class="c4 c5"
@@ -5009,11 +5015,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                     Join the research panel
                                   </span>
                                   <span
-                                    class="c20"
+                                    class="c34"
                                   >
                                     <img
                                       alt="external"
-                                      class="c21"
+                                      class="c61"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5052,27 +5058,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c90"
+                        class="c91"
                       >
                         <div
-                          class="c91 c92"
+                          class="c92 c93"
                         >
                           <div
-                            class="c9 c93"
+                            class="c9 c94"
                           >
                             <h3
-                              class="c94"
+                              class="c95"
                             >
                               Give your feedback
                             </h3>
                             <p
-                              class="c95"
+                              class="c96"
                             >
                               Teachers are at the heart of everything we build. Have your say by taking part in research or road-testing new resources in your school. 
                             </p>
                           </div>
                           <div
-                            class="c9 c96"
+                            class="c9 c97"
                           >
                             <div
                               class="c4 c5"
@@ -5098,11 +5104,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                     Get in touch
                                   </span>
                                   <span
-                                    class="c20"
+                                    class="c34"
                                   >
                                     <img
                                       alt="external"
-                                      class="c21"
+                                      class="c61"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5123,37 +5129,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c79 c97"
+              class="c80 c98"
             >
               <div
-                class="c9 c98 c99"
+                class="c9 c99 c100"
               >
                 <div
-                  class="c9 c92"
+                  class="c9 c93"
                 >
                   <div
-                    class="c9 c71"
+                    class="c9 c72"
                   >
                     <h2
-                      class="c83"
+                      class="c84"
                     >
                       Work with us
                     </h2>
                     <div
-                      class="c100 c101"
+                      class="c101 c102"
                     >
                       <p
-                        class="c95"
+                        class="c96"
                       >
                         We're a fast-paced and innovative team, working to support and inspire teachers to deliver great teaching, so every pupil benefits. All our roles are remote-first. If you want to be part of something unique that's making a difference to millions of children's lives, we'd love to hear from you.
                       </p>
                     </div>
                   </div>
                   <div
-                    class="c9 c102"
+                    class="c9 c103"
                   >
                     <div
                       class="c4 c5"
@@ -5179,11 +5185,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Permanent roles
                           </span>
                           <span
-                            class="c20"
+                            class="c34"
                           >
                             <img
                               alt="external"
-                              class="c21"
+                              class="c61"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5218,11 +5224,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Freelance roles
                           </span>
                           <span
-                            class="c20"
+                            class="c34"
                           >
                             <img
                               alt="external"
-                              class="c21"
+                              class="c61"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5237,20 +5243,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c103 c104"
+                class="c9 c104 c105"
               >
                 <div
-                  class="c9 c105"
+                  class="c9 c106"
                 >
                   <div
-                    class="c106 c45"
+                    class="c107 c45"
                   >
                     <span
-                      class="c87"
+                      class="c88"
                     >
                       <img
                         alt=""
-                        class="c107"
+                        class="c108"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -5262,21 +5268,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c9 c108"
+                    class="c9 c109"
                   >
                     <img
                       alt="'In Escape the City's top 1% of employers'"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/top-1-percent-logo_hyga8g.svg"
                     />
                     <img
                       alt="Awarded Gold in Investors In People"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/investor-in-people_eymeqv.svg"
                     />
                     <img
                       alt="Certified as Disability Confident Committed"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/disability-confident_ym07wl.png"
                     />
                   </div>
@@ -5285,14 +5291,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c110"
+            class="c111"
             style="margin-top: -72px;"
           >
             <div
-              class="c111"
+              class="c112"
             >
               <span
-                class="c112"
+                class="c113"
                 style="pointer-events: none;"
               >
                 <img
@@ -5306,13 +5312,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c113 c114"
+                  class="c114 c115"
                 >
                   <h2
-                    class="c115"
+                    class="c116"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5321,31 +5327,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c116"
+                      class="c117"
                     >
                       <li
-                        class="c117"
+                        class="c118"
                       >
                         <div
-                          class="c118 c119"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c120 c121 c122"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c123"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5355,7 +5361,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c124 c125"
+                                class="c125 c126"
                               >
                                 About Oak
                               </div>
@@ -5363,11 +5369,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c76"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5381,28 +5387,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c117"
+                        class="c118"
                       >
                         <div
-                          class="c118 c119"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c120 c121 c122"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c123"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5412,7 +5418,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c124 c125"
+                                class="c125 c126"
                               >
                                 Oak's curricula
                               </div>
@@ -5420,11 +5426,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c76"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5438,28 +5444,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c117"
+                        class="c118"
                       >
                         <div
-                          class="c118 c119"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c120 c121 c122"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c123"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5469,7 +5475,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c124 c125"
+                                class="c125 c126"
                               >
                                 Meet the team
                               </div>
@@ -5477,11 +5483,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c76"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5495,28 +5501,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c117"
+                        class="c118"
                       >
                         <div
-                          class="c118 c119"
+                          class="c119 c120"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c120 c121 c122"
+                              class="c121 c122 c123"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c123"
+                                  class="c124"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5526,7 +5532,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c124 c125"
+                                class="c125 c126"
                               >
                                 Get involved
                               </div>
@@ -5534,11 +5540,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c76"
+                                  class="c77"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5558,33 +5564,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c126"
+            class="c127"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c127"
+                class="c9 c45 c128"
               >
                 <div
-                  class="c128 c1"
+                  class="c129 c1"
                 >
                   <div
-                    class="c9 c129"
+                    class="c9 c130"
                   >
                     <div
-                      class="c9 c45 c130"
+                      class="c9 c45 c131"
                     >
                       <div
-                        class="c131 c132"
+                        class="c132 c133"
                       >
                         <span
-                          class="c133"
+                          class="c134"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5593,13 +5599,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c134"
+                          class="c135"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c135"
+                        class="c136"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5619,18 +5625,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c136 c45 c130"
+                      class="c137 c45 c131"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c137"
+                        class="c138"
                         novalidate=""
                       >
                         <div
-                          class="c138 c139 c140"
+                          class="c139 c140 c141"
                         >
                           <div
-                            class="c141 "
+                            class="c142 "
                           >
                             <div
                               aria-hidden="true"
@@ -5639,7 +5645,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5664,7 +5670,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5689,7 +5695,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5714,7 +5720,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5739,11 +5745,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c143 "
+                              class="c144 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c144 c145 c146"
+                                class="c145 c146 c147"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5755,7 +5761,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c147"
+                                    class="c148"
                                   >
                                     (required)
                                   </span>
@@ -5766,7 +5772,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c148 c149"
+                              class="c149 c150"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5774,7 +5780,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c150 c151 c152"
+                              class="c151 c152 c153"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5787,10 +5793,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c138 c139 c140"
+                          class="c139 c140 c141"
                         >
                           <div
-                            class="c141 "
+                            class="c142 "
                           >
                             <div
                               aria-hidden="true"
@@ -5799,7 +5805,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5824,7 +5830,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5849,7 +5855,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5874,7 +5880,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c142"
+                                class="c143"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5899,11 +5905,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c143 "
+                              class="c144 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c144 c145 c146"
+                                class="c145 c146 c147"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5915,7 +5921,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c147"
+                                    class="c148"
                                   >
                                     (required)
                                   </span>
@@ -5926,7 +5932,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c148 c149"
+                              class="c149 c150"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5934,7 +5940,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c150 c151 c152"
+                              class="c151 c152 c153"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5947,7 +5953,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c153 c80 c154"
+                          class="c154 c81 c155"
                         >
                           <div
                             aria-hidden="true"
@@ -5956,7 +5962,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c142"
+                              class="c143"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5981,7 +5987,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c142"
+                              class="c143"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -6006,7 +6012,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c142"
+                              class="c143"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6031,7 +6037,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c142"
+                              class="c143"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6057,7 +6063,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c150 c151 c152 c155"
+                            class="c151 c152 c153 c156"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6068,10 +6074,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c156 c45"
+                            class="c157 c45"
                           >
                             <label
-                              class="c144 c145 c146"
+                              class="c145 c146 c147"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6083,16 +6089,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c157 c158"
+                            class="c158 c159"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c159 c40 c160"
+                              class="c160 c40 c161"
                             >
                               <span
-                                class="c161 c162"
+                                class="c162 c163"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6101,11 +6107,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c20"
+                              class="c34"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6116,7 +6122,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c163 c5"
+                          class="c164 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -6125,7 +6131,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c164 c19 internal-button"
+                            class="c165 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -6140,12 +6146,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c165"
+                          class="c166"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c166"
+                          class="c167"
                         />
                       </form>
                     </div>
@@ -6157,14 +6163,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c167"
+        class="c168"
       >
         <div
-          class="c168 c45"
+          class="c169 c45"
         >
           <svg
             aria-hidden="true"
-            class="c169"
+            class="c170"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6187,33 +6193,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c170 c171"
+            class="c171 c172"
           >
             <div
-              class="c9 c129"
+              class="c9 c130"
             >
               <div
-                class="c9 c45 c172"
+                class="c9 c45 c173"
               >
                 <div
-                  class="c173 c80"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c174"
+                    class="c175"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c175 c176"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/pupils/years"
                         >
                           <span
@@ -6227,27 +6233,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c179"
+                  class="c180"
                 />
                 <div
-                  class="c173 c80"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c174"
+                    class="c175"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c175 c176"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6258,10 +6264,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6272,10 +6278,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6285,14 +6291,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c180"
+                            class="c181"
                           >
                             <span
-                              class="c76 c181 c182"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6304,10 +6310,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/blog"
                         >
                           <span
@@ -6322,27 +6328,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c172"
+                class="c9 c45 c173"
               >
                 <div
-                  class="c173 c80"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c174"
+                    class="c175"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c175 c176"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/"
                         >
                           <span
@@ -6353,10 +6359,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6367,10 +6373,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6381,10 +6387,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6395,10 +6401,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6409,11 +6415,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c178 "
+                          class="c179 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6423,14 +6429,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c180"
+                            class="c181"
                           >
                             <span
-                              class="c76 c181 c182"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6442,10 +6448,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/contact-us"
                         >
                           <span
@@ -6456,11 +6462,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c178 "
+                          class="c179 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6470,14 +6476,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c180"
+                            class="c181"
                           >
                             <span
-                              class="c76 c181 c182"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6489,10 +6495,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/webinars"
                         >
                           <span
@@ -6503,11 +6509,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c178 "
+                          class="c179 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6517,14 +6523,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c180"
+                            class="c181"
                           >
                             <span
-                              class="c76 c181 c182"
+                              class="c77 c182 c183"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6540,27 +6546,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c172"
+                class="c9 c45 c173"
               >
                 <div
-                  class="c173 c80"
+                  class="c174 c81"
                 >
                   <h2
-                    class="c174"
+                    class="c175"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c175 c176"
+                    class="c176 c177"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6571,10 +6577,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6585,10 +6591,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6599,10 +6605,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <button
-                          class="c178 "
+                          class="c179 "
                         >
                           <span
                             class="c25"
@@ -6612,10 +6618,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6626,10 +6632,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6640,10 +6646,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6654,10 +6660,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6668,10 +6674,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6682,10 +6688,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c177"
+                        class="c178"
                       >
                         <a
-                          class="c178 "
+                          class="c179 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6700,20 +6706,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c172"
+                class="c9 c45 c173"
               >
                 <div
-                  class="c173 c183"
+                  class="c174 c184"
                 >
                   <div
                     class="c38"
                   >
                     <span
-                      class="c184"
+                      class="c185"
                     >
                       <img
                         alt=""
-                        class="c27"
+                        class="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6723,10 +6729,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c185 c186"
+                    class="c186 c187"
                   >
                     <div
-                      class="c44 c45 c187 c188"
+                      class="c44 c45 c188 c189"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6737,13 +6743,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c189 c51 icon-container"
+                            class="c190 c51 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6764,7 +6770,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c187 c188"
+                      class="c44 c45 c188 c189"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6775,13 +6781,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c189 c51 icon-container"
+                            class="c190 c51 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6802,7 +6808,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c187 c188"
+                      class="c44 c45 c188 c189"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6813,13 +6819,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c189 c51 icon-container"
+                            class="c190 c51 icon-container"
                           >
                             <div
-                              class="c190 shadow"
+                              class="c191 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6844,12 +6850,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c87 c191"
+              class="c88 c192"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c27"
+                class="c21"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6860,13 +6866,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c192 c193"
+              class="c193 c194"
             >
               <div
-                class="c194 c195"
+                class="c195 c196"
               >
                 <div
-                  class="c44 c45 c187 c188"
+                  class="c44 c45 c188 c189"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6877,13 +6883,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c189 c51 icon-container"
+                        class="c190 c51 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6904,7 +6910,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c187 c188"
+                  class="c44 c45 c188 c189"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6915,13 +6921,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c189 c51 icon-container"
+                        class="c190 c51 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6942,7 +6948,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c187 c188"
+                  class="c44 c45 c188 c189"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6953,13 +6959,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c189 c51 icon-container"
+                        class="c190 c51 icon-container"
                       >
                         <div
-                          class="c190 shadow"
+                          class="c191 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6984,11 +6990,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c55"
               >
                 <span
-                  class="c184"
+                  class="c185"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -6998,15 +7004,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c173 c80"
+                class="c174 c81"
               >
                 <p
-                  class="c196"
+                  class="c197"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c197"
+                  class="c198"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7015,11 +7021,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c198"
+          class="c199"
         >
           <img
             alt=""
-            class="c199"
+            class="c200"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7028,11 +7034,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c200"
+          class="c201"
         >
           <img
             alt=""
-            class="c201"
+            class="c202"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7044,27 +7050,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c202 c203 c204"
+      class="c203 c204 c205"
     />
   </div>
   <div
-    class="c205"
+    class="c206"
   >
     <div
-      class="c206"
+      class="c207"
       data-testid="cookie-banner"
     >
       <div
-        class="c207"
+        class="c208"
       >
         <div
-          class="c208 c209"
+          class="c209 c210"
         >
           <div
-            class="c210"
+            class="c211"
           >
             <strong
-              class="c211"
+              class="c212"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -7072,13 +7078,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c212"
+            class="c9 c213"
           >
             <div
-              class="c213 c40"
+              class="c214 c40"
             >
               <button
-                class="c214"
+                class="c215"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -7122,7 +7128,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c215 c19 internal-button"
+                class="c216 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -60,9 +60,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 .c20 {
   position: relative;
   width: 1.5rem;
-  min-width: 1.5rem;
   height: 1.5rem;
-  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -84,6 +82,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   width: 2rem;
   height: 2.5rem;
   padding: 0rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c34 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -194,34 +202,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c93 {
+.c94 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -230,7 +238,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -238,7 +246,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -246,12 +254,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   padding-bottom: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   position: -webkit-sticky;
   position: sticky;
   top: 1.25rem;
@@ -261,7 +269,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -272,14 +280,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   padding: 1rem;
   background: #fff7cc;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c96 {
+.c97 {
   width: 100%;
   height: 100%;
   background: #ffffff;
@@ -287,21 +295,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c98 {
+.c99 {
   height: 100%;
   padding: 1rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c101 {
   height: 100%;
   padding-top: 0rem;
   padding-bottom: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c106 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -312,27 +320,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c108 {
+.c109 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c109 {
+.c110 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   position: absolute;
   top: 0rem;
   left: 0rem;
   width: 100%;
-  min-width: 100%;
   height: 100%;
-  min-height: 100%;
   display: none;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
@@ -340,26 +346,26 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c111 {
+.c112 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -369,7 +375,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -380,7 +386,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c124 {
+.c125 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -390,14 +396,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c128 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -409,12 +415,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c132 {
+.c133 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -428,36 +434,36 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c136 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c151 {
+.c152 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c155 {
+.c156 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c159 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c162 {
+.c163 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c166 {
+.c167 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -467,13 +473,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c167 {
+.c168 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c169 {
+.c170 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -485,12 +491,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c172 {
+.c173 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c175 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -502,18 +508,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c178 {
+.c179 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c179 {
+.c180 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c183 {
+.c184 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -522,7 +528,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c185 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -530,7 +536,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c189 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -541,7 +547,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c190 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -552,14 +558,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c191 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c193 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -567,12 +573,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c194 {
+.c195 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c199 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -590,7 +596,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c200 {
+.c201 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -608,7 +614,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c202 {
+.c203 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -618,7 +624,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c205 {
+.c206 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -626,7 +632,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c206 {
+.c207 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -634,13 +640,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c207 {
+.c208 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c208 {
+.c209 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -648,7 +654,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c210 {
+.c211 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -659,7 +665,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c213 {
+.c214 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -721,7 +727,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -740,7 +746,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -839,7 +845,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c152 {
+.c153 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -849,7 +855,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -865,7 +871,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -876,7 +882,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c78 {
+.c79 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -884,7 +890,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c83 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -899,7 +905,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c87 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -914,7 +920,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c89 {
+.c90 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -925,7 +931,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c90 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -936,7 +942,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c101 {
+.c102 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -951,7 +957,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c104 {
+.c105 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -966,7 +972,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c112 {
+.c113 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -977,7 +983,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c119 {
+.c120 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -992,7 +998,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c123 {
+.c124 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1003,7 +1009,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c131 {
+.c132 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1017,7 +1023,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c170 {
+.c171 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1035,7 +1041,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c182 {
+.c183 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1046,7 +1052,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c185 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1062,7 +1068,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c193 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1080,7 +1086,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c195 {
+.c196 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1093,7 +1099,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c203 {
+.c204 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1108,7 +1114,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c209 {
+.c210 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1123,7 +1129,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c212 {
+.c213 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1173,7 +1179,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1196,14 +1202,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #ffe555;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c84 {
+.c85 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -1215,7 +1221,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1226,7 +1232,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c160 {
+.c161 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1237,7 +1243,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c212 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1248,7 +1254,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c168 {
+.c169 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1347,7 +1353,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c30 {
   background: none;
   color: inherit;
   border: none;
@@ -1370,7 +1376,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c30:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1412,7 +1418,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1442,12 +1448,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1471,12 +1477,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c163 {
+.c164 {
   background: none;
   color: inherit;
   border: none;
@@ -1500,12 +1506,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c163:disabled {
+.c164:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c215 {
+.c216 {
   background: none;
   color: inherit;
   border: none;
@@ -1528,12 +1534,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c215:disabled {
+.c216:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c61 {
   object-fit: contain;
 }
 
@@ -1549,19 +1555,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c199 {
+.c200 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c201 {
+.c202 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c27 {
+.c21 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1646,13 +1652,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1660,37 +1666,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c31:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c31:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c31:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c31:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c31:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1698,27 +1704,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1815,31 +1821,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   background: #222222;
 }
 
-.c186 > :first-child:focus-visible .shadow {
+.c187 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c186 > :first-child:hover .shadow {
+.c187 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c186 > :first-child:active .shadow {
+.c187 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c186 > :first-child:disabled .icon-container {
+.c187 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c186 > :first-child:hover .icon-container {
+.c187 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c186 > :first-child:active .icon-container {
+.c187 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1850,7 +1856,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1861,7 +1867,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c102 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1872,7 +1878,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c113 {
+.c114 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1884,7 +1890,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: center;
 }
 
-.c133 {
+.c134 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1895,7 +1901,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c173 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1908,7 +1914,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c29 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1916,7 +1922,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c176 {
+.c177 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1925,7 +1931,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1936,7 +1942,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c92 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -1947,18 +1953,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c103 {
+.c104 {
   font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 
-.c134 {
+.c135 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c164 {
+.c165 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1971,7 +1977,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c165 {
+.c166 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1983,7 +1989,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c196 {
+.c197 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1994,7 +2000,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c197 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2005,7 +2011,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c107 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2016,7 +2022,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c175 {
+.c176 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2027,7 +2033,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c28 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2048,7 +2054,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c80 {
+.c81 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2068,7 +2074,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c181 {
+.c182 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2099,7 +2105,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c180 {
+.c24 .c181 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2114,7 +2120,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c180 {
+.c24:visited .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2124,7 +2130,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c180 {
+.c24:active .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2134,12 +2140,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c180 {
+.c24[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c177 {
+.c178 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2163,47 +2169,47 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c177 .c180 {
+.c178 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c177:focus-visible {
+.c178:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c177:visited {
+.c178:visited {
   color: #222222;
 }
 
-.c177:visited .c180 {
+.c178:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c177:active {
+.c178:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c177:active .c180 {
+.c178:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c177[disabled] {
+.c178[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c177[disabled] .c180 {
+.c178[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c214 {
+.c215 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2236,42 +2242,42 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c214 .c180 {
+.c215 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c214:focus-visible {
+.c215:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c214:visited {
+.c215:visited {
   color: #222222;
 }
 
-.c214:visited .c180 {
+.c215:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c214:active {
+.c215:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c214:active .c180 {
+.c215:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c214[disabled] {
+.c215[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c214[disabled] .c180 {
+.c215[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2334,7 +2340,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   background: #ffffff;
 }
 
-.c94 {
+.c95 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2344,13 +2350,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(auto-fit,minmax(200px,1fr));
 }
 
-.c128 {
+.c129 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c129 {
+.c130 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2359,7 +2365,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c171 {
+.c172 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2368,52 +2374,52 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c97 {
+.c98 {
   box-shadow: none;
 }
 
-.c97:has(a:hover,button:hover) {
+.c98:has(a:hover,button:hover) {
   background-color: #f2f2f2;
   box-shadow: none;
 }
 
-.c97:has( a, button) {
+.c98:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c97:has( a, button)  a,
-.c97:has( a, button) button {
+.c98:has( a, button)  a,
+.c98:has( a, button) button {
   outline: none;
 }
 
-.c97:has(a:active,button:active) {
+.c98:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c117 {
+.c118 {
   box-shadow: none;
 }
 
-.c117:has(a:hover,button:hover) {
+.c118:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c117:has( a, button) {
+.c118:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c117:has( a, button)  a,
-.c117:has( a, button) button {
+.c118:has( a, button)  a,
+.c118:has( a, button) button {
   outline: none;
 }
 
-.c117:has(a:active,button:active) {
+.c118:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c99 {
+.c100 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2421,18 +2427,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c99:hover h1,
-.c99:hover h2,
-.c99:hover h3,
-.c99:hover h4,
-.c99:hover h5,
-.c99:hover h6,
-.c99:hover span {
+.c100:hover h1,
+.c100:hover h2,
+.c100:hover h3,
+.c100:hover h4,
+.c100:hover h5,
+.c100:hover h6,
+.c100:hover span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c99:hover span {
+.c100:hover span {
   -webkit-text-decoration-thickness: 18%;
   text-decoration-thickness: 18%;
 }
@@ -2445,69 +2451,69 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c81 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-column-gap: 1rem;
-  column-gap: 1rem;
-  padding-left: 0rem;
-  padding-right: 0rem;
-}
-
-.c81:focus-visible {
-  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-  border-color: transparent;
-  border-radius: 4px;
-}
-
-.c86 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-column-gap: 1rem;
-  column-gap: 1rem;
-  padding-left: 0rem;
-  padding-right: 0rem;
-}
-
-.c86:focus-visible {
-  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-  border-color: transparent;
-  border-radius: 4px;
-}
-
 .c82 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
+}
+
+.c82:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+.c87 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
+}
+
+.c87:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2516,27 +2522,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c204 {
+.c205 {
   top: 152px;
 }
 
-.c187 .icon-container > *:first-child {
+.c188 .icon-container > *:first-child {
   border: 0;
 }
 
-.c191 {
+.c192 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c148 {
+.c149 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c138 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2547,23 +2553,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c137::-webkit-scrollbar-track {
+.c138::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c137::-webkit-scrollbar {
+.c138::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c137::-webkit-scrollbar-thumb {
+.c138::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c140 {
+.c141 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2572,23 +2578,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c140::-webkit-scrollbar-track {
+.c141::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar {
+.c141::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar-thumb {
+.c141::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c142 {
+.c143 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2596,30 +2602,30 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c142::-webkit-scrollbar-track {
+.c143::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c142::-webkit-scrollbar {
+.c143::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c142::-webkit-scrollbar-thumb {
+.c143::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c138 {
+.c139 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c156 {
+.c157 {
   background: none;
   color: inherit;
   border: none;
@@ -2630,21 +2636,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c120:hover {
+.c121:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c115 {
+.c116 {
   padding: 0;
   margin: 0;
 }
 
-.c114 {
+.c115 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2656,7 +2662,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c141 {
+.c142 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2668,7 +2674,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c146 {
+.c147 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2679,32 +2685,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c146::-webkit-input-placeholder {
+.c147::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c146::-moz-placeholder {
+.c147::-moz-placeholder {
   color: #575757;
 }
 
-.c146:-ms-input-placeholder {
+.c147:-ms-input-placeholder {
   color: #575757;
 }
 
-.c146::placeholder {
+.c147::placeholder {
   color: #575757;
 }
 
-.c146::-webkit-search-decoration,
-.c146::-webkit-search-cancel-button,
-.c146::-webkit-search-results-button,
-.c146::-webkit-search-results-decoration {
+.c147::-webkit-search-decoration,
+.c147::-webkit-search-cancel-button,
+.c147::-webkit-search-results-button,
+.c147::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c144 {
+.c145 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2714,7 +2720,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c150 {
+.c151 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2727,7 +2733,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c145 {
+.c146 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2738,16 +2744,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c139:focus-within .c143 {
+.c140:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c139:focus-within .c149 {
+.c140:focus-within .c150 {
   display: inline;
 }
 
-.c147 {
+.c148 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2763,7 +2769,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: none;
 }
 
-.c147::-webkit-input-placeholder {
+.c148::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2771,7 +2777,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c147::-moz-placeholder {
+.c148::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2779,7 +2785,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c147:-ms-input-placeholder {
+.c148:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2787,7 +2793,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c147::placeholder {
+.c148::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2795,40 +2801,40 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c147:valid:not([value=""]) {
+.c148:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c147:valid:not([value=""])::-webkit-input-placeholder {
+.c148:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c147:valid:not([value=""])::-moz-placeholder {
+.c148:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c147:valid:not([value=""]):-ms-input-placeholder {
+.c148:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c147:valid:not([value=""])::placeholder {
+.c148:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c154 {
+.c155 {
   display: none;
 }
 
-.c153:focus-within .c143 {
+.c154:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c157 {
+.c158 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2855,28 +2861,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #575757;
 }
 
-.c159 {
+.c160 {
   max-width: calc(100% - 20px);
 }
 
-.c161 {
+.c162 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c136 {
+.c137 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c127 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c95 {
+.c96 {
   list-style: none;
 }
 
@@ -2984,19 +2990,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3010,97 +3016,97 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c79 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3109,7 +3115,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3118,13 +3124,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3132,7 +3138,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3140,79 +3146,79 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c112 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c112 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c112 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c112 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c169 {
+  .c170 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c169 {
+  .c170 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c172 {
+  .c173 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c178 {
+  .c179 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c184 {
+  .c185 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c195 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3221,13 +3227,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c199 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c199 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3235,7 +3241,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c198 {
+  .c199 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3243,19 +3249,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3263,61 +3269,61 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3364,31 +3370,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3396,38 +3402,38 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-column-gap: 0.25rem;
     column-gap: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c182 {
+  .c183 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3436,13 +3442,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c185 {
+  .c186 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3450,7 +3456,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3459,7 +3465,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3468,7 +3474,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c195 {
+  .c196 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3477,7 +3483,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c203 {
+  .c204 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3486,7 +3492,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3494,7 +3500,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3502,7 +3508,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3511,7 +3517,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3520,19 +3526,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c209 {
+  .c210 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3540,7 +3546,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3548,7 +3554,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c212 {
+  .c213 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3556,7 +3562,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     gap: 2rem;
   }
 }
@@ -3616,25 +3622,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3667,43 +3673,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3712,7 +3718,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3721,43 +3727,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3766,7 +3772,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3775,43 +3781,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3820,7 +3826,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3829,43 +3835,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3874,7 +3880,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3883,49 +3889,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3934,7 +3940,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3952,16 +3958,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c180,
-  .c24:visited:hover .c180 {
+  .c24:hover .c181,
+  .c24:visited:hover .c181 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c177:hover,
-  .c177:visited:hover {
+  .c178:hover,
+  .c178:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3969,16 +3975,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c177:hover .c180,
-  .c177:visited:hover .c180 {
+  .c178:hover .c181,
+  .c178:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c214:hover,
-  .c214:visited:hover {
+  .c215:hover,
+  .c215:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3986,8 +3992,8 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c214:hover .c180,
-  .c214:visited:hover .c180 {
+  .c215:hover .c181,
+  .c215:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -4007,23 +4013,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c130 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c171 {
+  .c172 {
     grid-column: span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     border-left: 4px solid #222222;
   }
 
-  .c81:hover {
+  .c82:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #575757;
@@ -4031,7 +4037,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4039,7 +4045,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4048,23 +4054,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-right: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     border-left: 4px solid transparent;
   }
 
-  .c86:hover {
+  .c87:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
@@ -4072,7 +4078,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4080,7 +4086,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4089,37 +4095,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-right: 0.75rem;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:800px) {
-  .c114 {
+  .c115 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c147 {
+  .c148 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c127 {
     max-width: 870px;
   }
 }
@@ -4311,7 +4317,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               >
                 <img
                   alt=""
-                  class="c27"
+                  class="c21"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4322,7 +4328,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c27"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4330,10 +4336,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c28"
               >
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4347,15 +4353,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Primary
                         </span>
@@ -4364,7 +4370,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4378,15 +4384,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Secondary
                         </span>
@@ -4395,7 +4401,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4409,15 +4415,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Guidance
                         </span>
@@ -4426,7 +4432,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4440,15 +4446,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           About us
                         </span>
@@ -4457,7 +4463,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4470,21 +4476,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -4548,7 +4554,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             class="c52 shadow"
                           />
                           <span
-                            class="c20"
+                            class="c34"
                             data-icon-for="button"
                           >
                             <img
@@ -4591,7 +4597,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c52 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4626,7 +4632,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4635,7 +4641,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4651,13 +4657,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c32"
                   >
                     <span
-                      class="c34"
+                      class="c33"
                     >
                       Sign in
                     </span>
@@ -4667,7 +4673,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4681,14 +4687,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
                   class="c9 c49"
                 >
                   <span
-                    class="c20"
+                    class="c34"
                   >
                     <img
                       alt=""
@@ -4710,45 +4716,45 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Meet the team
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   Learn more about the experts from across education, technology, school support and education who make up our leadership team and board.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4762,44 +4768,44 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c77 c78"
+              class="c78 c79"
             >
               <div
-                class="c77"
+                class="c78"
               >
                 <nav
                   aria-label="page sections"
-                  class="c79"
+                  class="c80"
                 >
                   <ul
-                    class="c80"
+                    class="c81"
                   >
                     <li
-                      class="c30"
+                      class="c29"
                     >
                       <a
                         aria-current="true"
-                        class="c81 c82"
+                        class="c82 c83"
                         href="#our-leadership"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Our leadership
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4810,27 +4816,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c30"
+                      class="c29"
                     >
                       <a
-                        class="c86 c82"
+                        class="c87 c83"
                         href="#our-board"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Our board
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4841,27 +4847,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c30"
+                      class="c29"
                     >
                       <a
-                        class="c86 c82"
+                        class="c87 c83"
                         href="#documents"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Documents
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4875,76 +4881,76 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </nav>
               </div>
               <div
-                class="c9 c87"
+                class="c9 c88"
               >
                 <div
-                  class="c88"
+                  class="c89"
                   id="our-leadership"
                 >
                   <div
-                    class="c9 c89"
+                    class="c9 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <h2
-                        class="c91"
+                        class="c92"
                       >
                         Our leadership
                       </h2>
                       <p
-                        class="c92"
+                        class="c93"
                       >
                         Our leadership team brings together experts to deliver the best support to teachers and value for money for the public.
                       </p>
                     </div>
                     <ul
-                      class="c93 c94"
+                      class="c94 c95"
                     >
                       <li
-                        class="c95"
+                        class="c96"
                       >
                         <div
-                          class="c96 c97"
+                          class="c97 c98"
                         >
                           <a
-                            class="c98 c90 c99"
+                            class="c99 c91 c100"
                             href="/about-us/meet-the-team/ed-southall?section=leadership"
                           >
                             <div
-                              class="c100 c101"
+                              class="c101 c102"
                             >
                               <div
-                                class="c9 c90"
+                                class="c9 c91"
                               >
                                 <h3
-                                  class="c102"
+                                  class="c103"
                                 >
                                   Ed Southall
                                 </h3>
                                 <p
-                                  class="c103"
+                                  class="c104"
                                 >
                                   Subject Lead (maths)
                                 </p>
                               </div>
                               <div
-                                class="c9 c104"
+                                class="c9 c105"
                               >
                                 <div
                                   class="c9 c40"
                                 >
                                   <span
-                                    class="c105"
+                                    class="c106"
                                   >
                                     See bio
                                   </span>
                                   <span
-                                    class="c20"
+                                    class="c34"
                                   >
                                     <img
                                       alt=""
-                                      class="c21"
+                                      class="c61"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -4962,73 +4968,73 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c88"
+                  class="c89"
                   id="our-board"
                 >
                   <div
-                    class="c9 c89"
+                    class="c9 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <h2
-                        class="c91"
+                        class="c92"
                       >
                         Our board
                       </h2>
                       <p
-                        class="c92"
+                        class="c93"
                       >
                         Our Board oversees all of our work at Oak National Academy. They provide strategic direction and safeguard our independence.
                       </p>
                     </div>
                     <ul
-                      class="c93 c94"
+                      class="c94 c95"
                     >
                       <li
-                        class="c95"
+                        class="c96"
                       >
                         <div
-                          class="c96 c97"
+                          class="c97 c98"
                         >
                           <a
-                            class="c98 c90 c99"
+                            class="c99 c91 c100"
                             href="/about-us/meet-the-team/ed-southall?section=board"
                           >
                             <div
-                              class="c100 c101"
+                              class="c101 c102"
                             >
                               <div
-                                class="c9 c90"
+                                class="c9 c91"
                               >
                                 <h3
-                                  class="c102"
+                                  class="c103"
                                 >
                                   Ed Southall
                                 </h3>
                                 <p
-                                  class="c103"
+                                  class="c104"
                                 >
                                   Subject Lead (maths)
                                 </p>
                               </div>
                               <div
-                                class="c9 c104"
+                                class="c9 c105"
                               >
                                 <div
                                   class="c9 c40"
                                 >
                                   <span
-                                    class="c105"
+                                    class="c106"
                                   >
                                     See bio
                                   </span>
                                   <span
-                                    class="c20"
+                                    class="c34"
                                   >
                                     <img
                                       alt=""
-                                      class="c21"
+                                      class="c61"
                                       data-nimg="fill"
                                       decoding="async"
                                       loading="lazy"
@@ -5046,15 +5052,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c90"
+                  class="c9 c91"
                 >
                   <h2
-                    class="c91"
+                    class="c92"
                   >
                     Governance
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <p>
                       Test governance text
@@ -5065,14 +5071,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c108"
+            class="c109"
             style="margin-top: -72px;"
           >
             <div
-              class="c109"
+              class="c110"
             >
               <span
-                class="c110"
+                class="c111"
                 style="pointer-events: none;"
               >
                 <img
@@ -5086,13 +5092,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c111 c112"
+                  class="c112 c113"
                 >
                   <h2
-                    class="c113"
+                    class="c114"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5101,31 +5107,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c114"
+                      class="c115"
                     >
                       <li
-                        class="c115"
+                        class="c116"
                       >
                         <div
-                          class="c116 c117"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c121"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5135,7 +5141,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c122 c123"
+                                class="c123 c124"
                               >
                                 About Oak
                               </div>
@@ -5143,11 +5149,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5161,28 +5167,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c115"
+                        class="c116"
                       >
                         <div
-                          class="c116 c117"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c121"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5192,7 +5198,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c122 c123"
+                                class="c123 c124"
                               >
                                 Oak's curricula
                               </div>
@@ -5200,11 +5206,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5218,28 +5224,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c115"
+                        class="c116"
                       >
                         <div
-                          class="c116 c117"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c121"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5249,7 +5255,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c122 c123"
+                                class="c123 c124"
                               >
                                 Meet the team
                               </div>
@@ -5257,11 +5263,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5275,28 +5281,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c115"
+                        class="c116"
                       >
                         <div
-                          class="c116 c117"
+                          class="c117 c118"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c121"
+                                  class="c122"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5306,7 +5312,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c122 c123"
+                                class="c123 c124"
                               >
                                 Get involved
                               </div>
@@ -5314,11 +5320,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c124"
+                                  class="c125"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5338,33 +5344,33 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c125"
+            class="c126"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c126"
+                class="c9 c45 c127"
               >
                 <div
-                  class="c127 c1"
+                  class="c128 c1"
                 >
                   <div
-                    class="c9 c128"
+                    class="c9 c129"
                   >
                     <div
-                      class="c9 c45 c129"
+                      class="c9 c45 c130"
                     >
                       <div
-                        class="c130 c131"
+                        class="c131 c132"
                       >
                         <span
-                          class="c132"
+                          class="c133"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5373,13 +5379,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c133"
+                          class="c134"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c134"
+                        class="c135"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5399,18 +5405,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c135 c45 c129"
+                      class="c136 c45 c130"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c136"
+                        class="c137"
                         novalidate=""
                       >
                         <div
-                          class="c137 c138 c139"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c140 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
@@ -5419,7 +5425,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5444,7 +5450,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5469,7 +5475,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5494,7 +5500,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5519,11 +5525,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c142 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c143 c144 c145"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5535,7 +5541,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c105"
+                                    class="c106"
                                   >
                                     (required)
                                   </span>
@@ -5546,7 +5552,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c146 c147"
+                              class="c147 c148"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5554,7 +5560,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c148 c149 c150"
+                              class="c149 c150 c151"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5567,10 +5573,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c137 c138 c139"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c140 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
@@ -5579,7 +5585,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5604,7 +5610,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5629,7 +5635,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5654,7 +5660,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5679,11 +5685,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c142 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c143 c144 c145"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5695,7 +5701,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c105"
+                                    class="c106"
                                   >
                                     (required)
                                   </span>
@@ -5706,7 +5712,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c146 c147"
+                              class="c147 c148"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5714,7 +5720,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c148 c149 c150"
+                              class="c149 c150 c151"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5727,7 +5733,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c151 c152 c153"
+                          class="c152 c153 c154"
                         >
                           <div
                             aria-hidden="true"
@@ -5736,7 +5742,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5761,7 +5767,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5786,7 +5792,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5811,7 +5817,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5837,7 +5843,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c148 c149 c150 c154"
+                            class="c149 c150 c151 c155"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5848,10 +5854,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c155 c45"
+                            class="c156 c45"
                           >
                             <label
-                              class="c143 c144 c145"
+                              class="c144 c145 c146"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5863,16 +5869,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c156 c157"
+                            class="c157 c158"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c158 c40 c159"
+                              class="c159 c40 c160"
                             >
                               <span
-                                class="c160 c161"
+                                class="c161 c162"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5881,11 +5887,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c20"
+                              class="c34"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5896,7 +5902,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c162 c5"
+                          class="c163 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -5905,7 +5911,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c163 c19 internal-button"
+                            class="c164 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -5920,12 +5926,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c164"
+                          class="c165"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c165"
+                          class="c166"
                         />
                       </form>
                     </div>
@@ -5937,14 +5943,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c166"
+        class="c167"
       >
         <div
-          class="c167 c45"
+          class="c168 c45"
         >
           <svg
             aria-hidden="true"
-            class="c168"
+            class="c169"
             height="100%"
             name="header-underline"
             width="100%"
@@ -5967,33 +5973,33 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c169 c170"
+            class="c170 c171"
           >
             <div
-              class="c9 c128"
+              class="c9 c129"
             >
               <div
-                class="c9 c45 c171"
+                class="c9 c45 c172"
               >
                 <div
-                  class="c172 c152"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/pupils/years"
                         >
                           <span
@@ -6007,27 +6013,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c178"
+                  class="c179"
                 />
                 <div
-                  class="c172 c152"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6038,10 +6044,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6052,10 +6058,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6065,14 +6071,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c124 c180 c181"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6084,10 +6090,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/blog"
                         >
                           <span
@@ -6102,27 +6108,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c45 c172"
               >
                 <div
-                  class="c172 c152"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/"
                         >
                           <span
@@ -6133,10 +6139,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6147,10 +6153,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6161,10 +6167,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6175,10 +6181,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6189,11 +6195,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6203,14 +6209,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c124 c180 c181"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6222,10 +6228,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/contact-us"
                         >
                           <span
@@ -6236,11 +6242,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6250,14 +6256,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c124 c180 c181"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6269,10 +6275,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/webinars"
                         >
                           <span
@@ -6283,11 +6289,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6297,14 +6303,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c124 c180 c181"
+                              class="c125 c181 c182"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6320,27 +6326,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c45 c172"
               >
                 <div
-                  class="c172 c152"
+                  class="c173 c153"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6351,10 +6357,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6365,10 +6371,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6379,10 +6385,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <button
-                          class="c177 "
+                          class="c178 "
                         >
                           <span
                             class="c25"
@@ -6392,10 +6398,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6406,10 +6412,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6420,10 +6426,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6434,10 +6440,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6448,10 +6454,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6462,10 +6468,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6480,20 +6486,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c45 c172"
               >
                 <div
-                  class="c172 c182"
+                  class="c173 c183"
                 >
                   <div
                     class="c38"
                   >
                     <span
-                      class="c183"
+                      class="c184"
                     >
                       <img
                         alt=""
-                        class="c27"
+                        class="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6503,10 +6509,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c184 c185"
+                    class="c185 c186"
                   >
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6517,13 +6523,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6544,7 +6550,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6555,13 +6561,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6582,7 +6588,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6593,13 +6599,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6624,12 +6630,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c190 c191"
+              class="c191 c192"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c27"
+                class="c21"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6640,13 +6646,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c192 c193"
+              class="c193 c194"
             >
               <div
-                class="c194 c195"
+                class="c195 c196"
               >
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6657,13 +6663,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6684,7 +6690,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6695,13 +6701,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6722,7 +6728,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6733,13 +6739,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6764,11 +6770,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c55"
               >
                 <span
-                  class="c183"
+                  class="c184"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -6778,15 +6784,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c172 c152"
+                class="c173 c153"
               >
                 <p
-                  class="c196"
+                  class="c197"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c197"
+                  class="c198"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6795,11 +6801,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c198"
+          class="c199"
         >
           <img
             alt=""
-            class="c199"
+            class="c200"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6808,11 +6814,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c200"
+          class="c201"
         >
           <img
             alt=""
-            class="c201"
+            class="c202"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6824,27 +6830,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c202 c203 c204"
+      class="c203 c204 c205"
     />
   </div>
   <div
-    class="c205"
+    class="c206"
   >
     <div
-      class="c206"
+      class="c207"
       data-testid="cookie-banner"
     >
       <div
-        class="c207"
+        class="c208"
       >
         <div
-          class="c208 c209"
+          class="c209 c210"
         >
           <div
-            class="c210"
+            class="c211"
           >
             <strong
-              class="c211"
+              class="c212"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6852,13 +6858,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c212"
+            class="c9 c213"
           >
             <div
-              class="c213 c40"
+              class="c214 c40"
             >
               <button
-                class="c214"
+                class="c215"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6902,7 +6908,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c215 c19 internal-button"
+                class="c216 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -60,9 +60,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 .c20 {
   position: relative;
   width: 1.5rem;
-  min-width: 1.5rem;
   height: 1.5rem;
-  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -84,6 +82,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   width: 2rem;
   height: 2.5rem;
   padding: 0rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c34 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -194,34 +202,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c80 {
+.c81 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -230,7 +238,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -238,7 +246,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -246,18 +254,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   background: #f5e9f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c78 {
+.c79 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c83 {
+.c84 {
   padding: 1.5rem;
   background: #ffffff;
   border: 0.125rem solid;
@@ -266,7 +274,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -277,7 +285,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c87 {
+.c88 {
   position: relative;
   width: 5rem;
   min-width: 5rem;
@@ -288,7 +296,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   position: relative;
   width: 4.5rem;
   min-width: 4.5rem;
@@ -299,7 +307,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c90 {
   position: relative;
   width: 4rem;
   min-width: 4rem;
@@ -310,21 +318,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c90 {
+.c91 {
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c97 {
+.c98 {
   position: relative;
   width: 100%;
   height: 22.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c98 {
+.c99 {
   position: relative;
   object-position: center;
   width: 100%;
@@ -333,33 +341,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c99 {
+.c100 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c101 {
+.c102 {
   background: transparent;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c103 {
   padding-right: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c104 {
+.c105 {
   width: 0.5rem;
   background: #deb7d5;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c108 {
+.c109 {
   max-width: 40rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c111 {
+.c112 {
   position: relative;
   top: 0.5rem;
   left: 0.5rem;
@@ -387,7 +395,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 298;
 }
 
-.c112 {
+.c113 {
   position: relative;
   border: 0.125rem solid;
   border-color: #222222;
@@ -396,7 +404,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 150;
 }
 
-.c113 {
+.c114 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -404,12 +412,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   width: 100%;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0rem;
@@ -418,7 +426,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -426,7 +434,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   position: relative;
   width: 0.125rem;
   height: 3rem;
@@ -434,7 +442,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c129 {
   width: 100%;
   border-top-left-radius: 0rem;
   border-top-right-radius: 0.25rem;
@@ -443,14 +451,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c130 {
   padding-left: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -462,7 +470,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c131 {
+.c132 {
   position: absolute;
   right: 0rem;
   width: -webkit-fit-content;
@@ -476,13 +484,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 3;
 }
 
-.c134 {
+.c135 {
   padding-top: 5rem;
   padding-bottom: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c141 {
   position: relative;
   width: 100%;
   height: 100%;
@@ -490,27 +498,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c141 {
+.c142 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c142 {
+.c143 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c143 {
+.c144 {
   position: absolute;
   top: 0rem;
   left: 0rem;
   width: 100%;
-  min-width: 100%;
   height: 100%;
-  min-height: 100%;
   display: none;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
@@ -518,26 +524,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c144 {
+.c145 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c149 {
+.c150 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c151 {
+.c152 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c154 {
+.c155 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -547,7 +553,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c155 {
+.c156 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -558,7 +564,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c157 {
+.c158 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -568,14 +574,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c159 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c160 {
+.c161 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -587,12 +593,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c164 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c165 {
+.c166 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -606,36 +612,36 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c168 {
+.c169 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c185 {
+.c186 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c189 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c192 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c196 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c200 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -645,13 +651,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c200 {
+.c201 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c202 {
+.c203 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -663,23 +669,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c205 {
+.c206 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c210 {
+.c211 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c211 {
+.c212 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c215 {
+.c216 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -688,7 +694,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c216 {
+.c217 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -696,7 +702,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c220 {
+.c221 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -707,7 +713,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c221 {
+.c222 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -718,14 +724,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c222 {
+.c223 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c224 {
+.c225 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -733,12 +739,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c226 {
+.c227 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c230 {
+.c231 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -756,7 +762,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c232 {
+.c233 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -774,7 +780,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c234 {
+.c235 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -784,7 +790,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c237 {
+.c238 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -792,7 +798,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c238 {
+.c239 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -800,13 +806,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c239 {
+.c240 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c240 {
+.c241 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -814,7 +820,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c242 {
+.c243 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -825,7 +831,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c245 {
+.c246 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -887,7 +893,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -906,7 +912,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1005,7 +1011,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c136 {
+.c137 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1016,7 +1022,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c94 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1026,7 +1032,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1042,7 +1048,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1053,7 +1059,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c79 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1064,7 +1070,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c81 {
+.c82 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1079,7 +1085,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c84 {
+.c85 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1100,7 +1106,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-basis: 0;
 }
 
-.c91 {
+.c92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1116,7 +1122,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1138,7 +1144,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 4rem;
 }
 
-.c100 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1149,7 +1155,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3rem;
 }
 
-.c103 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1161,7 +1167,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   column-gap: 1.5rem;
 }
 
-.c105 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1171,7 +1177,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c109 {
+.c110 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1182,7 +1188,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1201,7 +1207,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c115 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1219,7 +1225,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c117 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1229,7 +1235,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-self: stretch;
 }
 
-.c127 {
+.c128 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1240,14 +1246,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c132 {
+.c133 {
   display: none;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.c145 {
+.c146 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1258,7 +1264,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c152 {
+.c153 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1273,7 +1279,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c156 {
+.c157 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1284,7 +1290,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c164 {
+.c165 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1298,7 +1304,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c203 {
+.c204 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1316,7 +1322,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c214 {
+.c215 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1327,7 +1333,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c217 {
+.c218 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1343,7 +1349,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c225 {
+.c226 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1361,7 +1367,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c227 {
+.c228 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1374,7 +1380,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c235 {
+.c236 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1389,7 +1395,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c241 {
+.c242 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1404,7 +1410,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c244 {
+.c245 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1454,7 +1460,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1477,14 +1483,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #deb7d5;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c123 {
+.c124 {
   color: #222222;
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1497,7 +1503,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c179 {
+.c180 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1508,7 +1514,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c193 {
+.c194 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1519,7 +1525,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c243 {
+.c244 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1530,7 +1536,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c201 {
+.c202 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1629,7 +1635,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c30 {
   background: none;
   color: inherit;
   border: none;
@@ -1652,7 +1658,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c30:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1694,7 +1700,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1724,12 +1730,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1753,12 +1759,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c133 {
+.c134 {
   background: none;
   color: inherit;
   border: none;
@@ -1781,12 +1787,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c133:disabled {
+.c134:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c196 {
+.c197 {
   background: none;
   color: inherit;
   border: none;
@@ -1810,12 +1816,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c196:disabled {
+.c197:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c61 {
   object-fit: contain;
 }
 
@@ -1831,19 +1837,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c231 {
+.c232 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c233 {
+.c234 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c27 {
+.c21 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1928,13 +1934,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1942,37 +1948,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c31:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c31:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c31:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c31:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c31:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1980,27 +1986,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -2097,31 +2103,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   background: #222222;
 }
 
-.c218 > :first-child:focus-visible .shadow {
+.c219 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c218 > :first-child:hover .shadow {
+.c219 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c218 > :first-child:active .shadow {
+.c219 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c218 > :first-child:disabled .icon-container {
+.c219 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c218 > :first-child:hover .icon-container {
+.c219 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c218 > :first-child:active .icon-container {
+.c219 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2132,7 +2138,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c95 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2143,7 +2149,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c106 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2156,7 +2162,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c110 {
+.c111 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2167,7 +2173,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c135 {
+.c136 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2178,7 +2184,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c146 {
+.c147 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2190,7 +2196,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: center;
 }
 
-.c166 {
+.c167 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2201,7 +2207,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c206 {
+.c207 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -2214,7 +2220,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c29 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2222,7 +2228,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c139 {
+.c140 {
   overflow: hidden;
   aspect-ratio: 1/1;
   border-color: #cacaca;
@@ -2238,7 +2244,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c208 {
+.c209 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2247,7 +2253,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -2258,7 +2264,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c86 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
@@ -2271,7 +2277,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c96 {
+.c97 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2284,7 +2290,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-bottom: 0.75rem;
 }
 
-.c107 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2295,7 +2301,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c124 {
+.c125 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2307,7 +2313,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c137 {
+.c138 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2318,13 +2324,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c167 {
+.c168 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c197 {
+.c198 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2337,7 +2343,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c198 {
+.c199 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2349,7 +2355,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c228 {
+.c229 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2360,7 +2366,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c229 {
+.c230 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2371,7 +2377,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c207 {
+.c208 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2382,7 +2388,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c28 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2403,7 +2409,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c213 {
+.c214 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2434,7 +2440,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c212 {
+.c24 .c213 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2449,7 +2455,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c212 {
+.c24:visited .c213 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2459,7 +2465,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c212 {
+.c24:active .c213 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2469,12 +2475,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c212 {
+.c24[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c209 {
+.c210 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2498,47 +2504,47 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c209 .c212 {
+.c210 .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c209:focus-visible {
+.c210:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c209:visited {
+.c210:visited {
   color: #222222;
 }
 
-.c209:visited .c212 {
+.c210:visited .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c209:active {
+.c210:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c209:active .c212 {
+.c210:active .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c209[disabled] {
+.c210[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c209[disabled] .c212 {
+.c210[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c246 {
+.c247 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2571,42 +2577,42 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c246 .c212 {
+.c247 .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c246:focus-visible {
+.c247:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c246:visited {
+.c247:visited {
   color: #222222;
 }
 
-.c246:visited .c212 {
+.c247:visited .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c246:active {
+.c247:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c246:active .c212 {
+.c247:active .c213 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c246[disabled] {
+.c247[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c246[disabled] .c212 {
+.c247[disabled] .c213 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2669,7 +2675,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   background: #ffffff;
 }
 
-.c138 {
+.c139 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2679,13 +2685,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c161 {
+.c162 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c162 {
+.c163 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2694,7 +2700,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c204 {
+.c205 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2703,46 +2709,46 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c119 {
+.c120 {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c119:has(a:hover,button:hover) {
+.c120:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c119:has( a, button) {
+.c120:has( a, button) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c119:has( a, button)  a,
-.c119:has( a, button) button {
+.c120:has( a, button)  a,
+.c120:has( a, button) button {
   outline: none;
 }
 
-.c119:has(a:active,button:active) {
+.c120:has(a:active,button:active) {
   box-shadow: none;
 }
 
-.c150 {
+.c151 {
   box-shadow: none;
 }
 
-.c150:has(a:hover,button:hover) {
+.c151:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c150:has( a, button) {
+.c151:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c150:has( a, button)  a,
-.c150:has( a, button) button {
+.c151:has( a, button)  a,
+.c151:has( a, button) button {
   outline: none;
 }
 
-.c150:has(a:active,button:active) {
+.c151:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
@@ -2754,27 +2760,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c236 {
+.c237 {
   top: 152px;
 }
 
-.c219 .icon-container > *:first-child {
+.c220 .icon-container > *:first-child {
   border: 0;
 }
 
-.c223 {
+.c224 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c182 {
+.c183 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c171 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2785,23 +2791,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c170::-webkit-scrollbar-track {
+.c171::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c170::-webkit-scrollbar {
+.c171::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c170::-webkit-scrollbar-thumb {
+.c171::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c173 {
+.c174 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2810,23 +2816,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c173::-webkit-scrollbar-track {
+.c174::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c173::-webkit-scrollbar {
+.c174::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c173::-webkit-scrollbar-thumb {
+.c174::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c175 {
+.c176 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2834,39 +2840,39 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c175::-webkit-scrollbar-track {
+.c176::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c175::-webkit-scrollbar {
+.c176::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c175::-webkit-scrollbar-thumb {
+.c176::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c171 {
+.c172 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c153:hover {
+.c154:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c148 {
+.c149 {
   padding: 0;
   margin: 0;
 }
 
-.c147 {
+.c148 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2878,7 +2884,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c126 {
+.c127 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2891,7 +2897,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c174 {
+.c175 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2903,7 +2909,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c180 {
+.c181 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2914,32 +2920,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c180::-webkit-input-placeholder {
+.c181::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c180::-moz-placeholder {
+.c181::-moz-placeholder {
   color: #575757;
 }
 
-.c180:-ms-input-placeholder {
+.c181:-ms-input-placeholder {
   color: #575757;
 }
 
-.c180::placeholder {
+.c181::placeholder {
   color: #575757;
 }
 
-.c180::-webkit-search-decoration,
-.c180::-webkit-search-cancel-button,
-.c180::-webkit-search-results-button,
-.c180::-webkit-search-results-decoration {
+.c181::-webkit-search-decoration,
+.c181::-webkit-search-cancel-button,
+.c181::-webkit-search-results-button,
+.c181::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c177 {
+.c178 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2949,7 +2955,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c184 {
+.c185 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2962,7 +2968,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c178 {
+.c179 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2973,16 +2979,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c172:focus-within .c176 {
+.c173:focus-within .c177 {
   background: #374cf1;
   color: #fff;
 }
 
-.c172:focus-within .c183 {
+.c173:focus-within .c184 {
   display: inline;
 }
 
-.c181 {
+.c182 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2998,7 +3004,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: none;
 }
 
-.c181::-webkit-input-placeholder {
+.c182::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3006,7 +3012,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c181::-moz-placeholder {
+.c182::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3014,7 +3020,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c181:-ms-input-placeholder {
+.c182:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3022,7 +3028,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c181::placeholder {
+.c182::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3030,31 +3036,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c181:valid:not([value=""]) {
+.c182:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c181:valid:not([value=""])::-webkit-input-placeholder {
+.c182:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c181:valid:not([value=""])::-moz-placeholder {
+.c182:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c181:valid:not([value=""]):-ms-input-placeholder {
+.c182:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c181:valid:not([value=""])::placeholder {
+.c182:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c189 {
+.c190 {
   background: none;
   color: inherit;
   border: none;
@@ -3065,16 +3071,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c187 {
+.c188 {
   display: none;
 }
 
-.c186:focus-within .c176 {
+.c187:focus-within .c177 {
   background: #374cf1;
   color: #fff;
 }
 
-.c190 {
+.c191 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -3101,37 +3107,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #575757;
 }
 
-.c192 {
+.c193 {
   max-width: calc(100% - 20px);
 }
 
-.c194 {
+.c195 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c169 {
+.c170 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c159 {
+.c160 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c120 {
+.c121 {
   box-shadow: none;
 }
 
-.c121 {
+.c122 {
   background: none;
   width: 100%;
   border: none;
@@ -3145,13 +3151,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: pointer;
 }
 
-.c92 {
+.c93 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c82 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3266,19 +3272,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3292,151 +3298,151 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     padding: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c90 {
+  .c91 {
     padding: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     padding-bottom: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c132 {
     max-width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c131 {
+  .c132 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3444,7 +3450,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c143 {
+  .c144 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3452,79 +3458,79 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c144 {
+  .c145 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c144 {
+  .c145 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c160 {
+  .c161 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c160 {
+  .c161 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c206 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c224 {
+  .c225 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c226 {
+  .c227 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3533,13 +3539,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c230 {
+  .c231 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c230 {
+  .c231 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3547,7 +3553,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c230 {
+  .c231 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3555,19 +3561,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c232 {
+  .c233 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c235 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c235 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3575,61 +3581,61 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c235 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c235 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c241 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c240 {
+  .c241 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c241 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c240 {
+  .c241 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3676,19 +3682,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3696,19 +3702,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     gap: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     gap: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3717,7 +3723,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3726,7 +3732,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
@@ -3735,7 +3741,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -3743,19 +3749,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3763,25 +3769,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c145 {
+  .c146 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c145 {
+  .c146 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c214 {
+  .c215 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3790,13 +3796,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c225 {
+  .c226 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3804,7 +3810,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c225 {
+  .c226 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3813,7 +3819,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c225 {
+  .c226 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3822,7 +3828,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c227 {
+  .c228 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3831,7 +3837,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c235 {
+  .c236 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3840,7 +3846,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c242 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3848,7 +3854,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c241 {
+  .c242 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3856,7 +3862,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c242 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3865,7 +3871,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c241 {
+  .c242 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3874,19 +3880,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c241 {
+  .c242 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c241 {
+  .c242 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c244 {
+  .c245 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3894,7 +3900,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c244 {
+  .c245 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3902,7 +3908,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c244 {
+  .c245 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3910,7 +3916,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c244 {
+  .c245 {
     gap: 2rem;
   }
 }
@@ -3970,25 +3976,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c243 {
+  .c244 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c243 {
+  .c244 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c243 {
+  .c244 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c243 {
+  .c244 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4021,43 +4027,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4066,7 +4072,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4075,25 +4081,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4102,43 +4108,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4147,7 +4153,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4156,43 +4162,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c135 {
+  .c136 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c135 {
+  .c136 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c135 {
+  .c136 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4201,7 +4207,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c135 {
+  .c136 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4210,43 +4216,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4255,7 +4261,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4264,43 +4270,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4309,7 +4315,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4318,25 +4324,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4345,7 +4351,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c167 {
+  .c168 {
     margin-right: 1.5rem;
   }
 }
@@ -4360,16 +4366,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c212,
-  .c24:visited:hover .c212 {
+  .c24:hover .c213,
+  .c24:visited:hover .c213 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c209:hover,
-  .c209:visited:hover {
+  .c210:hover,
+  .c210:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4377,16 +4383,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c209:hover .c212,
-  .c209:visited:hover .c212 {
+  .c210:hover .c213,
+  .c210:visited:hover .c213 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c246:hover,
-  .c246:visited:hover {
+  .c247:hover,
+  .c247:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4394,8 +4400,8 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c246:hover .c212,
-  .c246:visited:hover .c212 {
+  .c247:hover .c213,
+  .c247:visited:hover .c213 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -4415,55 +4421,55 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c139 {
     grid-template-columns: repeat(5,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c138 {
+  .c139 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c162 {
+  .c163 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c204 {
+  .c205 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c147 {
+  .c148 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c181 {
+  .c182 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c159 {
+  .c160 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:920px) {
-  .c92 {
+  .c93 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -4657,7 +4663,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               >
                 <img
                   alt=""
-                  class="c27"
+                  class="c21"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4668,7 +4674,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c27"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4676,10 +4682,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c28"
               >
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4693,15 +4699,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Primary
                         </span>
@@ -4710,7 +4716,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4724,15 +4730,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Secondary
                         </span>
@@ -4741,7 +4747,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4755,15 +4761,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Guidance
                         </span>
@@ -4772,7 +4778,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4786,15 +4792,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           About us
                         </span>
@@ -4803,7 +4809,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4816,21 +4822,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -4894,7 +4900,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             class="c52 shadow"
                           />
                           <span
-                            class="c20"
+                            class="c34"
                             data-icon-for="button"
                           >
                             <img
@@ -4937,7 +4943,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c52 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4972,7 +4978,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4981,7 +4987,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4997,13 +5003,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c32"
                   >
                     <span
-                      class="c34"
+                      class="c33"
                     >
                       Sign in
                     </span>
@@ -5013,7 +5019,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -5027,14 +5033,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
                   class="c9 c49"
                 >
                   <span
-                    class="c20"
+                    class="c34"
                   >
                     <img
                       alt=""
@@ -5056,45 +5062,45 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Oak's curricula
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   Oak offers complete curriculum support for clarity and coherence in every national curriculum subject.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -5108,30 +5114,30 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c77"
+            class="c78"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c78 c79"
+                class="c79 c80"
               >
                 <ul
-                  class="c80 c81"
+                  class="c81 c82"
                 >
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c85"
+                        class="c86"
                         data-testid="icon-clipboard"
                       >
                         <img
                           alt=""
-                          class="c21"
+                          class="c61"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5140,25 +5146,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         National curriculum and exam board aligned
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c87"
+                        class="c88"
                         data-testid="icon-free-tag"
                       >
                         <img
                           alt=""
-                          class="c21"
+                          class="c61"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5167,25 +5173,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Free and always will be
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c88"
+                        class="c89"
                         data-testid="icon-book-steps"
                       >
                         <img
                           alt=""
-                          class="c21"
+                          class="c61"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5194,25 +5200,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Covers key stages 1-4 across 20 subjects
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c89"
+                        class="c90"
                         data-testid="icon-threads"
                       >
                         <img
                           alt=""
-                          class="c21"
+                          class="c61"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5221,7 +5227,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Fully sequenced and ready to adapt
                       </p>
@@ -5229,34 +5235,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </li>
                 </ul>
                 <div
-                  class="c90 c91 c92"
+                  class="c91 c92 c93"
                 >
                   <div
-                    class="c9 c93"
+                    class="c9 c94"
                   >
                     <div
-                      class="c9 c94"
+                      class="c9 c95"
                     >
                       <h2
-                        class="c95"
+                        class="c96"
                       >
                         Our guiding principles
                       </h2>
                       <p
-                        class="c96"
+                        class="c97"
                       >
                         Our guiding principles guide our approach.
                       </p>
                     </div>
                     <div
-                      class="c97 c45"
+                      class="c98 c45"
                     >
                       <span
-                        class="c98"
+                        class="c99"
                       >
                         <img
                           alt=""
-                          class="c27"
+                          class="c21"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5269,29 +5275,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c99 c100"
+                    class="c100 c101"
                   >
                     <div
-                      class="c101"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c102 c103"
+                        class="c103 c104"
                       >
                         <div
-                          class="c104 c105"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c9 c94"
+                          class="c9 c95"
                         >
                           <h3
-                            class="c106"
+                            class="c107"
                           >
                             Evidence-informed
                           </h3>
                           <p
-                            class="c107"
+                            class="c108"
                           >
                             Our approach enables the rigorous application of research outcomes.
                           </p>
@@ -5299,26 +5305,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c101"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c102 c103"
+                        class="c103 c104"
                       >
                         <div
-                          class="c104 c105"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c9 c94"
+                          class="c9 c95"
                         >
                           <h3
-                            class="c106"
+                            class="c107"
                           >
                             Knowledge and vocabulary rich
                           </h3>
                           <p
-                            class="c107"
+                            class="c108"
                           >
                             Our curriculum is knowledge and vocabulary rich.
                           </p>
@@ -5328,57 +5334,57 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c108 c109"
+                  class="c109 c110"
                 >
                   <h2
-                    class="c110"
+                    class="c111"
                   >
                     See Oak's curricula in practice
                   </h2>
                   <nav
                     aria-labelledby="choose-curriculum-label"
-                    class="c66"
+                    class="c67"
                   >
                     <div
-                      class="c111"
+                      class="c112"
                       id="choose-curriculum-label"
                     >
                       Choose a curriculum
                     </div>
                     <div
-                      class="c112"
+                      class="c113"
                       data-testid="lot-picker"
                     >
                       <div
-                        class="c113 c114"
+                        class="c114 c115"
                       >
                         <div
-                          class="c66 c115"
+                          class="c67 c116"
                         >
                           <div
-                            class="c116 c117"
+                            class="c117 c118"
                             style="width: 50%;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                             >
                               <button
                                 aria-expanded="false"
-                                class="c121"
+                                class="c122"
                                 data-testid="subject-picker-button"
                                 title="Subject"
                               >
                                 <div
-                                  class="c122"
+                                  class="c123"
                                 >
                                   <span
-                                    class="c123"
+                                    class="c124"
                                     data-testid="subject-picker-button-heading"
                                   >
                                     Subject
                                   </span>
                                   <p
-                                    class="c124"
+                                    class="c125"
                                   >
                                     Select
                                   </p>
@@ -5387,7 +5393,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </div>
                           </div>
                           <div
-                            class="c125"
+                            class="c126"
                           >
                             <div
                               aria-hidden="true"
@@ -5396,7 +5402,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c126"
+                                class="c127"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5426,28 +5432,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             style="width: 50%;"
                           >
                             <div
-                              class="c116 c127"
+                              class="c117 c128"
                             >
                               <div
-                                class="c128 c119 c120"
+                                class="c129 c120 c121"
                               >
                                 <button
                                   aria-expanded="false"
-                                  class="c121"
+                                  class="c122"
                                   data-testid="phase-picker-button"
                                   title="Phase"
                                 >
                                   <div
-                                    class="c129"
+                                    class="c130"
                                   >
                                     <span
-                                      class="c123"
+                                      class="c124"
                                       data-testid="phase-picker-button-heading"
                                     >
                                       School phase
                                     </span>
                                     <div
-                                      class="c130"
+                                      class="c131"
                                     >
                                       Select
                                     </div>
@@ -5455,7 +5461,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </button>
                               </div>
                               <div
-                                class="c131 c132"
+                                class="c132 c133"
                               >
                                 <div
                                   class="c4 c5"
@@ -5467,7 +5473,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                     class="c6 yellow-shadow"
                                   />
                                   <button
-                                    class="c133 c19 internal-button"
+                                    class="c134 c19 internal-button"
                                     data-testid="lot-picker-view-curriculum-button"
                                   >
                                     <div
@@ -5479,7 +5485,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                         View
                                       </span>
                                       <span
-                                        class="c20"
+                                        class="c34"
                                       >
                                         <img
                                           alt=""
@@ -5506,29 +5512,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c134 c79"
+              class="c135 c80"
             >
               <h2
-                class="c135"
+                class="c136"
               >
                 Curriculum partners
               </h2>
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <div
-                  class="c9 c136"
+                  class="c9 c137"
                 >
                   <h3
-                    class="c110"
+                    class="c111"
                   >
                     Current
                   </h3>
                   <p
-                    class="c137"
+                    class="c138"
                   >
                     Our current partners
                   </p>
@@ -5537,17 +5543,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c9"
                 >
                   <ul
-                    class="c80 c138"
+                    class="c81 c139"
                   >
                     <li
-                      class="c139"
+                      class="c140"
                     >
                       <span
-                        class="c140"
+                        class="c141"
                       >
                         <img
                           alt=""
-                          class="c27"
+                          class="c21"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5562,18 +5568,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <div
-                  class="c9 c136"
+                  class="c9 c137"
                 >
                   <h3
-                    class="c110"
+                    class="c111"
                   >
                     Legacy
                   </h3>
                   <p
-                    class="c137"
+                    class="c138"
                   >
                     Our legacy partners
                   </p>
@@ -5582,17 +5588,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c9"
                 >
                   <ul
-                    class="c80 c138"
+                    class="c81 c139"
                   >
                     <li
-                      class="c139"
+                      class="c140"
                     >
                       <span
-                        class="c140"
+                        class="c141"
                       >
                         <img
                           alt=""
-                          class="c27"
+                          class="c21"
                           data-nimg="fill"
                           decoding="async"
                           loading="lazy"
@@ -5609,14 +5615,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c141"
+            class="c142"
             style="margin-top: -72px;"
           >
             <div
-              class="c142"
+              class="c143"
             >
               <span
-                class="c143"
+                class="c144"
                 style="pointer-events: none;"
               >
                 <img
@@ -5630,13 +5636,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c144 c145"
+                  class="c145 c146"
                 >
                   <h2
-                    class="c146"
+                    class="c147"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5645,31 +5651,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c147"
+                      class="c148"
                     >
                       <li
-                        class="c148"
+                        class="c149"
                       >
                         <div
-                          class="c149 c150"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c151 c152 c153"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c154"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5679,7 +5685,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c155 c156"
+                                class="c156 c157"
                               >
                                 About Oak
                               </div>
@@ -5687,11 +5693,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c157"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5705,28 +5711,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c148"
+                        class="c149"
                       >
                         <div
-                          class="c149 c150"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c151 c152 c153"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c154"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5736,7 +5742,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c155 c156"
+                                class="c156 c157"
                               >
                                 Oak's curricula
                               </div>
@@ -5744,11 +5750,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c157"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5762,28 +5768,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c148"
+                        class="c149"
                       >
                         <div
-                          class="c149 c150"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c151 c152 c153"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c154"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5793,7 +5799,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c155 c156"
+                                class="c156 c157"
                               >
                                 Meet the team
                               </div>
@@ -5801,11 +5807,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c157"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5819,28 +5825,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c148"
+                        class="c149"
                       >
                         <div
-                          class="c149 c150"
+                          class="c150 c151"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c151 c152 c153"
+                              class="c152 c153 c154"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c154"
+                                  class="c155"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5850,7 +5856,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c155 c156"
+                                class="c156 c157"
                               >
                                 Get involved
                               </div>
@@ -5858,11 +5864,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c157"
+                                  class="c158"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5882,33 +5888,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c158"
+            class="c159"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c159"
+                class="c9 c45 c160"
               >
                 <div
-                  class="c160 c1"
+                  class="c161 c1"
                 >
                   <div
-                    class="c9 c161"
+                    class="c9 c162"
                   >
                     <div
-                      class="c9 c45 c162"
+                      class="c9 c45 c163"
                     >
                       <div
-                        class="c163 c164"
+                        class="c164 c165"
                       >
                         <span
-                          class="c165"
+                          class="c166"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5917,13 +5923,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c166"
+                          class="c167"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c167"
+                        class="c168"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5943,18 +5949,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c168 c45 c162"
+                      class="c169 c45 c163"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c169"
+                        class="c170"
                         novalidate=""
                       >
                         <div
-                          class="c170 c171 c172"
+                          class="c171 c172 c173"
                         >
                           <div
-                            class="c173 "
+                            class="c174 "
                           >
                             <div
                               aria-hidden="true"
@@ -5963,7 +5969,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5988,7 +5994,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6013,7 +6019,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6038,7 +6044,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6063,11 +6069,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c175 "
+                              class="c176 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c176 c177 c178"
+                                class="c177 c178 c179"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -6079,7 +6085,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c179"
+                                    class="c180"
                                   >
                                     (required)
                                   </span>
@@ -6090,7 +6096,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c180 c181"
+                              class="c181 c182"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -6098,7 +6104,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c182 c183 c184"
+                              class="c183 c184 c185"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6111,10 +6117,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c170 c171 c172"
+                          class="c171 c172 c173"
                         >
                           <div
-                            class="c173 "
+                            class="c174 "
                           >
                             <div
                               aria-hidden="true"
@@ -6123,7 +6129,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -6148,7 +6154,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6173,7 +6179,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6198,7 +6204,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c174"
+                                class="c175"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6223,11 +6229,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c175 "
+                              class="c176 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c176 c177 c178"
+                                class="c177 c178 c179"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -6239,7 +6245,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c179"
+                                    class="c180"
                                   >
                                     (required)
                                   </span>
@@ -6250,7 +6256,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c180 c181"
+                              class="c181 c182"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -6258,7 +6264,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c182 c183 c184"
+                              class="c183 c184 c185"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6271,7 +6277,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c185 c94 c186"
+                          class="c186 c95 c187"
                         >
                           <div
                             aria-hidden="true"
@@ -6280,7 +6286,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c174"
+                              class="c175"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -6305,7 +6311,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c174"
+                              class="c175"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -6330,7 +6336,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c174"
+                              class="c175"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6355,7 +6361,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c174"
+                              class="c175"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6381,7 +6387,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c182 c183 c184 c187"
+                            class="c183 c184 c185 c188"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6392,10 +6398,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c188 c45"
+                            class="c189 c45"
                           >
                             <label
-                              class="c176 c177 c178"
+                              class="c177 c178 c179"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6407,16 +6413,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c189 c190"
+                            class="c190 c191"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c191 c40 c192"
+                              class="c192 c40 c193"
                             >
                               <span
-                                class="c193 c194"
+                                class="c194 c195"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6425,11 +6431,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c20"
+                              class="c34"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6440,7 +6446,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c195 c5"
+                          class="c196 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -6449,7 +6455,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c196 c19 internal-button"
+                            class="c197 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -6464,12 +6470,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c197"
+                          class="c198"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c198"
+                          class="c199"
                         />
                       </form>
                     </div>
@@ -6481,14 +6487,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c199"
+        class="c200"
       >
         <div
-          class="c200 c45"
+          class="c201 c45"
         >
           <svg
             aria-hidden="true"
-            class="c201"
+            class="c202"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6511,33 +6517,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c202 c203"
+            class="c203 c204"
           >
             <div
-              class="c9 c161"
+              class="c9 c162"
             >
               <div
-                class="c9 c45 c204"
+                class="c9 c45 c205"
               >
                 <div
-                  class="c205 c94"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c206"
+                    class="c207"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c130 c207"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/pupils/years"
                         >
                           <span
@@ -6551,27 +6557,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c210"
+                  class="c211"
                 />
                 <div
-                  class="c205 c94"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c206"
+                    class="c207"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c130 c207"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6582,10 +6588,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6596,10 +6602,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6609,14 +6615,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c211"
+                            class="c212"
                           >
                             <span
-                              class="c157 c212 c213"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6628,10 +6634,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/blog"
                         >
                           <span
@@ -6646,27 +6652,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c204"
+                class="c9 c45 c205"
               >
                 <div
-                  class="c205 c94"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c206"
+                    class="c207"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c130 c207"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/"
                         >
                           <span
@@ -6677,10 +6683,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6691,10 +6697,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6705,10 +6711,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6719,10 +6725,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6733,11 +6739,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c209 "
+                          class="c210 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6747,14 +6753,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c211"
+                            class="c212"
                           >
                             <span
-                              class="c157 c212 c213"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6766,10 +6772,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/contact-us"
                         >
                           <span
@@ -6780,11 +6786,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c209 "
+                          class="c210 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6794,14 +6800,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c211"
+                            class="c212"
                           >
                             <span
-                              class="c157 c212 c213"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6813,10 +6819,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/webinars"
                         >
                           <span
@@ -6827,11 +6833,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c209 "
+                          class="c210 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6841,14 +6847,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c211"
+                            class="c212"
                           >
                             <span
-                              class="c157 c212 c213"
+                              class="c158 c213 c214"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6864,27 +6870,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c204"
+                class="c9 c45 c205"
               >
                 <div
-                  class="c205 c94"
+                  class="c206 c95"
                 >
                   <h2
-                    class="c206"
+                    class="c207"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c130 c207"
+                    class="c131 c208"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6895,10 +6901,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6909,10 +6915,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6923,10 +6929,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <button
-                          class="c209 "
+                          class="c210 "
                         >
                           <span
                             class="c25"
@@ -6936,10 +6942,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6950,10 +6956,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6964,10 +6970,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6978,10 +6984,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6992,10 +6998,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/complaints"
                         >
                           <span
@@ -7006,10 +7012,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c208"
+                        class="c209"
                       >
                         <a
-                          class="c209 "
+                          class="c210 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -7024,20 +7030,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c204"
+                class="c9 c45 c205"
               >
                 <div
-                  class="c205 c214"
+                  class="c206 c215"
                 >
                   <div
                     class="c38"
                   >
                     <span
-                      class="c215"
+                      class="c216"
                     >
                       <img
                         alt=""
-                        class="c27"
+                        class="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -7047,10 +7053,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c216 c217"
+                    class="c217 c218"
                   >
                     <div
-                      class="c44 c45 c218 c219"
+                      class="c44 c45 c219 c220"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -7061,13 +7067,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c220 c51 icon-container"
+                            class="c221 c51 icon-container"
                           >
                             <div
-                              class="c221 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -7088,7 +7094,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c218 c219"
+                      class="c44 c45 c219 c220"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -7099,13 +7105,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c220 c51 icon-container"
+                            class="c221 c51 icon-container"
                           >
                             <div
-                              class="c221 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -7126,7 +7132,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c218 c219"
+                      class="c44 c45 c219 c220"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -7137,13 +7143,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c220 c51 icon-container"
+                            class="c221 c51 icon-container"
                           >
                             <div
-                              class="c221 shadow"
+                              class="c222 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -7168,12 +7174,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c222 c223"
+              class="c223 c224"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c27"
+                class="c21"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -7184,13 +7190,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c224 c225"
+              class="c225 c226"
             >
               <div
-                class="c226 c227"
+                class="c227 c228"
               >
                 <div
-                  class="c44 c45 c218 c219"
+                  class="c44 c45 c219 c220"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -7201,13 +7207,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c220 c51 icon-container"
+                        class="c221 c51 icon-container"
                       >
                         <div
-                          class="c221 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -7228,7 +7234,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c218 c219"
+                  class="c44 c45 c219 c220"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -7239,13 +7245,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c220 c51 icon-container"
+                        class="c221 c51 icon-container"
                       >
                         <div
-                          class="c221 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -7266,7 +7272,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c218 c219"
+                  class="c44 c45 c219 c220"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -7277,13 +7283,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c220 c51 icon-container"
+                        class="c221 c51 icon-container"
                       >
                         <div
-                          class="c221 shadow"
+                          class="c222 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -7308,11 +7314,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c55"
               >
                 <span
-                  class="c215"
+                  class="c216"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -7322,15 +7328,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c205 c94"
+                class="c206 c95"
               >
                 <p
-                  class="c228"
+                  class="c229"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c229"
+                  class="c230"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7339,11 +7345,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c230"
+          class="c231"
         >
           <img
             alt=""
-            class="c231"
+            class="c232"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7352,11 +7358,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c232"
+          class="c233"
         >
           <img
             alt=""
-            class="c233"
+            class="c234"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7368,27 +7374,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c234 c235 c236"
+      class="c235 c236 c237"
     />
   </div>
   <div
-    class="c237"
+    class="c238"
   >
     <div
-      class="c238"
+      class="c239"
       data-testid="cookie-banner"
     >
       <div
-        class="c239"
+        class="c240"
       >
         <div
-          class="c240 c241"
+          class="c241 c242"
         >
           <div
-            class="c242"
+            class="c243"
           >
             <strong
-              class="c243"
+              class="c244"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -7396,13 +7402,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c244"
+            class="c9 c245"
           >
             <div
-              class="c245 c40"
+              class="c246 c40"
             >
               <button
-                class="c246"
+                class="c247"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -7446,7 +7452,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c133 c19 internal-button"
+                class="c134 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -156,11 +156,11 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                   pupils
                 </span>
                 <span
-                  class="sc-aXZVg jJQFnr"
+                  class="sc-aXZVg jZQmlG"
                 >
                   <img
                     alt=""
-                    class="sc-iGgWBj cMzyFO"
+                    class="sc-iGgWBj dZvqhO"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -758,12 +758,12 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
               class="sc-aXZVg fMrRXk"
             >
               <span
-                class="sc-aXZVg cegGxk"
+                class="sc-aXZVg kZhQgx"
                 style="pointer-events: none;"
               >
                 <img
                   alt=""
-                  class="sc-iGgWBj cMzyFO"
+                  class="sc-iGgWBj dZvqhO"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -787,10 +787,10 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-ea54c430-2 flLvBT"
+                      class="sc-36a6b83-2 gdcpHp"
                     >
                       <li
-                        class="sc-ea54c430-1 duAgam"
+                        class="sc-36a6b83-1 jXqwfI"
                       >
                         <div
                           class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -800,7 +800,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                             style="outline: none;"
                           >
                             <div
-                              class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                              class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
@@ -847,7 +847,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         </div>
                       </li>
                       <li
-                        class="sc-ea54c430-1 duAgam"
+                        class="sc-36a6b83-1 jXqwfI"
                       >
                         <div
                           class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -857,7 +857,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                             style="outline: none;"
                           >
                             <div
-                              class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                              class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
@@ -904,7 +904,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         </div>
                       </li>
                       <li
-                        class="sc-ea54c430-1 duAgam"
+                        class="sc-36a6b83-1 jXqwfI"
                       >
                         <div
                           class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -914,7 +914,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                             style="outline: none;"
                           >
                             <div
-                              class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                              class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
@@ -961,7 +961,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         </div>
                       </li>
                       <li
-                        class="sc-ea54c430-1 duAgam"
+                        class="sc-36a6b83-1 jXqwfI"
                       >
                         <div
                           class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -971,7 +971,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                             style="outline: none;"
                           >
                             <div
-                              class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                              class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                               data-testid="who-we-are-explore-item"
                             >
                               <div

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -60,9 +60,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 .c20 {
   position: relative;
   width: 1.5rem;
-  min-width: 1.5rem;
   height: 1.5rem;
-  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -84,6 +82,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   width: 2rem;
   height: 2.5rem;
   padding: 0rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c34 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -194,28 +202,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -224,7 +232,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -232,7 +240,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -240,21 +248,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   margin-left: auto;
   margin-right: auto;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   min-width: 100%;
   aspect-ratio: 4/3;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c82 {
+.c83 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 3.5rem;
@@ -262,17 +270,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   background: #ebfbeb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c86 {
+.c87 {
   padding-top: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -283,12 +291,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c96 {
+.c97 {
   width: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c98 {
+.c99 {
   width: 1.5rem;
   height: 1.5rem;
   background: #bef2bd;
@@ -299,7 +307,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c101 {
   width: 0rem;
   border: 0rem solid;
   border-left: 0.188rem solid;
@@ -308,12 +316,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c101 {
+.c102 {
   margin-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -324,7 +332,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c104 {
+.c105 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -335,13 +343,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c107 {
+.c108 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c113 {
+.c114 {
   height: 15rem;
   padding: 1.5rem;
   background: #a0b6f2;
@@ -349,27 +357,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c119 {
+.c120 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   position: absolute;
   top: 0rem;
   left: 0rem;
   width: 100%;
-  min-width: 100%;
   height: 100%;
-  min-height: 100%;
   display: none;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
@@ -377,26 +383,26 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c128 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -406,7 +412,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c132 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -417,7 +423,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c132 {
+.c133 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -427,14 +433,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c134 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c136 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -446,12 +452,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c138 {
+.c139 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c141 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -465,36 +471,36 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c143 {
+.c144 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c160 {
+.c161 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c164 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c166 {
+.c167 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c171 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c175 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -504,13 +510,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c175 {
+.c176 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c177 {
+.c178 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -522,12 +528,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c180 {
+.c181 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c182 {
+.c183 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -539,18 +545,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c186 {
+.c187 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c187 {
+.c188 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c192 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -559,7 +565,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c193 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -567,7 +573,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c197 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -578,7 +584,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c197 {
+.c198 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -589,14 +595,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c198 {
+.c199 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c200 {
+.c201 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -604,12 +610,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c202 {
+.c203 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c207 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -627,7 +633,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c208 {
+.c209 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -645,7 +651,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c210 {
+.c211 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -655,7 +661,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c213 {
+.c214 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -663,7 +669,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c214 {
+.c215 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -671,13 +677,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c215 {
+.c216 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c216 {
+.c217 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -685,7 +691,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c218 {
+.c219 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -696,7 +702,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c221 {
+.c222 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -758,7 +764,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -777,7 +783,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -876,7 +882,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c90 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -887,7 +893,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c94 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -897,7 +903,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -913,7 +919,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -924,7 +930,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c80 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -935,7 +941,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c83 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -949,7 +955,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 1;
 }
 
-.c87 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -960,7 +966,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2.5rem;
 }
 
-.c95 {
+.c96 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -968,7 +974,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c97 {
+.c98 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -985,7 +991,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c99 {
+.c100 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -996,7 +1002,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 0;
 }
 
-.c108 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1007,7 +1013,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c115 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1018,7 +1024,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c128 {
+.c129 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1033,7 +1039,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c139 {
+.c140 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1047,7 +1053,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c178 {
+.c179 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1065,7 +1071,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c190 {
+.c191 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1076,7 +1082,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c193 {
+.c194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1092,7 +1098,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c201 {
+.c202 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1110,7 +1116,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c203 {
+.c204 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1123,7 +1129,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c211 {
+.c212 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1138,7 +1144,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c217 {
+.c218 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1153,7 +1159,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c220 {
+.c221 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1203,7 +1209,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1226,14 +1232,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #bef2bd;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c154 {
+.c155 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1244,7 +1250,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c168 {
+.c169 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1255,7 +1261,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c219 {
+.c220 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1266,7 +1272,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c176 {
+.c177 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1365,7 +1371,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c30 {
   background: none;
   color: inherit;
   border: none;
@@ -1388,7 +1394,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c30:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1430,7 +1436,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1460,12 +1466,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1489,12 +1495,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c171 {
+.c172 {
   background: none;
   color: inherit;
   border: none;
@@ -1518,12 +1524,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c171:disabled {
+.c172:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c223 {
+.c224 {
   background: none;
   color: inherit;
   border: none;
@@ -1546,12 +1552,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c223:disabled {
+.c224:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c61 {
   object-fit: contain;
 }
 
@@ -1567,19 +1573,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c207 {
+.c208 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c209 {
+.c210 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c27 {
+.c21 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1664,13 +1670,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1678,37 +1684,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c31:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c31:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c31:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c31:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c31:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1716,27 +1722,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1833,31 +1839,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   background: #222222;
 }
 
-.c194 > :first-child:focus-visible .shadow {
+.c195 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c194 > :first-child:hover .shadow {
+.c195 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c194 > :first-child:active .shadow {
+.c195 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c194 > :first-child:disabled .icon-container {
+.c195 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c194 > :first-child:hover .icon-container {
+.c195 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c194 > :first-child:active .icon-container {
+.c195 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1868,7 +1874,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c92 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1879,7 +1885,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c103 {
+.c104 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1890,7 +1896,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c109 {
+.c110 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1902,7 +1908,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c116 {
+.c117 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1913,7 +1919,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c122 {
+.c123 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1925,7 +1931,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: center;
 }
 
-.c141 {
+.c142 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1936,7 +1942,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c181 {
+.c182 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1949,7 +1955,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c29 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1957,7 +1963,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c184 {
+.c185 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1966,7 +1972,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1977,7 +1983,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c84 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1988,7 +1994,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2000,7 +2006,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c117 {
+.c118 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2011,13 +2017,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c142 {
+.c143 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c172 {
+.c173 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2030,7 +2036,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c173 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2042,7 +2048,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c204 {
+.c205 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -2053,7 +2059,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c205 {
+.c206 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2064,7 +2070,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c183 {
+.c184 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2075,7 +2081,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c28 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2096,7 +2102,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c189 {
+.c190 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2127,7 +2133,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c188 {
+.c24 .c189 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2142,7 +2148,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c188 {
+.c24:visited .c189 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2152,7 +2158,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c188 {
+.c24:active .c189 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2162,12 +2168,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c188 {
+.c24[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c185 {
+.c186 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2191,47 +2197,47 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c185 .c188 {
+.c186 .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c185:focus-visible {
+.c186:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c185:visited {
+.c186:visited {
   color: #222222;
 }
 
-.c185:visited .c188 {
+.c186:visited .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c185:active {
+.c186:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c185:active .c188 {
+.c186:active .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c185[disabled] {
+.c186[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c185[disabled] .c188 {
+.c186[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c222 {
+.c223 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2264,42 +2270,42 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c222 .c188 {
+.c223 .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c222:focus-visible {
+.c223:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c222:visited {
+.c223:visited {
   color: #222222;
 }
 
-.c222:visited .c188 {
+.c223:visited .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c222:active {
+.c223:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c222:active .c188 {
+.c223:active .c189 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c222[disabled] {
+.c223[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c222[disabled] .c188 {
+.c223[disabled] .c189 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -2362,7 +2368,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   background: #ffffff;
 }
 
-.c88 {
+.c89 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2371,7 +2377,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c110 {
+.c111 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2380,13 +2386,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c136 {
+.c137 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c89 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2396,7 +2402,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c93 {
+.c94 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2406,7 +2412,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c111 {
+.c112 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2415,7 +2421,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c137 {
+.c138 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2424,7 +2430,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c179 {
+.c180 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2433,25 +2439,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c126 {
+.c127 {
   box-shadow: none;
 }
 
-.c126:has(a:hover,button:hover) {
+.c127:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c126:has( a, button) {
+.c127:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c126:has( a, button)  a,
-.c126:has( a, button) button {
+.c127:has( a, button)  a,
+.c127:has( a, button) button {
   outline: none;
 }
 
-.c126:has(a:active,button:active) {
+.c127:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
@@ -2463,11 +2469,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c212 {
+.c213 {
   top: 152px;
 }
 
-.c164 {
+.c165 {
   background: none;
   color: inherit;
   border: none;
@@ -2478,16 +2484,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c106:first-child {
+.c107:first-child {
   margin-top: 0;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c145 {
+.c146 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2498,23 +2504,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c145::-webkit-scrollbar-track {
+.c146::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c145::-webkit-scrollbar {
+.c146::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c145::-webkit-scrollbar-thumb {
+.c146::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c148 {
+.c149 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2523,23 +2529,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c148::-webkit-scrollbar-track {
+.c149::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c148::-webkit-scrollbar {
+.c149::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c148::-webkit-scrollbar-thumb {
+.c149::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c150 {
+.c151 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2547,86 +2553,86 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c150::-webkit-scrollbar-track {
+.c151::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c150::-webkit-scrollbar {
+.c151::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c150::-webkit-scrollbar-thumb {
+.c151::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c81 {
+.c82 {
   object-fit: cover;
   width: 100%;
   height: auto;
 }
 
-.c81::-webkit-scrollbar-track {
+.c82::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c81::-webkit-scrollbar {
+.c82::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c81::-webkit-scrollbar-thumb {
+.c82::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c114 {
+.c115 {
   object-fit: contain;
   width: 100%;
   height: 100%;
 }
 
-.c114::-webkit-scrollbar-track {
+.c115::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c114::-webkit-scrollbar {
+.c115::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c114::-webkit-scrollbar-thumb {
+.c115::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c78 {
+.c79 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
 
-.c112 {
+.c113 {
   grid-column: span 3;
 }
 
-.c129:hover {
+.c130:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c124 {
+.c125 {
   padding: 0;
   margin: 0;
 }
 
-.c123 {
+.c124 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2638,20 +2644,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c157 {
+.c158 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c146 {
+.c147 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c149 {
+.c150 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2663,7 +2669,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c155 {
+.c156 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2674,32 +2680,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c155::-webkit-input-placeholder {
+.c156::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c155::-moz-placeholder {
+.c156::-moz-placeholder {
   color: #575757;
 }
 
-.c155:-ms-input-placeholder {
+.c156:-ms-input-placeholder {
   color: #575757;
 }
 
-.c155::placeholder {
+.c156::placeholder {
   color: #575757;
 }
 
-.c155::-webkit-search-decoration,
-.c155::-webkit-search-cancel-button,
-.c155::-webkit-search-results-button,
-.c155::-webkit-search-results-decoration {
+.c156::-webkit-search-decoration,
+.c156::-webkit-search-cancel-button,
+.c156::-webkit-search-results-button,
+.c156::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c152 {
+.c153 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2709,7 +2715,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c159 {
+.c160 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2722,7 +2728,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c153 {
+.c154 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2733,16 +2739,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c147:focus-within .c151 {
+.c148:focus-within .c152 {
   background: #374cf1;
   color: #fff;
 }
 
-.c147:focus-within .c158 {
+.c148:focus-within .c159 {
   display: inline;
 }
 
-.c156 {
+.c157 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2758,7 +2764,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: none;
 }
 
-.c156::-webkit-input-placeholder {
+.c157::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2766,7 +2772,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c156::-moz-placeholder {
+.c157::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2774,7 +2780,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c156:-ms-input-placeholder {
+.c157:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2782,7 +2788,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c156::placeholder {
+.c157::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2790,40 +2796,40 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c156:valid:not([value=""]) {
+.c157:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c156:valid:not([value=""])::-webkit-input-placeholder {
+.c157:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c156:valid:not([value=""])::-moz-placeholder {
+.c157:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c156:valid:not([value=""]):-ms-input-placeholder {
+.c157:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c156:valid:not([value=""])::placeholder {
+.c157:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c162 {
+.c163 {
   display: none;
 }
 
-.c161:focus-within .c151 {
+.c162:focus-within .c152 {
   background: #374cf1;
   color: #fff;
 }
 
-.c165 {
+.c166 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2850,32 +2856,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #575757;
 }
 
-.c167 {
+.c168 {
   max-width: calc(100% - 20px);
 }
 
-.c169 {
+.c170 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c144 {
+.c145 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c135 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c195 .icon-container > *:first-child {
+.c196 .icon-container > *:first-child {
   border: 0;
 }
 
-.c199 {
+.c200 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -2985,19 +2991,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3011,115 +3017,115 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c79 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-left: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-right: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3128,31 +3134,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c102 {
     margin-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3161,37 +3167,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c121 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c121 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3199,7 +3205,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c121 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3207,79 +3213,79 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c121 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c121 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c177 {
+  .c178 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c177 {
+  .c178 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c180 {
+  .c181 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c186 {
+  .c187 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3288,13 +3294,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c207 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c207 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3302,7 +3308,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c207 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3310,19 +3316,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3330,61 +3336,61 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c216 {
+  .c217 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c216 {
+  .c217 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3431,37 +3437,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c190 {
+  .c191 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3470,13 +3476,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3484,7 +3490,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3493,7 +3499,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3502,7 +3508,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c203 {
+  .c204 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3511,7 +3517,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3520,7 +3526,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3528,7 +3534,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c217 {
+  .c218 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3536,7 +3542,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3545,7 +3551,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c217 {
+  .c218 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3554,19 +3560,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c217 {
+  .c218 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c220 {
+  .c221 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3574,7 +3580,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c220 {
+  .c221 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3582,7 +3588,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c220 {
+  .c221 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3590,7 +3596,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c220 {
+  .c221 {
     gap: 2rem;
   }
 }
@@ -3650,25 +3656,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3701,43 +3707,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3746,7 +3752,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3755,25 +3761,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3782,25 +3788,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3809,43 +3815,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3854,7 +3860,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3863,55 +3869,55 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3920,7 +3926,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3929,43 +3935,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3974,7 +3980,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3983,43 +3989,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4028,7 +4034,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4037,25 +4043,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4064,25 +4070,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4091,31 +4097,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4124,7 +4130,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     margin-right: 1.5rem;
   }
 }
@@ -4139,16 +4145,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c188,
-  .c24:visited:hover .c188 {
+  .c24:hover .c189,
+  .c24:visited:hover .c189 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c185:hover,
-  .c185:visited:hover {
+  .c186:hover,
+  .c186:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4156,16 +4162,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c185:hover .c188,
-  .c185:visited:hover .c188 {
+  .c186:hover .c189,
+  .c186:visited:hover .c189 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c222:hover,
-  .c222:visited:hover {
+  .c223:hover,
+  .c223:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4173,8 +4179,8 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c222:hover .c188,
-  .c222:visited:hover .c188 {
+  .c223:hover .c189,
+  .c223:visited:hover .c189 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -4194,73 +4200,73 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column: 2 / span 9;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     grid-column: 3 / span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c137 {
+  .c138 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c179 {
+  .c180 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:1212px) {
-  .c78 {
+  .c79 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4268,31 +4274,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (max-width:1040px) {
-  .c112 {
+  .c113 {
     grid-column: span 6;
   }
 }
 
 @media (max-width:749px) {
-  .c112 {
+  .c113 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:800px) {
-  .c123 {
+  .c124 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c156 {
+  .c157 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     max-width: 870px;
   }
 }
@@ -4484,7 +4490,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               >
                 <img
                   alt=""
-                  class="c27"
+                  class="c21"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -4495,7 +4501,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c27"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4503,10 +4509,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c28"
               >
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4520,15 +4526,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Primary
                         </span>
@@ -4537,7 +4543,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4551,15 +4557,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Secondary
                         </span>
@@ -4568,7 +4574,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4582,15 +4588,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Guidance
                         </span>
@@ -4599,7 +4605,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4613,15 +4619,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           About us
                         </span>
@@ -4630,7 +4636,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -4643,21 +4649,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -4721,7 +4727,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             class="c52 shadow"
                           />
                           <span
-                            class="c20"
+                            class="c34"
                             data-icon-for="button"
                           >
                             <img
@@ -4764,7 +4770,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c52 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4799,7 +4805,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4808,7 +4814,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4824,13 +4830,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c32"
                   >
                     <span
-                      class="c34"
+                      class="c33"
                     >
                       Sign in
                     </span>
@@ -4840,7 +4846,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4854,14 +4860,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
                   class="c9 c49"
                 >
                   <span
-                    class="c20"
+                    class="c34"
                   >
                     <img
                       alt=""
@@ -4883,45 +4889,45 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     About Oak
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   We create free resources for teachers.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4935,14 +4941,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c77 c45 c78"
+            class="c78 c45 c79"
           >
             <div
-              class="c79 c80"
+              class="c80 c81"
             >
               <img
                 alt=""
-                class="c81"
+                class="c82"
                 data-nimg="1"
                 decoding="async"
                 height="300"
@@ -4954,44 +4960,44 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </div>
             <div
-              class="c82 c83"
+              class="c83 c84"
             >
               <p
-                class="c84"
+                class="c85"
               >
                 Oak National Academy was created in response to the pandemic.
               </p>
             </div>
           </div>
           <div
-            class="c85"
+            class="c86"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c86 c87"
+                class="c87 c88"
               >
                 <div
-                  class="c9 c88"
+                  class="c9 c89"
                 >
                   <div
-                    class="c9 c45 c89"
+                    class="c9 c45 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <div
-                        class="c91"
+                        class="c92"
                       >
                         <span
-                          class="c73"
+                          class="c74"
                         >
                           Oak’s story
                         </span>
                       </div>
                       <h2
-                        class="c92"
+                        class="c93"
                       >
                         As teaching evolves, so do we...
                       </h2>
@@ -4999,50 +5005,50 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c88"
+                  class="c9 c89"
                 >
                   <div
-                    class="c9 c45 c93"
+                    class="c9 c45 c94"
                   >
                     <div
-                      class="c9 c94"
+                      class="c9 c95"
                     >
                       <div
-                        class="c9 c95"
+                        class="c9 c96"
                         data-testid="timetable-timeline-item"
                       >
                         <div
-                          class="c96 c97"
+                          class="c97 c98"
                         >
                           <div
-                            class="c98 c99"
+                            class="c99 c100"
                           />
                           <div
-                            class="c100 c80"
+                            class="c101 c81"
                           />
                         </div>
                         <div
-                          class="c101 c90"
+                          class="c102 c91"
                         >
                           <div
-                            class="c102"
+                            class="c103"
                           >
                             <span
-                              class="c73"
+                              class="c74"
                             >
                               Oak is born
                             </span>
                           </div>
                           <h3
-                            class="c103"
+                            class="c104"
                           >
                             2020
                           </h3>
                           <div
-                            class="c104 c94"
+                            class="c105 c95"
                           >
                             <p
-                              class="c105 c106"
+                              class="c106 c107"
                             >
                               Oak launched during lockdown.
                             </p>
@@ -5056,32 +5062,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c107 c108"
+              class="c108 c109"
             >
               <h2
-                class="c109"
+                class="c110"
               >
                 We are...
               </h2>
               <div
-                class="c9 c110"
+                class="c9 c111"
               >
                 <div
-                  class="c9 c45 c111 c112"
+                  class="c9 c45 c112 c113"
                   data-testid="who-we-are-desc-item"
                 >
                   <div
-                    class="c9 c71"
+                    class="c9 c72"
                   >
                     <div
-                      class="c113"
+                      class="c114"
                     >
                       <img
                         alt=""
-                        class="c114"
+                        class="c115"
                         data-nimg="1"
                         decoding="async"
                         height="300"
@@ -5093,15 +5099,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       />
                     </div>
                     <div
-                      class="c9 c115"
+                      class="c9 c116"
                     >
                       <h3
-                        class="c116"
+                        class="c117"
                       >
                         Free
                       </h3>
                       <p
-                        class="c117"
+                        class="c118"
                       >
                         All our resources are free.
                       </p>
@@ -5112,14 +5118,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c118"
+            class="c119"
             style="margin-top: -72px;"
           >
             <div
-              class="c119"
+              class="c120"
             >
               <span
-                class="c120"
+                class="c121"
                 style="pointer-events: none;"
               >
                 <img
@@ -5133,13 +5139,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c121 c108"
+                  class="c122 c109"
                 >
                   <h2
-                    class="c122"
+                    class="c123"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5148,31 +5154,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c123"
+                      class="c124"
                     >
                       <li
-                        class="c124"
+                        class="c125"
                       >
                         <div
-                          class="c125 c126"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/who-we-are"
                             style="outline: none;"
                           >
                             <div
-                              class="c127 c128 c129"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c130"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5182,7 +5188,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c131 c80"
+                                class="c132 c81"
                               >
                                 About Oak
                               </div>
@@ -5190,11 +5196,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c132"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5208,28 +5214,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c124"
+                        class="c125"
                       >
                         <div
-                          class="c125 c126"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/oaks-curricula"
                             style="outline: none;"
                           >
                             <div
-                              class="c127 c128 c129"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c130"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5239,7 +5245,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c131 c80"
+                                class="c132 c81"
                               >
                                 Oak's curricula
                               </div>
@@ -5247,11 +5253,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c132"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5265,28 +5271,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c124"
+                        class="c125"
                       >
                         <div
-                          class="c125 c126"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/meet-the-team"
                             style="outline: none;"
                           >
                             <div
-                              class="c127 c128 c129"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c130"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5296,7 +5302,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c131 c80"
+                                class="c132 c81"
                               >
                                 Meet the team
                               </div>
@@ -5304,11 +5310,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c132"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5322,28 +5328,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                       </li>
                       <li
-                        class="c124"
+                        class="c125"
                       >
                         <div
-                          class="c125 c126"
+                          class="c126 c127"
                         >
                           <a
                             href="/about-us/get-involved"
                             style="outline: none;"
                           >
                             <div
-                              class="c127 c128 c129"
+                              class="c128 c129 c130"
                               data-testid="who-we-are-explore-item"
                             >
                               <div
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c130"
+                                  class="c131"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5353,7 +5359,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 </span>
                               </div>
                               <div
-                                class="c131 c80"
+                                class="c132 c81"
                               >
                                 Get involved
                               </div>
@@ -5361,11 +5367,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                 class="c9 c45"
                               >
                                 <span
-                                  class="c132"
+                                  class="c133"
                                 >
                                   <img
                                     alt=""
-                                    class="c21"
+                                    class="c61"
                                     data-nimg="fill"
                                     decoding="async"
                                     loading="lazy"
@@ -5385,33 +5391,33 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c133"
+            class="c134"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c134"
+                class="c9 c45 c135"
               >
                 <div
-                  class="c135 c1"
+                  class="c136 c1"
                 >
                   <div
-                    class="c9 c136"
+                    class="c9 c137"
                   >
                     <div
-                      class="c9 c45 c137"
+                      class="c9 c45 c138"
                     >
                       <div
-                        class="c138 c139"
+                        class="c139 c140"
                       >
                         <span
-                          class="c140"
+                          class="c141"
                         >
                           <img
                             alt=""
-                            class="c21"
+                            class="c61"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5420,13 +5426,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c141"
+                          class="c142"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c142"
+                        class="c143"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5446,18 +5452,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c143 c45 c137"
+                      class="c144 c45 c138"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c144"
+                        class="c145"
                         novalidate=""
                       >
                         <div
-                          class="c145 c146 c147"
+                          class="c146 c147 c148"
                         >
                           <div
-                            class="c148 "
+                            class="c149 "
                           >
                             <div
                               aria-hidden="true"
@@ -5466,7 +5472,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5491,7 +5497,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5516,7 +5522,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5541,7 +5547,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5566,11 +5572,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c150 "
+                              class="c151 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c151 c152 c153"
+                                class="c152 c153 c154"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5582,7 +5588,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c154"
+                                    class="c155"
                                   >
                                     (required)
                                   </span>
@@ -5593,7 +5599,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c155 c156"
+                              class="c156 c157"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5601,7 +5607,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c157 c158 c159"
+                              class="c158 c159 c160"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5614,10 +5620,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c145 c146 c147"
+                          class="c146 c147 c148"
                         >
                           <div
-                            class="c148 "
+                            class="c149 "
                           >
                             <div
                               aria-hidden="true"
@@ -5626,7 +5632,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5651,7 +5657,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5676,7 +5682,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5701,7 +5707,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c149"
+                                class="c150"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5726,11 +5732,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c150 "
+                              class="c151 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c151 c152 c153"
+                                class="c152 c153 c154"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5742,7 +5748,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c154"
+                                    class="c155"
                                   >
                                     (required)
                                   </span>
@@ -5753,7 +5759,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c155 c156"
+                              class="c156 c157"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5761,7 +5767,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c157 c158 c159"
+                              class="c158 c159 c160"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5774,7 +5780,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c160 c94 c161"
+                          class="c161 c95 c162"
                         >
                           <div
                             aria-hidden="true"
@@ -5783,7 +5789,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c149"
+                              class="c150"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5808,7 +5814,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c149"
+                              class="c150"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5833,7 +5839,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c149"
+                              class="c150"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5858,7 +5864,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c149"
+                              class="c150"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5884,7 +5890,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c157 c158 c159 c162"
+                            class="c158 c159 c160 c163"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5895,10 +5901,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c163 c45"
+                            class="c164 c45"
                           >
                             <label
-                              class="c151 c152 c153"
+                              class="c152 c153 c154"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5910,16 +5916,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c164 c165"
+                            class="c165 c166"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c166 c40 c167"
+                              class="c167 c40 c168"
                             >
                               <span
-                                class="c168 c169"
+                                class="c169 c170"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5928,11 +5934,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <span
-                              class="c20"
+                              class="c34"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5943,7 +5949,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c170 c5"
+                          class="c171 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -5952,7 +5958,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c171 c19 internal-button"
+                            class="c172 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -5967,12 +5973,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c172"
+                          class="c173"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c173"
+                          class="c174"
                         />
                       </form>
                     </div>
@@ -5984,14 +5990,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c174"
+        class="c175"
       >
         <div
-          class="c175 c45"
+          class="c176 c45"
         >
           <svg
             aria-hidden="true"
-            class="c176"
+            class="c177"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6014,33 +6020,33 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c177 c178"
+            class="c178 c179"
           >
             <div
-              class="c9 c136"
+              class="c9 c137"
             >
               <div
-                class="c9 c45 c179"
+                class="c9 c45 c180"
               >
                 <div
-                  class="c180 c94"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c181"
+                    class="c182"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c182 c183"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/pupils/years"
                         >
                           <span
@@ -6054,27 +6060,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c186"
+                  class="c187"
                 />
                 <div
-                  class="c180 c94"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c181"
+                    class="c182"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c182 c183"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6085,10 +6091,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6099,10 +6105,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6112,14 +6118,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c187"
+                            class="c188"
                           >
                             <span
-                              class="c132 c188 c189"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6131,10 +6137,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/blog"
                         >
                           <span
@@ -6149,27 +6155,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c179"
+                class="c9 c45 c180"
               >
                 <div
-                  class="c180 c94"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c181"
+                    class="c182"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c182 c183"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/"
                         >
                           <span
@@ -6180,10 +6186,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6194,10 +6200,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6208,10 +6214,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6222,10 +6228,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6236,11 +6242,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c185 "
+                          class="c186 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6250,14 +6256,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c187"
+                            class="c188"
                           >
                             <span
-                              class="c132 c188 c189"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6269,10 +6275,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/contact-us"
                         >
                           <span
@@ -6283,11 +6289,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c185 "
+                          class="c186 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6297,14 +6303,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c187"
+                            class="c188"
                           >
                             <span
-                              class="c132 c188 c189"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6316,10 +6322,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/webinars"
                         >
                           <span
@@ -6330,11 +6336,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c185 "
+                          class="c186 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6344,14 +6350,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c187"
+                            class="c188"
                           >
                             <span
-                              class="c132 c188 c189"
+                              class="c133 c189 c190"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6367,27 +6373,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c179"
+                class="c9 c45 c180"
               >
                 <div
-                  class="c180 c94"
+                  class="c181 c95"
                 >
                   <h2
-                    class="c181"
+                    class="c182"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c182 c183"
+                    class="c183 c184"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6398,10 +6404,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6412,10 +6418,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6426,10 +6432,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <button
-                          class="c185 "
+                          class="c186 "
                         >
                           <span
                             class="c25"
@@ -6439,10 +6445,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6453,10 +6459,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6467,10 +6473,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6481,10 +6487,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6495,10 +6501,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6509,10 +6515,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c184"
+                        class="c185"
                       >
                         <a
-                          class="c185 "
+                          class="c186 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6527,20 +6533,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c179"
+                class="c9 c45 c180"
               >
                 <div
-                  class="c180 c190"
+                  class="c181 c191"
                 >
                   <div
                     class="c38"
                   >
                     <span
-                      class="c191"
+                      class="c192"
                     >
                       <img
                         alt=""
-                        class="c27"
+                        class="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -6550,10 +6556,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c192 c193"
+                    class="c193 c194"
                   >
                     <div
-                      class="c44 c45 c194 c195"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -6564,13 +6570,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c196 c51 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
-                              class="c197 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6591,7 +6597,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c194 c195"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -6602,13 +6608,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c196 c51 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
-                              class="c197 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6629,7 +6635,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c194 c195"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -6640,13 +6646,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c196 c51 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
-                              class="c197 shadow"
+                              class="c198 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -6671,12 +6677,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c198 c199"
+              class="c199 c200"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c27"
+                class="c21"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -6687,13 +6693,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c200 c201"
+              class="c201 c202"
             >
               <div
-                class="c202 c203"
+                class="c203 c204"
               >
                 <div
-                  class="c44 c45 c194 c195"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -6704,13 +6710,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c196 c51 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
-                          class="c197 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6731,7 +6737,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c194 c195"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -6742,13 +6748,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c196 c51 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
-                          class="c197 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6769,7 +6775,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c194 c195"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -6780,13 +6786,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c196 c51 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
-                          class="c197 shadow"
+                          class="c198 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -6811,11 +6817,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c55"
               >
                 <span
-                  class="c191"
+                  class="c192"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -6825,15 +6831,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c180 c94"
+                class="c181 c95"
               >
                 <p
-                  class="c204"
+                  class="c205"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c205"
+                  class="c206"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6842,11 +6848,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c206"
+          class="c207"
         >
           <img
             alt=""
-            class="c207"
+            class="c208"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6855,11 +6861,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c208"
+          class="c209"
         >
           <img
             alt=""
-            class="c209"
+            class="c210"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6871,27 +6877,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c210 c211 c212"
+      class="c211 c212 c213"
     />
   </div>
   <div
-    class="c213"
+    class="c214"
   >
     <div
-      class="c214"
+      class="c215"
       data-testid="cookie-banner"
     >
       <div
-        class="c215"
+        class="c216"
       >
         <div
-          class="c216 c217"
+          class="c217 c218"
         >
           <div
-            class="c218"
+            class="c219"
           >
             <strong
-              class="c219"
+              class="c220"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6899,13 +6905,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c220"
+            class="c9 c221"
           >
             <div
-              class="c221 c40"
+              class="c222 c40"
             >
               <button
-                class="c222"
+                class="c223"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6949,7 +6955,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c223 c19 internal-button"
+                class="c224 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -60,9 +60,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 .c20 {
   position: relative;
   width: 1.5rem;
-  min-width: 1.5rem;
   height: 1.5rem;
-  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -84,6 +82,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   width: 2rem;
   height: 2.5rem;
   padding: 0rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c34 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -194,22 +202,22 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -218,18 +226,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c69 {
   padding-top: 1.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c74 {
   overflow: hidden;
   min-width: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -238,7 +246,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c74 {
+.c75 {
   position: relative;
   width: 1.25rem;
   min-width: 1.25rem;
@@ -248,20 +256,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c75 {
+.c76 {
   padding-top: 2.5rem;
   padding-bottom: 3.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c81 {
+.c82 {
   padding-left: 0rem;
   padding-right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c84 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -272,14 +280,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c87 {
+.c88 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   background: #ffe555;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -290,7 +298,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c90 {
+.c91 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -302,7 +310,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c96 {
+.c97 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -312,13 +320,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 0;
 }
 
-.c97 {
+.c98 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c99 {
+.c100 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -330,12 +338,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c103 {
+.c104 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c106 {
+.c107 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -347,18 +355,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c109 {
+.c110 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c111 {
+.c112 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -368,7 +376,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c115 {
+.c116 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -377,7 +385,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +393,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -396,7 +404,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -407,14 +415,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -422,12 +430,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c127 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -445,7 +453,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c132 {
+.c133 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -463,7 +471,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c134 {
+.c135 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -473,7 +481,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 1;
 }
 
-.c137 {
+.c138 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -481,7 +489,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 299;
 }
 
-.c138 {
+.c139 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -489,13 +497,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c140 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c141 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -503,7 +511,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c143 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -514,7 +522,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c145 {
+.c146 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -576,7 +584,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -595,7 +603,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -694,7 +702,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c104 {
+.c105 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,14 +712,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c77 {
+.c78 {
   display: none;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
 }
 
-.c79 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -719,17 +727,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
-}
-
-.c82 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  gap: 1.5rem;
 }
 
 .c83 {
@@ -740,10 +737,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c84 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   gap: 0.25rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -751,7 +759,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c100 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -769,7 +777,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -780,7 +788,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: left;
 }
 
-.c117 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -796,7 +804,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c125 {
+.c126 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -814,7 +822,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c127 {
+.c128 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -827,7 +835,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c135 {
+.c136 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -842,7 +850,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c141 {
+.c142 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -857,7 +865,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c144 {
+.c145 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -907,7 +915,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -930,7 +938,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c143 {
+.c144 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -941,7 +949,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c98 {
+.c99 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1040,7 +1048,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c30 {
   background: none;
   color: inherit;
   border: none;
@@ -1063,7 +1071,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c30:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1105,7 +1113,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1135,12 +1143,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1164,12 +1172,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c94 {
+.c95 {
   background: none;
   color: inherit;
   border: none;
@@ -1192,12 +1200,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c94:disabled {
+.c95:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c147 {
+.c148 {
   background: none;
   color: inherit;
   border: none;
@@ -1220,12 +1228,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c147:disabled {
+.c148:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c61 {
   object-fit: contain;
 }
 
@@ -1241,19 +1249,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c131 {
+.c132 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c133 {
+.c134 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
 }
 
-.c27 {
+.c21 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1338,13 +1346,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1352,37 +1360,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c31:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c31:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c31:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c31:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c31:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1390,37 +1398,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c95 {
+.c96 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c95:hover {
+.c96:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1428,27 +1436,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c95:hover [data-state="selected"] {
+.c96:hover [data-state="selected"] {
   display: none;
 }
 
-.c95:active {
+.c96:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c95:active [data-state="selected"] {
+.c96:active [data-state="selected"] {
   display: none;
 }
 
-.c95:disabled {
+.c96:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c95:disabled [data-state="selected"] {
+.c96:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1545,31 +1553,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   background: #222222;
 }
 
-.c118 > :first-child:focus-visible .shadow {
+.c119 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:hover .shadow {
+.c119 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c118 > :first-child:active .shadow {
+.c119 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:disabled .icon-container {
+.c119 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c118 > :first-child:hover .icon-container {
+.c119 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c118 > :first-child:active .icon-container {
+.c119 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c86 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2.5rem;
@@ -1580,7 +1588,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1593,7 +1601,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c29 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1601,7 +1609,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c108 {
+.c109 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1610,7 +1618,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1622,7 +1630,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c128 {
+.c129 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
@@ -1633,7 +1641,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c129 {
+.c130 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1644,7 +1652,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c85 {
+.c86 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1655,7 +1663,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c89 {
+.c90 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1666,7 +1674,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c107 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1677,7 +1685,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c28 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -1698,7 +1706,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c113 {
+.c114 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -1729,7 +1737,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c112 {
+.c24 .c113 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -1744,7 +1752,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c112 {
+.c24:visited .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -1754,7 +1762,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c112 {
+.c24:active .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -1764,12 +1772,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c112 {
+.c24[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c72 {
+.c73 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1793,47 +1801,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c72 .c112 {
+.c73 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c72:focus-visible {
+.c73:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c72:visited {
+.c73:visited {
   color: #222222;
 }
 
-.c72:visited .c112 {
+.c73:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c72:active {
+.c73:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c72:active .c112 {
+.c73:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c72[disabled] {
+.c73[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c72[disabled] .c112 {
+.c73[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c146 {
+.c147 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1866,42 +1874,42 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c146 .c112 {
+.c147 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c146:focus-visible {
+.c147:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c146:visited {
+.c147:visited {
   color: #222222;
 }
 
-.c146:visited .c112 {
+.c147:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c146:active {
+.c147:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c146:active .c112 {
+.c147:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c146[disabled] {
+.c147[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c146[disabled] .c112 {
+.c147[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -1964,7 +1972,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   background: #ffffff;
 }
 
-.c76 {
+.c77 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -1973,13 +1981,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c101 {
+.c102 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c78 {
+.c79 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -1991,7 +1999,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c80 {
+.c81 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2003,7 +2011,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c102 {
+.c103 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2012,7 +2020,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c70 {
+.c71 {
   margin: 0rem;
   padding: 0rem;
   list-style: none;
@@ -2032,7 +2040,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-wrap: wrap;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2056,21 +2064,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c136 {
+.c137 {
   top: 152px;
 }
 
-.c119 .icon-container > *:first-child {
+.c120 .icon-container > *:first-child {
   border: 0;
 }
 
-.c123 {
+.c124 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c92:first-child {
+.c93:first-child {
   margin-top: 0;
 }
 
@@ -2178,19 +2186,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -2204,61 +2212,61 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c67 {
+  .c68 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c67 {
+  .c68 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c75 {
+  .c76 {
     padding-top: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c75 {
+  .c76 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2267,25 +2275,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2294,25 +2302,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2321,43 +2329,43 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c125 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c127 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2366,13 +2374,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -2380,7 +2388,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c130 {
+  .c131 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -2388,19 +2396,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2408,61 +2416,61 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c141 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c140 {
+  .c141 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c141 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c140 {
+  .c141 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2509,13 +2517,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c77 {
+  .c78 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -2524,13 +2532,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2538,7 +2546,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2547,7 +2555,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -2556,7 +2564,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2565,7 +2573,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -2574,7 +2582,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -2582,7 +2590,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2590,7 +2598,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2599,7 +2607,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2608,19 +2616,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2628,7 +2636,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -2636,7 +2644,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c144 {
+  .c145 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -2644,7 +2652,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     gap: 2rem;
   }
 }
@@ -2704,25 +2712,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     font-weight: 700;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2755,25 +2763,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2782,25 +2790,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2809,31 +2817,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2842,25 +2850,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2878,16 +2886,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c112,
-  .c24:visited:hover .c112 {
+  .c24:hover .c113,
+  .c24:visited:hover .c113 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c72:hover,
-  .c72:visited:hover {
+  .c73:hover,
+  .c73:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2895,16 +2903,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c72:hover .c112,
-  .c72:visited:hover .c112 {
+  .c73:hover .c113,
+  .c73:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c146:hover,
-  .c146:visited:hover {
+  .c147:hover,
+  .c147:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2912,8 +2920,8 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c146:hover .c112,
-  .c146:visited:hover .c112 {
+  .c147:hover .c113,
+  .c147:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
@@ -2933,26 +2941,26 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c77 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     grid-column: span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c80 {
+  .c81 {
     grid-column: span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c102 {
+  .c103 {
     grid-column: span 3;
   }
 }
@@ -3144,7 +3152,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               >
                 <img
                   alt=""
-                  class="c27"
+                  class="c21"
                   data-nimg="fill"
                   decoding="async"
                   loading="lazy"
@@ -3155,7 +3163,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c27"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -3163,10 +3171,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c28"
               >
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -3180,15 +3188,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Primary
                         </span>
@@ -3197,7 +3205,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -3211,15 +3219,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Secondary
                         </span>
@@ -3228,7 +3236,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -3242,15 +3250,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Guidance
                         </span>
@@ -3259,7 +3267,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -3273,15 +3281,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           About us
                         </span>
@@ -3290,7 +3298,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c29"
                 >
                   <div
                     class="c4 c15"
@@ -3303,21 +3311,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c30 c31 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Ai experiments
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -3381,7 +3389,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             class="c52 shadow"
                           />
                           <span
-                            class="c20"
+                            class="c34"
                             data-icon-for="button"
                           >
                             <img
@@ -3424,7 +3432,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c52 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -3459,7 +3467,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3468,7 +3476,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -3484,13 +3492,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c32"
                   >
                     <span
-                      class="c34"
+                      class="c33"
                     >
                       Sign in
                     </span>
@@ -3500,7 +3508,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -3514,14 +3522,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
                   class="c9 c49"
                 >
                   <span
-                    class="c20"
+                    class="c34"
                   >
                     <img
                       alt=""
@@ -3543,27 +3551,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68 c45"
+            class="c69 c45"
           >
             <nav
               aria-label="Breadcrumb"
-              class="c69"
+              class="c70"
             >
               <ul
-                class="c70"
+                class="c71"
               >
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <a
-                    class="c72"
+                    class="c73"
                     href="/"
                     style="overflow: hidden;"
                   >
@@ -3571,7 +3579,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c25"
                     >
                       <div
-                        class="c73"
+                        class="c74"
                       >
                         Home
                       </div>
@@ -3579,14 +3587,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <span
-                    class="c74"
+                    class="c75"
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3595,7 +3603,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <a
-                    class="c72"
+                    class="c73"
                     href="/about-us/meet-the-team"
                     style="overflow: hidden;"
                   >
@@ -3603,7 +3611,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c25"
                     >
                       <div
-                        class="c73"
+                        class="c74"
                       >
                         Meet the team
                       </div>
@@ -3611,14 +3619,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <span
-                    class="c74"
+                    class="c75"
                   >
                     <img
                       alt=""
-                      class="c21"
+                      class="c61"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3628,7 +3636,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </span>
                   <div
                     aria-current="page"
-                    class="c73"
+                    class="c74"
                   >
                     Ed Southall
                   </div>
@@ -3637,56 +3645,56 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </nav>
           </div>
           <div
-            class="c75 c76"
+            class="c76 c77"
           >
             <div
-              class="c38 c77 c78"
+              class="c38 c78 c79"
             />
             <div
-              class="c9 c79 c80"
+              class="c9 c80 c81"
             >
               <div
-                class="c81 c82"
+                class="c82 c83"
               >
                 <div
-                  class="c9 c82"
+                  class="c9 c83"
                 >
                   <div
-                    class="c9 c83"
+                    class="c9 c84"
                   >
                     <div
-                      class="c84 c85"
+                      class="c85 c86"
                     >
                       Our leadership
                     </div>
                     <h1
-                      class="c86"
+                      class="c87"
                     >
                       Ed Southall
                     </h1>
                   </div>
                   <div
-                    class="c87"
+                    class="c88"
                   >
                     <div
-                      class="c88 c89"
+                      class="c89 c90"
                     >
                       Subject Lead (maths)
                     </div>
                   </div>
                 </div>
                 <div
-                  class="c90"
+                  class="c91"
                 >
                   <p
-                    class="c91 c92"
+                    class="c92 c93"
                   >
                     Test bio text
                   </p>
                 </div>
                 <nav
                   aria-label="Team member navigation"
-                  class="c9 c93"
+                  class="c9 c94"
                 >
                   <div
                     class="c4 c5"
@@ -3698,14 +3706,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c6 yellow-shadow"
                     />
                     <a
-                      class="c94 c95 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/previous-member?section=leadership"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -3718,7 +3726,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           />
                         </span>
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Previous profile
                         </span>
@@ -3735,19 +3743,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c6 yellow-shadow"
                     />
                     <a
-                      class="c94 c95 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/next-member?section=board"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c32"
                       >
                         <span
-                          class="c34"
+                          class="c33"
                         >
                           Next profile
                         </span>
                         <span
-                          class="c20"
+                          class="c34"
                         >
                           <img
                             alt=""
@@ -3769,14 +3777,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c96"
+        class="c97"
       >
         <div
-          class="c97 c45"
+          class="c98 c45"
         >
           <svg
             aria-hidden="true"
-            class="c98"
+            class="c99"
             height="100%"
             name="header-underline"
             width="100%"
@@ -3799,33 +3807,33 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c99 c100"
+            class="c100 c101"
           >
             <div
-              class="c9 c101"
+              class="c9 c102"
             >
               <div
-                class="c9 c45 c102"
+                class="c9 c45 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/pupils/years"
                         >
                           <span
@@ -3839,27 +3847,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c109"
+                  class="c110"
                 />
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -3870,10 +3878,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/lesson-planning"
                         >
                           <span
@@ -3884,10 +3892,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -3897,14 +3905,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -3916,10 +3924,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/blog"
                         >
                           <span
@@ -3934,27 +3942,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c45 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/"
                         >
                           <span
@@ -3965,10 +3973,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -3979,10 +3987,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -3993,10 +4001,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -4007,10 +4015,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -4021,11 +4029,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -4035,14 +4043,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4054,10 +4062,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/contact-us"
                         >
                           <span
@@ -4068,11 +4076,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -4082,14 +4090,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4101,10 +4109,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/webinars"
                         >
                           <span
@@ -4115,11 +4123,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -4129,14 +4137,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
-                                class="c21"
+                                class="c61"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4152,27 +4160,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c45 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -4183,10 +4191,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -4197,10 +4205,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -4211,10 +4219,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <button
-                          class="c72 "
+                          class="c73 "
                         >
                           <span
                             class="c25"
@@ -4224,10 +4232,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -4238,10 +4246,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -4252,10 +4260,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -4266,10 +4274,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -4280,10 +4288,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/complaints"
                         >
                           <span
@@ -4294,10 +4302,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -4312,20 +4320,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c45 c103"
               >
                 <div
-                  class="c103 c114"
+                  class="c104 c115"
                 >
                   <div
                     class="c38"
                   >
                     <span
-                      class="c115"
+                      class="c116"
                     >
                       <img
                         alt=""
-                        class="c27"
+                        class="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -4335,10 +4343,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c116 c117"
+                    class="c117 c118"
                   >
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
@@ -4349,13 +4357,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -4376,7 +4384,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
@@ -4387,13 +4395,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -4414,7 +4422,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
@@ -4425,13 +4433,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           class="c9 c49"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
-                              class="c20"
+                              class="c34"
                               data-icon-for="button"
                             >
                               <img
@@ -4456,12 +4464,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c122 c123"
+              class="c123 c124"
               data-percy-hide="contents"
             >
               <img
                 alt="Cyber Essentials Logo"
-                class="c27"
+                class="c21"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -4472,13 +4480,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               />
             </span>
             <div
-              class="c124 c125"
+              class="c125 c126"
             >
               <div
-                class="c126 c127"
+                class="c127 c128"
               >
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
@@ -4489,13 +4497,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4516,7 +4524,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
@@ -4527,13 +4535,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4554,7 +4562,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
@@ -4565,13 +4573,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c9 c49"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
-                          class="c20"
+                          class="c34"
                           data-icon-for="button"
                         >
                           <img
@@ -4596,11 +4604,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c55"
               >
                 <span
-                  class="c115"
+                  class="c116"
                 >
                   <img
                     alt=""
-                    class="c27"
+                    class="c21"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -4610,15 +4618,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c103 c104"
+                class="c104 c105"
               >
                 <p
-                  class="c128"
+                  class="c129"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c129"
+                  class="c130"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -4627,11 +4635,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c130"
+          class="c131"
         >
           <img
             alt=""
-            class="c131"
+            class="c132"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4640,11 +4648,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           />
         </span>
         <span
-          class="c132"
+          class="c133"
         >
           <img
             alt=""
-            class="c133"
+            class="c134"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4656,27 +4664,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c134 c135 c136"
+      class="c135 c136 c137"
     />
   </div>
   <div
-    class="c137"
+    class="c138"
   >
     <div
-      class="c138"
+      class="c139"
       data-testid="cookie-banner"
     >
       <div
-        class="c139"
+        class="c140"
       >
         <div
-          class="c140 c141"
+          class="c141 c142"
         >
           <div
-            class="c142"
+            class="c143"
           >
             <strong
-              class="c143"
+              class="c144"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -4684,13 +4692,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c144"
+            class="c9 c145"
           >
             <div
-              class="c145 c40"
+              class="c146 c40"
             >
               <button
-                class="c146"
+                class="c147"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -4734,7 +4742,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c147 c19 internal-button"
+                class="c148 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/components/AppComponents/TopNav/TopNavMinimal.tsx
+++ b/src/components/AppComponents/TopNav/TopNavMinimal.tsx
@@ -6,7 +6,6 @@ import TabLink from "./TabLink/TabLink";
 import {
   OakBox,
   OakFlex,
-  OakIcon,
   OakImage,
   OakLink,
   useMediaQuery,
@@ -78,8 +77,9 @@ const TopNavMinimal = ({
           isSelected={activeArea === "PUPILS"}
           href={resolveOakHref({ page: "pupil-year-index" })}
           iconOverride={
-            <OakIcon
-              iconName="pencil"
+            <OakImage
+              alt=""
+              src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1765890807/icons/pencil.svg`}
               $width={"spacing-24"}
               $height={"spacing-24"}
             />

--- a/src/components/GenericPagesComponents/PupilTab/PupilTab.tsx
+++ b/src/components/GenericPagesComponents/PupilTab/PupilTab.tsx
@@ -5,8 +5,8 @@ import {
   OakTypography,
   OakHeading,
   OakFlex,
-  OakIcon,
   OakMaxWidth,
+  OakImage,
 } from "@oaknational/oak-components";
 
 import ImageContainer from "@/components/GenericPagesComponents/ImageContainer";
@@ -71,8 +71,9 @@ const PupilTab: FC = () => {
               sizes={getSizes([100, 518])}
             >
               {/* @todo check left position with marketing */}
-              <OakIcon
-                iconName="burst"
+              <OakImage
+                alt=""
+                src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1734537152/OWA/ui-graphics/burst_k0mkht.svg`}
                 $position={"absolute"}
                 $top={"spacing-0"}
                 $left={"spacing-0"}

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -7,12 +7,12 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
       class="sc-aXZVg fMrRXk"
     >
       <span
-        class="sc-aXZVg cegGxk"
+        class="sc-aXZVg kZhQgx"
         style="pointer-events: none;"
       >
         <img
           alt=""
-          class="sc-iGgWBj cMzyFO"
+          class="sc-iGgWBj dZvqhO"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -36,10 +36,10 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-ea54c430-2 flLvBT"
+              class="sc-36a6b83-2 gdcpHp"
             >
               <li
-                class="sc-ea54c430-1 duAgam"
+                class="sc-36a6b83-1 jXqwfI"
               >
                 <div
                   class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -49,7 +49,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                     style="outline: none;"
                   >
                     <div
-                      class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                      class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                       data-testid="who-we-are-explore-item"
                     >
                       <div
@@ -96,7 +96,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                 </div>
               </li>
               <li
-                class="sc-ea54c430-1 duAgam"
+                class="sc-36a6b83-1 jXqwfI"
               >
                 <div
                   class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -106,7 +106,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                     style="outline: none;"
                   >
                     <div
-                      class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                      class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                       data-testid="who-we-are-explore-item"
                     >
                       <div
@@ -153,7 +153,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                 </div>
               </li>
               <li
-                class="sc-ea54c430-1 duAgam"
+                class="sc-36a6b83-1 jXqwfI"
               >
                 <div
                   class="sc-aXZVg sc-hZDyAQ kBnJtM bXQMrr"
@@ -163,7 +163,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                     style="outline: none;"
                   >
                     <div
-                      class="sc-aXZVg sc-gEvEer sc-ea54c430-0 jtqxcT egjftS egvGNM"
+                      class="sc-aXZVg sc-gEvEer sc-36a6b83-0 jtqxcT egjftS dPYnxC"
                       data-testid="who-we-are-explore-item"
                     >
                       <div

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
@@ -6,6 +6,7 @@ import {
   OakIconProps,
   OakFocusIndicator,
   parseSpacing,
+  OakImage,
 } from "@oaknational/oak-components";
 import Link from "next/link";
 import { useId } from "react";
@@ -64,8 +65,9 @@ export function WhoAreWeExplore({
 
   return (
     <OakBox $background={"bg-decorative1-main"} $position={"relative"}>
-      <OakIcon
-        iconName="confetti"
+      <OakImage
+        alt=""
+        src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1763546694/ui-graphics/confetti-background_xbvfrc.svg`}
         $position={"absolute"}
         $top={"spacing-0"}
         $left={"spacing-0"}

--- a/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
+++ b/src/components/TeacherComponents/DownloadConfirmation/DownloadConfirmation.tsx
@@ -4,9 +4,9 @@ import {
   OakHeading,
   OakSpan,
   OakBox,
-  OakIcon,
   OakLink,
   OakTertiaryButton,
+  OakImage,
 } from "@oaknational/oak-components";
 import { useOakConsent } from "@oaknational/oak-consent-client";
 import styled from "styled-components";
@@ -146,8 +146,9 @@ const DownloadConfirmation: FC<DownloadConfirmationProps> = ({
           $justifyContent={"center"}
           $position={"relative"}
         >
-          <OakIcon
-            iconName="tick-mark-happiness"
+          <OakImage
+            alt={""}
+            src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1734537080/OWA/ui-graphics/tick-mark-happiness_fyst07.svg`}
             $height={"100%"}
             $width={"100%"}
           />

--- a/src/components/TeacherComponents/LessonOverviewSpeechBubble/LessonOverviewSpeechBubble.tsx
+++ b/src/components/TeacherComponents/LessonOverviewSpeechBubble/LessonOverviewSpeechBubble.tsx
@@ -1,5 +1,10 @@
 import { FC } from "react";
-import { OakSpan, OakIcon, OakBox, OakFlex } from "@oaknational/oak-components";
+import {
+  OakSpan,
+  OakBox,
+  OakFlex,
+  OakImage,
+} from "@oaknational/oak-components";
 
 type LessonOverviewSpeechBubbleProps = {
   text?: string | null | undefined;
@@ -39,8 +44,9 @@ const LessonOverviewSpeechBubble: FC<LessonOverviewSpeechBubbleProps> = ({
             {text}
           </OakSpan>
         </OakFlex>
-        <OakIcon
-          iconName="speech-bubble"
+        <OakImage
+          alt=""
+          src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1734537300/OWA/ui-graphics/speech-bubble_magqjf.svg`}
           $position={"absolute"}
           $top={"spacing-4"}
           $height={"spacing-360"}


### PR DESCRIPTION
## Description
We're about to remove the colour icons from oak-components. Change colour icons from `<OakIcon/>` to `<OakImage/>`

## Issue(s)
References `OC-28`

## How to test
QA
1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
