### PR TITLE
chore: prepare for resource-adapter packages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -203,6 +203,7 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
       "@ooxml-tools/units",
       "@ooxml-tools/xml",
       "@oaknational/oak-components",
+      "@oaknational/resource-adapter",
     ],
 
     webpack: function getWebpackConfig(

--- a/next.config.ts
+++ b/next.config.ts
@@ -204,6 +204,7 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
       "@ooxml-tools/xml",
       "@oaknational/oak-components",
       "@oaknational/resource-adapter",
+      "@oaknational/resource-adapter-contracts",
     ],
 
     webpack: function getWebpackConfig(

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "remove-local-components": "yalc remove @oaknational/oak-components && $npm_execpath install @oaknational/oak-components",
     "use-local-schema": "$npm_execpath remove @oaknational/oak-curriculum-schema && yalc add @oaknational/oak-curriculum-schema",
     "remove-local-schema": "pnpx yalc remove @oaknational/oak-curriculum-schema && $npm_execpath add @oaknational/oak-curriculum-schema",
+    "use-local-resource-adapter": "$npm_execpath remove @oaknational/resource-adapter && yalc add @oaknational/resource-adapter",
+    "remove-local-resource-adapter": "yalc remove @oaknational/resource-adapter && $npm_execpath install @oaknational/resource-adapter",
     "build-storybook": "storybook build",
     "use-local-classroom-addon": "$npm_execpath remove @oaknational/google-classroom-addon && yalc add @oaknational/google-classroom-addon",
     "remove-local-classroom-addon": "yalc remove @oaknational/google-classroom-addon && $npm_execpath install @oaknational/google-classroom-addon",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ minimumReleaseAgeExclude:
   - "@oaknational/oak-components"
   - "@oaknational/oak-consent-client"
   - "@oaknational/oak-curriculum-schema"
+  - "@oaknational/resource-adapter"
+  - "@oaknational/resource-adapter-contracts"
 allowBuilds:
   "@clerk/shared": true
   "@percy/core": true


### PR DESCRIPTION
## Description

Prepares OWA to consume the upcoming `@oaknational/resource-adapter` and `@oaknational/resource-adapter-contracts` packages, built in [oak-resource-adapter](https://github.com/oaknational/oak-resource-adapter) (not yet on npm). 

- Adds `use-local-resource-adapter` / `remove-local-resource-adapter` yalc scripts mirroring the existing `use-local-components` pattern, 
- Excludes both packages from the 7-day `minimumReleaseAge` quarantine in `pnpm-workspace.yaml`, matching the other four `@oaknational` packages.
- Also adds `@oaknational/resource-adapter` to `transpilePackages` in `next.config.ts`. 

## Issue(s)

Relates to [ADAPT-18](https://linear.app/oaknational/issue/ADAPT-18/set-up-npm-package-publishing)

## How to test

No runtime behaviour changes. Nothing is installed or imported yet.

1. Run `pnpm install`: completes cleanly with the new `pnpm-workspace.yaml` settings.
2. End-to-end check: follow the yalc workflow in the adapter repo's [`docs/UI_LOCAL_DEVELOPMENT.md`](https://github.com/oaknational/oak-resource-adapter/blob/main/docs/UI_LOCAL_DEVELOPMENT.md). Note `use-local-resource-adapter` errors until the package is an OWA dependency (`pnpm remove` fails on an absent package); until adoption, use `yalc add` directly as that doc describes. 

> The `use-local-resource-adapter` shortcut begins by uninstalling the npm copy of the package, and pnpm refuses to uninstall something that isn't installed. This means that until OWA actually depends on the package, the shortcut dies on its first step. Until this happens you can run the underlying yalc add command yourself.

## Screenshots

<img width="1580" height="706" alt="image" src="https://github.com/user-attachments/assets/a7ef3627-a038-4785-8574-3d25badb5b00" />

## Checklist

- [ ] ~~Added or updated tests where appropriate~~ (scripts and install config only)
- [ ] ~~Manually tested across browsers / devices~~ (no runtime change)
- [ ] ~~Considered impact on accessibility~~
- [ ] ~~Design sign-off~~
- [ ] ~~Approved by product owner~~
- [ ] ~~Does this PR update a package with a breaking change~~ (no package versions change)