### PR TITLE
Fix/lesq 2164/lesson page mobile rendering

### DIFF
--- a/src/components/GenericPagesComponents/PostFootnotes/PostFootnotes.tsx
+++ b/src/components/GenericPagesComponents/PostFootnotes/PostFootnotes.tsx
@@ -11,7 +11,6 @@ import {
   OakLink,
   OakOL,
   OakSpan,
-  parseColor,
 } from "@oaknational/oak-components";
 
 import AnchorTarget from "@/components/SharedComponents/AnchorTarget";
@@ -93,17 +92,6 @@ type PostFootnotesSectionProps = {
   footnotes: Footnote[];
 };
 
-/**
- * Using a styled link instead of OakLink here as we don't want
- * any of the OakLink functionality, and OakLink appears to mangle
- * in-page anchor links by prepending the whole path to the href
- */
-const FootnoteLink = styled.a`
-  display: inline;
-  text-decoration: underline;
-  color: ${parseColor("text-link-active")};
-`;
-
 const StyledLabel = styled.span`
   word-wrap: break-word;
   max-width: 100%;
@@ -128,13 +116,13 @@ export const PostFootnotesSection: FC<PostFootnotesSectionProps> = ({
               ) : (
                 <StyledLabel>{label}</StyledLabel>
               )}{" "}
-              <FootnoteLink
+              <OakLink
                 href={`#${footnoteBackLinkAnchor(markKey)}`}
                 aria-label={`Back to reference ${index}`}
                 role="doc-backlink"
               >
                 ↩
-              </FootnoteLink>
+              </OakLink>
             </OakLI>
           );
         })}

--- a/src/components/GenericPagesComponents/PostFootnotes/PostFootnotes.tsx
+++ b/src/components/GenericPagesComponents/PostFootnotes/PostFootnotes.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   OakBox,
   OakLI,
+  OakLink,
   OakOL,
   OakSpan,
   parseColor,
@@ -123,7 +124,7 @@ export const PostFootnotesSection: FC<PostFootnotesSectionProps> = ({
           return (
             <OakLI id={footnoteCitationAnchor(markKey)} key={markKey}>
               {source ? (
-                <FootnoteLink href={source}>{label}</FootnoteLink>
+                <OakLink href={source}>{label}</OakLink>
               ) : (
                 <StyledLabel>{label}</StyledLabel>
               )}{" "}

--- a/src/components/GenericPagesComponents/PostPortableText/PostPortableText.test.tsx
+++ b/src/components/GenericPagesComponents/PostPortableText/PostPortableText.test.tsx
@@ -224,7 +224,7 @@ describe("components/PostPortableText", () => {
 
       const footnote = getAllByRole("listitem")[0];
 
-      const footnote2 = getByText("And the second, with a link");
+      const footnote2 = getByText("And the second, with a link").closest("a");
 
       const firstFootnoteBacklink = within(footnote as HTMLElement).getByRole(
         "doc-backlink",


### PR DESCRIPTION
## Description

Music year: 1957

- Render footnote links with OakLink

Took me a while to understand what was going on. It seems that on Chrome the footnote links under 'Scaffolding' were rendering link 2 as a footnote link and causing side scroll. The same would happen to any footnote that had a link source.

## How to test

1. Open Chrome to the environment link
2. Ensure you are using mobile view
3. Go to `/lesson-planning`
4. In the contents table, click `9 Scaffolding`
5. Check the text wraps correctly in the footnotes

## Screenshots

Left is with fix, right is before fix. Notice the side scrolling bar and cut off link on the right side, fixed on the left side.

<img width="811" height="495" alt="image" src="https://github.com/user-attachments/assets/7fd7384a-2955-4fa6-ae34-942f23ad0a23" />

## Checklist

- [x] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
