### PR TITLE
Fix/lesq 1854/oak icon flashes

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`Teachers Page Page component renders 1`] = `
                 class="sc-eqUAAy iGfTGj"
               >
                 <span
-                  class="sc-aXZVg cZEtHK"
+                  class="sc-aXZVg etAHNY"
                 >
                   <img
                     alt=""
@@ -194,6 +194,19 @@ exports[`Teachers Page Page component renders 1`] = `
                     decoding="async"
                     loading="lazy"
                     src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1711468346/logo-mark.svg"
+                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                  />
+                </span>
+                <span
+                  class="sc-aXZVg bmLRQH"
+                >
+                  <img
+                    alt=""
+                    class="sc-iGgWBj dZvqhO"
+                    data-nimg="fill"
+                    decoding="async"
+                    loading="lazy"
+                    src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
                     style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
                 </span>

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -88,19 +88,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c28 {
+  position: relative;
+  width: 6.25rem;
+  height: 3rem;
+  padding: 0rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -121,17 +130,17 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c39:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c43 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -139,7 +148,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -150,7 +159,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -159,12 +168,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c55 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c58 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -184,7 +193,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c60 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -194,28 +203,28 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -224,7 +233,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -232,7 +241,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -242,41 +251,41 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c78 {
+.c79 {
   background: #e3e9fb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   height: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c87 {
+.c88 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c90 {
+.c91 {
   background: #ffffff;
   border-radius: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c92 {
   padding: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c101 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -287,26 +296,26 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c106 {
+.c107 {
   width: 100%;
   aspect-ratio: 16/9;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c111 {
+.c112 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c112 {
+.c113 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -321,26 +330,26 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c113 {
+.c114 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c117 {
+.c118 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c119 {
+.c120 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -350,7 +359,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c123 {
+.c124 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 1.125rem;
@@ -361,14 +370,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c125 {
+.c126 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c127 {
+.c128 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -380,12 +389,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c132 {
+.c133 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -399,36 +408,36 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c136 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c152 {
+.c153 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c155 {
+.c156 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c159 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c162 {
+.c163 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c166 {
+.c167 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -438,13 +447,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c167 {
+.c168 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c169 {
+.c170 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -456,12 +465,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c172 {
+.c173 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c174 {
+.c175 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -473,18 +482,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c178 {
+.c179 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c179 {
+.c180 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c183 {
+.c184 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -493,7 +502,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c184 {
+.c185 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -501,7 +510,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c189 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -512,7 +521,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c189 {
+.c190 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -523,7 +532,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c192 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -531,12 +540,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c194 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c197 {
+.c198 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -554,7 +563,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c199 {
+.c200 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -572,7 +581,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c201 {
+.c202 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -582,7 +591,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 300;
 }
 
-.c204 {
+.c205 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -590,7 +599,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c205 {
+.c206 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -598,13 +607,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c207 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c207 {
+.c208 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -612,7 +621,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c209 {
+.c210 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -623,7 +632,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c212 {
+.c213 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -685,7 +694,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,7 +713,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -723,7 +732,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -735,7 +744,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -746,14 +755,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -772,7 +781,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -787,7 +796,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -803,7 +812,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c80 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -813,7 +822,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -829,7 +838,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -840,7 +849,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c86 {
+.c87 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -851,7 +860,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: flex-end;
 }
 
-.c92 {
+.c93 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -862,7 +871,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -873,7 +882,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c96 {
+.c97 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -884,7 +893,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c98 {
+.c99 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -895,7 +904,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c101 {
+.c102 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -906,7 +915,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.25rem;
 }
 
-.c102 {
+.c103 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -920,7 +929,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c103 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -931,7 +940,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c105 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -942,7 +951,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c108 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -961,7 +970,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   row-gap: 1.5rem;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -972,7 +981,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c120 {
+.c121 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -987,7 +996,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c124 {
+.c125 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -998,7 +1007,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c131 {
+.c132 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1012,7 +1021,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c170 {
+.c171 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1030,7 +1039,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c182 {
+.c183 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1041,7 +1050,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c185 {
+.c186 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1057,7 +1066,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c192 {
+.c193 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1075,7 +1084,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c194 {
+.c195 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1088,7 +1097,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c202 {
+.c203 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1103,7 +1112,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c208 {
+.c209 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1118,7 +1127,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c211 {
+.c212 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1168,7 +1177,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1180,7 +1189,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: left;
 }
 
-.c54 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1191,14 +1200,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #a0b6f2;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c146 {
+.c147 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1209,7 +1218,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c160 {
+.c161 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1220,7 +1229,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c210 {
+.c211 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1231,7 +1240,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c168 {
+.c169 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1330,7 +1339,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1353,12 +1362,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c47 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1372,12 +1381,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c47:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c56 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1390,12 +1399,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1425,12 +1434,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1454,12 +1463,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c163 {
+.c164 {
   background: none;
   color: inherit;
   border: none;
@@ -1483,12 +1492,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c163:disabled {
+.c164:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c214 {
+.c215 {
   background: none;
   color: inherit;
   border: none;
@@ -1511,7 +1520,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c214:disabled {
+.c215:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1520,25 +1529,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c35 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c53 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c198 {
+.c199 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c200 {
+.c201 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1553,7 +1562,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c107 {
+.c108 {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
   background-color: #e7f6f5;
   background-size: 4rem;
@@ -1638,13 +1647,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1652,37 +1661,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1690,27 +1699,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1764,74 +1773,74 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c48 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c48:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c48:active {
+.c49:active {
   color: #222222;
 }
 
-.c48:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c46 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c46 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c46 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c46 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c186 > :first-child:focus-visible .shadow {
+.c187 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c186 > :first-child:hover .shadow {
+.c187 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c186 > :first-child:active .shadow {
+.c187 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c186 > :first-child:disabled .icon-container {
+.c187 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c186 > :first-child:hover .icon-container {
+.c187 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c186 > :first-child:active .icon-container {
+.c187 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1842,7 +1851,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c83 {
+.c84 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1853,7 +1862,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c94 {
+.c95 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1864,7 +1873,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c115 {
+.c116 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1876,7 +1885,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: center;
 }
 
-.c133 {
+.c134 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1887,7 +1896,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c173 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1900,7 +1909,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1908,7 +1917,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c176 {
+.c177 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1917,7 +1926,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1928,7 +1937,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c95 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1939,13 +1948,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c134 {
+.c135 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c164 {
+.c165 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1958,7 +1967,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c165 {
+.c166 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1970,7 +1979,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c195 {
+.c196 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1981,7 +1990,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c196 {
+.c197 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1992,7 +2001,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c175 {
+.c176 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2003,7 +2012,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2024,7 +2033,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c181 {
+.c182 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2055,7 +2064,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c180 {
+.c24 .c181 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2070,7 +2079,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c180 {
+.c24:visited .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2080,7 +2089,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c180 {
+.c24:active .c181 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2090,12 +2099,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c180 {
+.c24[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c177 {
+.c178 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2119,47 +2128,47 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c177 .c180 {
+.c178 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c177:focus-visible {
+.c178:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c177:visited {
+.c178:visited {
   color: #222222;
 }
 
-.c177:visited .c180 {
+.c178:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c177:active {
+.c178:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c177:active .c180 {
+.c178:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c177[disabled] {
+.c178[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c177[disabled] .c180 {
+.c178[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c213 {
+.c214 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2192,47 +2201,47 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c213 .c180 {
+.c214 .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c213:focus-visible {
+.c214:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c213:visited {
+.c214:visited {
   color: #222222;
 }
 
-.c213:visited .c180 {
+.c214:visited .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c213:active {
+.c214:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c213:active .c180 {
+.c214:active .c181 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c213[disabled] {
+.c214[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c213[disabled] .c180 {
+.c214[disabled] .c181 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c42 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2248,49 +2257,49 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   width: 100%;
 }
 
-.c42::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c42::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c42:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c42::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c42::-webkit-search-decoration,
-.c42::-webkit-search-cancel-button,
-.c42::-webkit-search-results-button,
-.c42::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c42:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c41 {
+.c42 {
   background: #ffffff;
 }
 
-.c41:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c81 {
+.c82 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2300,7 +2309,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(4,1fr);
 }
 
-.c97 {
+.c98 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2309,13 +2318,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c128 {
+.c129 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c82 {
+.c83 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2326,7 +2335,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 1;
 }
 
-.c84 {
+.c85 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2337,7 +2346,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 3;
 }
 
-.c89 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2348,7 +2357,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row-start: 2;
 }
 
-.c99 {
+.c100 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2358,7 +2367,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c104 {
+.c105 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2368,7 +2377,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-column-start: 1;
 }
 
-.c129 {
+.c130 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2377,7 +2386,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c171 {
+.c172 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2386,58 +2395,58 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c118 {
+.c119 {
   list-style: none;
   margin: 0;
   padding: 0;
   box-shadow: none;
 }
 
-.c118:has(a:hover,button:hover) {
+.c119:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c118:has( a, button) {
+.c119:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c118:has( a, button)  a,
-.c118:has( a, button) button {
+.c119:has( a, button)  a,
+.c119:has( a, button) button {
   outline: none;
 }
 
-.c118:has(a:active,button:active) {
+.c119:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c57:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c57:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c203 {
+.c204 {
   top: 152px;
 }
 
-.c187 .icon-container > *:first-child {
+.c188 .icon-container > *:first-child {
   border: 0;
 }
 
-.c190 {
+.c191 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c121:hover {
+.c122:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c116 {
+.c117 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2449,13 +2458,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c149 {
+.c150 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c138 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2466,23 +2475,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c137::-webkit-scrollbar-track {
+.c138::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c137::-webkit-scrollbar {
+.c138::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c137::-webkit-scrollbar-thumb {
+.c138::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c140 {
+.c141 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2491,23 +2500,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c140::-webkit-scrollbar-track {
+.c141::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar {
+.c141::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar-thumb {
+.c141::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c142 {
+.c143 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2515,30 +2524,30 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: flex;
 }
 
-.c142::-webkit-scrollbar-track {
+.c143::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c142::-webkit-scrollbar {
+.c143::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c142::-webkit-scrollbar-thumb {
+.c143::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c138 {
+.c139 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c141 {
+.c142 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2550,7 +2559,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c147 {
+.c148 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2561,32 +2570,32 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c147::-webkit-input-placeholder {
+.c148::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c147::-moz-placeholder {
+.c148::-moz-placeholder {
   color: #575757;
 }
 
-.c147:-ms-input-placeholder {
+.c148:-ms-input-placeholder {
   color: #575757;
 }
 
-.c147::placeholder {
+.c148::placeholder {
   color: #575757;
 }
 
-.c147::-webkit-search-decoration,
-.c147::-webkit-search-cancel-button,
-.c147::-webkit-search-results-button,
-.c147::-webkit-search-results-decoration {
+.c148::-webkit-search-decoration,
+.c148::-webkit-search-cancel-button,
+.c148::-webkit-search-results-button,
+.c148::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c144 {
+.c145 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2596,7 +2605,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c151 {
+.c152 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2609,7 +2618,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c145 {
+.c146 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2620,16 +2629,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c139:focus-within .c143 {
+.c140:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c139:focus-within .c150 {
+.c140:focus-within .c151 {
   display: inline;
 }
 
-.c148 {
+.c149 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2645,7 +2654,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   outline: none;
 }
 
-.c148::-webkit-input-placeholder {
+.c149::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2653,7 +2662,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c148::-moz-placeholder {
+.c149::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2661,7 +2670,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c148:-ms-input-placeholder {
+.c149:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2669,7 +2678,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c148::placeholder {
+.c149::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2677,31 +2686,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c148:valid:not([value=""]) {
+.c149:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c148:valid:not([value=""])::-webkit-input-placeholder {
+.c149:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c148:valid:not([value=""])::-moz-placeholder {
+.c149:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c148:valid:not([value=""]):-ms-input-placeholder {
+.c149:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c148:valid:not([value=""])::placeholder {
+.c149:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c156 {
+.c157 {
   background: none;
   color: inherit;
   border: none;
@@ -2712,16 +2721,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c154 {
+.c155 {
   display: none;
 }
 
-.c153:focus-within .c143 {
+.c154:focus-within .c144 {
   background: #374cf1;
   color: #fff;
 }
 
-.c157 {
+.c158 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2748,43 +2757,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #575757;
 }
 
-.c159 {
+.c160 {
   max-width: calc(100% - 20px);
 }
 
-.c161 {
+.c162 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c136 {
+.c137 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c127 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c77 {
+.c78 {
   height: 125%;
   -webkit-filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
   filter: invert(70%) sepia(24%) saturate(580%) hue-rotate(188deg) brightness(100%) contrast(94%);
 }
 
-.c88 {
+.c89 {
   height: 260px;
 }
 
-.c109 {
+.c110 {
   max-height: 40px;
   height: auto;
   width: auto;
@@ -2837,18 +2846,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c26 {
-    width: 6.25rem;
+    display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
-    height: 3rem;
+  .c28 {
+    display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2857,19 +2866,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2877,37 +2886,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c55 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -2921,79 +2930,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3002,7 +3011,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c100 {
+  .c101 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3011,13 +3020,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3025,7 +3034,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3033,79 +3042,79 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c113 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c113 {
+  .c114 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c169 {
+  .c170 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c169 {
+  .c170 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c172 {
+  .c173 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c178 {
+  .c179 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c184 {
+  .c185 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c192 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3114,13 +3123,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c198 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c197 {
+  .c198 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3128,7 +3137,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c197 {
+  .c198 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3136,19 +3145,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c200 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3156,61 +3165,61 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c208 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c208 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3228,19 +3237,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3257,31 +3266,31 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c98 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3290,7 +3299,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c98 {
+  .c99 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3299,25 +3308,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c102 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c109 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3325,7 +3334,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c109 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3333,19 +3342,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c114 {
+  .c115 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c182 {
+  .c183 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3354,13 +3363,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c185 {
+  .c186 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3368,7 +3377,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3377,7 +3386,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3386,7 +3395,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c194 {
+  .c195 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3395,7 +3404,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3404,7 +3413,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3412,7 +3421,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3420,7 +3429,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3429,7 +3438,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3438,19 +3447,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c208 {
+  .c209 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3458,7 +3467,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3466,7 +3475,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c211 {
+  .c212 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3474,7 +3483,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c211 {
+  .c212 {
     gap: 2rem;
   }
 }
@@ -3534,25 +3543,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-weight: 500;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3585,43 +3594,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3630,7 +3639,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3639,43 +3648,43 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c83 {
+  .c84 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3684,169 +3693,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c83 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c94 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c94 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    font-size: 2rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    line-height: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c115 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c115 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    font-weight: 400;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    font-weight: 400;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    font-size: 2.5rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    font-size: 2.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c74 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:1280px) {
-  .c74 {
+  .c84 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3856,24 +3703,186 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c95 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c95 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c95 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c116 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c116 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    font-weight: 400;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    font-weight: 400;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    font-size: 2.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    font-size: 2.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c75 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c75 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c96 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3882,7 +3891,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     margin-right: 1.5rem;
   }
 }
@@ -3897,16 +3906,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c180,
-  .c24:visited:hover .c180 {
+  .c24:hover .c181,
+  .c24:visited:hover .c181 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c177:hover,
-  .c177:visited:hover {
+  .c178:hover,
+  .c178:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3914,16 +3923,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c177:hover .c180,
-  .c177:visited:hover .c180 {
+  .c178:hover .c181,
+  .c178:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c213:hover,
-  .c213:visited:hover {
+  .c214:hover,
+  .c214:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3931,288 +3940,288 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c213:hover .c180,
-  .c213:visited:hover .c180 {
+  .c214:hover .c181,
+  .c214:visited:hover .c181 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c42 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c41:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c81 {
+  .c82 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     grid-template-columns: repeat(8,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c81 {
+  .c82 {
     grid-template-columns: repeat(12,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     row-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     row-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     -webkit-column-gap: 2.5rem;
     column-gap: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-column: 2 / span 3;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-column: 3 / span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-row: 1 / span 1;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c84 {
+  .c85 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column: 5 / span 4;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column-start: 5;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-row-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c99 {
+  .c100 {
     grid-column: 1 / span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:1280px) {
-  .c99 {
+  .c100 {
     grid-column-start: 1;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c105 {
     grid-column: 6 / span 7;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:1280px) {
-  .c104 {
+  .c105 {
     grid-column-start: 6;
   }
 }
 
 @media (min-width:750px) {
-  .c129 {
+  .c130 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c171 {
+  .c172 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c116 {
+  .c117 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c148 {
+  .c149 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c127 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c77 {
+  .c78 {
     min-width: 400px;
   }
 }
 
 @media (min-width:921px) and (max-width:1050px) {
-  .c77 {
+  .c78 {
     display: block;
     -webkit-translate: 14% -35%;
     translate: 14% -35%;
@@ -4223,7 +4232,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1051px) and (max-width:1180px) {
-  .c77 {
+  .c78 {
     -webkit-translate: 21% -33%;
     translate: 21% -33%;
     -webkit-transform: scale(1.6) rotate(-9deg);
@@ -4233,7 +4242,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1181px) and (max-width:1279px) {
-  .c77 {
+  .c78 {
     -webkit-transform: scale(1.55) rotate(-8.5deg);
     -ms-transform: scale(1.55) rotate(-8.5deg);
     transform: scale(1.55) rotate(-8.5deg);
@@ -4243,7 +4252,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c77 {
+  .c78 {
     -webkit-translate: 20% -41%;
     translate: 20% -41%;
     -webkit-transform: scale(1.7) rotate(-8deg);
@@ -4253,25 +4262,25 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     height: 380px;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c89 {
     height: 430px;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     max-height: 56px;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     max-height: 64px;
   }
 }
@@ -4471,10 +4480,23 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>
+              <span
+                class="c28"
+              >
+                <img
+                  alt=""
+                  class="c27"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4482,10 +4504,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c30"
               >
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4499,15 +4521,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4516,7 +4538,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4530,15 +4552,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4547,7 +4569,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4561,15 +4583,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4578,7 +4600,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4592,15 +4614,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4609,7 +4631,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4622,16 +4644,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
@@ -4640,7 +4662,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4655,24 +4677,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c9 c36"
+              class="c9 c37"
             >
               <form
                 action="/teachers/search"
-                class="c37"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c38"
+                  class="c39"
                 >
                   <div
-                    class="c39 c40 c41"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c42"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4680,24 +4702,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c43"
+                  class="c44"
                 >
                   <div
-                    class="c44 c45 c46"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c47 c48"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c9 c49"
+                        class="c9 c50"
                       >
                         <div
-                          class="c50 c51 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c52 shadow"
+                            class="c53 shadow"
                           />
                           <span
                             class="c20"
@@ -4705,7 +4727,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c53"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4715,7 +4737,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c54"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4723,24 +4745,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c55"
+                class="c56"
               >
                 <div
-                  class="c44 c45 c46"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c50 c51 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c52 shadow"
+                          class="c53 shadow"
                         />
                         <span
                           class="c20"
@@ -4748,7 +4770,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c53"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4758,7 +4780,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4766,14 +4788,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c56 c57"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c58 c59 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c60"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4787,7 +4809,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4803,13 +4825,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c34"
                   >
                     <span
-                      class="c34"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4819,7 +4841,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4833,18 +4855,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c49"
+                  class="c9 c50"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c35"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4862,41 +4884,41 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Get involved
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   We need your help to understand what's needed in the classroom. Want to get involved? We can't wait to hear from you.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76 c77"
+                  class="c77 c78"
                   data-testid="about-shared-loop"
                 >
                   <img
@@ -4913,34 +4935,34 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c78"
+            class="c79"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c79 c80"
+                class="c80 c81"
               >
                 <div
-                  class="c9 c81"
+                  class="c9 c82"
                 >
                   <div
-                    class="c9 c45 c82"
+                    class="c9 c46 c83"
                   >
                     <h2
-                      class="c83"
+                      class="c84"
                     >
                       Collaborate with us
                     </h2>
                   </div>
                   <div
-                    class="c9 c45 c84"
+                    class="c9 c46 c85"
                   >
                     <div
-                      class="c85 c86"
+                      class="c86 c87"
                     >
                       <span
-                        class="c87 c88"
+                        class="c88 c89"
                       >
                         <img
                           alt=""
@@ -4955,33 +4977,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9 c45 c89"
+                    class="c9 c46 c90"
                   >
                     <div
-                      class="c9 c71"
+                      class="c9 c72"
                     >
                       <div
-                        class="c90"
+                        class="c91"
                       >
                         <div
-                          class="c91 c92"
+                          class="c92 c93"
                         >
                           <div
-                            class="c9 c93"
+                            class="c9 c94"
                           >
                             <h3
-                              class="c94"
+                              class="c95"
                             >
                               Join our teacher research panel
                             </h3>
                             <p
-                              class="c95"
+                              class="c96"
                             >
                               Share your story and we'll send you a gift voucher as a thanks for your time. Whether you've planned more efficiently, strengthened your subject knowledge or refreshed your curriculum design, your experience can inspire other teachers.
                             </p>
                           </div>
                           <div
-                            class="c9 c96"
+                            class="c9 c97"
                           >
                             <div
                               class="c4 c5"
@@ -5050,27 +5072,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c90"
+                        class="c91"
                       >
                         <div
-                          class="c91 c92"
+                          class="c92 c93"
                         >
                           <div
-                            class="c9 c93"
+                            class="c9 c94"
                           >
                             <h3
-                              class="c94"
+                              class="c95"
                             >
                               Give your feedback
                             </h3>
                             <p
-                              class="c95"
+                              class="c96"
                             >
                               Teachers are at the heart of everything we build. Have your say by taking part in research or road-testing new resources in your school. 
                             </p>
                           </div>
                           <div
-                            class="c9 c96"
+                            class="c9 c97"
                           >
                             <div
                               class="c4 c5"
@@ -5121,37 +5143,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c79 c97"
+              class="c80 c98"
             >
               <div
-                class="c9 c98 c99"
+                class="c9 c99 c100"
               >
                 <div
-                  class="c9 c92"
+                  class="c9 c93"
                 >
                   <div
-                    class="c9 c71"
+                    class="c9 c72"
                   >
                     <h2
-                      class="c83"
+                      class="c84"
                     >
                       Work with us
                     </h2>
                     <div
-                      class="c100 c101"
+                      class="c101 c102"
                     >
                       <p
-                        class="c95"
+                        class="c96"
                       >
                         We're a fast-paced and innovative team, working to support and inspire teachers to deliver great teaching, so every pupil benefits. All our roles are remote-first. If you want to be part of something unique that's making a difference to millions of children's lives, we'd love to hear from you.
                       </p>
                     </div>
                   </div>
                   <div
-                    class="c9 c102"
+                    class="c9 c103"
                   >
                     <div
                       class="c4 c5"
@@ -5235,20 +5257,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c103 c104"
+                class="c9 c104 c105"
               >
                 <div
-                  class="c9 c105"
+                  class="c9 c106"
                 >
                   <div
-                    class="c106 c45"
+                    class="c107 c46"
                   >
                     <span
-                      class="c87"
+                      class="c88"
                     >
                       <img
                         alt=""
-                        class="c107"
+                        class="c108"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -5260,21 +5282,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c9 c108"
+                    class="c9 c109"
                   >
                     <img
                       alt="'In Escape the City's top 1% of employers'"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/top-1-percent-logo_hyga8g.svg"
                     />
                     <img
                       alt="Awarded Gold in Investors In People"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/investor-in-people_eymeqv.svg"
                     />
                     <img
                       alt="Certified as Disability Confident Committed"
-                      class="c109"
+                      class="c110"
                       src="https://res.cloudinary.com/oak-web-application/image/upload/v1764066553/about-us/disability-confident_ym07wl.png"
                     />
                   </div>
@@ -5283,14 +5305,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c110"
+            class="c111"
             style="margin-top: -72px;"
           >
             <div
-              class="c111"
+              class="c112"
             >
               <span
-                class="c112"
+                class="c113"
                 style="pointer-events: none;"
               >
                 <img
@@ -5304,13 +5326,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c113 c114"
+                  class="c114 c115"
                 >
                   <h2
-                    class="c115"
+                    class="c116"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5319,24 +5341,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c116"
+                      class="c117"
                     >
                       <li
-                        class="c117 c118"
+                        class="c118 c119"
                       >
                         <a
                           href="/about-us/who-we-are"
                           style="outline: none;"
                         >
                           <div
-                            class="c119 c120 c121"
+                            class="c120 c121 c122"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5350,15 +5372,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c123 c124"
+                              class="c124 c125"
                             >
                               About Oak
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c76"
+                                class="c77"
                               >
                                 <img
                                   alt=""
@@ -5375,21 +5397,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c117 c118"
+                        class="c118 c119"
                       >
                         <a
                           href="/about-us/oaks-curricula"
                           style="outline: none;"
                         >
                           <div
-                            class="c119 c120 c121"
+                            class="c120 c121 c122"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5403,15 +5425,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c123 c124"
+                              class="c124 c125"
                             >
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c76"
+                                class="c77"
                               >
                                 <img
                                   alt=""
@@ -5428,21 +5450,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c117 c118"
+                        class="c118 c119"
                       >
                         <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
                           <div
-                            class="c119 c120 c121"
+                            class="c120 c121 c122"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5456,15 +5478,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c123 c124"
+                              class="c124 c125"
                             >
                               Meet the team
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c76"
+                                class="c77"
                               >
                                 <img
                                   alt=""
@@ -5481,21 +5503,21 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c117 c118"
+                        class="c118 c119"
                       >
                         <a
                           href="/about-us/get-involved"
                           style="outline: none;"
                         >
                           <div
-                            class="c119 c120 c121"
+                            class="c120 c121 c122"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5509,15 +5531,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c123 c124"
+                              class="c124 c125"
                             >
                               Get involved
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c76"
+                                class="c77"
                               >
                                 <img
                                   alt=""
@@ -5540,29 +5562,29 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c125"
+            class="c126"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c126"
+                class="c9 c46 c127"
               >
                 <div
-                  class="c127 c1"
+                  class="c128 c1"
                 >
                   <div
-                    class="c9 c128"
+                    class="c9 c129"
                   >
                     <div
-                      class="c9 c45 c129"
+                      class="c9 c46 c130"
                     >
                       <div
-                        class="c130 c131"
+                        class="c131 c132"
                       >
                         <span
-                          class="c132"
+                          class="c133"
                         >
                           <img
                             alt=""
@@ -5575,13 +5597,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c133"
+                          class="c134"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c134"
+                        class="c135"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5601,18 +5623,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c135 c45 c129"
+                      class="c136 c46 c130"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c136"
+                        class="c137"
                         novalidate=""
                       >
                         <div
-                          class="c137 c138 c139"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c140 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
@@ -5621,7 +5643,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5646,7 +5668,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5671,7 +5693,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5696,7 +5718,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5721,11 +5743,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c142 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c143 c144 c145"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5737,7 +5759,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c146"
+                                    class="c147"
                                   >
                                     (required)
                                   </span>
@@ -5748,7 +5770,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c147 c148"
+                              class="c148 c149"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5756,7 +5778,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c149 c150 c151"
+                              class="c150 c151 c152"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5769,10 +5791,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c137 c138 c139"
+                          class="c138 c139 c140"
                         >
                           <div
-                            class="c140 "
+                            class="c141 "
                           >
                             <div
                               aria-hidden="true"
@@ -5781,7 +5803,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5806,7 +5828,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5831,7 +5853,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5856,7 +5878,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c141"
+                                class="c142"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5881,11 +5903,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c142 "
+                              class="c143 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c143 c144 c145"
+                                class="c144 c145 c146"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5897,7 +5919,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c146"
+                                    class="c147"
                                   >
                                     (required)
                                   </span>
@@ -5908,7 +5930,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c147 c148"
+                              class="c148 c149"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5916,7 +5938,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c149 c150 c151"
+                              class="c150 c151 c152"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5929,7 +5951,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c152 c80 c153"
+                          class="c153 c81 c154"
                         >
                           <div
                             aria-hidden="true"
@@ -5938,7 +5960,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5963,7 +5985,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5988,7 +6010,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6013,7 +6035,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c141"
+                              class="c142"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6039,7 +6061,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c149 c150 c151 c154"
+                            class="c150 c151 c152 c155"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6050,10 +6072,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c155 c45"
+                            class="c156 c46"
                           >
                             <label
-                              class="c143 c144 c145"
+                              class="c144 c145 c146"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6065,16 +6087,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c156 c157"
+                            class="c157 c158"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c158 c40 c159"
+                              class="c159 c41 c160"
                             >
                               <span
-                                class="c160 c161"
+                                class="c161 c162"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6098,7 +6120,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c162 c5"
+                          class="c163 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -6107,7 +6129,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c163 c19 internal-button"
+                            class="c164 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -6122,12 +6144,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c164"
+                          class="c165"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c165"
+                          class="c166"
                         />
                       </form>
                     </div>
@@ -6139,14 +6161,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c166"
+        class="c167"
       >
         <div
-          class="c167 c45"
+          class="c168 c46"
         >
           <svg
             aria-hidden="true"
-            class="c168"
+            class="c169"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6169,33 +6191,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c169 c170"
+            class="c170 c171"
           >
             <div
-              class="c9 c128"
+              class="c9 c129"
             >
               <div
-                class="c9 c45 c171"
+                class="c9 c46 c172"
               >
                 <div
-                  class="c172 c80"
+                  class="c173 c81"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/pupils/years"
                         >
                           <span
@@ -6209,27 +6231,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c178"
+                  class="c179"
                 />
                 <div
-                  class="c172 c80"
+                  class="c173 c81"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6240,10 +6262,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6254,10 +6276,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6267,10 +6289,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c76 c180 c181"
+                              class="c77 c181 c182"
                             >
                               <img
                                 alt=""
@@ -6286,10 +6308,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/blog"
                         >
                           <span
@@ -6304,27 +6326,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c46 c172"
               >
                 <div
-                  class="c172 c80"
+                  class="c173 c81"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/"
                         >
                           <span
@@ -6335,10 +6357,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6349,10 +6371,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6363,10 +6385,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6377,10 +6399,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6391,11 +6413,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6405,10 +6427,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c76 c180 c181"
+                              class="c77 c181 c182"
                             >
                               <img
                                 alt=""
@@ -6424,10 +6446,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/contact-us"
                         >
                           <span
@@ -6438,11 +6460,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6452,10 +6474,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c76 c180 c181"
+                              class="c77 c181 c182"
                             >
                               <img
                                 alt=""
@@ -6471,10 +6493,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/webinars"
                         >
                           <span
@@ -6485,11 +6507,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c177 "
+                          class="c178 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6499,10 +6521,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c179"
+                            class="c180"
                           >
                             <span
-                              class="c76 c180 c181"
+                              class="c77 c181 c182"
                             >
                               <img
                                 alt=""
@@ -6522,27 +6544,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c46 c172"
               >
                 <div
-                  class="c172 c80"
+                  class="c173 c81"
                 >
                   <h2
-                    class="c173"
+                    class="c174"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c174 c175"
+                    class="c175 c176"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6553,10 +6575,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6567,10 +6589,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6581,10 +6603,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <button
-                          class="c177 "
+                          class="c178 "
                         >
                           <span
                             class="c25"
@@ -6594,10 +6616,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6608,10 +6630,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6622,10 +6644,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6636,10 +6658,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6650,10 +6672,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6664,10 +6686,10 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c176"
+                        class="c177"
                       >
                         <a
-                          class="c177 "
+                          class="c178 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6682,16 +6704,16 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c171"
+                class="c9 c46 c172"
               >
                 <div
-                  class="c172 c182"
+                  class="c173 c183"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                   >
                     <span
-                      class="c183"
+                      class="c184"
                     >
                       <img
                         alt=""
@@ -6705,24 +6727,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c184 c185"
+                    class="c185 c186"
                   >
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
                               class="c20"
@@ -6730,7 +6752,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6740,27 +6762,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
                               class="c20"
@@ -6768,7 +6790,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6778,27 +6800,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c186 c187"
+                      class="c45 c46 c187 c188"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c188 c51 icon-container"
+                            class="c189 c52 icon-container"
                           >
                             <div
-                              class="c189 shadow"
+                              class="c190 shadow"
                             />
                             <span
                               class="c20"
@@ -6806,7 +6828,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6816,7 +6838,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6826,7 +6848,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c87 c190"
+              class="c88 c191"
               data-percy-hide="contents"
             >
               <img
@@ -6842,27 +6864,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c191 c192"
+              class="c192 c193"
             >
               <div
-                class="c193 c194"
+                class="c194 c195"
               >
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
                           class="c20"
@@ -6870,7 +6892,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6880,27 +6902,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
                           class="c20"
@@ -6908,7 +6930,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6918,27 +6940,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c186 c187"
+                  class="c45 c46 c187 c188"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c188 c51 icon-container"
+                        class="c189 c52 icon-container"
                       >
                         <div
-                          class="c189 shadow"
+                          class="c190 shadow"
                         />
                         <span
                           class="c20"
@@ -6946,7 +6968,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6956,17 +6978,17 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c55"
+                class="c56"
               >
                 <span
-                  class="c183"
+                  class="c184"
                 >
                   <img
                     alt=""
@@ -6980,15 +7002,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c172 c80"
+                class="c173 c81"
               >
                 <p
-                  class="c195"
+                  class="c196"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c196"
+                  class="c197"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6997,11 +7019,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c197"
+          class="c198"
         >
           <img
             alt=""
-            class="c198"
+            class="c199"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7010,11 +7032,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c199"
+          class="c200"
         >
           <img
             alt=""
-            class="c200"
+            class="c201"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7026,27 +7048,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c201 c202 c203"
+      class="c202 c203 c204"
     />
   </div>
   <div
-    class="c204"
+    class="c205"
   >
     <div
-      class="c205"
+      class="c206"
       data-testid="cookie-banner"
     >
       <div
-        class="c206"
+        class="c207"
       >
         <div
-          class="c207 c208"
+          class="c208 c209"
         >
           <div
-            class="c209"
+            class="c210"
           >
             <strong
-              class="c210"
+              class="c211"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -7054,13 +7076,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c211"
+            class="c9 c212"
           >
             <div
-              class="c212 c40"
+              class="c213 c41"
             >
               <button
-                class="c213"
+                class="c214"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -7104,7 +7126,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c214 c19 internal-button"
+                class="c215 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -88,19 +88,28 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c28 {
+  position: relative;
+  width: 6.25rem;
+  height: 3rem;
+  padding: 0rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -121,17 +130,17 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c39:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c43 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -139,7 +148,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -150,7 +159,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -159,12 +168,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c55 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c58 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -184,7 +193,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c60 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -194,34 +203,34 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c93 {
+.c94 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -230,7 +239,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -238,7 +247,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -246,12 +255,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   padding-bottom: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   position: -webkit-sticky;
   position: sticky;
   top: 1.25rem;
@@ -261,7 +270,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -272,14 +281,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   padding: 1rem;
   background: #fff7cc;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c95 {
+.c96 {
   width: 100%;
   height: 100%;
   background: #ffffff;
@@ -287,13 +296,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c97 {
+.c98 {
   height: 100%;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -304,20 +313,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c107 {
+.c108 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c108 {
+.c109 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c109 {
+.c110 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -332,26 +341,26 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c114 {
+.c115 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c119 {
+.c120 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -361,7 +370,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 1.125rem;
@@ -372,7 +381,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c122 {
+.c123 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -382,14 +391,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c123 {
+.c124 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -401,12 +410,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c129 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -420,36 +429,36 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c134 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c149 {
+.c150 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c153 {
+.c154 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c156 {
+.c157 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c160 {
+.c161 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c164 {
+.c165 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -459,13 +468,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c165 {
+.c166 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c168 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -477,12 +486,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c170 {
+.c171 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c172 {
+.c173 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -494,18 +503,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c176 {
+.c177 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c177 {
+.c178 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c181 {
+.c182 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -514,7 +523,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c182 {
+.c183 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -522,7 +531,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c186 {
+.c187 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -533,7 +542,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c187 {
+.c188 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -544,14 +553,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c188 {
+.c189 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c191 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -559,12 +568,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c192 {
+.c193 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c197 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -582,7 +591,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c198 {
+.c199 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -600,7 +609,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c200 {
+.c201 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -610,7 +619,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 300;
 }
 
-.c203 {
+.c204 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -618,7 +627,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c204 {
+.c205 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -626,13 +635,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c205 {
+.c206 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c206 {
+.c207 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -640,7 +649,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c208 {
+.c209 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -651,7 +660,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c211 {
+.c212 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -713,7 +722,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -732,7 +741,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -751,7 +760,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -763,7 +772,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -774,14 +783,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -800,7 +809,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -815,7 +824,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -831,7 +840,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c150 {
+.c151 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -841,7 +850,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -857,7 +866,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -868,7 +877,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c78 {
+.c79 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -876,7 +885,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c83 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -891,7 +900,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c87 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -906,7 +915,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c89 {
+.c90 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -917,7 +926,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c90 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -928,7 +937,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c98 {
+.c99 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -936,7 +945,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c100 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -951,7 +960,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c103 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -966,7 +975,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c111 {
+.c112 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -977,7 +986,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c117 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -992,7 +1001,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c121 {
+.c122 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1003,7 +1012,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c129 {
+.c130 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1017,7 +1026,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c168 {
+.c169 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1035,7 +1044,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c180 {
+.c181 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1046,7 +1055,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c183 {
+.c184 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1062,7 +1071,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c191 {
+.c192 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1080,7 +1089,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c193 {
+.c194 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1093,7 +1102,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c201 {
+.c202 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1108,7 +1117,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c207 {
+.c208 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1123,7 +1132,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c210 {
+.c211 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1173,7 +1182,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1185,7 +1194,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: left;
 }
 
-.c54 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1196,14 +1205,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #ffe555;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c84 {
+.c85 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -1215,7 +1224,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c104 {
+.c105 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1226,7 +1235,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c158 {
+.c159 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1237,7 +1246,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c209 {
+.c210 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1248,7 +1257,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c166 {
+.c167 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1347,7 +1356,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1370,12 +1379,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c47 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1389,12 +1398,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c47:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c56 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1407,12 +1416,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1442,12 +1451,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1471,12 +1480,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c161 {
+.c162 {
   background: none;
   color: inherit;
   border: none;
@@ -1500,12 +1509,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c161:disabled {
+.c162:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c213 {
+.c214 {
   background: none;
   color: inherit;
   border: none;
@@ -1528,7 +1537,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c213:disabled {
+.c214:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1537,25 +1546,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c35 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c53 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c197 {
+.c198 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c199 {
+.c200 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1646,13 +1655,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1660,37 +1669,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1698,27 +1707,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1772,74 +1781,74 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c48 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c48:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c48:active {
+.c49:active {
   color: #222222;
 }
 
-.c48:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c46 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c46 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c46 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c46 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c184 > :first-child:focus-visible .shadow {
+.c185 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c184 > :first-child:hover .shadow {
+.c185 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c184 > :first-child:active .shadow {
+.c185 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c184 > :first-child:disabled .icon-container {
+.c185 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c184 > :first-child:hover .icon-container {
+.c185 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c184 > :first-child:active .icon-container {
+.c185 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1850,7 +1859,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1861,7 +1870,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c101 {
+.c102 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1872,7 +1881,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c112 {
+.c113 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1884,7 +1893,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: center;
 }
 
-.c131 {
+.c132 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1895,7 +1904,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c171 {
+.c172 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1908,7 +1917,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1916,7 +1925,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c174 {
+.c175 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1925,7 +1934,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1936,7 +1945,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c92 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -1947,18 +1956,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c102 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 
-.c132 {
+.c133 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c162 {
+.c163 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1971,7 +1980,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c163 {
+.c164 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -1983,7 +1992,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c194 {
+.c195 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1994,7 +2003,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c195 {
+.c196 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2005,7 +2014,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c106 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2016,7 +2025,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c173 {
+.c174 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2027,7 +2036,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2048,7 +2057,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c80 {
+.c81 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2068,7 +2077,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c179 {
+.c180 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2099,7 +2108,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c178 {
+.c24 .c179 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2114,7 +2123,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c178 {
+.c24:visited .c179 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2124,7 +2133,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c178 {
+.c24:active .c179 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2134,12 +2143,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c178 {
+.c24[disabled] .c179 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c175 {
+.c176 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2163,47 +2172,47 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c175 .c178 {
+.c176 .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c175:focus-visible {
+.c176:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c175:visited {
+.c176:visited {
   color: #222222;
 }
 
-.c175:visited .c178 {
+.c176:visited .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c175:active {
+.c176:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c175:active .c178 {
+.c176:active .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c175[disabled] {
+.c176[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c175[disabled] .c178 {
+.c176[disabled] .c179 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c212 {
+.c213 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2236,47 +2245,47 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c212 .c178 {
+.c213 .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c212:focus-visible {
+.c213:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c212:visited {
+.c213:visited {
   color: #222222;
 }
 
-.c212:visited .c178 {
+.c213:visited .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c212:active {
+.c213:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c212:active .c178 {
+.c213:active .c179 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c212[disabled] {
+.c213[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c212[disabled] .c178 {
+.c213[disabled] .c179 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c42 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2292,49 +2301,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   width: 100%;
 }
 
-.c42::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c42::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c42:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c42::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c42::-webkit-search-decoration,
-.c42::-webkit-search-cancel-button,
-.c42::-webkit-search-results-button,
-.c42::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c42:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c41 {
+.c42 {
   background: #ffffff;
 }
 
-.c41:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c94 {
+.c95 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2344,13 +2353,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(auto-fit,minmax(200px,1fr));
 }
 
-.c126 {
+.c127 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c127 {
+.c128 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2359,7 +2368,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c169 {
+.c170 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2368,58 +2377,58 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c96 {
+.c97 {
   list-style: none;
   margin: 0;
   padding: 0;
   box-shadow: none;
 }
 
-.c96:has(a:hover,button:hover) {
+.c97:has(a:hover,button:hover) {
   background-color: #f2f2f2;
   box-shadow: none;
 }
 
-.c96:has( a, button) {
+.c97:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c96:has( a, button)  a,
-.c96:has( a, button) button {
+.c97:has( a, button)  a,
+.c97:has( a, button) button {
   outline: none;
 }
 
-.c96:has(a:active,button:active) {
+.c97:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c115 {
+.c116 {
   list-style: none;
   margin: 0;
   padding: 0;
   box-shadow: none;
 }
 
-.c115:has(a:hover,button:hover) {
+.c116:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c115:has( a, button) {
+.c116:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c115:has( a, button)  a,
-.c115:has( a, button) button {
+.c116:has( a, button)  a,
+.c116:has( a, button) button {
   outline: none;
 }
 
-.c115:has(a:active,button:active) {
+.c116:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c99 {
+.c100 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2430,93 +2439,93 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c99:hover h1,
-.c99:hover h2,
-.c99:hover h3,
-.c99:hover h4,
-.c99:hover h5,
-.c99:hover h6,
-.c99:hover span {
+.c100:hover h1,
+.c100:hover h2,
+.c100:hover h3,
+.c100:hover h4,
+.c100:hover h5,
+.c100:hover h6,
+.c100:hover span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c99:hover span {
+.c100:hover span {
   -webkit-text-decoration-thickness: 18%;
   text-decoration-thickness: 18%;
 }
 
-.c57:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c57:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-}
-
-.c81 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-column-gap: 1rem;
-  column-gap: 1rem;
-  padding-left: 0rem;
-  padding-right: 0rem;
-}
-
-.c81:focus-visible {
-  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-  border-color: transparent;
-  border-radius: 4px;
-}
-
-.c86 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-column-gap: 1rem;
-  column-gap: 1rem;
-  padding-left: 0rem;
-  padding-right: 0rem;
-}
-
-.c86:focus-visible {
-  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-  border-color: transparent;
-  border-radius: 4px;
 }
 
 .c82 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
+}
+
+.c82:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+.c87 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
+}
+
+.c87:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2525,21 +2534,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c202 {
+.c203 {
   top: 152px;
 }
 
-.c185 .icon-container > *:first-child {
+.c186 .icon-container > *:first-child {
   border: 0;
 }
 
-.c189 {
+.c190 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c154 {
+.c155 {
   background: none;
   color: inherit;
   border: none;
@@ -2550,16 +2559,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c118:hover {
+.c119:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c113 {
+.c114 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2571,13 +2580,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c146 {
+.c147 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c135 {
+.c136 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2588,23 +2597,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c135::-webkit-scrollbar-track {
+.c136::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c135::-webkit-scrollbar {
+.c136::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c135::-webkit-scrollbar-thumb {
+.c136::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c138 {
+.c139 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2613,23 +2622,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c138::-webkit-scrollbar-track {
+.c139::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c138::-webkit-scrollbar {
+.c139::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c138::-webkit-scrollbar-thumb {
+.c139::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c140 {
+.c141 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2637,30 +2646,30 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: flex;
 }
 
-.c140::-webkit-scrollbar-track {
+.c141::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar {
+.c141::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c140::-webkit-scrollbar-thumb {
+.c141::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c136 {
+.c137 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c139 {
+.c140 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2672,7 +2681,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c144 {
+.c145 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2683,32 +2692,32 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c144::-webkit-input-placeholder {
+.c145::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c144::-moz-placeholder {
+.c145::-moz-placeholder {
   color: #575757;
 }
 
-.c144:-ms-input-placeholder {
+.c145:-ms-input-placeholder {
   color: #575757;
 }
 
-.c144::placeholder {
+.c145::placeholder {
   color: #575757;
 }
 
-.c144::-webkit-search-decoration,
-.c144::-webkit-search-cancel-button,
-.c144::-webkit-search-results-button,
-.c144::-webkit-search-results-decoration {
+.c145::-webkit-search-decoration,
+.c145::-webkit-search-cancel-button,
+.c145::-webkit-search-results-button,
+.c145::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c142 {
+.c143 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2718,7 +2727,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c148 {
+.c149 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2731,7 +2740,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c143 {
+.c144 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2742,16 +2751,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c137:focus-within .c141 {
+.c138:focus-within .c142 {
   background: #374cf1;
   color: #fff;
 }
 
-.c137:focus-within .c147 {
+.c138:focus-within .c148 {
   display: inline;
 }
 
-.c145 {
+.c146 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2767,7 +2776,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   outline: none;
 }
 
-.c145::-webkit-input-placeholder {
+.c146::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2775,7 +2784,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c145::-moz-placeholder {
+.c146::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2783,7 +2792,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c145:-ms-input-placeholder {
+.c146:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2791,7 +2800,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c145::placeholder {
+.c146::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2799,40 +2808,40 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c145:valid:not([value=""]) {
+.c146:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c145:valid:not([value=""])::-webkit-input-placeholder {
+.c146:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c145:valid:not([value=""])::-moz-placeholder {
+.c146:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c145:valid:not([value=""]):-ms-input-placeholder {
+.c146:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c145:valid:not([value=""])::placeholder {
+.c146:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c152 {
+.c153 {
   display: none;
 }
 
-.c151:focus-within .c141 {
+.c152:focus-within .c142 {
   background: #374cf1;
   color: #fff;
 }
 
-.c155 {
+.c156 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2859,23 +2868,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #575757;
 }
 
-.c157 {
+.c158 {
   max-width: calc(100% - 20px);
 }
 
-.c159 {
+.c160 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c134 {
+.c135 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   max-width: 100%;
   justify-self: center;
 }
@@ -2926,18 +2935,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c26 {
-    width: 6.25rem;
+    display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
-    height: 3rem;
+  .c28 {
+    display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2946,19 +2955,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2966,37 +2975,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c55 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3010,97 +3019,97 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c79 {
+  .c80 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c88 {
+  .c89 {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3109,7 +3118,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c105 {
+  .c106 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3118,13 +3127,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3132,7 +3141,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3140,79 +3149,79 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c167 {
+  .c168 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c167 {
+  .c168 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c170 {
+  .c171 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c176 {
+  .c177 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c182 {
+  .c183 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c190 {
+  .c191 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3221,13 +3230,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c197 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c196 {
+  .c197 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3235,7 +3244,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c196 {
+  .c197 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3243,19 +3252,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c198 {
+  .c199 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3263,61 +3272,61 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c207 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c207 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c206 {
+  .c207 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c206 {
+  .c207 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c208 {
+  .c209 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3335,19 +3344,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3364,31 +3373,31 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c78 {
+  .c79 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3396,38 +3405,38 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c83 {
+  .c84 {
     -webkit-column-gap: 0.25rem;
     column-gap: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c111 {
+  .c112 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c111 {
+  .c112 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c180 {
+  .c181 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3436,13 +3445,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c183 {
+  .c184 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c192 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3450,7 +3459,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c192 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3459,7 +3468,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c192 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3468,7 +3477,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c193 {
+  .c194 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3477,7 +3486,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3486,7 +3495,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3494,7 +3503,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c208 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3502,7 +3511,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3511,7 +3520,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c208 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3520,19 +3529,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c207 {
+  .c208 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3540,7 +3549,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3548,7 +3557,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c210 {
+  .c211 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3556,7 +3565,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     gap: 2rem;
   }
 }
@@ -3616,25 +3625,25 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     font-weight: 500;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3667,43 +3676,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3712,7 +3721,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3721,43 +3730,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3766,7 +3775,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3775,43 +3784,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c112 {
+  .c113 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3820,7 +3829,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c112 {
+  .c113 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3829,43 +3838,43 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3874,7 +3883,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3883,49 +3892,49 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c106 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3934,7 +3943,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c106 {
+  .c107 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3952,16 +3961,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c178,
-  .c24:visited:hover .c178 {
+  .c24:hover .c179,
+  .c24:visited:hover .c179 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c175:hover,
-  .c175:visited:hover {
+  .c176:hover,
+  .c176:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3969,16 +3978,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c175:hover .c178,
-  .c175:visited:hover .c178 {
+  .c176:hover .c179,
+  .c176:visited:hover .c179 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c212:hover,
-  .c212:visited:hover {
+  .c213:hover,
+  .c213:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -3986,44 +3995,44 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c212:hover .c178,
-  .c212:visited:hover .c178 {
+  .c213:hover .c179,
+  .c213:visited:hover .c179 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c42 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c41:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c169 {
+  .c170 {
     grid-column: span 3;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     border-left: 4px solid #222222;
   }
 
-  .c81:hover {
+  .c82:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #575757;
@@ -4031,7 +4040,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4039,7 +4048,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4048,23 +4057,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-right: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     border-left: 4px solid transparent;
   }
 
-  .c86:hover {
+  .c87:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
@@ -4072,7 +4081,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4080,7 +4089,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -4089,37 +4098,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-right: 0.75rem;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:800px) {
-  .c113 {
+  .c114 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c145 {
+  .c146 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c125 {
     max-width: 870px;
   }
 }
@@ -4319,10 +4328,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>
+              <span
+                class="c28"
+              >
+                <img
+                  alt=""
+                  class="c27"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4330,10 +4352,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c30"
               >
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4347,15 +4369,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4364,7 +4386,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4378,15 +4400,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4395,7 +4417,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4409,15 +4431,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4426,7 +4448,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4440,15 +4462,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4457,7 +4479,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4470,16 +4492,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
@@ -4488,7 +4510,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4503,24 +4525,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c9 c36"
+              class="c9 c37"
             >
               <form
                 action="/teachers/search"
-                class="c37"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c38"
+                  class="c39"
                 >
                   <div
-                    class="c39 c40 c41"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c42"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4528,24 +4550,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c43"
+                  class="c44"
                 >
                   <div
-                    class="c44 c45 c46"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c47 c48"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c9 c49"
+                        class="c9 c50"
                       >
                         <div
-                          class="c50 c51 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c52 shadow"
+                            class="c53 shadow"
                           />
                           <span
                             class="c20"
@@ -4553,7 +4575,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c53"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4563,7 +4585,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c54"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4571,24 +4593,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c55"
+                class="c56"
               >
                 <div
-                  class="c44 c45 c46"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c50 c51 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c52 shadow"
+                          class="c53 shadow"
                         />
                         <span
                           class="c20"
@@ -4596,7 +4618,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c53"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4606,7 +4628,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4614,14 +4636,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c56 c57"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c58 c59 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c60"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4635,7 +4657,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4651,13 +4673,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c34"
                   >
                     <span
-                      class="c34"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4667,7 +4689,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4681,18 +4703,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c49"
+                  class="c9 c50"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c35"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4710,41 +4732,41 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Meet the team
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   Learn more about the experts from across education, technology, school support and education who make up our leadership team and board.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
@@ -4762,40 +4784,40 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c77 c78"
+              class="c78 c79"
             >
               <div
-                class="c77"
+                class="c78"
               >
                 <nav
                   aria-label="page sections"
-                  class="c79"
+                  class="c80"
                 >
                   <ul
-                    class="c80"
+                    class="c81"
                   >
                     <li
-                      class="c30"
+                      class="c31"
                     >
                       <a
                         aria-current="true"
-                        class="c81 c82"
+                        class="c82 c83"
                         href="#our-leadership"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Our leadership
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
@@ -4810,23 +4832,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c30"
+                      class="c31"
                     >
                       <a
-                        class="c86 c82"
+                        class="c87 c83"
                         href="#our-board"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Our board
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
@@ -4841,23 +4863,23 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </a>
                     </li>
                     <li
-                      class="c30"
+                      class="c31"
                     >
                       <a
-                        class="c86 c82"
+                        class="c87 c83"
                         href="#documents"
                       >
                         <div
-                          class="c9 c83"
+                          class="c9 c84"
                         >
                           <span
-                            class="c84"
+                            class="c85"
                           >
                             Documents
                           </span>
                         </div>
                         <span
-                          class="c85"
+                          class="c86"
                         >
                           <img
                             alt=""
@@ -4875,64 +4897,64 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </nav>
               </div>
               <div
-                class="c9 c87"
+                class="c9 c88"
               >
                 <div
-                  class="c88"
+                  class="c89"
                   id="our-leadership"
                 >
                   <div
-                    class="c9 c89"
+                    class="c9 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <h2
-                        class="c91"
+                        class="c92"
                       >
                         Our leadership
                       </h2>
                       <p
-                        class="c92"
+                        class="c93"
                       >
                         Our leadership team brings together experts to deliver the best support to teachers and value for money for the public.
                       </p>
                     </div>
                     <ul
-                      class="c93 c94"
+                      class="c94 c95"
                     >
                       <li
-                        class="c95 c96"
+                        class="c96 c97"
                       >
                         <a
-                          class="c97 c98 c99"
+                          class="c98 c99 c100"
                           href="/about-us/meet-the-team/ed-southall?section=leadership"
                         >
                           <div
-                            class="c9 c100"
+                            class="c9 c101"
                           >
                             <div
-                              class="c9 c90"
+                              class="c9 c91"
                             >
                               <h3
-                                class="c101"
+                                class="c102"
                               >
                                 Ed Southall
                               </h3>
                               <p
-                                class="c102"
+                                class="c103"
                               >
                                 Subject Lead (maths)
                               </p>
                             </div>
                             <div
-                              class="c9 c103"
+                              class="c9 c104"
                             >
                               <div
-                                class="c9 c40"
+                                class="c9 c41"
                               >
                                 <span
-                                  class="c104"
+                                  class="c105"
                                 >
                                   See bio
                                 </span>
@@ -4958,61 +4980,61 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c88"
+                  class="c89"
                   id="our-board"
                 >
                   <div
-                    class="c9 c89"
+                    class="c9 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <h2
-                        class="c91"
+                        class="c92"
                       >
                         Our board
                       </h2>
                       <p
-                        class="c92"
+                        class="c93"
                       >
                         Our Board oversees all of our work at Oak National Academy. They provide strategic direction and safeguard our independence.
                       </p>
                     </div>
                     <ul
-                      class="c93 c94"
+                      class="c94 c95"
                     >
                       <li
-                        class="c95 c96"
+                        class="c96 c97"
                       >
                         <a
-                          class="c97 c98 c99"
+                          class="c98 c99 c100"
                           href="/about-us/meet-the-team/ed-southall?section=board"
                         >
                           <div
-                            class="c9 c100"
+                            class="c9 c101"
                           >
                             <div
-                              class="c9 c90"
+                              class="c9 c91"
                             >
                               <h3
-                                class="c101"
+                                class="c102"
                               >
                                 Ed Southall
                               </h3>
                               <p
-                                class="c102"
+                                class="c103"
                               >
                                 Subject Lead (maths)
                               </p>
                             </div>
                             <div
-                              class="c9 c103"
+                              class="c9 c104"
                             >
                               <div
-                                class="c9 c40"
+                                class="c9 c41"
                               >
                                 <span
-                                  class="c104"
+                                  class="c105"
                                 >
                                   See bio
                                 </span>
@@ -5038,15 +5060,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c90"
+                  class="c9 c91"
                 >
                   <h2
-                    class="c91"
+                    class="c92"
                   >
                     Governance
                   </h2>
                   <div
-                    class="c105 c106"
+                    class="c106 c107"
                   >
                     <p>
                       Test governance text
@@ -5057,14 +5079,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c107"
+            class="c108"
             style="margin-top: -72px;"
           >
             <div
-              class="c108"
+              class="c109"
             >
               <span
-                class="c109"
+                class="c110"
                 style="pointer-events: none;"
               >
                 <img
@@ -5078,13 +5100,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c110 c111"
+                  class="c111 c112"
                 >
                   <h2
-                    class="c112"
+                    class="c113"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5093,24 +5115,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c113"
+                      class="c114"
                     >
                       <li
-                        class="c114 c115"
+                        class="c115 c116"
                       >
                         <a
                           href="/about-us/who-we-are"
                           style="outline: none;"
                         >
                           <div
-                            class="c116 c117 c118"
+                            class="c117 c118 c119"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c119"
+                                class="c120"
                               >
                                 <img
                                   alt=""
@@ -5124,15 +5146,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c120 c121"
+                              class="c121 c122"
                             >
                               About Oak
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5149,21 +5171,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c114 c115"
+                        class="c115 c116"
                       >
                         <a
                           href="/about-us/oaks-curricula"
                           style="outline: none;"
                         >
                           <div
-                            class="c116 c117 c118"
+                            class="c117 c118 c119"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c119"
+                                class="c120"
                               >
                                 <img
                                   alt=""
@@ -5177,15 +5199,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c120 c121"
+                              class="c121 c122"
                             >
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5202,21 +5224,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c114 c115"
+                        class="c115 c116"
                       >
                         <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
                           <div
-                            class="c116 c117 c118"
+                            class="c117 c118 c119"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c119"
+                                class="c120"
                               >
                                 <img
                                   alt=""
@@ -5230,15 +5252,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c120 c121"
+                              class="c121 c122"
                             >
                               Meet the team
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5255,21 +5277,21 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c114 c115"
+                        class="c115 c116"
                       >
                         <a
                           href="/about-us/get-involved"
                           style="outline: none;"
                         >
                           <div
-                            class="c116 c117 c118"
+                            class="c117 c118 c119"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c119"
+                                class="c120"
                               >
                                 <img
                                   alt=""
@@ -5283,15 +5305,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c120 c121"
+                              class="c121 c122"
                             >
                               Get involved
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c122"
+                                class="c123"
                               >
                                 <img
                                   alt=""
@@ -5314,29 +5336,29 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c123"
+            class="c124"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c124"
+                class="c9 c46 c125"
               >
                 <div
-                  class="c125 c1"
+                  class="c126 c1"
                 >
                   <div
-                    class="c9 c126"
+                    class="c9 c127"
                   >
                     <div
-                      class="c9 c45 c127"
+                      class="c9 c46 c128"
                     >
                       <div
-                        class="c128 c129"
+                        class="c129 c130"
                       >
                         <span
-                          class="c130"
+                          class="c131"
                         >
                           <img
                             alt=""
@@ -5349,13 +5371,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c131"
+                          class="c132"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c132"
+                        class="c133"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5375,18 +5397,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c133 c45 c127"
+                      class="c134 c46 c128"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c134"
+                        class="c135"
                         novalidate=""
                       >
                         <div
-                          class="c135 c136 c137"
+                          class="c136 c137 c138"
                         >
                           <div
-                            class="c138 "
+                            class="c139 "
                           >
                             <div
                               aria-hidden="true"
@@ -5395,7 +5417,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5420,7 +5442,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5445,7 +5467,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5470,7 +5492,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5495,11 +5517,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c140 "
+                              class="c141 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c141 c142 c143"
+                                class="c142 c143 c144"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5511,7 +5533,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c104"
+                                    class="c105"
                                   >
                                     (required)
                                   </span>
@@ -5522,7 +5544,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c144 c145"
+                              class="c145 c146"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5530,7 +5552,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c146 c147 c148"
+                              class="c147 c148 c149"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5543,10 +5565,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c135 c136 c137"
+                          class="c136 c137 c138"
                         >
                           <div
-                            class="c138 "
+                            class="c139 "
                           >
                             <div
                               aria-hidden="true"
@@ -5555,7 +5577,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5580,7 +5602,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5605,7 +5627,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5630,7 +5652,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c139"
+                                class="c140"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5655,11 +5677,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c140 "
+                              class="c141 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c141 c142 c143"
+                                class="c142 c143 c144"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5671,7 +5693,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c104"
+                                    class="c105"
                                   >
                                     (required)
                                   </span>
@@ -5682,7 +5704,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c144 c145"
+                              class="c145 c146"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5690,7 +5712,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c146 c147 c148"
+                              class="c147 c148 c149"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5703,7 +5725,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c149 c150 c151"
+                          class="c150 c151 c152"
                         >
                           <div
                             aria-hidden="true"
@@ -5712,7 +5734,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c139"
+                              class="c140"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5737,7 +5759,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c139"
+                              class="c140"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5762,7 +5784,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c139"
+                              class="c140"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5787,7 +5809,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c139"
+                              class="c140"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5813,7 +5835,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c146 c147 c148 c152"
+                            class="c147 c148 c149 c153"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5824,10 +5846,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c153 c45"
+                            class="c154 c46"
                           >
                             <label
-                              class="c141 c142 c143"
+                              class="c142 c143 c144"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5839,16 +5861,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c154 c155"
+                            class="c155 c156"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c156 c40 c157"
+                              class="c157 c41 c158"
                             >
                               <span
-                                class="c158 c159"
+                                class="c159 c160"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5872,7 +5894,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c160 c5"
+                          class="c161 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -5881,7 +5903,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c161 c19 internal-button"
+                            class="c162 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -5896,12 +5918,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c162"
+                          class="c163"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c163"
+                          class="c164"
                         />
                       </form>
                     </div>
@@ -5913,14 +5935,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c164"
+        class="c165"
       >
         <div
-          class="c165 c45"
+          class="c166 c46"
         >
           <svg
             aria-hidden="true"
-            class="c166"
+            class="c167"
             height="100%"
             name="header-underline"
             width="100%"
@@ -5943,33 +5965,33 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c167 c168"
+            class="c168 c169"
           >
             <div
-              class="c9 c126"
+              class="c9 c127"
             >
               <div
-                class="c9 c45 c169"
+                class="c9 c46 c170"
               >
                 <div
-                  class="c170 c150"
+                  class="c171 c151"
                 >
                   <h2
-                    class="c171"
+                    class="c172"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c172 c173"
+                    class="c173 c174"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/pupils/years"
                         >
                           <span
@@ -5983,27 +6005,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c176"
+                  class="c177"
                 />
                 <div
-                  class="c170 c150"
+                  class="c171 c151"
                 >
                   <h2
-                    class="c171"
+                    class="c172"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c172 c173"
+                    class="c173 c174"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6014,10 +6036,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6028,10 +6050,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6041,10 +6063,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c177"
+                            class="c178"
                           >
                             <span
-                              class="c122 c178 c179"
+                              class="c123 c179 c180"
                             >
                               <img
                                 alt=""
@@ -6060,10 +6082,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/blog"
                         >
                           <span
@@ -6078,27 +6100,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c169"
+                class="c9 c46 c170"
               >
                 <div
-                  class="c170 c150"
+                  class="c171 c151"
                 >
                   <h2
-                    class="c171"
+                    class="c172"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c172 c173"
+                    class="c173 c174"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/"
                         >
                           <span
@@ -6109,10 +6131,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6123,10 +6145,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6137,10 +6159,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6151,10 +6173,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6165,11 +6187,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c175 "
+                          class="c176 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6179,10 +6201,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c177"
+                            class="c178"
                           >
                             <span
-                              class="c122 c178 c179"
+                              class="c123 c179 c180"
                             >
                               <img
                                 alt=""
@@ -6198,10 +6220,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/contact-us"
                         >
                           <span
@@ -6212,11 +6234,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c175 "
+                          class="c176 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6226,10 +6248,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c177"
+                            class="c178"
                           >
                             <span
-                              class="c122 c178 c179"
+                              class="c123 c179 c180"
                             >
                               <img
                                 alt=""
@@ -6245,10 +6267,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/webinars"
                         >
                           <span
@@ -6259,11 +6281,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c175 "
+                          class="c176 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6273,10 +6295,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c177"
+                            class="c178"
                           >
                             <span
-                              class="c122 c178 c179"
+                              class="c123 c179 c180"
                             >
                               <img
                                 alt=""
@@ -6296,27 +6318,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c169"
+                class="c9 c46 c170"
               >
                 <div
-                  class="c170 c150"
+                  class="c171 c151"
                 >
                   <h2
-                    class="c171"
+                    class="c172"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c172 c173"
+                    class="c173 c174"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6327,10 +6349,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6341,10 +6363,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6355,10 +6377,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <button
-                          class="c175 "
+                          class="c176 "
                         >
                           <span
                             class="c25"
@@ -6368,10 +6390,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6382,10 +6404,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6396,10 +6418,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6410,10 +6432,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6424,10 +6446,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6438,10 +6460,10 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c174"
+                        class="c175"
                       >
                         <a
-                          class="c175 "
+                          class="c176 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6456,16 +6478,16 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c169"
+                class="c9 c46 c170"
               >
                 <div
-                  class="c170 c180"
+                  class="c171 c181"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                   >
                     <span
-                      class="c181"
+                      class="c182"
                     >
                       <img
                         alt=""
@@ -6479,24 +6501,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c182 c183"
+                    class="c183 c184"
                   >
                     <div
-                      class="c44 c45 c184 c185"
+                      class="c45 c46 c185 c186"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c186 c51 icon-container"
+                            class="c187 c52 icon-container"
                           >
                             <div
-                              class="c187 shadow"
+                              class="c188 shadow"
                             />
                             <span
                               class="c20"
@@ -6504,7 +6526,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6514,27 +6536,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c184 c185"
+                      class="c45 c46 c185 c186"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c186 c51 icon-container"
+                            class="c187 c52 icon-container"
                           >
                             <div
-                              class="c187 shadow"
+                              class="c188 shadow"
                             />
                             <span
                               class="c20"
@@ -6542,7 +6564,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6552,27 +6574,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c184 c185"
+                      class="c45 c46 c185 c186"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c186 c51 icon-container"
+                            class="c187 c52 icon-container"
                           >
                             <div
-                              class="c187 shadow"
+                              class="c188 shadow"
                             />
                             <span
                               class="c20"
@@ -6580,7 +6602,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6590,7 +6612,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6600,7 +6622,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c188 c189"
+              class="c189 c190"
               data-percy-hide="contents"
             >
               <img
@@ -6616,27 +6638,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c190 c191"
+              class="c191 c192"
             >
               <div
-                class="c192 c193"
+                class="c193 c194"
               >
                 <div
-                  class="c44 c45 c184 c185"
+                  class="c45 c46 c185 c186"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c186 c51 icon-container"
+                        class="c187 c52 icon-container"
                       >
                         <div
-                          class="c187 shadow"
+                          class="c188 shadow"
                         />
                         <span
                           class="c20"
@@ -6644,7 +6666,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6654,27 +6676,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c184 c185"
+                  class="c45 c46 c185 c186"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c186 c51 icon-container"
+                        class="c187 c52 icon-container"
                       >
                         <div
-                          class="c187 shadow"
+                          class="c188 shadow"
                         />
                         <span
                           class="c20"
@@ -6682,7 +6704,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6692,27 +6714,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c184 c185"
+                  class="c45 c46 c185 c186"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c186 c51 icon-container"
+                        class="c187 c52 icon-container"
                       >
                         <div
-                          class="c187 shadow"
+                          class="c188 shadow"
                         />
                         <span
                           class="c20"
@@ -6720,7 +6742,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6730,17 +6752,17 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c55"
+                class="c56"
               >
                 <span
-                  class="c181"
+                  class="c182"
                 >
                   <img
                     alt=""
@@ -6754,15 +6776,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c170 c150"
+                class="c171 c151"
               >
                 <p
-                  class="c194"
+                  class="c195"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c195"
+                  class="c196"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6771,11 +6793,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c196"
+          class="c197"
         >
           <img
             alt=""
-            class="c197"
+            class="c198"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6784,11 +6806,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c198"
+          class="c199"
         >
           <img
             alt=""
-            class="c199"
+            class="c200"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6800,27 +6822,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c200 c201 c202"
+      class="c201 c202 c203"
     />
   </div>
   <div
-    class="c203"
+    class="c204"
   >
     <div
-      class="c204"
+      class="c205"
       data-testid="cookie-banner"
     >
       <div
-        class="c205"
+        class="c206"
       >
         <div
-          class="c206 c207"
+          class="c207 c208"
         >
           <div
-            class="c208"
+            class="c209"
           >
             <strong
-              class="c209"
+              class="c210"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6828,13 +6850,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c210"
+            class="c9 c211"
           >
             <div
-              class="c211 c40"
+              class="c212 c41"
             >
               <button
-                class="c212"
+                class="c213"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6878,7 +6900,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c213 c19 internal-button"
+                class="c214 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -88,19 +88,28 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c28 {
+  position: relative;
+  width: 6.25rem;
+  height: 3rem;
+  padding: 0rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -121,17 +130,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c39:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c43 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -139,7 +148,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -150,7 +159,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -159,12 +168,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c55 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c58 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -184,7 +193,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c60 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -194,34 +203,34 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c80 {
+.c81 {
   padding: 0rem;
   margin: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -230,7 +239,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -238,7 +247,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -246,18 +255,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   background: #f5e9f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c78 {
+.c79 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c83 {
+.c84 {
   padding: 1.5rem;
   background: #ffffff;
   border: 0.125rem solid;
@@ -266,7 +275,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -277,7 +286,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c87 {
+.c88 {
   position: relative;
   width: 5rem;
   min-width: 5rem;
@@ -288,7 +297,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   position: relative;
   width: 4.5rem;
   min-width: 4.5rem;
@@ -299,7 +308,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c89 {
+.c90 {
   position: relative;
   width: 4rem;
   min-width: 4rem;
@@ -310,21 +319,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c90 {
+.c91 {
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c97 {
+.c98 {
   position: relative;
   width: 100%;
   height: 22.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c98 {
+.c99 {
   position: relative;
   object-position: center;
   width: 100%;
@@ -333,33 +342,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c99 {
+.c100 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c101 {
+.c102 {
   background: transparent;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c103 {
   padding-right: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c104 {
+.c105 {
   width: 0.5rem;
   background: #deb7d5;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c108 {
+.c109 {
   max-width: 40rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c111 {
+.c112 {
   position: relative;
   top: 0.5rem;
   left: 0.5rem;
@@ -387,7 +396,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 298;
 }
 
-.c112 {
+.c113 {
   position: relative;
   border: 0.125rem solid;
   border-color: #222222;
@@ -396,7 +405,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 150;
 }
 
-.c113 {
+.c114 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -404,12 +413,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   width: 100%;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0rem;
@@ -418,7 +427,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -426,7 +435,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c125 {
+.c126 {
   position: relative;
   width: 0.125rem;
   height: 3rem;
@@ -434,7 +443,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c128 {
+.c129 {
   width: 100%;
   border-top-left-radius: 0rem;
   border-top-right-radius: 0.25rem;
@@ -443,14 +452,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   padding-left: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c131 {
+.c132 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -462,7 +471,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c132 {
+.c133 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -474,12 +483,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 3;
 }
 
-.c135 {
+.c136 {
   padding-top: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c141 {
+.c142 {
   position: relative;
   width: 100%;
   height: 100%;
@@ -487,31 +496,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c143 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c148 {
+.c149 {
   aspect-ratio: 4/3;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c151 {
+.c152 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c152 {
+.c153 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c153 {
+.c154 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -526,26 +535,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c154 {
+.c155 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c158 {
+.c159 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c160 {
+.c161 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c163 {
+.c164 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -555,7 +564,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c164 {
+.c165 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 1.125rem;
@@ -566,7 +575,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c165 {
+.c166 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -576,14 +585,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c166 {
+.c167 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c168 {
+.c169 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -595,12 +604,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c171 {
+.c172 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c173 {
+.c174 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -614,36 +623,36 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c176 {
+.c177 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c193 {
+.c194 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c197 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c200 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c203 {
+.c204 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c207 {
+.c208 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -653,13 +662,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c208 {
+.c209 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c210 {
+.c211 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -671,23 +680,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c213 {
+.c214 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c218 {
+.c219 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c219 {
+.c220 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c223 {
+.c224 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -696,7 +705,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c224 {
+.c225 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,7 +713,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c228 {
+.c229 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -715,7 +724,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c229 {
+.c230 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -726,14 +735,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c230 {
+.c231 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c232 {
+.c233 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -741,12 +750,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c234 {
+.c235 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c238 {
+.c239 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -764,7 +773,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c240 {
+.c241 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -782,7 +791,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c242 {
+.c243 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -792,7 +801,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 300;
 }
 
-.c245 {
+.c246 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -800,7 +809,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c246 {
+.c247 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -808,13 +817,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c247 {
+.c248 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c248 {
+.c249 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -822,7 +831,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c250 {
+.c251 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -833,7 +842,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c253 {
+.c254 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -895,7 +904,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -914,7 +923,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -933,7 +942,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -945,7 +954,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -956,14 +965,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -982,7 +991,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -997,7 +1006,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1013,7 +1022,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c137 {
+.c138 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1024,7 +1033,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c94 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1034,7 +1043,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1050,7 +1059,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1061,7 +1070,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c79 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1072,7 +1081,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c81 {
+.c82 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1087,7 +1096,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c84 {
+.c85 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1108,7 +1117,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-basis: 0;
 }
 
-.c91 {
+.c92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1124,7 +1133,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3.5rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1146,7 +1155,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 4rem;
 }
 
-.c100 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1157,7 +1166,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 3rem;
 }
 
-.c103 {
+.c104 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1169,7 +1178,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   column-gap: 1.5rem;
 }
 
-.c105 {
+.c106 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1179,7 +1188,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c109 {
+.c110 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1190,7 +1199,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1209,7 +1218,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c115 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1227,7 +1236,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c117 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1237,7 +1246,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-self: stretch;
 }
 
-.c127 {
+.c128 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1248,7 +1257,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c129 {
+.c130 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1256,7 +1265,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c133 {
+.c134 {
   display: none;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -1266,7 +1275,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-self: center;
 }
 
-.c145 {
+.c146 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1285,7 +1294,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c149 {
+.c150 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1296,7 +1305,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c155 {
+.c156 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1307,7 +1316,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c161 {
+.c162 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1322,7 +1331,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c172 {
+.c173 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1336,7 +1345,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c211 {
+.c212 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1354,7 +1363,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c222 {
+.c223 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1365,7 +1374,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c225 {
+.c226 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1381,7 +1390,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c233 {
+.c234 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1399,7 +1408,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c235 {
+.c236 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1412,7 +1421,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c243 {
+.c244 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1427,7 +1436,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c249 {
+.c250 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1442,7 +1451,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c252 {
+.c253 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1492,7 +1501,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1504,7 +1513,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: left;
 }
 
-.c54 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1515,14 +1524,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #deb7d5;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c123 {
+.c124 {
   color: #222222;
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1535,7 +1544,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c187 {
+.c188 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1546,7 +1555,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c201 {
+.c202 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1557,7 +1566,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c251 {
+.c252 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1568,7 +1577,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c209 {
+.c210 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1667,7 +1676,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1690,12 +1699,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c47 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1709,12 +1718,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c47:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c56 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1727,12 +1736,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1762,12 +1771,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1791,12 +1800,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c134 {
+.c135 {
   background: none;
   color: inherit;
   border: none;
@@ -1819,12 +1828,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c134:disabled {
+.c135:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c204 {
+.c205 {
   background: none;
   color: inherit;
   border: none;
@@ -1848,7 +1857,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c204:disabled {
+.c205:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1857,25 +1866,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c35 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c53 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c239 {
+.c240 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c241 {
+.c242 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1966,13 +1975,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1980,37 +1989,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -2018,27 +2027,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -2092,74 +2101,74 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c48 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c48:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c48:active {
+.c49:active {
   color: #222222;
 }
 
-.c48:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c46 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c46 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c46 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c46 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c226 > :first-child:focus-visible .shadow {
+.c227 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c226 > :first-child:hover .shadow {
+.c227 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c226 > :first-child:active .shadow {
+.c227 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c226 > :first-child:disabled .icon-container {
+.c227 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c226 > :first-child:hover .icon-container {
+.c227 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c226 > :first-child:active .icon-container {
+.c227 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2170,7 +2179,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c95 {
+.c96 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2181,7 +2190,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c106 {
+.c107 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2194,7 +2203,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c110 {
+.c111 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2205,7 +2214,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c136 {
+.c137 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -2216,7 +2225,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c146 {
+.c147 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2227,7 +2236,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c156 {
+.c157 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2239,7 +2248,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: center;
 }
 
-.c174 {
+.c175 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -2250,7 +2259,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c214 {
+.c215 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -2263,7 +2272,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2271,7 +2280,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c140 {
+.c141 {
   overflow: hidden;
   aspect-ratio: 1/1;
   border-color: #cacaca;
@@ -2287,7 +2296,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c216 {
+.c217 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -2296,7 +2305,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -2307,7 +2316,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c86 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
@@ -2320,7 +2329,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c96 {
+.c97 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2333,7 +2342,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-bottom: 0.75rem;
 }
 
-.c107 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -2344,7 +2353,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c124 {
+.c125 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2356,7 +2365,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c138 {
+.c139 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2367,13 +2376,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c175 {
+.c176 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c205 {
+.c206 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2386,7 +2395,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c206 {
+.c207 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2398,7 +2407,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c236 {
+.c237 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -2409,7 +2418,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c237 {
+.c238 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2420,7 +2429,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c215 {
+.c216 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2431,7 +2440,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2452,7 +2461,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c221 {
+.c222 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2483,7 +2492,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c220 {
+.c24 .c221 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2498,7 +2507,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c220 {
+.c24:visited .c221 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2508,7 +2517,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c220 {
+.c24:active .c221 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2518,12 +2527,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c220 {
+.c24[disabled] .c221 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c217 {
+.c218 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2547,47 +2556,47 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c217 .c220 {
+.c218 .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c217:focus-visible {
+.c218:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c217:visited {
+.c218:visited {
   color: #222222;
 }
 
-.c217:visited .c220 {
+.c218:visited .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c217:active {
+.c218:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c217:active .c220 {
+.c218:active .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c217[disabled] {
+.c218[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c217[disabled] .c220 {
+.c218[disabled] .c221 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c254 {
+.c255 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2620,47 +2629,47 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c254 .c220 {
+.c255 .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c254:focus-visible {
+.c255:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c254:visited {
+.c255:visited {
   color: #222222;
 }
 
-.c254:visited .c220 {
+.c255:visited .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c254:active {
+.c255:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c254:active .c220 {
+.c255:active .c221 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c254[disabled] {
+.c255[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c254[disabled] .c220 {
+.c255[disabled] .c221 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c42 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2676,49 +2685,49 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   width: 100%;
 }
 
-.c42::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c42::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c42:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c42::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c42::-webkit-search-decoration,
-.c42::-webkit-search-cancel-button,
-.c42::-webkit-search-results-button,
-.c42::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c42:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c41 {
+.c42 {
   background: #ffffff;
 }
 
-.c41:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c139 {
+.c140 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2728,7 +2737,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c143 {
+.c144 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2737,13 +2746,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c169 {
+.c170 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c144 {
+.c145 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2752,7 +2761,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c147 {
+.c148 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2762,7 +2771,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c170 {
+.c171 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2771,7 +2780,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c212 {
+.c213 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2780,79 +2789,79 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c119 {
+.c120 {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c119:has(a:hover,button:hover) {
+.c120:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c119:has( a, button) {
+.c120:has( a, button) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c119:has( a, button)  a,
-.c119:has( a, button) button {
+.c120:has( a, button)  a,
+.c120:has( a, button) button {
   outline: none;
 }
 
-.c119:has(a:active,button:active) {
+.c120:has(a:active,button:active) {
   box-shadow: none;
 }
 
-.c159 {
+.c160 {
   list-style: none;
   margin: 0;
   padding: 0;
   box-shadow: none;
 }
 
-.c159:has(a:hover,button:hover) {
+.c160:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c159:has( a, button) {
+.c160:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c159:has( a, button)  a,
-.c159:has( a, button) button {
+.c160:has( a, button)  a,
+.c160:has( a, button) button {
   outline: none;
 }
 
-.c159:has(a:active,button:active) {
+.c160:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c57:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c57:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c244 {
+.c245 {
   top: 152px;
 }
 
-.c227 .icon-container > *:first-child {
+.c228 .icon-container > *:first-child {
   border: 0;
 }
 
-.c231 {
+.c232 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c162:hover {
+.c163:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c157 {
+.c158 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2864,13 +2873,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c190 {
+.c191 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c178 {
+.c179 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2881,23 +2890,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c178::-webkit-scrollbar-track {
+.c179::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c178::-webkit-scrollbar {
+.c179::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c178::-webkit-scrollbar-thumb {
+.c179::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c181 {
+.c182 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2906,23 +2915,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c181::-webkit-scrollbar-track {
+.c182::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c181::-webkit-scrollbar {
+.c182::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c181::-webkit-scrollbar-thumb {
+.c182::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c183 {
+.c184 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2930,30 +2939,30 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: flex;
 }
 
-.c183::-webkit-scrollbar-track {
+.c184::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c183::-webkit-scrollbar {
+.c184::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c183::-webkit-scrollbar-thumb {
+.c184::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c179 {
+.c180 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c126 {
+.c127 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2966,7 +2975,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c182 {
+.c183 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2978,7 +2987,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c188 {
+.c189 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2989,32 +2998,32 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c188::-webkit-input-placeholder {
+.c189::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c188::-moz-placeholder {
+.c189::-moz-placeholder {
   color: #575757;
 }
 
-.c188:-ms-input-placeholder {
+.c189:-ms-input-placeholder {
   color: #575757;
 }
 
-.c188::placeholder {
+.c189::placeholder {
   color: #575757;
 }
 
-.c188::-webkit-search-decoration,
-.c188::-webkit-search-cancel-button,
-.c188::-webkit-search-results-button,
-.c188::-webkit-search-results-decoration {
+.c189::-webkit-search-decoration,
+.c189::-webkit-search-cancel-button,
+.c189::-webkit-search-results-button,
+.c189::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c185 {
+.c186 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -3024,7 +3033,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c192 {
+.c193 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -3037,7 +3046,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c186 {
+.c187 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -3048,16 +3057,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c180:focus-within .c184 {
+.c181:focus-within .c185 {
   background: #374cf1;
   color: #fff;
 }
 
-.c180:focus-within .c191 {
+.c181:focus-within .c192 {
   display: inline;
 }
 
-.c189 {
+.c190 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -3073,7 +3082,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   outline: none;
 }
 
-.c189::-webkit-input-placeholder {
+.c190::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3081,7 +3090,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c189::-moz-placeholder {
+.c190::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3089,7 +3098,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c189:-ms-input-placeholder {
+.c190:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3097,7 +3106,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c189::placeholder {
+.c190::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -3105,31 +3114,31 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c189:valid:not([value=""]) {
+.c190:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c189:valid:not([value=""])::-webkit-input-placeholder {
+.c190:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c189:valid:not([value=""])::-moz-placeholder {
+.c190:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c189:valid:not([value=""]):-ms-input-placeholder {
+.c190:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c189:valid:not([value=""])::placeholder {
+.c190:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c197 {
+.c198 {
   background: none;
   color: inherit;
   border: none;
@@ -3140,16 +3149,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c195 {
+.c196 {
   display: none;
 }
 
-.c194:focus-within .c184 {
+.c195:focus-within .c185 {
   background: #374cf1;
   color: #fff;
 }
 
-.c198 {
+.c199 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -3176,41 +3185,41 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #575757;
 }
 
-.c200 {
+.c201 {
   max-width: calc(100% - 20px);
 }
 
-.c202 {
+.c203 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c177 {
+.c178 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c167 {
+.c168 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c120 {
-  box-shadow: none;
-}
-
-.c120:has([data-testid="lot-picker-view-curriculum-button"]:focus-visible) {
-  box-shadow: none;
-}
-
 .c121 {
+  box-shadow: none;
+}
+
+.c121:has([data-testid="lot-picker-view-curriculum-button"]:focus-visible) {
+  box-shadow: none;
+}
+
+.c122 {
   background: none;
   width: 100%;
   min-width: 0;
@@ -3225,35 +3234,35 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: pointer;
 }
 
-.c150 {
+.c151 {
   object-fit: contain;
   width: 100%;
   height: auto;
 }
 
-.c150::-webkit-scrollbar-track {
+.c151::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c150::-webkit-scrollbar {
+.c151::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c150::-webkit-scrollbar-thumb {
+.c151::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c92 {
+.c93 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c82 {
+.c83 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3310,18 +3319,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c26 {
-    width: 6.25rem;
+    display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
-    height: 3rem;
+  .c28 {
+    display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3330,19 +3339,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -3350,37 +3359,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c55 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3394,175 +3403,175 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     padding: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c90 {
+  .c91 {
     padding: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     width: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c97 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c97 {
+  .c98 {
     height: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     padding-bottom: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c118 {
+  .c119 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-top-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-top-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-bottom-left-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c128 {
+  .c129 {
     border-bottom-right-radius: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     max-width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c142 {
+  .c143 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c142 {
+  .c143 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c153 {
+  .c154 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c153 {
+  .c154 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3570,7 +3579,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c153 {
+  .c154 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3578,79 +3587,79 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c154 {
+  .c155 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c154 {
+  .c155 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c154 {
+  .c155 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c154 {
+  .c155 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c168 {
+  .c169 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c168 {
+  .c169 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c213 {
+  .c214 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c224 {
+  .c225 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c232 {
+  .c233 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c234 {
+  .c235 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3659,13 +3668,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c238 {
+  .c239 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c238 {
+  .c239 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3673,7 +3682,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c238 {
+  .c239 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3681,19 +3690,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c240 {
+  .c241 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3701,61 +3710,61 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c242 {
+  .c243 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c248 {
+  .c249 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c248 {
+  .c249 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c248 {
+  .c249 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c248 {
+  .c249 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c250 {
+  .c251 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c250 {
+  .c251 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c250 {
+  .c251 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c250 {
+  .c251 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3773,19 +3782,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3802,19 +3811,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3822,19 +3831,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     gap: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c91 {
+  .c92 {
     gap: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3843,7 +3852,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3852,7 +3861,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
@@ -3861,7 +3870,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c100 {
+  .c101 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -3869,19 +3878,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     gap: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3889,25 +3898,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c133 {
+  .c134 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c155 {
+  .c156 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c155 {
+  .c156 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c222 {
+  .c223 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3916,13 +3925,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c225 {
+  .c226 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c233 {
+  .c234 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3930,7 +3939,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c233 {
+  .c234 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3939,7 +3948,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c233 {
+  .c234 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3948,7 +3957,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c235 {
+  .c236 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3957,7 +3966,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c243 {
+  .c244 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3966,7 +3975,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c249 {
+  .c250 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3974,7 +3983,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c249 {
+  .c250 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3982,7 +3991,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c249 {
+  .c250 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3991,7 +4000,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c249 {
+  .c250 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -4000,19 +4009,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c249 {
+  .c250 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c249 {
+  .c250 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c252 {
+  .c253 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -4020,7 +4029,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c252 {
+  .c253 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -4028,7 +4037,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c252 {
+  .c253 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -4036,7 +4045,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c252 {
+  .c253 {
     gap: 2rem;
   }
 }
@@ -4096,25 +4105,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c251 {
+  .c252 {
     font-weight: 500;
   }
 }
 
 @media (min-width:750px) {
-  .c251 {
+  .c252 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c251 {
+  .c252 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c251 {
+  .c252 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4147,43 +4156,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4192,7 +4201,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4201,25 +4210,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c95 {
+  .c96 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4228,43 +4237,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4273,7 +4282,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c110 {
+  .c111 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4282,43 +4291,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c137 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c136 {
+  .c137 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c137 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c136 {
+  .c137 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c137 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c136 {
+  .c137 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c137 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4327,7 +4336,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c136 {
+  .c137 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4336,43 +4345,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c146 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4381,7 +4390,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c146 {
+  .c147 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4390,43 +4399,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c156 {
+  .c157 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c156 {
+  .c157 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c156 {
+  .c157 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c156 {
+  .c157 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c156 {
+  .c157 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c156 {
+  .c157 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c156 {
+  .c157 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4435,7 +4444,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c156 {
+  .c157 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4444,43 +4453,43 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4489,7 +4498,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4498,25 +4507,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c139 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c139 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c139 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c138 {
+  .c139 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4525,7 +4534,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c175 {
+  .c176 {
     margin-right: 1.5rem;
   }
 }
@@ -4540,16 +4549,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c220,
-  .c24:visited:hover .c220 {
+  .c24:hover .c221,
+  .c24:visited:hover .c221 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c217:hover,
-  .c217:visited:hover {
+  .c218:hover,
+  .c218:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4557,16 +4566,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c217:hover .c220,
-  .c217:visited:hover .c220 {
+  .c218:hover .c221,
+  .c218:visited:hover .c221 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c254:hover,
-  .c254:visited:hover {
+  .c255:hover,
+  .c255:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4574,112 +4583,112 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c254:hover .c220,
-  .c254:visited:hover .c220 {
+  .c255:hover .c221,
+  .c255:visited:hover .c221 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c42 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c41:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c139 {
+  .c140 {
     grid-template-columns: repeat(5,1fr);
   }
 }
 
 @media (min-width:1280px) {
-  .c139 {
+  .c140 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c144 {
+  .c145 {
     grid-column: span 5;
   }
 }
 
 @media (min-width:750px) {
-  .c147 {
+  .c148 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:1280px) {
-  .c147 {
+  .c148 {
     grid-column: 7 / span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c147 {
+  .c148 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:1280px) {
-  .c147 {
+  .c148 {
     grid-column-start: 7;
   }
 }
 
 @media (min-width:750px) {
-  .c170 {
+  .c171 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c212 {
+  .c213 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:800px) {
-  .c157 {
+  .c158 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c189 {
+  .c190 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c167 {
+  .c168 {
     max-width: 870px;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (min-width:920px) {
-  .c92 {
+  .c93 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -4881,10 +4890,23 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>
+              <span
+                class="c28"
+              >
+                <img
+                  alt=""
+                  class="c27"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4892,10 +4914,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c30"
               >
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4909,15 +4931,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4926,7 +4948,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4940,15 +4962,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4957,7 +4979,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4971,15 +4993,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4988,7 +5010,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -5002,15 +5024,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -5019,7 +5041,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -5032,16 +5054,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
@@ -5050,7 +5072,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5065,24 +5087,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c9 c36"
+              class="c9 c37"
             >
               <form
                 action="/teachers/search"
-                class="c37"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c38"
+                  class="c39"
                 >
                   <div
-                    class="c39 c40 c41"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c42"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -5090,24 +5112,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c43"
+                  class="c44"
                 >
                   <div
-                    class="c44 c45 c46"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c47 c48"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c9 c49"
+                        class="c9 c50"
                       >
                         <div
-                          class="c50 c51 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c52 shadow"
+                            class="c53 shadow"
                           />
                           <span
                             class="c20"
@@ -5115,7 +5137,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c53"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5125,7 +5147,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c54"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -5133,24 +5155,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c55"
+                class="c56"
               >
                 <div
-                  class="c44 c45 c46"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c50 c51 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c52 shadow"
+                          class="c53 shadow"
                         />
                         <span
                           class="c20"
@@ -5158,7 +5180,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c53"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5168,7 +5190,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -5176,14 +5198,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c56 c57"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c58 c59 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c60"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -5197,7 +5219,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -5213,13 +5235,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c34"
                   >
                     <span
-                      class="c34"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -5229,7 +5251,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -5243,18 +5265,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c49"
+                  class="c9 c50"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c35"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -5272,41 +5294,41 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     Oak's curricula
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   Oak offers complete curriculum support for clarity and coherence in every national curriculum subject.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
@@ -5324,25 +5346,25 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c77"
+            class="c78"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c78 c79"
+                class="c79 c80"
               >
                 <ul
-                  class="c80 c81"
+                  class="c81 c82"
                 >
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c85"
+                        class="c86"
                         data-testid="icon-clipboard"
                       >
                         <img
@@ -5356,20 +5378,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         National curriculum and exam board aligned
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c87"
+                        class="c88"
                         data-testid="icon-free-tag"
                       >
                         <img
@@ -5383,20 +5405,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Free and always will be
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c88"
+                        class="c89"
                         data-testid="icon-book-steps"
                       >
                         <img
@@ -5410,20 +5432,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Covers key stages 1-4 across 20 subjects
                       </p>
                     </div>
                   </li>
                   <li
-                    class="c82"
+                    class="c83"
                   >
                     <div
-                      class="c83 c84"
+                      class="c84 c85"
                     >
                       <span
-                        class="c89"
+                        class="c90"
                         data-testid="icon-threads"
                       >
                         <img
@@ -5437,7 +5459,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                       </span>
                       <p
-                        class="c86"
+                        class="c87"
                       >
                         Fully sequenced and ready to adapt
                       </p>
@@ -5445,30 +5467,30 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </li>
                 </ul>
                 <div
-                  class="c90 c91 c92"
+                  class="c91 c92 c93"
                 >
                   <div
-                    class="c9 c93"
+                    class="c9 c94"
                   >
                     <div
-                      class="c9 c94"
+                      class="c9 c95"
                     >
                       <h2
-                        class="c95"
+                        class="c96"
                       >
                         Our guiding principles
                       </h2>
                       <p
-                        class="c96"
+                        class="c97"
                       >
                         Our guiding principles guide our approach.
                       </p>
                     </div>
                     <div
-                      class="c97 c45"
+                      class="c98 c46"
                     >
                       <span
-                        class="c98"
+                        class="c99"
                       >
                         <img
                           alt=""
@@ -5485,29 +5507,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c99 c100"
+                    class="c100 c101"
                   >
                     <div
-                      class="c101"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c102 c103"
+                        class="c103 c104"
                       >
                         <div
-                          class="c104 c105"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c9 c94"
+                          class="c9 c95"
                         >
                           <h3
-                            class="c106"
+                            class="c107"
                           >
                             Evidence-informed
                           </h3>
                           <p
-                            class="c107"
+                            class="c108"
                           >
                             Our approach enables the rigorous application of research outcomes.
                           </p>
@@ -5515,26 +5537,26 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c101"
+                      class="c102"
                       data-testid="curric-quote"
                     >
                       <div
-                        class="c102 c103"
+                        class="c103 c104"
                       >
                         <div
-                          class="c104 c105"
+                          class="c105 c106"
                           data-testid="decorative-bar"
                         />
                         <div
-                          class="c9 c94"
+                          class="c9 c95"
                         >
                           <h3
-                            class="c106"
+                            class="c107"
                           >
                             Knowledge and vocabulary rich
                           </h3>
                           <p
-                            class="c107"
+                            class="c108"
                           >
                             Our curriculum is knowledge and vocabulary rich.
                           </p>
@@ -5544,57 +5566,57 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c108 c109"
+                  class="c109 c110"
                 >
                   <h2
-                    class="c110"
+                    class="c111"
                   >
                     See Oak's curricula in practice
                   </h2>
                   <nav
                     aria-labelledby="choose-curriculum-label"
-                    class="c66"
+                    class="c67"
                   >
                     <div
-                      class="c111"
+                      class="c112"
                       id="choose-curriculum-label"
                     >
                       Choose a curriculum
                     </div>
                     <div
-                      class="c112"
+                      class="c113"
                       data-testid="lot-picker"
                     >
                       <div
-                        class="c113 c114"
+                        class="c114 c115"
                       >
                         <div
-                          class="c66 c115"
+                          class="c67 c116"
                         >
                           <div
-                            class="c116 c117"
+                            class="c117 c118"
                             style="width: 50%;"
                           >
                             <div
-                              class="c118 c119 c120"
+                              class="c119 c120 c121"
                             >
                               <button
                                 aria-expanded="false"
-                                class="c121"
+                                class="c122"
                                 data-testid="subject-picker-button"
                                 title="Subject"
                               >
                                 <div
-                                  class="c122"
+                                  class="c123"
                                 >
                                   <span
-                                    class="c123"
+                                    class="c124"
                                     data-testid="subject-picker-button-heading"
                                   >
                                     Subject
                                   </span>
                                   <p
-                                    class="c124"
+                                    class="c125"
                                   >
                                     Select
                                   </p>
@@ -5603,7 +5625,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </div>
                           </div>
                           <div
-                            class="c125"
+                            class="c126"
                           >
                             <div
                               aria-hidden="true"
@@ -5612,7 +5634,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c126"
+                                class="c127"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5642,38 +5664,38 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             style="width: 50%;"
                           >
                             <div
-                              class="c116 c127"
+                              class="c117 c128"
                             >
                               <div
-                                class="c128 c119 c120"
+                                class="c129 c120 c121"
                               >
                                 <div
-                                  class="c9 c129"
+                                  class="c9 c130"
                                 >
                                   <button
                                     aria-expanded="false"
-                                    class="c121"
+                                    class="c122"
                                     data-testid="phase-picker-button"
                                     title="Phase"
                                   >
                                     <div
-                                      class="c130"
+                                      class="c131"
                                     >
                                       <span
-                                        class="c123"
+                                        class="c124"
                                         data-testid="phase-picker-button-heading"
                                       >
                                         School phase
                                       </span>
                                       <div
-                                        class="c131"
+                                        class="c132"
                                       >
                                         Select
                                       </div>
                                     </div>
                                   </button>
                                   <div
-                                    class="c132 c133"
+                                    class="c133 c134"
                                   >
                                     <div
                                       class="c4 c5"
@@ -5685,7 +5707,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                         class="c6 yellow-shadow"
                                       />
                                       <button
-                                        class="c134 c19 internal-button"
+                                        class="c135 c19 internal-button"
                                         data-testid="lot-picker-view-curriculum-button"
                                       >
                                         <div
@@ -5701,7 +5723,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                           >
                                             <img
                                               alt=""
-                                              class="c53"
+                                              class="c54"
                                               data-nimg="fill"
                                               decoding="async"
                                               loading="lazy"
@@ -5726,29 +5748,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c135 c79"
+              class="c136 c80"
             >
               <h2
-                class="c136"
+                class="c137"
               >
                 Curriculum partners
               </h2>
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <div
-                  class="c9 c137"
+                  class="c9 c138"
                 >
                   <h3
-                    class="c110"
+                    class="c111"
                   >
                     Current
                   </h3>
                   <p
-                    class="c138"
+                    class="c139"
                   >
                     Our current partners
                   </p>
@@ -5757,13 +5779,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c9"
                 >
                   <ul
-                    class="c80 c139"
+                    class="c81 c140"
                   >
                     <li
-                      class="c140"
+                      class="c141"
                     >
                       <span
-                        class="c141"
+                        class="c142"
                       >
                         <img
                           alt=""
@@ -5782,18 +5804,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <div
-                  class="c9 c137"
+                  class="c9 c138"
                 >
                   <h3
-                    class="c110"
+                    class="c111"
                   >
                     Legacy
                   </h3>
                   <p
-                    class="c138"
+                    class="c139"
                   >
                     Our legacy partners
                   </p>
@@ -5802,13 +5824,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c9"
                 >
                   <ul
-                    class="c80 c139"
+                    class="c81 c140"
                   >
                     <li
-                      class="c140"
+                      class="c141"
                     >
                       <span
-                        class="c141"
+                        class="c142"
                       >
                         <img
                           alt=""
@@ -5829,36 +5851,36 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c142"
+            class="c143"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c143"
+                class="c9 c144"
               >
                 <div
-                  class="c9 c45 c144"
+                  class="c9 c46 c145"
                 >
                   <div
-                    class="c9 c145"
+                    class="c9 c146"
                   >
                     <div
-                      class="c9 c71"
+                      class="c9 c72"
                     >
                       <h2
-                        class="c146"
+                        class="c147"
                       >
                         Discover how Oak can support you
                       </h2>
                       <p
-                        class="c107"
+                        class="c108"
                       >
                         To explore the impact Oak’s curricula could have in your school or trust, fill out the form below and one of our experts will be in touch shortly.
                       </p>
                     </div>
                     <div
-                      class="c9 c94"
+                      class="c9 c95"
                     >
                       <div
                         class="c4 c5"
@@ -5871,7 +5893,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         />
                         <a
                           aria-label="Get in touch with an expert (opens in new tab)"
-                          class="c134 c19 internal-button"
+                          class="c135 c19 internal-button"
                           href="https://share.hsforms.com/2yBT-92_WT6CvX1b6L3Iw8Qbvumd"
                           target="_blank"
                         >
@@ -5888,7 +5910,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c53"
+                                class="c54"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5903,14 +5925,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c45 c147"
+                  class="c9 c46 c148"
                 >
                   <div
-                    class="c148 c149"
+                    class="c149 c150"
                   >
                     <img
                       alt=""
-                      class="c150"
+                      class="c151"
                       data-nimg="1"
                       decoding="async"
                       height="454"
@@ -5926,14 +5948,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c151"
+            class="c152"
             style="margin-top: -72px;"
           >
             <div
-              class="c152"
+              class="c153"
             >
               <span
-                class="c153"
+                class="c154"
                 style="pointer-events: none;"
               >
                 <img
@@ -5947,13 +5969,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c154 c155"
+                  class="c155 c156"
                 >
                   <h2
-                    class="c156"
+                    class="c157"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5962,24 +5984,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c157"
+                      class="c158"
                     >
                       <li
-                        class="c158 c159"
+                        class="c159 c160"
                       >
                         <a
                           href="/about-us/who-we-are"
                           style="outline: none;"
                         >
                           <div
-                            class="c160 c161 c162"
+                            class="c161 c162 c163"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c163"
+                                class="c164"
                               >
                                 <img
                                   alt=""
@@ -5993,15 +6015,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c164 c149"
+                              class="c165 c150"
                             >
                               About Oak
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c165"
+                                class="c166"
                               >
                                 <img
                                   alt=""
@@ -6018,21 +6040,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c158 c159"
+                        class="c159 c160"
                       >
                         <a
                           href="/about-us/oaks-curricula"
                           style="outline: none;"
                         >
                           <div
-                            class="c160 c161 c162"
+                            class="c161 c162 c163"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c163"
+                                class="c164"
                               >
                                 <img
                                   alt=""
@@ -6046,15 +6068,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c164 c149"
+                              class="c165 c150"
                             >
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c165"
+                                class="c166"
                               >
                                 <img
                                   alt=""
@@ -6071,21 +6093,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c158 c159"
+                        class="c159 c160"
                       >
                         <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
                           <div
-                            class="c160 c161 c162"
+                            class="c161 c162 c163"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c163"
+                                class="c164"
                               >
                                 <img
                                   alt=""
@@ -6099,15 +6121,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c164 c149"
+                              class="c165 c150"
                             >
                               Meet the team
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c165"
+                                class="c166"
                               >
                                 <img
                                   alt=""
@@ -6124,21 +6146,21 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c158 c159"
+                        class="c159 c160"
                       >
                         <a
                           href="/about-us/get-involved"
                           style="outline: none;"
                         >
                           <div
-                            class="c160 c161 c162"
+                            class="c161 c162 c163"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c163"
+                                class="c164"
                               >
                                 <img
                                   alt=""
@@ -6152,15 +6174,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c164 c149"
+                              class="c165 c150"
                             >
                               Get involved
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c165"
+                                class="c166"
                               >
                                 <img
                                   alt=""
@@ -6183,29 +6205,29 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c166"
+            class="c167"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c167"
+                class="c9 c46 c168"
               >
                 <div
-                  class="c168 c1"
+                  class="c169 c1"
                 >
                   <div
-                    class="c9 c169"
+                    class="c9 c170"
                   >
                     <div
-                      class="c9 c45 c170"
+                      class="c9 c46 c171"
                     >
                       <div
-                        class="c171 c172"
+                        class="c172 c173"
                       >
                         <span
-                          class="c173"
+                          class="c174"
                         >
                           <img
                             alt=""
@@ -6218,13 +6240,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c174"
+                          class="c175"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c175"
+                        class="c176"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -6244,18 +6266,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c176 c45 c170"
+                      class="c177 c46 c171"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c177"
+                        class="c178"
                         novalidate=""
                       >
                         <div
-                          class="c178 c179 c180"
+                          class="c179 c180 c181"
                         >
                           <div
-                            class="c181 "
+                            class="c182 "
                           >
                             <div
                               aria-hidden="true"
@@ -6264,7 +6286,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -6289,7 +6311,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6314,7 +6336,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6339,7 +6361,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6364,11 +6386,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c183 "
+                              class="c184 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c184 c185 c186"
+                                class="c185 c186 c187"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -6380,7 +6402,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c187"
+                                    class="c188"
                                   >
                                     (required)
                                   </span>
@@ -6391,7 +6413,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c188 c189"
+                              class="c189 c190"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -6399,7 +6421,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c190 c191 c192"
+                              class="c191 c192 c193"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6412,10 +6434,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c178 c179 c180"
+                          class="c179 c180 c181"
                         >
                           <div
-                            class="c181 "
+                            class="c182 "
                           >
                             <div
                               aria-hidden="true"
@@ -6424,7 +6446,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -6449,7 +6471,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -6474,7 +6496,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -6499,7 +6521,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c182"
+                                class="c183"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -6524,11 +6546,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c183 "
+                              class="c184 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c184 c185 c186"
+                                class="c185 c186 c187"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -6540,7 +6562,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c187"
+                                    class="c188"
                                   >
                                     (required)
                                   </span>
@@ -6551,7 +6573,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c188 c189"
+                              class="c189 c190"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -6559,7 +6581,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c190 c191 c192"
+                              class="c191 c192 c193"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -6572,7 +6594,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c193 c94 c194"
+                          class="c194 c95 c195"
                         >
                           <div
                             aria-hidden="true"
@@ -6581,7 +6603,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c182"
+                              class="c183"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -6606,7 +6628,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c182"
+                              class="c183"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -6631,7 +6653,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c182"
+                              class="c183"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -6656,7 +6678,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c182"
+                              class="c183"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -6682,7 +6704,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c190 c191 c192 c195"
+                            class="c191 c192 c193 c196"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -6693,10 +6715,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c196 c45"
+                            class="c197 c46"
                           >
                             <label
-                              class="c184 c185 c186"
+                              class="c185 c186 c187"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -6708,16 +6730,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c197 c198"
+                            class="c198 c199"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c199 c40 c200"
+                              class="c200 c41 c201"
                             >
                               <span
-                                class="c201 c202"
+                                class="c202 c203"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -6741,7 +6763,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c203 c5"
+                          class="c204 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -6750,7 +6772,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c204 c19 internal-button"
+                            class="c205 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -6765,12 +6787,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c205"
+                          class="c206"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c206"
+                          class="c207"
                         />
                       </form>
                     </div>
@@ -6782,14 +6804,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c207"
+        class="c208"
       >
         <div
-          class="c208 c45"
+          class="c209 c46"
         >
           <svg
             aria-hidden="true"
-            class="c209"
+            class="c210"
             height="100%"
             name="header-underline"
             width="100%"
@@ -6812,33 +6834,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c210 c211"
+            class="c211 c212"
           >
             <div
-              class="c9 c169"
+              class="c9 c170"
             >
               <div
-                class="c9 c45 c212"
+                class="c9 c46 c213"
               >
                 <div
-                  class="c213 c94"
+                  class="c214 c95"
                 >
                   <h2
-                    class="c214"
+                    class="c215"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c131 c215"
+                    class="c132 c216"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/pupils/years"
                         >
                           <span
@@ -6852,27 +6874,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c218"
+                  class="c219"
                 />
                 <div
-                  class="c213 c94"
+                  class="c214 c95"
                 >
                   <h2
-                    class="c214"
+                    class="c215"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c131 c215"
+                    class="c132 c216"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6883,10 +6905,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6897,10 +6919,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6910,10 +6932,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c219"
+                            class="c220"
                           >
                             <span
-                              class="c165 c220 c221"
+                              class="c166 c221 c222"
                             >
                               <img
                                 alt=""
@@ -6929,10 +6951,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/blog"
                         >
                           <span
@@ -6947,27 +6969,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c212"
+                class="c9 c46 c213"
               >
                 <div
-                  class="c213 c94"
+                  class="c214 c95"
                 >
                   <h2
-                    class="c214"
+                    class="c215"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c131 c215"
+                    class="c132 c216"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/"
                         >
                           <span
@@ -6978,10 +7000,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6992,10 +7014,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -7006,10 +7028,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -7020,10 +7042,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -7034,11 +7056,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c217 "
+                          class="c218 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -7048,10 +7070,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c219"
+                            class="c220"
                           >
                             <span
-                              class="c165 c220 c221"
+                              class="c166 c221 c222"
                             >
                               <img
                                 alt=""
@@ -7067,10 +7089,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/contact-us"
                         >
                           <span
@@ -7081,11 +7103,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c217 "
+                          class="c218 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -7095,10 +7117,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c219"
+                            class="c220"
                           >
                             <span
-                              class="c165 c220 c221"
+                              class="c166 c221 c222"
                             >
                               <img
                                 alt=""
@@ -7114,10 +7136,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/webinars"
                         >
                           <span
@@ -7128,11 +7150,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c217 "
+                          class="c218 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -7142,10 +7164,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c219"
+                            class="c220"
                           >
                             <span
-                              class="c165 c220 c221"
+                              class="c166 c221 c222"
                             >
                               <img
                                 alt=""
@@ -7165,27 +7187,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c212"
+                class="c9 c46 c213"
               >
                 <div
-                  class="c213 c94"
+                  class="c214 c95"
                 >
                   <h2
-                    class="c214"
+                    class="c215"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c131 c215"
+                    class="c132 c216"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -7196,10 +7218,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -7210,10 +7232,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -7224,10 +7246,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <button
-                          class="c217 "
+                          class="c218 "
                         >
                           <span
                             class="c25"
@@ -7237,10 +7259,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -7251,10 +7273,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -7265,10 +7287,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -7279,10 +7301,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -7293,10 +7315,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/complaints"
                         >
                           <span
@@ -7307,10 +7329,10 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c216"
+                        class="c217"
                       >
                         <a
-                          class="c217 "
+                          class="c218 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -7325,16 +7347,16 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c212"
+                class="c9 c46 c213"
               >
                 <div
-                  class="c213 c222"
+                  class="c214 c223"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                   >
                     <span
-                      class="c223"
+                      class="c224"
                     >
                       <img
                         alt=""
@@ -7348,24 +7370,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c224 c225"
+                    class="c225 c226"
                   >
                     <div
-                      class="c44 c45 c226 c227"
+                      class="c45 c46 c227 c228"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c228 c51 icon-container"
+                            class="c229 c52 icon-container"
                           >
                             <div
-                              class="c229 shadow"
+                              class="c230 shadow"
                             />
                             <span
                               class="c20"
@@ -7373,7 +7395,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7383,27 +7405,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c226 c227"
+                      class="c45 c46 c227 c228"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c228 c51 icon-container"
+                            class="c229 c52 icon-container"
                           >
                             <div
-                              class="c229 shadow"
+                              class="c230 shadow"
                             />
                             <span
                               class="c20"
@@ -7411,7 +7433,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7421,27 +7443,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c226 c227"
+                      class="c45 c46 c227 c228"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c228 c51 icon-container"
+                            class="c229 c52 icon-container"
                           >
                             <div
-                              class="c229 shadow"
+                              class="c230 shadow"
                             />
                             <span
                               class="c20"
@@ -7449,7 +7471,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7459,7 +7481,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -7469,7 +7491,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c230 c231"
+              class="c231 c232"
               data-percy-hide="contents"
             >
               <img
@@ -7485,27 +7507,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c232 c233"
+              class="c233 c234"
             >
               <div
-                class="c234 c235"
+                class="c235 c236"
               >
                 <div
-                  class="c44 c45 c226 c227"
+                  class="c45 c46 c227 c228"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c228 c51 icon-container"
+                        class="c229 c52 icon-container"
                       >
                         <div
-                          class="c229 shadow"
+                          class="c230 shadow"
                         />
                         <span
                           class="c20"
@@ -7513,7 +7535,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7523,27 +7545,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c226 c227"
+                  class="c45 c46 c227 c228"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c228 c51 icon-container"
+                        class="c229 c52 icon-container"
                       >
                         <div
-                          class="c229 shadow"
+                          class="c230 shadow"
                         />
                         <span
                           class="c20"
@@ -7551,7 +7573,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7561,27 +7583,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c226 c227"
+                  class="c45 c46 c227 c228"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c228 c51 icon-container"
+                        class="c229 c52 icon-container"
                       >
                         <div
-                          class="c229 shadow"
+                          class="c230 shadow"
                         />
                         <span
                           class="c20"
@@ -7589,7 +7611,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7599,17 +7621,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c55"
+                class="c56"
               >
                 <span
-                  class="c223"
+                  class="c224"
                 >
                   <img
                     alt=""
@@ -7623,15 +7645,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c213 c94"
+                class="c214 c95"
               >
                 <p
-                  class="c236"
+                  class="c237"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c237"
+                  class="c238"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -7640,11 +7662,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c238"
+          class="c239"
         >
           <img
             alt=""
-            class="c239"
+            class="c240"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7653,11 +7675,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c240"
+          class="c241"
         >
           <img
             alt=""
-            class="c241"
+            class="c242"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -7669,27 +7691,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c242 c243 c244"
+      class="c243 c244 c245"
     />
   </div>
   <div
-    class="c245"
+    class="c246"
   >
     <div
-      class="c246"
+      class="c247"
       data-testid="cookie-banner"
     >
       <div
-        class="c247"
+        class="c248"
       >
         <div
-          class="c248 c249"
+          class="c249 c250"
         >
           <div
-            class="c250"
+            class="c251"
           >
             <strong
-              class="c251"
+              class="c252"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -7697,13 +7719,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c252"
+            class="c9 c253"
           >
             <div
-              class="c253 c40"
+              class="c254 c41"
             >
               <button
-                class="c254"
+                class="c255"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -7747,7 +7769,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c134 c19 internal-button"
+                class="c135 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
               class="sc-eqUAAy iGfTGj"
             >
               <span
-                class="sc-aXZVg cZEtHK"
+                class="sc-aXZVg etAHNY"
               >
                 <img
                   alt=""
@@ -193,6 +193,19 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                   decoding="async"
                   loading="lazy"
                   src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1711468346/logo-mark.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
+              <span
+                class="sc-aXZVg bmLRQH"
+              >
+                <img
+                  alt=""
+                  class="sc-iGgWBj dZvqhO"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -88,19 +88,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c28 {
+  position: relative;
+  width: 6.25rem;
+  height: 3rem;
+  padding: 0rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -121,17 +130,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c39:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c43 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -139,7 +148,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -150,7 +159,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -159,12 +168,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c55 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c58 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -184,7 +193,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c60 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -194,28 +203,28 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
-.c68 {
+.c69 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -224,7 +233,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   overflow: hidden;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
@@ -232,7 +241,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c76 {
+.c77 {
   position: relative;
   width: 22.5rem;
   height: 100%;
@@ -240,21 +249,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c77 {
+.c78 {
   margin-left: auto;
   margin-right: auto;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c79 {
+.c80 {
   min-width: 100%;
   aspect-ratio: 4/3;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c82 {
+.c83 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   padding-top: 3.5rem;
@@ -262,17 +271,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c85 {
+.c86 {
   background: #ebfbeb;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c86 {
+.c87 {
   padding-top: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -283,12 +292,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c96 {
+.c97 {
   width: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c98 {
+.c99 {
   width: 1.5rem;
   height: 1.5rem;
   background: #bef2bd;
@@ -299,7 +308,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c100 {
+.c101 {
   width: 0rem;
   border: 0rem solid;
   border-left: 0.188rem solid;
@@ -308,12 +317,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c101 {
+.c102 {
   margin-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c102 {
+.c103 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -324,7 +333,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c104 {
+.c105 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -335,13 +344,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c107 {
+.c108 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c113 {
+.c114 {
   height: 15rem;
   padding: 1.5rem;
   background: #a0b6f2;
@@ -349,20 +358,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c118 {
+.c119 {
   overflow: hidden;
   padding-top: 4.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
-.c119 {
+.c120 {
   position: relative;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -377,26 +386,26 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   position: relative;
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c127 {
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c129 {
+.c130 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -406,7 +415,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 1.125rem;
@@ -417,7 +426,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c131 {
+.c132 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -427,14 +436,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c132 {
+.c133 {
   padding-top: 3.5rem;
   padding-bottom: 3.5rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c134 {
+.c135 {
   position: relative;
   padding: 1.5rem;
   padding-left: 1.5rem;
@@ -446,12 +455,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c137 {
+.c138 {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c140 {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -465,36 +474,36 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c143 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c159 {
+.c160 {
   position: relative;
   margin-top: 2rem;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c162 {
+.c163 {
   position: absolute;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c165 {
+.c166 {
   padding-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c169 {
+.c170 {
   position: relative;
   width: 100%;
   height: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c173 {
+.c174 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -504,13 +513,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 0;
 }
 
-.c174 {
+.c175 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c176 {
+.c177 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -522,12 +531,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c179 {
+.c180 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c181 {
+.c182 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -539,18 +548,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c185 {
+.c186 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c186 {
+.c187 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c190 {
+.c191 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -559,7 +568,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c191 {
+.c192 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -567,7 +576,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c195 {
+.c196 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -578,7 +587,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c196 {
+.c197 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -589,14 +598,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c197 {
+.c198 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c199 {
+.c200 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -604,12 +613,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c201 {
+.c202 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c205 {
+.c206 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -627,7 +636,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c207 {
+.c208 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -645,7 +654,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: -1;
 }
 
-.c209 {
+.c210 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -655,7 +664,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 300;
 }
 
-.c212 {
+.c213 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -663,7 +672,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 299;
 }
 
-.c213 {
+.c214 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -671,13 +680,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c214 {
+.c215 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c215 {
+.c216 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -685,7 +694,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c217 {
+.c218 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -696,7 +705,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c220 {
+.c221 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -758,7 +767,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -777,7 +786,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -796,7 +805,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -808,7 +817,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -819,14 +828,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -845,7 +854,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -860,7 +869,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -876,7 +885,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c90 {
+.c91 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -887,7 +896,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.5rem;
 }
 
-.c94 {
+.c95 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -897,7 +906,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c70 {
+.c71 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -913,7 +922,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -924,7 +933,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c80 {
+.c81 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -935,7 +944,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c83 {
+.c84 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -949,7 +958,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 1;
 }
 
-.c87 {
+.c88 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -960,7 +969,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2.5rem;
 }
 
-.c95 {
+.c96 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -968,7 +977,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c97 {
+.c98 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -985,7 +994,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-shrink: 0;
 }
 
-.c99 {
+.c100 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -996,7 +1005,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 0;
 }
 
-.c108 {
+.c109 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1007,7 +1016,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 2rem;
 }
 
-.c115 {
+.c116 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1018,7 +1027,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c127 {
+.c128 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1033,7 +1042,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c138 {
+.c139 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1047,7 +1056,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c177 {
+.c178 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1065,7 +1074,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c189 {
+.c190 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1076,7 +1085,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: left;
 }
 
-.c192 {
+.c193 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1092,7 +1101,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c200 {
+.c201 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1110,7 +1119,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c202 {
+.c203 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1123,7 +1132,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c210 {
+.c211 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1138,7 +1147,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c216 {
+.c217 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1153,7 +1162,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c219 {
+.c220 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1203,7 +1212,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1215,7 +1224,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c54 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1226,14 +1235,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c73 {
+.c74 {
   background: #bef2bd;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c153 {
+.c154 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1244,7 +1253,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c167 {
+.c168 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1255,7 +1264,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c218 {
+.c219 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1266,7 +1275,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c175 {
+.c176 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1365,7 +1374,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1388,12 +1397,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c47 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1407,12 +1416,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c47:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c56 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1425,12 +1434,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1460,12 +1469,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1489,12 +1498,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c170 {
+.c171 {
   background: none;
   color: inherit;
   border: none;
@@ -1518,12 +1527,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c170:disabled {
+.c171:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c222 {
+.c223 {
   background: none;
   color: inherit;
   border: none;
@@ -1546,7 +1555,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c222:disabled {
+.c223:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1555,25 +1564,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c35 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c53 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c206 {
+.c207 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c208 {
+.c209 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1664,13 +1673,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1678,37 +1687,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1716,27 +1725,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1790,74 +1799,74 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c48 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c48:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c48:active {
+.c49:active {
   color: #222222;
 }
 
-.c48:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c46 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c46 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c46 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c46 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c193 > :first-child:focus-visible .shadow {
+.c194 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c193 > :first-child:hover .shadow {
+.c194 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c193 > :first-child:active .shadow {
+.c194 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c193 > :first-child:disabled .icon-container {
+.c194 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c193 > :first-child:hover .icon-container {
+.c194 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c193 > :first-child:active .icon-container {
+.c194 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c72 {
+.c73 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
@@ -1868,7 +1877,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c92 {
+.c93 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1879,7 +1888,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c103 {
+.c104 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1890,7 +1899,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c109 {
+.c110 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1902,7 +1911,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c116 {
+.c117 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -1913,7 +1922,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c122 {
+.c123 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1925,7 +1934,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: center;
 }
 
-.c140 {
+.c141 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -1936,7 +1945,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c180 {
+.c181 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1949,7 +1958,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1957,7 +1966,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c183 {
+.c184 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1966,7 +1975,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: revert;
 }
 
-.c74 {
+.c75 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1977,7 +1986,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c84 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1988,7 +1997,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2000,7 +2009,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c117 {
+.c118 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2011,13 +2020,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c141 {
+.c142 {
   font-family: --var(google-font),Lexend,sans-serif;
   margin-right: 0rem;
   margin-bottom: 1.5rem;
 }
 
-.c171 {
+.c172 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2030,7 +2039,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c172 {
+.c173 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -2042,7 +2051,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   margin-top: 0rem;
 }
 
-.c203 {
+.c204 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -2053,7 +2062,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c204 {
+.c205 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -2064,7 +2073,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c182 {
+.c183 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -2075,7 +2084,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -2096,7 +2105,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c188 {
+.c189 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -2127,7 +2136,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c187 {
+.c24 .c188 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -2142,7 +2151,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c187 {
+.c24:visited .c188 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2152,7 +2161,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c187 {
+.c24:active .c188 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -2162,12 +2171,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c187 {
+.c24[disabled] .c188 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c184 {
+.c185 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2191,47 +2200,47 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c184 .c187 {
+.c185 .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c184:focus-visible {
+.c185:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c184:visited {
+.c185:visited {
   color: #222222;
 }
 
-.c184:visited .c187 {
+.c185:visited .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c184:active {
+.c185:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c184:active .c187 {
+.c185:active .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c184[disabled] {
+.c185[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c184[disabled] .c187 {
+.c185[disabled] .c188 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c221 {
+.c222 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2264,47 +2273,47 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c221 .c187 {
+.c222 .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c221:focus-visible {
+.c222:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c221:visited {
+.c222:visited {
   color: #222222;
 }
 
-.c221:visited .c187 {
+.c222:visited .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c221:active {
+.c222:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c221:active .c187 {
+.c222:active .c188 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c221[disabled] {
+.c222[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c221[disabled] .c187 {
+.c222[disabled] .c188 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c42 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2320,49 +2329,49 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   width: 100%;
 }
 
-.c42::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c42::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c42:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c42::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c42::-webkit-search-decoration,
-.c42::-webkit-search-cancel-button,
-.c42::-webkit-search-results-button,
-.c42::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c42:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c41 {
+.c42 {
   background: #ffffff;
 }
 
-.c41:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c88 {
+.c89 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2371,7 +2380,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c110 {
+.c111 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -2380,13 +2389,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   column-gap: 1rem;
 }
 
-.c135 {
+.c136 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c89 {
+.c90 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2396,7 +2405,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c93 {
+.c94 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2406,7 +2415,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-column-start: 0;
 }
 
-.c111 {
+.c112 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2415,7 +2424,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c136 {
+.c137 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2424,7 +2433,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c178 {
+.c179 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2433,44 +2442,44 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c125 {
+.c126 {
   list-style: none;
   margin: 0;
   padding: 0;
   box-shadow: none;
 }
 
-.c125:has(a:hover,button:hover) {
+.c126:has(a:hover,button:hover) {
   box-shadow: none;
 }
 
-.c125:has( a, button) {
+.c126:has( a, button) {
   border-radius: 0.5rem;
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c125:has( a, button)  a,
-.c125:has( a, button) button {
+.c126:has( a, button)  a,
+.c126:has( a, button) button {
   outline: none;
 }
 
-.c125:has(a:active,button:active) {
+.c126:has(a:active,button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c57:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c57:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c211 {
+.c212 {
   top: 152px;
 }
 
-.c163 {
+.c164 {
   background: none;
   color: inherit;
   border: none;
@@ -2481,16 +2490,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: unset;
 }
 
-.c106:first-child {
+.c107:first-child {
   margin-top: 0;
 }
 
-.c75 {
+.c76 {
   height: 410px;
   width: auto;
 }
 
-.c144 {
+.c145 {
   width: 100%;
   margin-bottom: 2rem;
   background-color: #fff;
@@ -2501,23 +2510,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c144::-webkit-scrollbar-track {
+.c145::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c144::-webkit-scrollbar {
+.c145::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c144::-webkit-scrollbar-thumb {
+.c145::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c147 {
+.c148 {
   position: relative;
   width: 100%;
   display: -webkit-box;
@@ -2526,23 +2535,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c147::-webkit-scrollbar-track {
+.c148::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c147::-webkit-scrollbar {
+.c148::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c147::-webkit-scrollbar-thumb {
+.c148::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c149 {
+.c150 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2550,81 +2559,81 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: flex;
 }
 
-.c149::-webkit-scrollbar-track {
+.c150::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c149::-webkit-scrollbar {
+.c150::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c149::-webkit-scrollbar-thumb {
+.c150::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c81 {
+.c82 {
   object-fit: cover;
   width: 100%;
   height: auto;
 }
 
-.c81::-webkit-scrollbar-track {
+.c82::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c81::-webkit-scrollbar {
+.c82::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c81::-webkit-scrollbar-thumb {
+.c82::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c114 {
+.c115 {
   object-fit: contain;
   width: 100%;
   height: 100%;
 }
 
-.c114::-webkit-scrollbar-track {
+.c115::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c114::-webkit-scrollbar {
+.c115::-webkit-scrollbar {
   width: 10px;
   border-radius: 15px;
   background-color: #ffffff;
 }
 
-.c114::-webkit-scrollbar-thumb {
+.c115::-webkit-scrollbar-thumb {
   border-radius: 15px;
   background-color: #999999;
 }
 
-.c78 {
+.c79 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
 
-.c112 {
+.c113 {
   grid-column: span 3;
 }
 
-.c128:hover {
+.c129:hover {
   box-shadow: 2px 2px 0 0 #ffe555;
 }
 
-.c123 {
+.c124 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2636,20 +2645,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   grid-template-columns: repeat(3,1fr);
 }
 
-.c156 {
+.c157 {
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c145 {
+.c146 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c148 {
+.c149 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -2661,7 +2670,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   transition: all 0.3s ease;
 }
 
-.c154 {
+.c155 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2672,32 +2681,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: fontFamily;
 }
 
-.c154::-webkit-input-placeholder {
+.c155::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c154::-moz-placeholder {
+.c155::-moz-placeholder {
   color: #575757;
 }
 
-.c154:-ms-input-placeholder {
+.c155:-ms-input-placeholder {
   color: #575757;
 }
 
-.c154::placeholder {
+.c155::placeholder {
   color: #575757;
 }
 
-.c154::-webkit-search-decoration,
-.c154::-webkit-search-cancel-button,
-.c154::-webkit-search-results-button,
-.c154::-webkit-search-results-decoration {
+.c155::-webkit-search-decoration,
+.c155::-webkit-search-cancel-button,
+.c155::-webkit-search-results-button,
+.c155::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c151 {
+.c152 {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -2707,7 +2716,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115em;
 }
 
-.c158 {
+.c159 {
   display: none;
   position: absolute;
   bottom: -4px;
@@ -2720,7 +2729,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   z-index: 1;
 }
 
-.c152 {
+.c153 {
   position: relative;
   padding: 4px 8px;
   -webkit-transform: rotate(-2deg) translateY(-16px) translateX(8px);
@@ -2731,16 +2740,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c146:focus-within .c150 {
+.c147:focus-within .c151 {
   background: #374cf1;
   color: #fff;
 }
 
-.c146:focus-within .c157 {
+.c147:focus-within .c158 {
   display: inline;
 }
 
-.c155 {
+.c156 {
   color: #222222;
   height: 60px;
   border-radius: 8px;
@@ -2756,7 +2765,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   outline: none;
 }
 
-.c155::-webkit-input-placeholder {
+.c156::-webkit-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2764,7 +2773,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c155::-moz-placeholder {
+.c156::-moz-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2772,7 +2781,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c155:-ms-input-placeholder {
+.c156:-ms-input-placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2780,7 +2789,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c155::placeholder {
+.c156::placeholder {
   font-size: 16px;
   font-weight: 300;
   font-family: fontFamily;
@@ -2788,40 +2797,40 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   opacity: 1;
 }
 
-.c155:valid:not([value=""]) {
+.c156:valid:not([value=""]) {
   border-color: #2d2d2d;
 }
 
-.c155:valid:not([value=""])::-webkit-input-placeholder {
+.c156:valid:not([value=""])::-webkit-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c155:valid:not([value=""])::-moz-placeholder {
+.c156:valid:not([value=""])::-moz-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c155:valid:not([value=""]):-ms-input-placeholder {
+.c156:valid:not([value=""]):-ms-input-placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c155:valid:not([value=""])::placeholder {
+.c156:valid:not([value=""])::placeholder {
   font-size: 16px;
   color: #575757;
 }
 
-.c161 {
+.c162 {
   display: none;
 }
 
-.c160:focus-within .c150 {
+.c161:focus-within .c151 {
   background: #374cf1;
   color: #fff;
 }
 
-.c164 {
+.c165 {
   color: #222222;
   height: 60px;
   padding-left: 16px;
@@ -2848,32 +2857,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #575757;
 }
 
-.c166 {
+.c167 {
   max-width: calc(100% - 20px);
 }
 
-.c168 {
+.c169 {
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
   overflow: hidden;
 }
 
-.c143 {
+.c144 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c133 {
+.c134 {
   max-width: 100%;
   justify-self: center;
 }
 
-.c194 .icon-container > *:first-child {
+.c195 .icon-container > *:first-child {
   border: 0;
 }
 
-.c198 {
+.c199 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
@@ -2925,18 +2934,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c26 {
-    width: 6.25rem;
+    display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
-    height: 3rem;
+  .c28 {
+    display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2945,19 +2954,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2965,37 +2974,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c55 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -3009,115 +3018,115 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c68 {
+  .c69 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c69 {
+  .c70 {
     padding-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c79 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c79 {
+  .c80 {
     min-width: 40rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-left: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-right: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c82 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c82 {
+  .c83 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     padding-top: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3126,31 +3135,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c101 {
+  .c102 {
     margin-bottom: 4.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c104 {
+  .c105 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3159,37 +3168,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c107 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c107 {
+  .c108 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c121 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c120 {
+  .c121 {
     -webkit-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     -ms-transform: scale(1.1) translateX(-0.65%) translateY(4%);
     transform: scale(1.1) translateX(-0.65%) translateY(4%);
@@ -3197,7 +3206,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c120 {
+  .c121 {
     -webkit-transform: scale(1.4) translateY(4%);
     -ms-transform: scale(1.4) translateY(4%);
     transform: scale(1.4) translateY(4%);
@@ -3205,79 +3214,79 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c121 {
+  .c122 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c121 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c121 {
+  .c122 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-top: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c176 {
+  .c177 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c176 {
+  .c177 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c179 {
+  .c180 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c185 {
+  .c186 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c191 {
+  .c192 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c199 {
+  .c200 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c201 {
+  .c202 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3286,13 +3295,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c206 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c205 {
+  .c206 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -3300,7 +3309,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c205 {
+  .c206 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -3308,19 +3317,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c207 {
+  .c208 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -3328,61 +3337,61 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c209 {
+  .c210 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c216 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c215 {
+  .c216 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c215 {
+  .c216 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c215 {
+  .c216 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c217 {
+  .c218 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3400,19 +3409,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3429,37 +3438,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c70 {
+  .c71 {
     gap: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c70 {
+  .c71 {
     gap: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c87 {
+  .c88 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c108 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c108 {
+  .c109 {
     gap: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c189 {
+  .c190 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -3468,13 +3477,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c192 {
+  .c193 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3482,7 +3491,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3491,7 +3500,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c200 {
+  .c201 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -3500,7 +3509,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c202 {
+  .c203 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3509,7 +3518,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c210 {
+  .c211 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -3518,7 +3527,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -3526,7 +3535,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c216 {
+  .c217 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3534,7 +3543,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -3543,7 +3552,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c216 {
+  .c217 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -3552,19 +3561,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c216 {
+  .c217 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c216 {
+  .c217 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -3572,7 +3581,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3580,7 +3589,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c219 {
+  .c220 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -3588,7 +3597,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c219 {
+  .c220 {
     gap: 2rem;
   }
 }
@@ -3648,25 +3657,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     font-weight: 500;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c218 {
+  .c219 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -3699,43 +3708,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3744,7 +3753,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c72 {
+  .c73 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3753,25 +3762,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c92 {
+  .c93 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3780,25 +3789,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3807,43 +3816,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3852,7 +3861,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3861,55 +3870,55 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:1280px) {
-  .c109 {
+  .c110 {
     text-align: center;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3918,7 +3927,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c116 {
+  .c117 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3927,43 +3936,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c122 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3972,7 +3981,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c122 {
+  .c123 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -3981,43 +3990,43 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     font-size: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     line-height: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4026,7 +4035,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c74 {
+  .c75 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4035,25 +4044,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -4062,25 +4071,25 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4089,31 +4098,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c105 {
+  .c106 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -4122,7 +4131,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     margin-right: 1.5rem;
   }
 }
@@ -4137,16 +4146,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c187,
-  .c24:visited:hover .c187 {
+  .c24:hover .c188,
+  .c24:visited:hover .c188 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c184:hover,
-  .c184:visited:hover {
+  .c185:hover,
+  .c185:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4154,16 +4163,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c184:hover .c187,
-  .c184:visited:hover .c187 {
+  .c185:hover .c188,
+  .c185:visited:hover .c188 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c221:hover,
-  .c221:visited:hover {
+  .c222:hover,
+  .c222:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -4171,94 +4180,94 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c221:hover .c187,
-  .c221:visited:hover .c187 {
+  .c222:hover .c188,
+  .c222:visited:hover .c188 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c42 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c41:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column: 2 / span 9;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c89 {
+  .c90 {
     grid-column-start: 2;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     grid-column: span 12;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     grid-column: 3 / span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c93 {
+  .c94 {
     grid-column-start: 0;
   }
 }
 
 @media (min-width:1280px) {
-  .c93 {
+  .c94 {
     grid-column-start: 3;
   }
 }
 
 @media (min-width:750px) {
-  .c136 {
+  .c137 {
     grid-column: span 6;
   }
 }
 
 @media (min-width:750px) {
-  .c178 {
+  .c179 {
     grid-column: span 3;
   }
 }
 
 @media (max-width:920px) {
-  .c75 {
+  .c76 {
     display: none;
   }
 }
 
 @media (max-width:1212px) {
-  .c78 {
+  .c79 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -4266,31 +4275,31 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (max-width:1040px) {
-  .c112 {
+  .c113 {
     grid-column: span 6;
   }
 }
 
 @media (max-width:749px) {
-  .c112 {
+  .c113 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:800px) {
-  .c123 {
+  .c124 {
     grid-template-columns: repeat(1,1fr);
   }
 }
 
 @media (max-width:750px) {
-  .c155 {
+  .c156 {
     font-size: 16px;
   }
 }
 
 @media (min-width:750px) {
-  .c133 {
+  .c134 {
     max-width: 870px;
   }
 }
@@ -4490,10 +4499,23 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>
+              <span
+                class="c28"
+              >
+                <img
+                  alt=""
+                  class="c27"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -4501,10 +4523,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c30"
               >
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4518,15 +4540,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -4535,7 +4557,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4549,15 +4571,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -4566,7 +4588,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4580,15 +4602,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -4597,7 +4619,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4611,15 +4633,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -4628,7 +4650,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -4641,16 +4663,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
@@ -4659,7 +4681,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4674,24 +4696,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c9 c36"
+              class="c9 c37"
             >
               <form
                 action="/teachers/search"
-                class="c37"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c38"
+                  class="c39"
                 >
                   <div
-                    class="c39 c40 c41"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c42"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4699,24 +4721,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c43"
+                  class="c44"
                 >
                   <div
-                    class="c44 c45 c46"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c47 c48"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c9 c49"
+                        class="c9 c50"
                       >
                         <div
-                          class="c50 c51 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c52 shadow"
+                            class="c53 shadow"
                           />
                           <span
                             class="c20"
@@ -4724,7 +4746,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c53"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4734,7 +4756,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c54"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -4742,24 +4764,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c55"
+                class="c56"
               >
                 <div
-                  class="c44 c45 c46"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c50 c51 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c52 shadow"
+                          class="c53 shadow"
                         />
                         <span
                           class="c20"
@@ -4767,7 +4789,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c53"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4777,7 +4799,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -4785,14 +4807,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c56 c57"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c58 c59 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c60"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4806,7 +4828,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -4822,13 +4844,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c34"
                   >
                     <span
-                      class="c34"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -4838,7 +4860,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -4852,18 +4874,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c49"
+                  class="c9 c50"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c35"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4881,41 +4903,41 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c69 c70"
+              class="c70 c71"
             >
               <div
-                class="c9 c71"
+                class="c9 c72"
               >
                 <h1
-                  class="c72"
+                  class="c73"
                 >
                   <span
-                    class="c73"
+                    class="c74"
                   >
                     About Oak
                   </span>
                 </h1>
                 <p
-                  class="c74"
+                  class="c75"
                 >
                   We create free resources for teachers.
                 </p>
               </div>
               <div
-                class="c9 c75"
+                class="c9 c76"
               >
                 <span
-                  class="c76"
+                  class="c77"
                 >
                   <img
                     alt=""
@@ -4933,14 +4955,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c77 c45 c78"
+            class="c78 c46 c79"
           >
             <div
-              class="c79 c80"
+              class="c80 c81"
             >
               <img
                 alt=""
-                class="c81"
+                class="c82"
                 data-nimg="1"
                 decoding="async"
                 height="300"
@@ -4952,44 +4974,44 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </div>
             <div
-              class="c82 c83"
+              class="c83 c84"
             >
               <p
-                class="c84"
+                class="c85"
               >
                 Oak National Academy was created in response to the pandemic.
               </p>
             </div>
           </div>
           <div
-            class="c85"
+            class="c86"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c86 c87"
+                class="c87 c88"
               >
                 <div
-                  class="c9 c88"
+                  class="c9 c89"
                 >
                   <div
-                    class="c9 c45 c89"
+                    class="c9 c46 c90"
                   >
                     <div
-                      class="c9 c90"
+                      class="c9 c91"
                     >
                       <div
-                        class="c91"
+                        class="c92"
                       >
                         <span
-                          class="c73"
+                          class="c74"
                         >
                           Oak’s story
                         </span>
                       </div>
                       <h2
-                        class="c92"
+                        class="c93"
                       >
                         As teaching evolves, so do we...
                       </h2>
@@ -4997,50 +5019,50 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c88"
+                  class="c9 c89"
                 >
                   <div
-                    class="c9 c45 c93"
+                    class="c9 c46 c94"
                   >
                     <div
-                      class="c9 c94"
+                      class="c9 c95"
                     >
                       <div
-                        class="c9 c95"
+                        class="c9 c96"
                         data-testid="timetable-timeline-item"
                       >
                         <div
-                          class="c96 c97"
+                          class="c97 c98"
                         >
                           <div
-                            class="c98 c99"
+                            class="c99 c100"
                           />
                           <div
-                            class="c100 c80"
+                            class="c101 c81"
                           />
                         </div>
                         <div
-                          class="c101 c90"
+                          class="c102 c91"
                         >
                           <div
-                            class="c102"
+                            class="c103"
                           >
                             <span
-                              class="c73"
+                              class="c74"
                             >
                               Oak is born
                             </span>
                           </div>
                           <h3
-                            class="c103"
+                            class="c104"
                           >
                             2020
                           </h3>
                           <div
-                            class="c104 c94"
+                            class="c105 c95"
                           >
                             <p
-                              class="c105 c106"
+                              class="c106 c107"
                             >
                               Oak launched during lockdown.
                             </p>
@@ -5054,32 +5076,32 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c68"
+            class="c69"
           >
             <div
-              class="c107 c108"
+              class="c108 c109"
             >
               <h2
-                class="c109"
+                class="c110"
               >
                 We are...
               </h2>
               <div
-                class="c9 c110"
+                class="c9 c111"
               >
                 <div
-                  class="c9 c45 c111 c112"
+                  class="c9 c46 c112 c113"
                   data-testid="who-we-are-desc-item"
                 >
                   <div
-                    class="c9 c71"
+                    class="c9 c72"
                   >
                     <div
-                      class="c113"
+                      class="c114"
                     >
                       <img
                         alt=""
-                        class="c114"
+                        class="c115"
                         data-nimg="1"
                         decoding="async"
                         height="300"
@@ -5091,15 +5113,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       />
                     </div>
                     <div
-                      class="c9 c115"
+                      class="c9 c116"
                     >
                       <h3
-                        class="c116"
+                        class="c117"
                       >
                         Free
                       </h3>
                       <p
-                        class="c117"
+                        class="c118"
                       >
                         All our resources are free.
                       </p>
@@ -5110,14 +5132,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c118"
+            class="c119"
             style="margin-top: -72px;"
           >
             <div
-              class="c119"
+              class="c120"
             >
               <span
-                class="c120"
+                class="c121"
                 style="pointer-events: none;"
               >
                 <img
@@ -5131,13 +5153,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 />
               </span>
               <div
-                class="c68"
+                class="c69"
               >
                 <div
-                  class="c121 c108"
+                  class="c122 c109"
                 >
                   <h2
-                    class="c122"
+                    class="c123"
                     id="react-use-id-test-result"
                   >
                     Explore more about Oak
@@ -5146,24 +5168,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="c123"
+                      class="c124"
                     >
                       <li
-                        class="c124 c125"
+                        class="c125 c126"
                       >
                         <a
                           href="/about-us/who-we-are"
                           style="outline: none;"
                         >
                           <div
-                            class="c126 c127 c128"
+                            class="c127 c128 c129"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c129"
+                                class="c130"
                               >
                                 <img
                                   alt=""
@@ -5177,15 +5199,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c130 c80"
+                              class="c131 c81"
                             >
                               About Oak
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c131"
+                                class="c132"
                               >
                                 <img
                                   alt=""
@@ -5202,21 +5224,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c124 c125"
+                        class="c125 c126"
                       >
                         <a
                           href="/about-us/oaks-curricula"
                           style="outline: none;"
                         >
                           <div
-                            class="c126 c127 c128"
+                            class="c127 c128 c129"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c129"
+                                class="c130"
                               >
                                 <img
                                   alt=""
@@ -5230,15 +5252,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c130 c80"
+                              class="c131 c81"
                             >
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c131"
+                                class="c132"
                               >
                                 <img
                                   alt=""
@@ -5255,21 +5277,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c124 c125"
+                        class="c125 c126"
                       >
                         <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
                           <div
-                            class="c126 c127 c128"
+                            class="c127 c128 c129"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c129"
+                                class="c130"
                               >
                                 <img
                                   alt=""
@@ -5283,15 +5305,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c130 c80"
+                              class="c131 c81"
                             >
                               Meet the team
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c131"
+                                class="c132"
                               >
                                 <img
                                   alt=""
@@ -5308,21 +5330,21 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c124 c125"
+                        class="c125 c126"
                       >
                         <a
                           href="/about-us/get-involved"
                           style="outline: none;"
                         >
                           <div
-                            class="c126 c127 c128"
+                            class="c127 c128 c129"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c129"
+                                class="c130"
                               >
                                 <img
                                   alt=""
@@ -5336,15 +5358,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </span>
                             </div>
                             <div
-                              class="c130 c80"
+                              class="c131 c81"
                             >
                               Get involved
                             </div>
                             <div
-                              class="c9 c45"
+                              class="c9 c46"
                             >
                               <span
-                                class="c131"
+                                class="c132"
                               >
                                 <img
                                   alt=""
@@ -5367,29 +5389,29 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c132"
+            class="c133"
             id="newsletter-signup"
           >
             <div
-              class="c68"
+              class="c69"
             >
               <div
-                class="c9 c45 c133"
+                class="c9 c46 c134"
               >
                 <div
-                  class="c134 c1"
+                  class="c135 c1"
                 >
                   <div
-                    class="c9 c135"
+                    class="c9 c136"
                   >
                     <div
-                      class="c9 c45 c136"
+                      class="c9 c46 c137"
                     >
                       <div
-                        class="c137 c138"
+                        class="c138 c139"
                       >
                         <span
-                          class="c139"
+                          class="c140"
                         >
                           <img
                             alt=""
@@ -5402,13 +5424,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           />
                         </span>
                         <h2
-                          class="c140"
+                          class="c141"
                         >
                           Don’t miss out
                         </h2>
                       </div>
                       <p
-                        class="c141"
+                        class="c142"
                         color="text-primary"
                         id="react-use-id-test-result-newsletter-form-description"
                       >
@@ -5428,18 +5450,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c142 c45 c136"
+                      class="c143 c46 c137"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
-                        class="c143"
+                        class="c144"
                         novalidate=""
                       >
                         <div
-                          class="c144 c145 c146"
+                          class="c145 c146 c147"
                         >
                           <div
-                            class="c147 "
+                            class="c148 "
                           >
                             <div
                               aria-hidden="true"
@@ -5448,7 +5470,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5473,7 +5495,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5498,7 +5520,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5523,7 +5545,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5548,11 +5570,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c149 "
+                              class="c150 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c150 c151 c152"
+                                class="c151 c152 c153"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-name"
@@ -5564,7 +5586,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                   Name
                                    
                                   <span
-                                    class="c153"
+                                    class="c154"
                                   >
                                     (required)
                                   </span>
@@ -5575,7 +5597,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-name-label"
                               autocomplete="name"
-                              class="c154 c155"
+                              class="c155 c156"
                               id="react-use-id-test-result-newsletter-signup-name"
                               name="name"
                               placeholder="Anna Smith"
@@ -5583,7 +5605,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c156 c157 c158"
+                              class="c157 c158 c159"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5596,10 +5618,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c144 c145 c146"
+                          class="c145 c146 c147"
                         >
                           <div
-                            class="c147 "
+                            class="c148 "
                           >
                             <div
                               aria-hidden="true"
@@ -5608,7 +5630,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-top"
                                 style="height: 3px;"
@@ -5633,7 +5655,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-right"
                                 style="width: 3px; height: 90%;"
@@ -5658,7 +5680,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-bottom"
                                 style="height: 3px; width: 100%;"
@@ -5683,7 +5705,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="c148"
+                                class="c149"
                                 height="100%"
                                 name="box-border-left"
                                 style="width: 3px;"
@@ -5708,11 +5730,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c149 "
+                              class="c150 "
                             >
                               <label
                                 aria-hidden="true"
-                                class="c150 c151 c152"
+                                class="c151 c152 c153"
                                 color="black"
                                 data-testid="rotated-input-label"
                                 for="react-use-id-test-result-newsletter-signup-email"
@@ -5724,7 +5746,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                                   Email
                                    
                                   <span
-                                    class="c153"
+                                    class="c154"
                                   >
                                     (required)
                                   </span>
@@ -5735,7 +5757,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               aria-invalid="false"
                               aria-labelledby="react-use-id-test-result-newsletter-signup-email-label"
                               autocomplete="email"
-                              class="c154 c155"
+                              class="c155 c156"
                               id="react-use-id-test-result-newsletter-signup-email"
                               name="email"
                               placeholder="anna@amail.com"
@@ -5743,7 +5765,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                             <svg
                               aria-hidden="true"
-                              class="c156 c157 c158"
+                              class="c157 c158 c159"
                               height="100%"
                               name="underline-1"
                               width="100%"
@@ -5756,7 +5778,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c159 c94 c160"
+                          class="c160 c95 c161"
                         >
                           <div
                             aria-hidden="true"
@@ -5765,7 +5787,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="c148"
+                              class="c149"
                               height="100%"
                               name="box-border-top"
                               style="height: 3px;"
@@ -5790,7 +5812,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c148"
+                              class="c149"
                               height="100%"
                               name="box-border-right"
                               style="width: 3px; height: 90%;"
@@ -5815,7 +5837,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c148"
+                              class="c149"
                               height="100%"
                               name="box-border-bottom"
                               style="height: 3px; width: 100%;"
@@ -5840,7 +5862,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c148"
+                              class="c149"
                               height="100%"
                               name="box-border-left"
                               style="width: 3px;"
@@ -5866,7 +5888,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </div>
                           <svg
                             aria-hidden="true"
-                            class="c156 c157 c158 c161"
+                            class="c157 c158 c159 c162"
                             height="100%"
                             name="underline-1"
                             width="100%"
@@ -5877,10 +5899,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c162 c45"
+                            class="c163 c46"
                           >
                             <label
-                              class="c150 c151 c152"
+                              class="c151 c152 c153"
                               color="black"
                               id="react-use-id-test-result"
                             >
@@ -5892,16 +5914,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             aria-haspopup="listbox"
                             aria-invalid="false"
                             aria-labelledby="react-use-id-test-result react-use-id-test-result-button"
-                            class="c163 c164"
+                            class="c164 c165"
                             data-testid="select"
                             id="react-use-id-test-result-button"
                             type="button"
                           >
                             <div
-                              class="c165 c40 c166"
+                              class="c166 c41 c167"
                             >
                               <span
-                                class="c167 c168"
+                                class="c168 c169"
                                 data-testid="select-span"
                                 id="react-use-id-test-result-value"
                                 title="What describes you best?"
@@ -5925,7 +5947,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </button>
                         </div>
                         <div
-                          class="c169 c5"
+                          class="c170 c5"
                         >
                           <div
                             class="c6 grey-shadow"
@@ -5934,7 +5956,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             class="c6 yellow-shadow"
                           />
                           <button
-                            class="c170 c19 internal-button"
+                            class="c171 c19 internal-button"
                           >
                             <div
                               class="c9 c10"
@@ -5949,12 +5971,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </div>
                         <p
                           aria-live="assertive"
-                          class="c171"
+                          class="c172"
                           role="alert"
                         />
                         <p
                           aria-live="polite"
-                          class="c172"
+                          class="c173"
                         />
                       </form>
                     </div>
@@ -5966,14 +5988,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c173"
+        class="c174"
       >
         <div
-          class="c174 c45"
+          class="c175 c46"
         >
           <svg
             aria-hidden="true"
-            class="c175"
+            class="c176"
             height="100%"
             name="header-underline"
             width="100%"
@@ -5996,33 +6018,33 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c176 c177"
+            class="c177 c178"
           >
             <div
-              class="c9 c135"
+              class="c9 c136"
             >
               <div
-                class="c9 c45 c178"
+                class="c9 c46 c179"
               >
                 <div
-                  class="c179 c94"
+                  class="c180 c95"
                 >
                   <h2
-                    class="c180"
+                    class="c181"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c181 c182"
+                    class="c182 c183"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/pupils/years"
                         >
                           <span
@@ -6036,27 +6058,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c185"
+                  class="c186"
                 />
                 <div
-                  class="c179 c94"
+                  class="c180 c95"
                 >
                   <h2
-                    class="c180"
+                    class="c181"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c181 c182"
+                    class="c182 c183"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -6067,10 +6089,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/lesson-planning"
                         >
                           <span
@@ -6081,10 +6103,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -6094,10 +6116,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c186"
+                            class="c187"
                           >
                             <span
-                              class="c131 c187 c188"
+                              class="c132 c188 c189"
                             >
                               <img
                                 alt=""
@@ -6113,10 +6135,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/blog"
                         >
                           <span
@@ -6131,27 +6153,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c178"
+                class="c9 c46 c179"
               >
                 <div
-                  class="c179 c94"
+                  class="c180 c95"
                 >
                   <h2
-                    class="c180"
+                    class="c181"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c181 c182"
+                    class="c182 c183"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/"
                         >
                           <span
@@ -6162,10 +6184,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -6176,10 +6198,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -6190,10 +6212,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -6204,10 +6226,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -6218,11 +6240,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c184 "
+                          class="c185 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -6232,10 +6254,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c186"
+                            class="c187"
                           >
                             <span
-                              class="c131 c187 c188"
+                              class="c132 c188 c189"
                             >
                               <img
                                 alt=""
@@ -6251,10 +6273,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/contact-us"
                         >
                           <span
@@ -6265,11 +6287,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c184 "
+                          class="c185 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -6279,10 +6301,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c186"
+                            class="c187"
                           >
                             <span
-                              class="c131 c187 c188"
+                              class="c132 c188 c189"
                             >
                               <img
                                 alt=""
@@ -6298,10 +6320,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/webinars"
                         >
                           <span
@@ -6312,11 +6334,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c184 "
+                          class="c185 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -6326,10 +6348,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c186"
+                            class="c187"
                           >
                             <span
-                              class="c131 c187 c188"
+                              class="c132 c188 c189"
                             >
                               <img
                                 alt=""
@@ -6349,27 +6371,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c178"
+                class="c9 c46 c179"
               >
                 <div
-                  class="c179 c94"
+                  class="c180 c95"
                 >
                   <h2
-                    class="c180"
+                    class="c181"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c181 c182"
+                    class="c182 c183"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -6380,10 +6402,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -6394,10 +6416,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -6408,10 +6430,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <button
-                          class="c184 "
+                          class="c185 "
                         >
                           <span
                             class="c25"
@@ -6421,10 +6443,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -6435,10 +6457,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -6449,10 +6471,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -6463,10 +6485,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -6477,10 +6499,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/complaints"
                         >
                           <span
@@ -6491,10 +6513,10 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c183"
+                        class="c184"
                       >
                         <a
-                          class="c184 "
+                          class="c185 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -6509,16 +6531,16 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c178"
+                class="c9 c46 c179"
               >
                 <div
-                  class="c179 c189"
+                  class="c180 c190"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                   >
                     <span
-                      class="c190"
+                      class="c191"
                     >
                       <img
                         alt=""
@@ -6532,24 +6554,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c191 c192"
+                    class="c192 c193"
                   >
                     <div
-                      class="c44 c45 c193 c194"
+                      class="c45 c46 c194 c195"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c195 c51 icon-container"
+                            class="c196 c52 icon-container"
                           >
                             <div
-                              class="c196 shadow"
+                              class="c197 shadow"
                             />
                             <span
                               class="c20"
@@ -6557,7 +6579,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6567,27 +6589,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c193 c194"
+                      class="c45 c46 c194 c195"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c195 c51 icon-container"
+                            class="c196 c52 icon-container"
                           >
                             <div
-                              class="c196 shadow"
+                              class="c197 shadow"
                             />
                             <span
                               class="c20"
@@ -6595,7 +6617,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6605,27 +6627,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c193 c194"
+                      class="c45 c46 c194 c195"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c195 c51 icon-container"
+                            class="c196 c52 icon-container"
                           >
                             <div
-                              class="c196 shadow"
+                              class="c197 shadow"
                             />
                             <span
                               class="c20"
@@ -6633,7 +6655,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6643,7 +6665,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -6653,7 +6675,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c197 c198"
+              class="c198 c199"
               data-percy-hide="contents"
             >
               <img
@@ -6669,27 +6691,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               />
             </span>
             <div
-              class="c199 c200"
+              class="c200 c201"
             >
               <div
-                class="c201 c202"
+                class="c202 c203"
               >
                 <div
-                  class="c44 c45 c193 c194"
+                  class="c45 c46 c194 c195"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c195 c51 icon-container"
+                        class="c196 c52 icon-container"
                       >
                         <div
-                          class="c196 shadow"
+                          class="c197 shadow"
                         />
                         <span
                           class="c20"
@@ -6697,7 +6719,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6707,27 +6729,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c193 c194"
+                  class="c45 c46 c194 c195"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c195 c51 icon-container"
+                        class="c196 c52 icon-container"
                       >
                         <div
-                          class="c196 shadow"
+                          class="c197 shadow"
                         />
                         <span
                           class="c20"
@@ -6735,7 +6757,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6745,27 +6767,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c193 c194"
+                  class="c45 c46 c194 c195"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c195 c51 icon-container"
+                        class="c196 c52 icon-container"
                       >
                         <div
-                          class="c196 shadow"
+                          class="c197 shadow"
                         />
                         <span
                           class="c20"
@@ -6773,7 +6795,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6783,17 +6805,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c55"
+                class="c56"
               >
                 <span
-                  class="c190"
+                  class="c191"
                 >
                   <img
                     alt=""
@@ -6807,15 +6829,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c179 c94"
+                class="c180 c95"
               >
                 <p
-                  class="c203"
+                  class="c204"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c204"
+                  class="c205"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -6824,11 +6846,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c205"
+          class="c206"
         >
           <img
             alt=""
-            class="c206"
+            class="c207"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6837,11 +6859,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           />
         </span>
         <span
-          class="c207"
+          class="c208"
         >
           <img
             alt=""
-            class="c208"
+            class="c209"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -6853,27 +6875,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c209 c210 c211"
+      class="c210 c211 c212"
     />
   </div>
   <div
-    class="c212"
+    class="c213"
   >
     <div
-      class="c213"
+      class="c214"
       data-testid="cookie-banner"
     >
       <div
-        class="c214"
+        class="c215"
       >
         <div
-          class="c215 c216"
+          class="c216 c217"
         >
           <div
-            class="c217"
+            class="c218"
           >
             <strong
-              class="c218"
+              class="c219"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -6881,13 +6903,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c219"
+            class="c9 c220"
           >
             <div
-              class="c220 c40"
+              class="c221 c41"
             >
               <button
-                class="c221"
+                class="c222"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -6931,7 +6953,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c222 c19 internal-button"
+                class="c223 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -88,19 +88,28 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c28 {
+  position: relative;
+  width: 6.25rem;
+  height: 3rem;
+  padding: 0rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c38 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c39 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c40 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -121,17 +130,17 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c39:hover {
+.c40:hover {
   cursor: pointer;
 }
 
-.c43 {
+.c44 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c44 {
+.c45 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -139,7 +148,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c51 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -150,7 +159,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c53 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -159,12 +168,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c55 {
+.c56 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c58 {
+.c59 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -184,7 +193,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c60 {
+.c61 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -194,22 +203,22 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c61 {
+.c62 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c64 {
+.c65 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c67 {
+.c68 {
   max-width: 80rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
@@ -218,18 +227,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c68 {
+.c69 {
   padding-top: 1.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c69 {
+.c70 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c73 {
+.c74 {
   overflow: hidden;
   min-width: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -238,7 +247,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow: hidden;
 }
 
-.c74 {
+.c75 {
   position: relative;
   width: 1.25rem;
   min-width: 1.25rem;
@@ -248,20 +257,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c75 {
+.c76 {
   padding-top: 2.5rem;
   padding-bottom: 3.5rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c81 {
+.c82 {
   padding-left: 0rem;
   padding-right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c84 {
+.c85 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -272,14 +281,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c87 {
+.c88 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   background: #ffe555;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c88 {
+.c89 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -290,7 +299,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c90 {
+.c91 {
   padding-bottom: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -302,7 +311,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c96 {
+.c97 {
   position: relative;
   overflow: hidden;
   width: 100%;
@@ -312,13 +321,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 0;
 }
 
-.c97 {
+.c98 {
   position: relative;
   height: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c99 {
+.c100 {
   width: 100%;
   max-width: 30rem;
   padding-left: 1rem;
@@ -330,12 +339,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c103 {
+.c104 {
   margin-top: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c106 {
+.c107 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -347,18 +356,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c109 {
+.c110 {
   margin-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c110 {
+.c111 {
   padding-left: 0.25rem;
   display: inline-block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c111 {
+.c112 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -368,7 +377,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c115 {
+.c116 {
   position: relative;
   width: 10rem;
   height: 4rem;
@@ -377,7 +386,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c116 {
+.c117 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +394,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c120 {
+.c121 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -396,7 +405,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c121 {
+.c122 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -407,14 +416,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c122 {
+.c123 {
   position: relative;
   width: 100%;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c124 {
+.c125 {
   width: 100%;
   padding-top: 0.75rem;
   margin-top: 2rem;
@@ -422,12 +431,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c126 {
+.c127 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c130 {
+.c131 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -445,7 +454,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c132 {
+.c133 {
   position: absolute;
   top: 0rem;
   right: 0rem;
@@ -463,7 +472,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: -1;
 }
 
-.c134 {
+.c135 {
   position: fixed;
   right: 0rem;
   width: 100%;
@@ -473,7 +482,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 300;
 }
 
-.c137 {
+.c138 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0rem;
@@ -481,7 +490,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   z-index: 299;
 }
 
-.c138 {
+.c139 {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -489,13 +498,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c139 {
+.c140 {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c140 {
+.c141 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -503,7 +512,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c142 {
+.c143 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -514,7 +523,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c145 {
+.c146 {
   font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
@@ -576,7 +585,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -595,7 +604,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -614,7 +623,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -626,7 +635,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -637,14 +646,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -663,7 +672,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -678,7 +687,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -694,7 +703,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c104 {
+.c105 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,14 +713,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-direction: column;
 }
 
-.c77 {
+.c78 {
   display: none;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
 }
 
-.c79 {
+.c80 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -719,17 +728,6 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
-}
-
-.c82 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  gap: 1.5rem;
 }
 
 .c83 {
@@ -740,10 +738,21 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c84 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   gap: 0.25rem;
 }
 
-.c93 {
+.c94 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -751,7 +760,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c100 {
+.c101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -769,7 +778,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-grow: 1;
 }
 
-.c114 {
+.c115 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -780,7 +789,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: left;
 }
 
-.c117 {
+.c118 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -796,7 +805,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c125 {
+.c126 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -814,7 +823,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: flex-start;
 }
 
-.c127 {
+.c128 {
   display: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -827,7 +836,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1rem;
 }
 
-.c135 {
+.c136 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -842,7 +851,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c141 {
+.c142 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -857,7 +866,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c144 {
+.c145 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -907,7 +916,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c35 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -919,7 +928,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   text-align: left;
 }
 
-.c54 {
+.c55 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -930,7 +939,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c143 {
+.c144 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -941,7 +950,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c98 {
+.c99 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -1040,7 +1049,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c31 {
+.c32 {
   background: none;
   color: inherit;
   border: none;
@@ -1063,12 +1072,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c31:disabled {
+.c32:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c47 {
+.c48 {
   background: none;
   color: inherit;
   border: none;
@@ -1082,12 +1091,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c47:disabled {
+.c48:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c56 {
+.c57 {
   background: none;
   color: inherit;
   border: none;
@@ -1100,12 +1109,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56:disabled {
+.c57:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c62 {
+.c63 {
   background: none;
   color: inherit;
   border: none;
@@ -1135,12 +1144,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c62:disabled {
+.c63:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c65 {
+.c66 {
   background: none;
   color: inherit;
   border: none;
@@ -1164,12 +1173,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-style: none;
 }
 
-.c65:disabled {
+.c66:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c94 {
+.c95 {
   background: none;
   color: inherit;
   border: none;
@@ -1192,12 +1201,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c94:disabled {
+.c95:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c147 {
+.c148 {
   background: none;
   color: inherit;
   border: none;
@@ -1220,7 +1229,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c147:disabled {
+.c148:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1229,25 +1238,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c35 {
+.c36 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c53 {
+.c54 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c131 {
+.c132 {
   -webkit-filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   filter: brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%);
   object-fit: fill;
 }
 
-.c133 {
+.c134 {
   -webkit-filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   filter: brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%);
   object-fit: fill;
@@ -1338,13 +1347,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: none;
 }
 
-.c32 {
+.c33 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c32:hover {
+.c33:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1352,37 +1361,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #f2f2f2;
 }
 
-.c32:hover [data-state="selected"] {
+.c33:hover [data-state="selected"] {
   display: none;
 }
 
-.c32:active {
+.c33:active {
   background: #ffffff;
   border-color: #ffffff;
   color: #222222;
 }
 
-.c32:active [data-state="selected"] {
+.c33:active [data-state="selected"] {
   display: none;
 }
 
-.c32:disabled {
+.c33:disabled {
   background: #ffffff;
   border-color: #ffffff;
   color: #808080;
 }
 
-.c32:disabled [data-state="selected"] {
+.c33:disabled [data-state="selected"] {
   display: none;
 }
 
-.c63 {
+.c64 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c63:hover {
+.c64:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1390,37 +1399,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c63:hover [data-state="selected"] {
+.c64:hover [data-state="selected"] {
   display: none;
 }
 
-.c63:active {
+.c64:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c63:active [data-state="selected"] {
+.c64:active [data-state="selected"] {
   display: none;
 }
 
-.c63:disabled {
+.c64:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c63:disabled [data-state="selected"] {
+.c64:disabled [data-state="selected"] {
   display: none;
 }
 
-.c95 {
+.c96 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c95:hover {
+.c96:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -1428,27 +1437,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #222222;
 }
 
-.c95:hover [data-state="selected"] {
+.c96:hover [data-state="selected"] {
   display: none;
 }
 
-.c95:active {
+.c96:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c95:active [data-state="selected"] {
+.c96:active [data-state="selected"] {
   display: none;
 }
 
-.c95:disabled {
+.c96:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c95:disabled [data-state="selected"] {
+.c96:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1502,74 +1511,74 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c48 {
+.c49 {
   display: inline-block;
   position: relative;
 }
 
-.c48:hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c48:active {
+.c49:active {
   color: #222222;
 }
 
-.c48:disabled {
+.c49:disabled {
   color: #808080;
 }
 
-.c46 > :first-child:focus-visible .shadow {
+.c47 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:hover .shadow {
+.c47 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c46 > :first-child:active .shadow {
+.c47 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c46 > :first-child:disabled .icon-container {
+.c47 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c46 > :first-child:hover .icon-container {
+.c47 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c46 > :first-child:active .icon-container {
+.c47 > :first-child:active .icon-container {
   background: #222222;
 }
 
-.c118 > :first-child:focus-visible .shadow {
+.c119 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:hover .shadow {
+.c119 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c118 > :first-child:active .shadow {
+.c119 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c118 > :first-child:disabled .icon-container {
+.c119 > :first-child:disabled .icon-container {
   background: #e4e4e4;
 }
 
-.c118 > :first-child:hover .icon-container {
+.c119 > :first-child:hover .icon-container {
   background: #ffffff;
 }
 
-.c118 > :first-child:active .icon-container {
+.c119 > :first-child:active .icon-container {
   background: #ffffff;
 }
 
-.c86 {
+.c87 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2.5rem;
@@ -1580,7 +1589,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c105 {
+.c106 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1593,7 +1602,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c30 {
+.c31 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1601,7 +1610,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c108 {
+.c109 {
   margin-top: 0.75rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -1610,7 +1619,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: revert;
 }
 
-.c91 {
+.c92 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1622,7 +1631,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   margin-top: 1rem;
 }
 
-.c128 {
+.c129 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -1633,7 +1642,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c129 {
+.c130 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
@@ -1644,7 +1653,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c85 {
+.c86 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -1655,7 +1664,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c89 {
+.c90 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.5rem;
@@ -1666,7 +1675,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c107 {
+.c108 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -1677,7 +1686,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c29 {
+.c30 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -1698,7 +1707,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.75rem;
 }
 
-.c113 {
+.c114 {
   width: 1.25em;
   min-width: 1.25em;
   height: 1.25em;
@@ -1729,7 +1738,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c24 .c112 {
+.c24 .c113 {
   -webkit-filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   filter: invert(21%) sepia(90%) saturate(3220%) hue-rotate(232deg) brightness(71%) contrast(127%);
   display: inline-block;
@@ -1744,7 +1753,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #081676;
 }
 
-.c24:visited .c112 {
+.c24:visited .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -1754,7 +1763,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   outline: 1px solid #081676;
 }
 
-.c24:active .c112 {
+.c24:active .c113 {
   -webkit-filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
   filter: invert(12%) sepia(79%) saturate(3172%) hue-rotate(231deg) brightness(82%) contrast(114%);
 }
@@ -1764,12 +1773,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #808080;
 }
 
-.c24[disabled] .c112 {
+.c24[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c72 {
+.c73 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1793,47 +1802,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c72 .c112 {
+.c73 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c72:focus-visible {
+.c73:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c72:visited {
+.c73:visited {
   color: #222222;
 }
 
-.c72:visited .c112 {
+.c73:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c72:active {
+.c73:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c72:active .c112 {
+.c73:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c72[disabled] {
+.c73[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c72[disabled] .c112 {
+.c73[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c146 {
+.c147 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1866,47 +1875,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c146 .c112 {
+.c147 .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   display: inline-block;
   vertical-align: text-top;
 }
 
-.c146:focus-visible {
+.c147:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c146:visited {
+.c147:visited {
   color: #222222;
 }
 
-.c146:visited .c112 {
+.c147:visited .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c146:active {
+.c147:active {
   color: #222222;
   outline: 1px solid #222222;
 }
 
-.c146:active .c112 {
+.c147:active .c113 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c146[disabled] {
+.c147[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
-.c146[disabled] .c112 {
+.c147[disabled] .c113 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c42 {
+.c43 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -1922,49 +1931,49 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   width: 100%;
 }
 
-.c42::-webkit-input-placeholder {
+.c43::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c42::-moz-placeholder {
+.c43::-moz-placeholder {
   color: #575757;
 }
 
-.c42:-ms-input-placeholder {
+.c43:-ms-input-placeholder {
   color: #575757;
 }
 
-.c42::placeholder {
+.c43::placeholder {
   color: #575757;
 }
 
-.c42::-webkit-search-decoration,
-.c42::-webkit-search-cancel-button,
-.c42::-webkit-search-results-button,
-.c42::-webkit-search-results-decoration {
+.c43::-webkit-search-decoration,
+.c43::-webkit-search-cancel-button,
+.c43::-webkit-search-results-button,
+.c43::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c42:disabled {
+.c43:disabled {
   cursor: not-allowed;
 }
 
-.c41 {
+.c42 {
   background: #ffffff;
 }
 
-.c41:hover {
+.c42:hover {
   cursor: text;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
 
-.c76 {
+.c77 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -1973,13 +1982,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   column-gap: 0rem;
 }
 
-.c101 {
+.c102 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
 }
 
-.c78 {
+.c79 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -1991,7 +2000,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c80 {
+.c81 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2003,7 +2012,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c102 {
+.c103 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2012,7 +2021,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   grid-row: span 1;
 }
 
-.c70 {
+.c71 {
   margin: 0rem;
   padding: 0rem;
   list-style: none;
@@ -2032,7 +2041,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   flex-wrap: wrap;
 }
 
-.c71 {
+.c72 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2048,29 +2057,29 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   max-width: 100%;
 }
 
-.c57:hover .oak-save-count {
+.c58:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c57:focus-visible .oak-save-count {
+.c58:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c136 {
+.c137 {
   top: 152px;
 }
 
-.c119 .icon-container > *:first-child {
+.c120 .icon-container > *:first-child {
   border: 0;
 }
 
-.c123 {
+.c124 {
   height: 87px;
   width: 77px;
   margin-top: 2rem;
 }
 
-.c92:first-child {
+.c93:first-child {
   margin-top: 0;
 }
 
@@ -2120,18 +2129,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 
 @media (min-width:750px) {
   .c26 {
-    width: 6.25rem;
+    display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
-    height: 3rem;
+  .c28 {
+    display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c38 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2140,19 +2149,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c39 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c43 {
+  .c44 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2160,37 +2169,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c55 {
+  .c56 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c58 {
+  .c59 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c61 {
+  .c62 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c64 {
+  .c65 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c64 {
+  .c65 {
     display: none;
   }
 }
@@ -2204,61 +2213,61 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c67 {
+  .c68 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c67 {
+  .c68 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c75 {
+  .c76 {
     padding-top: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c75 {
+  .c76 {
     padding-bottom: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-left: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c81 {
+  .c82 {
     padding-right: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c84 {
+  .c85 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2267,25 +2276,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c88 {
+  .c89 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2294,25 +2303,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c90 {
+  .c91 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2321,43 +2330,43 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c99 {
+  .c100 {
     padding-top: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c103 {
+  .c104 {
     margin-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c109 {
+  .c110 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c116 {
+  .c117 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c124 {
+  .c125 {
     padding-top: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c126 {
+  .c127 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2366,13 +2375,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c130 {
+  .c131 {
     -webkit-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     -ms-transform: translate(25%,25%) scale(0.7) rotate(-10deg);
     transform: translate(25%,25%) scale(0.7) rotate(-10deg);
@@ -2380,7 +2389,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c130 {
+  .c131 {
     -webkit-transform: translate(25%,15%) rotate(-10deg);
     -ms-transform: translate(25%,15%) rotate(-10deg);
     transform: translate(25%,15%) rotate(-10deg);
@@ -2388,19 +2397,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c132 {
+  .c133 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     width: -webkit-max-content;
     width: -moz-max-content;
     width: max-content;
@@ -2408,61 +2417,61 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-left: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c134 {
+  .c135 {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c141 {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c140 {
+  .c141 {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c140 {
+  .c141 {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c140 {
+  .c141 {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c142 {
+  .c143 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2480,19 +2489,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c36 {
+  .c37 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c60 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -2509,13 +2518,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c77 {
+  .c78 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c114 {
+  .c115 {
     -webkit-box-pack: right;
     -webkit-justify-content: right;
     -ms-flex-pack: right;
@@ -2524,13 +2533,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c117 {
+  .c118 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2538,7 +2547,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2547,7 +2556,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c125 {
+  .c126 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
@@ -2556,7 +2565,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c127 {
+  .c128 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2565,7 +2574,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c135 {
+  .c136 {
     -webkit-align-items: flex-end;
     -webkit-box-align: flex-end;
     -ms-flex-align: flex-end;
@@ -2574,7 +2583,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -2582,7 +2591,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2590,7 +2599,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2599,7 +2608,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -2608,19 +2617,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c141 {
+  .c142 {
     gap: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c141 {
+  .c142 {
     gap: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2628,7 +2637,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -2636,7 +2645,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c144 {
+  .c145 {
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -2644,7 +2653,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c144 {
+  .c145 {
     gap: 2rem;
   }
 }
@@ -2704,25 +2713,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     font-weight: 500;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c143 {
+  .c144 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2755,25 +2764,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     font-size: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     line-height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c86 {
+  .c87 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2782,25 +2791,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -2809,31 +2818,31 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c91 {
+  .c92 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c85 {
+  .c86 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2842,25 +2851,25 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     font-weight: 400;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c89 {
+  .c90 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -2878,16 +2887,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c24:hover .c112,
-  .c24:visited:hover .c112 {
+  .c24:hover .c113,
+  .c24:visited:hover .c113 {
     -webkit-filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
     filter: invert(16%) sepia(72%) saturate(7176%) hue-rotate(239deg) brightness(61%) contrast(109%);
   }
 }
 
 @media (hover:hover) {
-  .c72:hover,
-  .c72:visited:hover {
+  .c73:hover,
+  .c73:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2895,16 +2904,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c72:hover .c112,
-  .c72:visited:hover .c112 {
+  .c73:hover .c113,
+  .c73:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (hover:hover) {
-  .c146:hover,
-  .c146:visited:hover {
+  .c147:hover,
+  .c147:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -2912,47 +2921,47 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     text-decoration-thickness: 18%;
   }
 
-  .c146:hover .c112,
-  .c146:visited:hover .c112 {
+  .c147:hover .c113,
+  .c147:visited:hover .c113 {
     -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
     filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   }
 }
 
 @media (max-width:750px) {
-  .c42 {
+  .c43 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c41:hover:not(:focus-within) {
+  .c42:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
 }
 
 @media (min-width:750px) {
-  .c76 {
+  .c77 {
     -webkit-column-gap: 1rem;
     column-gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c78 {
+  .c79 {
     grid-column: span 4;
   }
 }
 
 @media (min-width:750px) {
-  .c80 {
+  .c81 {
     grid-column: span 8;
   }
 }
 
 @media (min-width:750px) {
-  .c102 {
+  .c103 {
     grid-column: span 3;
   }
 }
@@ -3152,10 +3161,23 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                 />
               </span>
+              <span
+                class="c28"
+              >
+                <img
+                  alt=""
+                  class="c27"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1765468420/OakLogoWithText.svg"
+                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                />
+              </span>
             </span>
           </a>
           <div
-            class="c9 c28"
+            class="c9 c29"
             data-testid="teachers-subnav"
             id="teachers-subnav"
           >
@@ -3163,10 +3185,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               class="c9"
             >
               <ul
-                class="c29"
+                class="c30"
               >
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -3180,15 +3202,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-primary"
                       id="teachers-primary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Primary
                         </span>
@@ -3197,7 +3219,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -3211,15 +3233,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-secondary"
                       id="teachers-secondary"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Secondary
                         </span>
@@ -3228,7 +3250,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -3242,15 +3264,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-guidance"
                       id="teachers-guidance"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Guidance
                         </span>
@@ -3259,7 +3281,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -3273,15 +3295,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <button
                       aria-expanded="false"
                       aria-haspopup="true"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       data-testid="teachers-aboutUs"
                       id="teachers-aboutUs"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           About us
                         </span>
@@ -3290,7 +3312,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </li>
                 <li
-                  class="c30"
+                  class="c31"
                 >
                   <div
                     class="c4 c15"
@@ -3303,16 +3325,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                     <a
                       aria-label="Ai experiments (this will open in a new tab)"
-                      class="c31 c32 internal-button"
+                      class="c32 c33 internal-button"
                       href="https://labs.thenational.academy"
                       id="teachers-labs"
                       target="_blank"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Ai experiments
                         </span>
@@ -3321,7 +3343,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3336,24 +3358,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </ul>
             </div>
             <div
-              class="c9 c36"
+              class="c9 c37"
             >
               <form
                 action="/teachers/search"
-                class="c37"
+                class="c38"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c38"
+                  class="c39"
                 >
                   <div
-                    class="c39 c40 c41"
+                    class="c40 c41 c42"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c42"
+                      class="c43"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -3361,24 +3383,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c43"
+                  class="c44"
                 >
                   <div
-                    class="c44 c45 c46"
+                    class="c45 c46 c47"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c47 c48"
+                      class="c48 c49"
                       type="submit"
                     >
                       <div
-                        class="c9 c49"
+                        class="c9 c50"
                       >
                         <div
-                          class="c50 c51 icon-container"
+                          class="c51 c52 icon-container"
                         >
                           <div
-                            class="c52 shadow"
+                            class="c53 shadow"
                           />
                           <span
                             class="c20"
@@ -3386,7 +3408,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c53"
+                              class="c54"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -3396,7 +3418,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c54"
+                          class="c55"
                         />
                       </div>
                     </button>
@@ -3404,24 +3426,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c55"
+                class="c56"
               >
                 <div
-                  class="c44 c45 c46"
+                  class="c45 c46 c47"
                 >
                   <a
                     aria-label="Search"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c50 c51 icon-container"
+                        class="c51 c52 icon-container"
                       >
                         <div
-                          class="c52 shadow"
+                          class="c53 shadow"
                         />
                         <span
                           class="c20"
@@ -3429,7 +3451,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c53"
+                            class="c54"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3439,7 +3461,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
@@ -3447,14 +3469,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c56 c57"
+                class="c57 c58"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c58 c59 oak-save-count"
+                  class="c59 c60 oak-save-count"
                 >
                   <span
-                    class="c60"
+                    class="c61"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -3468,7 +3490,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c61"
+                    class="c62"
                   >
                     My library
                   </div>
@@ -3484,13 +3506,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c62 c63 internal-button"
+                  class="c63 c64 internal-button"
                 >
                   <div
-                    class="c9 c33"
+                    class="c9 c34"
                   >
                     <span
-                      class="c34"
+                      class="c35"
                     >
                       Sign in
                     </span>
@@ -3500,7 +3522,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c64"
+            class="c65"
           >
             <div
               class="c4 c5"
@@ -3514,18 +3536,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c65 c8 internal-button"
+                class="c66 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c49"
+                  class="c9 c50"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c35"
+                      class="c36"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3543,27 +3565,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </nav>
       </header>
       <main
-        class="c66 c1"
+        class="c67 c1"
         id="main"
       >
         <div
-          class="c67"
+          class="c68"
         >
           <div
-            class="c68 c45"
+            class="c69 c46"
           >
             <nav
               aria-label="Breadcrumb"
-              class="c69"
+              class="c70"
             >
               <ul
-                class="c70"
+                class="c71"
               >
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <a
-                    class="c72"
+                    class="c73"
                     href="/"
                     style="overflow: hidden;"
                   >
@@ -3571,7 +3593,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c25"
                     >
                       <div
-                        class="c73"
+                        class="c74"
                       >
                         Home
                       </div>
@@ -3579,10 +3601,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <span
-                    class="c74"
+                    class="c75"
                   >
                     <img
                       alt=""
@@ -3595,7 +3617,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <a
-                    class="c72"
+                    class="c73"
                     href="/about-us/meet-the-team"
                     style="overflow: hidden;"
                   >
@@ -3603,7 +3625,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c25"
                     >
                       <div
-                        class="c73"
+                        class="c74"
                       >
                         Meet the team
                       </div>
@@ -3611,10 +3633,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </a>
                 </li>
                 <li
-                  class="c71"
+                  class="c72"
                 >
                   <span
-                    class="c74"
+                    class="c75"
                   >
                     <img
                       alt=""
@@ -3628,7 +3650,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </span>
                   <div
                     aria-current="page"
-                    class="c73"
+                    class="c74"
                   >
                     Ed Southall
                   </div>
@@ -3637,56 +3659,56 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </nav>
           </div>
           <div
-            class="c75 c76"
+            class="c76 c77"
           >
             <div
-              class="c38 c77 c78"
+              class="c39 c78 c79"
             />
             <div
-              class="c9 c79 c80"
+              class="c9 c80 c81"
             >
               <div
-                class="c81 c82"
+                class="c82 c83"
               >
                 <div
-                  class="c9 c82"
+                  class="c9 c83"
                 >
                   <div
-                    class="c9 c83"
+                    class="c9 c84"
                   >
                     <div
-                      class="c84 c85"
+                      class="c85 c86"
                     >
                       Our leadership
                     </div>
                     <h1
-                      class="c86"
+                      class="c87"
                     >
                       Ed Southall
                     </h1>
                   </div>
                   <div
-                    class="c87"
+                    class="c88"
                   >
                     <div
-                      class="c88 c89"
+                      class="c89 c90"
                     >
                       Subject Lead (maths)
                     </div>
                   </div>
                 </div>
                 <div
-                  class="c90"
+                  class="c91"
                 >
                   <p
-                    class="c91 c92"
+                    class="c92 c93"
                   >
                     Test bio text
                   </p>
                 </div>
                 <nav
                   aria-label="Team member navigation"
-                  class="c9 c93"
+                  class="c9 c94"
                 >
                   <div
                     class="c4 c5"
@@ -3698,18 +3720,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c6 yellow-shadow"
                     />
                     <a
-                      class="c94 c95 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/previous-member?section=leadership"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
                           class="c20"
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3718,7 +3740,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           />
                         </span>
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Previous profile
                         </span>
@@ -3735,14 +3757,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       class="c6 yellow-shadow"
                     />
                     <a
-                      class="c94 c95 internal-button"
+                      class="c95 c96 internal-button"
                       href="/about-us/meet-the-team/next-member?section=board"
                     >
                       <div
-                        class="c9 c33"
+                        class="c9 c34"
                       >
                         <span
-                          class="c34"
+                          class="c35"
                         >
                           Next profile
                         </span>
@@ -3751,7 +3773,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3769,14 +3791,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         </div>
       </main>
       <footer
-        class="c96"
+        class="c97"
       >
         <div
-          class="c97 c45"
+          class="c98 c46"
         >
           <svg
             aria-hidden="true"
-            class="c98"
+            class="c99"
             height="100%"
             name="header-underline"
             width="100%"
@@ -3799,33 +3821,33 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           id="site-footer"
         >
           <div
-            class="c99 c100"
+            class="c100 c101"
           >
             <div
-              class="c9 c101"
+              class="c9 c102"
             >
               <div
-                class="c9 c45 c102"
+                class="c9 c46 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Pupils
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/pupils/years"
                         >
                           <span
@@ -3839,27 +3861,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c109"
+                  class="c110"
                 />
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Teachers
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/teachers/eyfs/maths"
                         >
                           <span
@@ -3870,10 +3892,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/lesson-planning"
                         >
                           <span
@@ -3884,10 +3906,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="https://labs.thenational.academy"
                           target="_blank"
                         >
@@ -3897,10 +3919,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Aila, Oak’s AI lesson assistant
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
@@ -3916,10 +3938,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/blog"
                         >
                           <span
@@ -3934,27 +3956,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c46 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Oak
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/"
                         >
                           <span
@@ -3965,10 +3987,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/who-we-are"
                         >
                           <span
@@ -3979,10 +4001,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/oaks-curricula"
                         >
                           <span
@@ -3993,10 +4015,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/get-involved"
                         >
                           <span
@@ -4007,10 +4029,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/about-us/meet-the-team"
                         >
                           <span
@@ -4021,11 +4043,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Careers (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://jobs.thenational.academy"
                           target="_blank"
                         >
@@ -4035,10 +4057,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Careers
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
@@ -4054,10 +4076,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/contact-us"
                         >
                           <span
@@ -4068,11 +4090,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Help (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://support.thenational.academy"
                           target="_blank"
                         >
@@ -4082,10 +4104,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Help
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
@@ -4101,10 +4123,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/webinars"
                         >
                           <span
@@ -4115,11 +4137,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
                           aria-label="Status (opens in a new tab)"
-                          class="c72 "
+                          class="c73 "
                           href="https://status.thenational.academy"
                           target="_blank"
                         >
@@ -4129,10 +4151,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             Status
                           </span>
                           <div
-                            class="c110"
+                            class="c111"
                           >
                             <span
-                              class="c111 c112 c113"
+                              class="c112 c113 c114"
                             >
                               <img
                                 alt=""
@@ -4152,27 +4174,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c46 c103"
               >
                 <div
-                  class="c103 c104"
+                  class="c104 c105"
                 >
                   <h2
-                    class="c105"
+                    class="c106"
                   >
                     Legal
                   </h2>
                   <div
-                    class="c106 c107"
+                    class="c107 c108"
                   >
                     <ul
                       role="list"
                     >
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/terms-and-conditions"
                         >
                           <span
@@ -4183,10 +4205,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/privacy-policy"
                         >
                           <span
@@ -4197,10 +4219,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/cookie-policy"
                         >
                           <span
@@ -4211,10 +4233,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <button
-                          class="c72 "
+                          class="c73 "
                         >
                           <span
                             class="c25"
@@ -4224,10 +4246,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </button>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/copyright-notice"
                         >
                           <span
@@ -4238,10 +4260,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/accessibility-statement"
                         >
                           <span
@@ -4252,10 +4274,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/safeguarding-statement"
                         >
                           <span
@@ -4266,10 +4288,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/physical-activity-disclaimer"
                         >
                           <span
@@ -4280,10 +4302,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/complaints"
                         >
                           <span
@@ -4294,10 +4316,10 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </a>
                       </li>
                       <li
-                        class="c108"
+                        class="c109"
                       >
                         <a
-                          class="c72 "
+                          class="c73 "
                           href="/legal/freedom-of-information-requests"
                         >
                           <span
@@ -4312,16 +4334,16 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c45 c102"
+                class="c9 c46 c103"
               >
                 <div
-                  class="c103 c114"
+                  class="c104 c115"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                   >
                     <span
-                      class="c115"
+                      class="c116"
                     >
                       <img
                         alt=""
@@ -4335,24 +4357,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     </span>
                   </div>
                   <div
-                    class="c116 c117"
+                    class="c117 c118"
                   >
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
                               class="c20"
@@ -4360,7 +4382,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4370,27 +4392,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
                               class="c20"
@@ -4398,7 +4420,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4408,27 +4430,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c44 c45 c118 c119"
+                      class="c45 c46 c119 c120"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c47 c48"
+                        class="c48 c49"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           <div
-                            class="c120 c51 icon-container"
+                            class="c121 c52 icon-container"
                           >
                             <div
-                              class="c121 shadow"
+                              class="c122 shadow"
                             />
                             <span
                               class="c20"
@@ -4436,7 +4458,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c35"
+                                class="c36"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4446,7 +4468,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c54"
+                            class="c55"
                           />
                         </div>
                       </a>
@@ -4456,7 +4478,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
             </div>
             <span
-              class="c122 c123"
+              class="c123 c124"
               data-percy-hide="contents"
             >
               <img
@@ -4472,27 +4494,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               />
             </span>
             <div
-              class="c124 c125"
+              class="c125 c126"
             >
               <div
-                class="c126 c127"
+                class="c127 c128"
               >
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
                           class="c20"
@@ -4500,7 +4522,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4510,27 +4532,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
                           class="c20"
@@ -4538,7 +4560,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4548,27 +4570,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c44 c45 c118 c119"
+                  class="c45 c46 c119 c120"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c47 c48"
+                    class="c48 c49"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       <div
-                        class="c120 c51 icon-container"
+                        class="c121 c52 icon-container"
                       >
                         <div
-                          class="c121 shadow"
+                          class="c122 shadow"
                         />
                         <span
                           class="c20"
@@ -4576,7 +4598,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c35"
+                            class="c36"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4586,17 +4608,17 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c54"
+                        class="c55"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c55"
+                class="c56"
               >
                 <span
-                  class="c115"
+                  class="c116"
                 >
                   <img
                     alt=""
@@ -4610,15 +4632,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </span>
               </div>
               <div
-                class="c103 c104"
+                class="c104 c105"
               >
                 <p
-                  class="c128"
+                  class="c129"
                 >
                   © Oak National Academy Limited, No 14174888
                 </p>
                 <p
-                  class="c129"
+                  class="c130"
                 >
                   1 Scott Place, 2 Hardman Street, Manchester, M3 3AA
                 </p>
@@ -4627,11 +4649,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           </div>
         </nav>
         <span
-          class="c130"
+          class="c131"
         >
           <img
             alt=""
-            class="c131"
+            class="c132"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4640,11 +4662,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           />
         </span>
         <span
-          class="c132"
+          class="c133"
         >
           <img
             alt=""
-            class="c133"
+            class="c134"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -4656,27 +4678,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
     </div>
     <div
       aria-live="polite"
-      class="c134 c135 c136"
+      class="c135 c136 c137"
     />
   </div>
   <div
-    class="c137"
+    class="c138"
   >
     <div
-      class="c138"
+      class="c139"
       data-testid="cookie-banner"
     >
       <div
-        class="c139"
+        class="c140"
       >
         <div
-          class="c140 c141"
+          class="c141 c142"
         >
           <div
-            class="c142"
+            class="c143"
           >
             <strong
-              class="c143"
+              class="c144"
             >
               This site uses cookies to store information on your computer.
             </strong>
@@ -4684,13 +4706,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.
           </div>
           <div
-            class="c9 c144"
+            class="c9 c145"
           >
             <div
-              class="c145 c40"
+              class="c146 c41"
             >
               <button
-                class="c146"
+                class="c147"
                 data-testid="cookie-banner-reject"
                 type="button"
               >
@@ -4734,7 +4756,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c6 yellow-shadow"
               />
               <button
-                class="c147 c19 internal-button"
+                class="c148 c19 internal-button"
                 data-testid="cookie-banner-accept"
               >
                 <div

--- a/src/components/AppComponents/TopNav/TopNavMinimal.tsx
+++ b/src/components/AppComponents/TopNav/TopNavMinimal.tsx
@@ -9,7 +9,6 @@ import {
   OakIcon,
   OakImage,
   OakLink,
-  useMediaQuery,
 } from "@/styles/oakThemeApp";
 import { getCloudinaryImageUrl } from "@/utils/getCloudinaryImageUrl";
 import { resolveOakHref } from "@/common-lib/urls";
@@ -37,7 +36,6 @@ const TopNavMinimal = ({
   menuSlot?: React.ReactNode;
 }) => {
   const activeArea = useSelectedArea();
-  const isMobile = useMediaQuery("mobile");
 
   return (
     <OakBox
@@ -108,15 +106,20 @@ const TopNavMinimal = ({
           aria-label="Home"
         >
           <OakImage
-            src={getCloudinaryImageUrl(
-              isMobile
-                ? "v1711468346/logo-mark.svg"
-                : "v1765468420/OakLogoWithText.svg",
-            )}
+            src={getCloudinaryImageUrl("v1711468346/logo-mark.svg")}
             alt=""
-            $height={["spacing-40", "spacing-48"]}
-            $width={["spacing-32", "spacing-100"]}
+            $height={"spacing-40"}
+            $width={"spacing-32"}
             $pa={"spacing-0"}
+            $display={["block", "none"]} // render this logo on mobile only
+          />
+          <OakImage
+            src={getCloudinaryImageUrl("v1765468420/OakLogoWithText.svg")}
+            alt=""
+            $height={"spacing-48"}
+            $width={"spacing-100"}
+            $pa={"spacing-0"}
+            $display={["none", "block"]} // render this logo on desktop only
           />
         </OakLink>
         {subnavSlot}


### PR DESCRIPTION
## Description

Music year: [2021](https://www.youtube.com/watch?v=lpznZJ4b6hk)

- Show the logo with CSS instead of JS to prevent the logo from flickering upon loading (since isMobile was initially set to false on load)

## How to test

1. Go to the preview
2. Set a mobile aspect ratio
3. You should see the logo with no flicker

## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
