### PR TITLE
fix(PUPIL-1780): prevent GC content guidance modal from reopening after dismiss

### DIFF
--- a/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.test.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.test.ts
@@ -32,11 +32,12 @@ jest.mock("@/context/PupilLessonAnalytics/usePupilLessonAnalytics", () => ({
   usePupilLessonAnalytics: () => track,
 }));
 
-let isClassroomAssignment = false;
+let isClassroomAssignment: boolean | null = false;
+let classroomAssignmentChecked = true;
 jest.mock("@/hooks/useAssignmentSearchParams", () => ({
   useAssignmentSearchParams: () => ({
     isClassroomAssignment,
-    classroomAssignmentChecked: true,
+    classroomAssignmentChecked,
   }),
 }));
 
@@ -58,6 +59,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   asPath = "/pupils/lessons/lesson-1/overview";
   isClassroomAssignment = false;
+  classroomAssignmentChecked = true;
   usePupilLessonProgress.setState(getDefaultLessonProgressState());
   usePupilLessonProgress.getState().initialiseLessonProgress({
     lessonSlug: "lesson-1",
@@ -130,5 +132,37 @@ describe("usePupilOverviewExperience", () => {
     const { result } = renderOverview();
     act(() => result.current.handleViewAllLessonsClick());
     expect(track.trackLessonAbandoned).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows content guidance to open immediately for non-classroom lessons", () => {
+    usePupilLessonProgress.setState(getDefaultLessonProgressState());
+    const { result } = renderOverview();
+
+    expect(result.current.contentGuidanceCanOpen).toBe(true);
+  });
+
+  it("waits for lesson progress init before allowing content guidance for classroom assignments", () => {
+    isClassroomAssignment = true;
+    usePupilLessonProgress.setState(getDefaultLessonProgressState());
+    const { result, rerender } = renderOverview();
+
+    expect(result.current.contentGuidanceCanOpen).toBe(false);
+
+    act(() => {
+      usePupilLessonProgress.getState().initialiseLessonProgress({
+        lessonSlug: lessonBrowseDataFixture({}).lessonSlug,
+        lessonReviewSections: [...reviewSections],
+      });
+    });
+    rerender();
+
+    expect(result.current.contentGuidanceCanOpen).toBe(true);
+  });
+
+  it("does not allow content guidance to open until classroom assignment check completes", () => {
+    classroomAssignmentChecked = false;
+    const { result } = renderOverview();
+
+    expect(result.current.contentGuidanceCanOpen).toBe(false);
   });
 });

--- a/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.ts
@@ -42,6 +42,7 @@ export const usePupilOverviewExperience = ({
     isReadOnly,
     isHydratingInitialProgress,
     contentGuidanceDismissed,
+    lessonSlug,
     markLessonStarted,
     dismissContentGuidance,
   } = usePupilLessonProgress(
@@ -53,10 +54,17 @@ export const usePupilOverviewExperience = ({
       isReadOnly: state.isReadOnly,
       isHydratingInitialProgress: state.isHydratingInitialProgress,
       contentGuidanceDismissed: state.contentGuidanceDismissed,
+      lessonSlug: state.lessonSlug,
       markLessonStarted: state.markLessonStarted,
       dismissContentGuidance: state.dismissContentGuidance,
     })),
   );
+
+  // GC-only: wait until progress init so dismiss cannot race
+  // initialiseLessonProgress resetting contentGuidanceDismissed.
+  const contentGuidanceCanOpen =
+    classroomAssignmentChecked &&
+    (isClassroomAssignment !== true || lessonSlug === browseData.lessonSlug);
 
   const {
     trackSectionStarted,
@@ -175,6 +183,7 @@ export const usePupilOverviewExperience = ({
     isClassroomAssignment,
     classroomAssignmentChecked,
     contentGuidanceDismissed,
+    contentGuidanceCanOpen,
     isMounted,
     redirectOverlayCleared,
     setRedirectOverlayCleared,

--- a/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilOverviewExperience.ts
@@ -60,8 +60,6 @@ export const usePupilOverviewExperience = ({
     })),
   );
 
-  // GC-only: wait until progress init so dismiss cannot race
-  // initialiseLessonProgress resetting contentGuidanceDismissed.
   const contentGuidanceCanOpen =
     classroomAssignmentChecked &&
     (isClassroomAssignment !== true || lessonSlug === browseData.lessonSlug);

--- a/src/components/PupilComponents/Views/PageContent/OverviewPageContent.tsx
+++ b/src/components/PupilComponents/Views/PageContent/OverviewPageContent.tsx
@@ -26,6 +26,7 @@ const OverviewContent = ({
     isClassroomAssignment,
     classroomAssignmentChecked,
     contentGuidanceDismissed,
+    contentGuidanceCanOpen,
     isMounted,
     redirectOverlayCleared,
     setRedirectOverlayCleared,
@@ -58,6 +59,7 @@ const OverviewContent = ({
       <PupilLessonOverviewContentGuidanceModal
         redirectOverlayCleared={redirectOverlayCleared}
         contentGuidanceDismissed={contentGuidanceDismissed}
+        contentGuidanceCanOpen={contentGuidanceCanOpen}
         contentGuidance={contentGuidance}
         supervisionLevel={supervisionLevel}
         ageRestriction={browseData.features?.ageRestriction}

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.stories.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.stories.tsx
@@ -15,6 +15,7 @@ const meta = {
   args: {
     redirectOverlayCleared: true,
     contentGuidanceDismissed: false,
+    contentGuidanceCanOpen: true,
     isClassroomAssignment: false,
     onAccept: () => {},
     onDecline: () => {},

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.test.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.test.tsx
@@ -18,6 +18,7 @@ const contentGuidance = [
 const defaultProps = {
   redirectOverlayCleared: true,
   contentGuidanceDismissed: false,
+  contentGuidanceCanOpen: true,
   contentGuidance,
   supervisionLevel: "Adult supervision recommended",
   ageRestriction: null,
@@ -59,6 +60,19 @@ describe("PupilLessonOverviewContentGuidanceModal", () => {
       <PupilLessonOverviewContentGuidanceModal
         {...defaultProps}
         contentGuidanceDismissed
+      />,
+    );
+
+    expect(
+      document.querySelector('[role="alertdialog"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render until content guidance can open", () => {
+    render(
+      <PupilLessonOverviewContentGuidanceModal
+        {...defaultProps}
+        contentGuidanceCanOpen={false}
       />,
     );
 

--- a/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
+++ b/src/components/PupilComponents/Views/PupilLessonOverview/PupilLessonOverviewContentGuidanceModal/PupilLessonOverviewContentGuidanceModal.tsx
@@ -16,6 +16,7 @@ export type ContentGuidanceTrackingArgs = {
 type PupilLessonOverviewContentGuidanceModalProps = {
   redirectOverlayCleared: boolean;
   contentGuidanceDismissed: boolean;
+  contentGuidanceCanOpen: boolean;
   contentGuidance: OakPupilContentGuidance[] | null | undefined;
   supervisionLevel: string | null | undefined;
   ageRestriction: string | null | undefined;
@@ -35,6 +36,7 @@ const defaultContentGuidance: OakPupilContentGuidance[] = [
 export const PupilLessonOverviewContentGuidanceModal = ({
   redirectOverlayCleared,
   contentGuidanceDismissed,
+  contentGuidanceCanOpen,
   contentGuidance,
   supervisionLevel,
   ageRestriction,
@@ -53,7 +55,10 @@ export const PupilLessonOverviewContentGuidanceModal = ({
     ageRestriction: ageRestriction ?? "all",
   };
   const isModalOpen =
-    hasContentGuidance && !contentGuidanceDismissed && redirectOverlayCleared;
+    hasContentGuidance &&
+    !contentGuidanceDismissed &&
+    redirectOverlayCleared &&
+    contentGuidanceCanOpen;
   const declineIcon = isClassroomAssignment ? "cross" : undefined;
   const declineText = isClassroomAssignment ? "Exit lesson" : undefined;
   const ageRestrictionProps: Partial<OakPupilJourneyContentGuidanceProps> = {

--- a/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
+++ b/src/pages/pupils/lessons/[lessonSlug]/shared/[variant]/overview.tsx
@@ -40,6 +40,7 @@ const OverviewPageContent = ({
     isClassroomAssignment,
     classroomAssignmentChecked,
     contentGuidanceDismissed,
+    contentGuidanceCanOpen,
     isMounted,
     redirectOverlayCleared,
     setRedirectOverlayCleared,
@@ -72,6 +73,7 @@ const OverviewPageContent = ({
       <PupilLessonOverviewContentGuidanceModal
         redirectOverlayCleared={redirectOverlayCleared}
         contentGuidanceDismissed={contentGuidanceDismissed}
+        contentGuidanceCanOpen={contentGuidanceCanOpen}
         contentGuidance={contentGuidance}
         supervisionLevel={supervisionLevel}
         ageRestriction={browseData.features?.ageRestriction}


### PR DESCRIPTION
## Description

Music year: n/a

- For Google Classroom pupil lessons, wait to open the content guidance modal until classroom progress has initialised for the lesson
- Prevents dismiss racing `initialiseLessonProgress`, which resets `contentGuidanceDismissed` and showed the modal twice
- Non-GC overview behaviour unchanged after the assignment check completes

## Issue(s)

Fixes PUPIL-1780  
Notion: https://www.notion.so/oaknationalacademy/GC-Pupil-Lesson-Content-Guidance-Modal-displayed-twice-on-lesson-open-39e26cc4e1b180df979de0c84cdce1cb

## How to test

Local GC verification was skipped (needs Classroom iframe / deployment). Please verify on the Vercel preview:

1. Open an assigned GC lesson with content guidance (e.g. Making Veggie Kebabs)
2. Dismiss the modal as soon as it appears
3. Wait for lesson state restore (~2–3s)
4. Modal must **not** reappear
5. Close and reopen the assignment — modal should show again (dismiss is not persisted across reopen)
6. Smoke non-GC browse/canonical overview with content guidance — one modal only, as today

## Screenshots


https://github.com/user-attachments/assets/285e08f8-68ad-4b7d-9eff-7a484676df7d



## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices (deferred to preview — GC iframe required)
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change

## Notes for reviewers

- Bugbot finding (nav not gated on `contentGuidanceCanOpen` during GC init) accepted: overview section items stay disabled until progress init populates `lessonReviewSections`

Made with [Cursor](https://cursor.com)