### PR TITLE
chore: hide placeholder video component from pally

### DIFF
--- a/pa11yci.config.js
+++ b/pa11yci.config.js
@@ -29,8 +29,10 @@ const config = {
        * Metomic
        * Avo
        * Anything labelled with .pa11y-ignore (doesn't work if element has shadow-dom children for some reason)
+       * The lazy Mux player placeholder, which renders `aria-hidden=""` (an
+       *   invalid ARIA value under React 18) on a custom element we don't control.
        */
-      '#mtm-root-container, #mtm-frame-container, #avo-debugger, .pa11y-ignore, div[class^="PostHogSurvey"]',
+      '#mtm-root-container, #mtm-frame-container, #avo-debugger, .pa11y-ignore, div[class^="PostHogSurvey"], mux-player[data-mux-player-react-lazy-placeholder]',
     ignore: [
       // We have multiple instances of high-contrast text being detected as low-contrast
       // because of low-contrast text shadows.


### PR DESCRIPTION
## Description

Music year: 1978

Since moving to app router the search page has been failing pally checks. The placeholder mux-player on the search page has the attribute aria-hidden on its component, which compiles to aria-hidden="" on the browser. Pally doesn't like this because it should be explicitly true or false. 

It's actually ok though, because when the component is scrolled into view this attribute disappears. Pally of course doesn't know this.

This PR ignores the placeholder component from pally checks, it does not hide the video player itself.

## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
