### PR TITLE
fix(pupil): avoid blocking navigation on classroom submission checks

### DIFF
--- a/src/components/PupilComponents/Views/Hooks/usePupilExperienceBase.test.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilExperienceBase.test.ts
@@ -58,19 +58,40 @@ describe("usePupilExperienceBase", () => {
     expect(routerPush).toHaveBeenCalledWith("/pupils/lessons/lesson-1/review");
   });
 
-  it("blocks progression and redirects when refresh resolves read-only", async () => {
-    const refreshReadOnly = jest.fn().mockResolvedValue(true);
+  it("allows progression immediately from cached writable state without refreshing", () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
     usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
 
     const { result } = renderHook(() => usePupilExperienceBase());
     let canProgress: boolean | undefined;
-    await act(async () => {
-      canProgress = await result.current.ensureCanProgress();
+    act(() => {
+      canProgress = result.current.ensureCanProgress();
     });
 
-    expect(refreshReadOnly).toHaveBeenCalledTimes(1);
+    expect(refreshReadOnly).not.toHaveBeenCalled();
+    expect(canProgress).toBe(true);
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("blocks progression immediately from cached read-only state", () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
+
+    const { result } = renderHook(() => usePupilExperienceBase());
+    act(() => usePupilLessonProgress.getState().setReadOnly(true));
+    routerPush.mockClear();
+
+    let canProgress: boolean | undefined;
+    act(() => {
+      canProgress = result.current.ensureCanProgress();
+    });
+
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(canProgress).toBe(false);
-    expect(usePupilLessonProgress.getState().isReadOnly).toBe(true);
     expect(routerPush).toHaveBeenCalledWith("/pupils/lessons/lesson-1/review");
   });
 });

--- a/src/components/PupilComponents/Views/Hooks/usePupilExperienceBase.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilExperienceBase.ts
@@ -8,12 +8,6 @@ import { usePupilLessonProgress } from "@/context/PupilLessonProgress";
 export const usePupilExperienceBase = () => {
   const router = useRouter();
   const isReadOnly = usePupilLessonProgress((state) => state.isReadOnly);
-  const refreshReadOnlyFromStore = usePupilLessonProgress(
-    (state) => state.refreshReadOnly,
-  );
-  const setReadOnlyFromStore = usePupilLessonProgress(
-    (state) => state.setReadOnly,
-  );
 
   const currentSearchParams = useMemo(
     () => new URLSearchParams(router.asPath.split("?")[1]),
@@ -43,24 +37,15 @@ export const usePupilExperienceBase = () => {
     goToSection("review");
   }, [goToSection, isReadOnly, router.asPath]);
 
-  const ensureCanProgress = useCallback(async () => {
+  const ensureCanProgress = useCallback(() => {
     if (isReadOnly) {
       goToSection("review");
       return false;
     }
 
-    const nextIsReadOnly = refreshReadOnlyFromStore
-      ? await refreshReadOnlyFromStore()
-      : false;
-    if (setReadOnlyFromStore) setReadOnlyFromStore(nextIsReadOnly);
-
-    if (nextIsReadOnly) {
-      goToSection("review");
-      return false;
-    }
-
+    // destination hydration refreshes submission state asynchronously
     return true;
-  }, [goToSection, isReadOnly, refreshReadOnlyFromStore, setReadOnlyFromStore]);
+  }, [goToSection, isReadOnly]);
 
   return {
     router,

--- a/src/components/PupilComponents/Views/Hooks/usePupilIntroExperience.test.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilIntroExperience.test.ts
@@ -72,11 +72,16 @@ beforeEach(() => {
 
 describe("usePupilIntroExperience", () => {
   it("on first proceed: completes the intro section, tracks completion, and navigates to overview", async () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
     const { result } = renderIntro();
     await act(async () => {
       await result.current.handleProceed();
     });
 
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(track.trackIntroCompleted).toHaveBeenCalledTimes(1);
     expect(
       usePupilLessonProgress.getState().sectionResults.intro?.isComplete,
@@ -103,16 +108,19 @@ describe("usePupilIntroExperience", () => {
     );
   });
 
-  it("redirects to review without completing intro when progression discovers read-only state", async () => {
-    usePupilLessonProgress
-      .getState()
-      .setRefreshReadOnly(jest.fn().mockResolvedValue(true));
+  it("redirects to review without completing intro when cached state is read-only", async () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
+    usePupilLessonProgress.getState().setReadOnly(true);
 
     const { result } = renderIntro();
     await act(async () => {
       await result.current.handleProceed();
     });
 
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(track.trackIntroCompleted).not.toHaveBeenCalled();
     expect(
       usePupilLessonProgress.getState().sectionResults.intro?.isComplete,

--- a/src/components/PupilComponents/Views/Hooks/usePupilIntroExperience.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilIntroExperience.ts
@@ -101,8 +101,8 @@ export const usePupilIntroExperience = ({
   /*****************************
    * Page interaction handlers *
    *****************************/
-  const handleProceed = async () => {
-    if (!(await ensureCanProgress())) return;
+  const handleProceed = () => {
+    if (!ensureCanProgress()) return;
 
     if (!sectionResults.intro?.isComplete) {
       setIsCompletingAndRedirecting(true);

--- a/src/components/PupilComponents/Views/Hooks/usePupilVideoExperience.test.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilVideoExperience.test.ts
@@ -67,11 +67,16 @@ describe("usePupilVideoExperience", () => {
   });
 
   it("on first proceed: completes the video section, tracks completion, and navigates", async () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
     const { result } = renderVideo();
     await act(async () => {
       await result.current.handleProceed();
     });
 
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(
       usePupilLessonProgress.getState().sectionResults.video?.isComplete,
     ).toBe(true);
@@ -81,16 +86,19 @@ describe("usePupilVideoExperience", () => {
     );
   });
 
-  it("redirects to review without completing video when progression discovers read-only state", async () => {
-    usePupilLessonProgress
-      .getState()
-      .setRefreshReadOnly(jest.fn().mockResolvedValue(true));
+  it("redirects to review without completing video when cached state is read-only", async () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    usePupilLessonProgress.getState().setRefreshReadOnly(refreshReadOnly);
+    usePupilLessonProgress.getState().setReadOnly(true);
 
     const { result } = renderVideo();
     await act(async () => {
       await result.current.handleProceed();
     });
 
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(
       usePupilLessonProgress.getState().sectionResults.video?.isComplete,
     ).toBeUndefined();

--- a/src/components/PupilComponents/Views/Hooks/usePupilVideoExperience.ts
+++ b/src/components/PupilComponents/Views/Hooks/usePupilVideoExperience.ts
@@ -196,8 +196,8 @@ export const usePupilVideoExperience = ({
     void router.push(overviewHref);
   };
 
-  const handleProceed = async () => {
-    if (!(await ensureCanProgress())) return;
+  const handleProceed = () => {
+    if (!ensureCanProgress()) return;
 
     if (!sectionResults.video?.isComplete) {
       setIsCompletingAndRedirecting(true);

--- a/src/components/PupilComponents/Views/ViewHelpers/Shared/useClassroomAddonContext.test.ts
+++ b/src/components/PupilComponents/Views/ViewHelpers/Shared/useClassroomAddonContext.test.ts
@@ -77,7 +77,7 @@ describe("useClassroomAddonContext", () => {
       submissionState: PostSubmissionState.RETURNED,
     });
 
-    const { result } = renderHook(() => useClassroomAddonContext());
+    const { result, rerender } = renderHook(() => useClassroomAddonContext());
 
     await waitFor(() => expect(result.current.isReady).toBe(true));
     expect(result.current.submissionId).toBe("submission-1");
@@ -88,6 +88,16 @@ describe("useClassroomAddonContext", () => {
     expect(result.current.initialSectionResults).toEqual({
       intro: { isComplete: true },
     });
+    expect(mockedApi.getPostSubmissionState).toHaveBeenCalledTimes(1);
+    expect(mockedApi.getPostSubmissionState).toHaveBeenCalledWith({
+      courseId: "course-1",
+      itemId: "item-1",
+      attachmentId: "attachment-1",
+      submissionId: "submission-1",
+    });
+
+    rerender();
+    expect(mockedApi.getPostSubmissionState).toHaveBeenCalledTimes(1);
   });
 
   it("stays usable when the add-on context fails to resolve", async () => {

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.test.tsx
@@ -304,7 +304,12 @@ describe("QuizPageContent", () => {
     expect(routerPush.mock.calls[0]?.[0]).toContain("review");
   });
 
-  it("completes the quiz and navigates to the overview when finishing the starter quiz", async () => {
+  it("completes and navigates without waiting for a submission-state refresh", () => {
+    const refreshReadOnly = jest.fn(
+      () => new Promise<boolean>(() => undefined),
+    );
+    progressState = buildProgressState({ refreshReadOnly });
+    progressHookMock.mockImplementation((selector) => selector(progressState));
     quizState = buildQuizState({
       questionState: [{ ...baseQuestionState, mode: "feedback", grade: 1 }],
       currentQuestionIndex: 0,
@@ -314,18 +319,19 @@ describe("QuizPageContent", () => {
     quizHookMock.mockImplementation((selector) => selector(quizState));
 
     const { getByRole } = renderPage();
-    await act(async () => {
-      fireEvent.click(getByRole("button", { name: "Continue lesson" }));
-    });
+    fireEvent.click(getByRole("button", { name: "Continue lesson" }));
+
+    expect(refreshReadOnly).not.toHaveBeenCalled();
     expect(progressState.completeSection).toHaveBeenCalledWith("starter-quiz");
     expect(trackQuizCompleted).toHaveBeenCalledTimes(1);
     expect(trackLessonStarted).toHaveBeenCalledTimes(1);
     expect(routerPush.mock.calls[0]?.[0]).toContain("overview");
   });
 
-  it("redirects to review without completing the quiz when progression discovers read-only state", async () => {
+  it("redirects to review without completing the quiz when cached state is read-only", async () => {
     progressState = buildProgressState({
-      refreshReadOnly: jest.fn().mockResolvedValue(true),
+      isReadOnly: true,
+      refreshReadOnly: jest.fn(() => new Promise<boolean>(() => undefined)),
       setReadOnly: jest.fn(),
     });
     progressHookMock.mockImplementation((selector) => selector(progressState));
@@ -343,6 +349,7 @@ describe("QuizPageContent", () => {
     });
 
     expect(progressState.completeSection).not.toHaveBeenCalled();
+    expect(progressState.refreshReadOnly).not.toHaveBeenCalled();
     expect(trackQuizCompleted).not.toHaveBeenCalled();
     expect(routerPush.mock.calls[0]?.[0]).toContain("review");
   });

--- a/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
+++ b/src/pages-helpers/pupil/lessons-pages/new/QuizPageContent.tsx
@@ -289,7 +289,7 @@ export const QuizPageContent = ({
     return nextSectionResults;
   };
 
-  const onNext = async () => {
+  const onNext = () => {
     const nextStep = getQuizNextStep({
       currentQuestionIndex,
       numQuestions,
@@ -308,7 +308,7 @@ export const QuizPageContent = ({
       return;
     }
 
-    if (!(await ensureCanProgress())) return;
+    if (!ensureCanProgress()) return;
 
     const nextSectionResults = completeQuizAndTrack();
     navigateToSection(
@@ -319,11 +319,11 @@ export const QuizPageContent = ({
     );
   };
 
-  const onBack = async () => {
+  const onBack = () => {
     const alreadyComplete = sectionResults[section]?.isComplete;
 
     if (!alreadyComplete && isQuizEffectivelyComplete()) {
-      if (!(await ensureCanProgress())) return;
+      if (!ensureCanProgress()) return;
       completeQuizAndTrack();
     } else if (!alreadyComplete) {
       if (!lessonStarted) {


### PR DESCRIPTION
## description

- prevent submission checks from blocking pupil navigation
- keep the expected submission check asynchronous during destination page hydration
- prevent duplicate submission requests caused by the navigation handler and destination hydration running in quick succession
- add coverage for intro, video, quiz, and classroom add-on flows

## issue(s)

fixes [pupil-1779](https://app.notion.com/p/39e26cc4e1b1807ea575f66ab4e7f35c)

## how to test

1. go to `/pupils/programmes/computing-primary-year-4/units/the-internet/lessons/sharing-information/overview` using the classroom assignment query parameters from the ticket
2. open the browser network panel and filter for `classroom/submission`
3. enter the introduction, starter quiz, video, or exit quiz
4. complete the section and click `continue lesson`
5. you should navigate immediately without waiting for the submission request
6. the click should not start an additional blocking submission request
7. a single asynchronous submission request during destination page hydration is expected
8. repeat the navigation and confirm there are no duplicate submission requests in quick succession
9. for an assignment that has been handed in or returned, confirm the hydrated read-only state redirects the pupil to the review page

## screenshots

n/a 

## checklist

- [x] added or updated tests where appropriate
- [ x] manually tested across browsers / devices
- [x] considered impact on accessibility
- [x] design sign-off not required because there are no visual changes
- [ ] approved by product owner
- [ ] does this pr update a package with a breaking change