### PR TITLE
Feat/lesq 2191/my library events

### DIFF
--- a/src/components/GenericPagesViews/HomePageLower/HomePageLower.view.tsx
+++ b/src/components/GenericPagesViews/HomePageLower/HomePageLower.view.tsx
@@ -18,7 +18,7 @@ import { PostListItemProps } from "@/components/SharedComponents/PostListItem";
 import { blogToPostListItem } from "@/components/GenericPagesViews/BlogIndex.view";
 import { SerializedPost } from "@/pages-helpers/home/getBlogPosts";
 import { webinarToPostListItem } from "@/components/GenericPagesViews/WebinarsIndex.view";
-import useAnalytics from "@/context/Analytics/useAnalytics";
+import { useOptionalTeacherBrowseAnalytics } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 import { Testimonials } from "@/components/GenericPagesComponents/Testimonials";
 import { HomePage } from "@/common-lib/cms-types";
 import CMSVideo from "@/components/SharedComponents/CMSVideo";
@@ -48,9 +48,11 @@ export const HomePageLowerView = (props: HomePageLowerViewProps) => {
   const blogListProps = usePostList({ items: posts, withImage: true });
   const { introVideo } = props;
 
-  const { track } = useAnalytics();
+  const newsletterSignUpCompleted = useOptionalTeacherBrowseAnalytics(
+    (store) => store.track.newsletterSignUpCompleted,
+  );
   const newsletterFormProps = useNewsletterForm({
-    onSubmit: track.newsletterSignUpCompleted,
+    onSubmit: newsletterSignUpCompleted,
   });
 
   const showCampaignBanner = campaignPromoBanner?.media[0];

--- a/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider.tsx
+++ b/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider.tsx
@@ -34,23 +34,32 @@ export const TeacherBrowseAnalyticsStoreProvider = ({
   children,
 }: TeacherBrowseAnalyticsStoreProviderProps) => {
   const { track, getSessionId } = useAnalytics();
+  const currentProgrammeState = programmeState?.programmeState ?? null;
 
   const sessionId = useMemo(() => getSessionId(), [getSessionId]);
 
   const journeyId = useMemo(() => {
-    if (!sessionId || !programmeState?.programmeState) {
+    if (!sessionId || !currentProgrammeState) {
       return null;
     }
-    return `${sessionId}:${programmeState.programmeState.programmeSlug}`;
-  }, [sessionId, programmeState?.programmeState]);
+    return `${sessionId}:${currentProgrammeState.programmeSlug}`;
+  }, [sessionId, currentProgrammeState]);
 
   const [store] = useState(() =>
     createTeacherBrowseAnalyticsStore({
-      programmeState: programmeState?.programmeState ?? null,
+      programmeState: currentProgrammeState,
       avo: track,
       journeyId,
     }),
   );
+
+  useEffect(() => {
+    store.setState({
+      avo: track,
+      journeyId,
+      programmeState: currentProgrammeState,
+    });
+  }, [store, track, journeyId, currentProgrammeState]);
 
   return (
     <TeacherBrowseAnalyticsStoreContext.Provider value={store}>

--- a/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider.tsx
+++ b/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider.tsx
@@ -1,5 +1,13 @@
 "use client";
-import { createContext, ReactNode, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useStore } from "zustand";
 
 import useAnalytics from "../Analytics/useAnalytics";
@@ -17,7 +25,7 @@ export const TeacherBrowseAnalyticsStoreContext = createContext<
 >(undefined);
 
 export interface TeacherBrowseAnalyticsStoreProviderProps {
-  programmeState: Pick<TeacherBrowseAnalyticsStore, "programmeState">;
+  programmeState?: Pick<TeacherBrowseAnalyticsStore, "programmeState">;
   children: ReactNode;
 }
 
@@ -30,15 +38,15 @@ export const TeacherBrowseAnalyticsStoreProvider = ({
   const sessionId = useMemo(() => getSessionId(), [getSessionId]);
 
   const journeyId = useMemo(() => {
-    if (!sessionId) {
+    if (!sessionId || !programmeState?.programmeState) {
       return null;
     }
     return `${sessionId}:${programmeState.programmeState.programmeSlug}`;
-  }, [sessionId, programmeState.programmeState.programmeSlug]);
+  }, [sessionId, programmeState?.programmeState]);
 
   const [store] = useState(() =>
     createTeacherBrowseAnalyticsStore({
-      ...programmeState,
+      programmeState: programmeState?.programmeState ?? null,
       avo: track,
       journeyId,
     }),
@@ -64,4 +72,28 @@ export const useTeacherBrowseAnalytics = <T,>(
   }
 
   return useStore(teacherBrowseAnalyticsStoreContext, selector);
+};
+
+export const useOptionalTeacherBrowseAnalytics = <T,>(
+  selector: (store: TeacherBrowseAnalyticsStore) => T,
+): T => {
+  const { track } = useAnalytics();
+  const teacherBrowseAnalyticsStoreContext = useContext(
+    TeacherBrowseAnalyticsStoreContext,
+  );
+  const fallbackStoreRef = useRef<TeacherBrowseAnalyticsStoreApi | null>(null);
+
+  fallbackStoreRef.current ??= createTeacherBrowseAnalyticsStore({
+    programmeState: null,
+    avo: track,
+    journeyId: null,
+  });
+
+  useEffect(() => {
+    fallbackStoreRef.current?.setState({ avo: track });
+  }, [track]);
+
+  const store = teacherBrowseAnalyticsStoreContext ?? fallbackStoreRef.current;
+
+  return useStore(store, selector);
 };

--- a/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
+++ b/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
@@ -31,8 +31,28 @@ export type TeacherBrowseAnalyticsStore = {
       downloadResourceButtonName: DownloadResourceButtonNameValueType,
     ) => void;
     unitDownloadInitiated: () => void;
-    contentSaved: (props: ContentSavedProperties) => void;
-    contentUnsaved: (props: ContentUnsavedProperties) => void;
+    contentSaved: (
+      props: Pick<
+        ContentSavedProperties,
+        | "componentType"
+        | "keyStageSlug"
+        | "keyStageTitle"
+        | "subjectSlug"
+        | "subjectTitle"
+        | "contentItemSlug"
+      >,
+    ) => void;
+    contentUnsaved: (
+      props: Pick<
+        ContentUnsavedProperties,
+        | "componentType"
+        | "keyStageSlug"
+        | "keyStageTitle"
+        | "subjectSlug"
+        | "subjectTitle"
+        | "contentItemSlug"
+      >,
+    ) => void;
     newsletterSignUpCompleted: () => void;
   };
 };

--- a/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
+++ b/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
@@ -11,9 +11,11 @@ import {
 import {
   AnalyticsUseCaseValueType,
   ComponentType,
+  ComponentTypeValueType,
   DownloadResourceButtonNameValueType,
   EngagementIntent,
   EventVersionValueType,
+  KeyStageTitleValueType,
   PlatformValueType,
   ProductValueType,
 } from "@/browser-lib/avo/Avo";
@@ -21,7 +23,7 @@ import errorReporter from "@/common-lib/error-reporter";
 import OakError from "@/errors/OakError";
 
 export type TeacherBrowseAnalyticsStore = {
-  programmeState: ProgrammeState;
+  programmeState: ProgrammeState | null;
   journeyId: string | null;
   avo: TrackFns;
   track: {
@@ -29,6 +31,23 @@ export type TeacherBrowseAnalyticsStore = {
       downloadResourceButtonName: DownloadResourceButtonNameValueType,
     ) => void;
     unitDownloadInitiated: () => void;
+    contentSaved: (props: {
+      componentType: ComponentTypeValueType;
+      keyStageTitle: KeyStageTitleValueType;
+      keyStageSlug: string;
+      subjectTitle: string;
+      subjectSlug: string;
+      contentItemSlug: string;
+    }) => void;
+    contentUnsaved: (props: {
+      componentType: ComponentTypeValueType;
+      keyStageTitle: KeyStageTitleValueType;
+      keyStageSlug: string;
+      subjectTitle: string;
+      subjectSlug: string;
+      contentItemSlug: string;
+    }) => void;
+    newsletterSignUpCompleted: () => void;
   };
 };
 
@@ -60,13 +79,13 @@ export const createTeacherBrowseAnalyticsStore = (
       ) => {
         const { avo, programmeState } = get();
 
-        if (programmeState.browseLevel !== "lesson") {
+        if (programmeState?.browseLevel !== "lesson") {
           reportError(
             new OakError({
               code: "analytics/teacher-browse",
               meta: {
                 event: "lessonResourceDownloadStarted",
-                browseLevel: programmeState.browseLevel,
+                browseLevel: programmeState?.browseLevel,
                 downloadResourceButtonName,
               },
             }),
@@ -90,13 +109,16 @@ export const createTeacherBrowseAnalyticsStore = (
         const { avo, programmeState } = get();
 
         // Can be tracked from the unit overview page or the lesson download success page
-        if (programmeState.browseLevel === "programme") {
+        if (
+          programmeState?.browseLevel !== "unit" &&
+          programmeState?.browseLevel !== "lesson"
+        ) {
           reportError(
             new OakError({
               code: "analytics/teacher-browse",
               meta: {
                 event: "unitDownloadInitiated",
-                browseLevel: programmeState.browseLevel,
+                browseLevel: programmeState?.browseLevel,
               },
             }),
           );
@@ -111,6 +133,55 @@ export const createTeacherBrowseAnalyticsStore = (
           ...coreProperties,
           ...analyticsProperties,
         });
+      },
+      contentSaved: ({
+        componentType,
+        keyStageTitle,
+        keyStageSlug,
+        subjectTitle,
+        subjectSlug,
+        contentItemSlug,
+      }) => {
+        const { avo } = get();
+
+        avo.contentSaved({
+          engagementIntent: EngagementIntent.USE,
+          componentType,
+          keyStageTitle,
+          keyStageSlug,
+          subjectTitle,
+          subjectSlug,
+          contentType: "unit",
+          contentItemSlug,
+          ...coreProperties,
+        });
+      },
+      contentUnsaved: ({
+        componentType,
+        keyStageTitle,
+        keyStageSlug,
+        subjectTitle,
+        subjectSlug,
+        contentItemSlug,
+      }) => {
+        const { avo } = get();
+
+        avo.contentUnsaved({
+          engagementIntent: EngagementIntent.USE,
+          componentType,
+          keyStageTitle,
+          keyStageSlug,
+          subjectTitle,
+          subjectSlug,
+          contentType: "unit",
+          contentItemSlug,
+          ...coreProperties,
+        });
+      },
+      newsletterSignUpCompleted: () => {
+        const { avo } = get();
+
+        avo.newsletterSignUpCompleted();
       },
     },
   }));

--- a/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
+++ b/src/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsStore.ts
@@ -11,11 +11,11 @@ import {
 import {
   AnalyticsUseCaseValueType,
   ComponentType,
-  ComponentTypeValueType,
+  ContentSavedProperties,
+  ContentUnsavedProperties,
   DownloadResourceButtonNameValueType,
   EngagementIntent,
   EventVersionValueType,
-  KeyStageTitleValueType,
   PlatformValueType,
   ProductValueType,
 } from "@/browser-lib/avo/Avo";
@@ -31,22 +31,8 @@ export type TeacherBrowseAnalyticsStore = {
       downloadResourceButtonName: DownloadResourceButtonNameValueType,
     ) => void;
     unitDownloadInitiated: () => void;
-    contentSaved: (props: {
-      componentType: ComponentTypeValueType;
-      keyStageTitle: KeyStageTitleValueType;
-      keyStageSlug: string;
-      subjectTitle: string;
-      subjectSlug: string;
-      contentItemSlug: string;
-    }) => void;
-    contentUnsaved: (props: {
-      componentType: ComponentTypeValueType;
-      keyStageTitle: KeyStageTitleValueType;
-      keyStageSlug: string;
-      subjectTitle: string;
-      subjectSlug: string;
-      contentItemSlug: string;
-    }) => void;
+    contentSaved: (props: ContentSavedProperties) => void;
+    contentUnsaved: (props: ContentUnsavedProperties) => void;
     newsletterSignUpCompleted: () => void;
   };
 };

--- a/src/context/TeacherBrowseAnalytics/teacherBrowseAnalytics.types.ts
+++ b/src/context/TeacherBrowseAnalytics/teacherBrowseAnalytics.types.ts
@@ -16,7 +16,8 @@ import {
   TeacherSchoolManualEntryDetails,
   UserAccountVerificationStatusValueType,
   UserRoleTypeValueType,
-  ComponentTypeValueType,
+  ContentSavedProperties,
+  ContentUnsavedProperties,
 } from "@/browser-lib/avo/Avo";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { VideoTrackingGetState } from "@/components/SharedComponents/VideoPlayer/useVideoTracking";
@@ -231,22 +232,28 @@ export type TeacherBrowseTrackFns = {
   }) => void;
 
   // MY LIBRARY
-  contentSaved: (props: {
-    componentType: ComponentTypeValueType;
-    keyStageTitle: KeyStageTitleValueType;
-    keyStageSlug: string;
-    subjectTitle: string;
-    subjectSlug: string;
-    contentItemSlug: string;
-  }) => void;
-  contentUnsaved: (props: {
-    componentType: ComponentTypeValueType;
-    keyStageTitle: KeyStageTitleValueType;
-    keyStageSlug: string;
-    subjectTitle: string;
-    subjectSlug: string;
-    contentItemSlug: string;
-  }) => void;
+  contentSaved: (
+    props: Pick<
+      ContentSavedProperties,
+      | "componentType"
+      | "keyStageSlug"
+      | "keyStageTitle"
+      | "subjectSlug"
+      | "subjectTitle"
+      | "contentItemSlug"
+    >,
+  ) => void;
+  contentUnsaved: (
+    props: Pick<
+      ContentUnsavedProperties,
+      | "componentType"
+      | "keyStageSlug"
+      | "keyStageTitle"
+      | "subjectSlug"
+      | "subjectTitle"
+      | "contentItemSlug"
+    >,
+  ) => void;
 
   // MISC
   newsletterSignUpCompleted: () => void;

--- a/src/context/TeacherBrowseAnalytics/teacherBrowseAnalytics.types.ts
+++ b/src/context/TeacherBrowseAnalytics/teacherBrowseAnalytics.types.ts
@@ -16,6 +16,7 @@ import {
   TeacherSchoolManualEntryDetails,
   UserAccountVerificationStatusValueType,
   UserRoleTypeValueType,
+  ComponentTypeValueType,
 } from "@/browser-lib/avo/Avo";
 import { ResourceFormValues } from "@/components/TeacherComponents/types/downloadAndShare.types";
 import { VideoTrackingGetState } from "@/components/SharedComponents/VideoPlayer/useVideoTracking";
@@ -230,8 +231,22 @@ export type TeacherBrowseTrackFns = {
   }) => void;
 
   // MY LIBRARY
-  contentSaved: () => void; // likely want to create two fns to wrap this for unit and lesson
-  contentUnsaved: () => void;
+  contentSaved: (props: {
+    componentType: ComponentTypeValueType;
+    keyStageTitle: KeyStageTitleValueType;
+    keyStageSlug: string;
+    subjectTitle: string;
+    subjectSlug: string;
+    contentItemSlug: string;
+  }) => void;
+  contentUnsaved: (props: {
+    componentType: ComponentTypeValueType;
+    keyStageTitle: KeyStageTitleValueType;
+    keyStageSlug: string;
+    subjectTitle: string;
+    subjectSlug: string;
+    contentItemSlug: string;
+  }) => void;
 
   // MISC
   newsletterSignUpCompleted: () => void;

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -171,12 +171,6 @@ export const useMyLibrary = () => {
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
-      platform: "owa",
-      product: "media clips",
-      engagementIntent: "use",
-      eventVersion: "2.0.0",
-      analyticsUseCase: "Pupil",
-      contentType: "",
     });
   };
 
@@ -209,12 +203,6 @@ export const useMyLibrary = () => {
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
-      platform: "owa",
-      product: "media clips",
-      engagementIntent: "use",
-      eventVersion: "2.0.0",
-      analyticsUseCase: "Pupil",
-      contentType: "",
     });
   };
 

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -171,6 +171,12 @@ export const useMyLibrary = () => {
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
+      platform: "owa",
+      product: "media clips",
+      engagementIntent: "use",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Pupil",
+      contentType: "",
     });
   };
 
@@ -203,6 +209,12 @@ export const useMyLibrary = () => {
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
+      platform: "owa",
+      product: "media clips",
+      engagementIntent: "use",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Pupil",
+      contentType: "",
     });
   };
 

--- a/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useMyLibrary.tsx
@@ -19,14 +19,19 @@ import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNot
 import { postEducatorData } from "@/node-lib/educator-api/helpers/postEducatorData";
 import errorReporter from "@/common-lib/error-reporter";
 import useSaveCountContext from "@/context/SaveCount/useSaveCountContext";
-import useAnalytics from "@/context/Analytics/useAnalytics";
 import { CollectionData } from "@/components/TeacherViews/MyLibrary/MyLibrary";
 import { getTeacherSubjectPhaseSlug } from "@/utils/curriculum/slugs";
+import { useOptionalTeacherBrowseAnalytics } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 
 const reportError = errorReporter("educatorApi");
 
 export const useMyLibrary = () => {
-  const { track } = useAnalytics();
+  const contentSaved = useOptionalTeacherBrowseAnalytics(
+    (store) => store.track.contentSaved,
+  );
+  const contentUnsaved = useOptionalTeacherBrowseAnalytics(
+    (store) => store.track.contentUnsaved,
+  );
   const { data: savedProgrammeUnits, isLoading } =
     useGetEducatorData<UserlistContentApiResponse>(
       `/api/educator/getSavedContentLists`,
@@ -159,19 +164,13 @@ export const useMyLibrary = () => {
       },
     );
     setIsSavingUnit(null);
-    track.contentSaved({
-      platform: "owa",
-      product: "teacher lesson resources",
-      engagementIntent: "use",
+    contentSaved({
       componentType: "unit_listing_save_button",
-      analyticsUseCase: "Teacher",
       keyStageSlug: trackingData.keyStageSlug,
       keyStageTitle: trackingData.keyStageTitle,
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
-      contentType: "unit",
       contentItemSlug: unitSlug,
-      eventVersion: "2.0.0",
     });
   };
 
@@ -197,19 +196,13 @@ export const useMyLibrary = () => {
       },
     );
     setIsSavingUnit(null);
-    track.contentUnsaved({
-      platform: "owa",
-      product: "teacher lesson resources",
-      engagementIntent: "use",
+    contentUnsaved({
       componentType: trackingData.savedFrom,
-      analyticsUseCase: "Teacher",
       keyStageSlug: trackingData.keyStageSlug,
       keyStageTitle: trackingData.keyStageTitle,
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
-      contentType: "unit",
       contentItemSlug: unitSlug,
-      eventVersion: "2.0.0",
     });
   };
 

--- a/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
@@ -106,12 +106,6 @@ export const useSaveUnits = (
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
-      platform: "owa",
-      product: "media clips",
-      engagementIntent: "use",
-      eventVersion: "2.0.0",
-      analyticsUseCase: "Pupil",
-      contentType: "",
     });
   };
 
@@ -137,12 +131,6 @@ export const useSaveUnits = (
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
-      platform: "owa",
-      product: "media clips",
-      engagementIntent: "refine",
-      eventVersion: "2.0.0",
-      analyticsUseCase: "Pupil",
-      contentType: "",
     });
   };
 

--- a/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
@@ -13,9 +13,9 @@ import {
 
 import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
 import { postEducatorData } from "@/node-lib/educator-api/helpers/postEducatorData";
-import useAnalytics from "@/context/Analytics/useAnalytics";
 import errorReporter from "@/common-lib/error-reporter";
 import useSaveCountContext from "@/context/SaveCount/useSaveCountContext";
+import { useOptionalTeacherBrowseAnalytics } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 
 const unitsResponseSchema = z.array(z.string());
 const reportError = errorReporter("educatorApi");
@@ -25,7 +25,12 @@ export const useSaveUnits = (
   trackingData: TrackingProgrammeData,
 ) => {
   const { isSignedIn, user } = useUser();
-  const { track } = useAnalytics();
+  const contentSaved = useOptionalTeacherBrowseAnalytics(
+    (store) => store.track.contentSaved,
+  );
+  const contentUnsaved = useOptionalTeacherBrowseAnalytics(
+    (store) => store.track.contentUnsaved,
+  );
 
   const { data: savedUnitsData, mutate } = useGetEducatorData<string[]>(
     `/api/educator/getSavedUnits/${programmeSlug}`,
@@ -94,19 +99,13 @@ export const useSaveUnits = (
       },
     );
     setIsSavingUnit(null);
-    track.contentSaved({
-      platform: "owa",
-      product: "teacher lesson resources",
-      engagementIntent: "use",
+    contentSaved({
       componentType: trackingData.savedFrom,
-      analyticsUseCase: "Teacher",
       keyStageSlug: trackingData.keyStageSlug,
       keyStageTitle: trackingData.keyStageTitle,
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
-      contentType: "unit",
       contentItemSlug: unitSlug,
-      eventVersion: "2.0.0",
     });
   };
 
@@ -125,19 +124,13 @@ export const useSaveUnits = (
       },
     );
     setIsSavingUnit(null);
-    track.contentUnsaved({
-      platform: "owa",
-      product: "teacher lesson resources",
-      engagementIntent: "use",
+    contentUnsaved({
       componentType: trackingData.savedFrom,
-      analyticsUseCase: "Teacher",
       keyStageSlug: trackingData.keyStageSlug,
       keyStageTitle: trackingData.keyStageTitle,
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
-      contentType: "unit",
       contentItemSlug: unitSlug,
-      eventVersion: "2.0.0",
     });
   };
 

--- a/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
+++ b/src/node-lib/educator-api/helpers/saveUnits/useSaveUnits.tsx
@@ -106,6 +106,12 @@ export const useSaveUnits = (
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
+      platform: "owa",
+      product: "media clips",
+      engagementIntent: "use",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Pupil",
+      contentType: "",
     });
   };
 
@@ -131,6 +137,12 @@ export const useSaveUnits = (
       subjectSlug: trackingData.subjectSlug,
       subjectTitle: trackingData.subjectTitle,
       contentItemSlug: unitSlug,
+      platform: "owa",
+      product: "media clips",
+      engagementIntent: "refine",
+      eventVersion: "2.0.0",
+      analyticsUseCase: "Pupil",
+      contentType: "",
     });
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,6 +17,7 @@ import getPageProps from "@/node-lib/getPageProps";
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
 import { SubjectPhasePickerData } from "@/components/SharedComponents/SubjectPhasePicker/SubjectPhasePicker";
 import { filterValidCurriculumPhaseOptions } from "@/pages-helpers/curriculum/docx/tab-helpers";
+import { TeacherBrowseAnalyticsStoreProvider } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 
 export type HomePageProps = BlogPostProps & {
   curriculumPhaseOptions: SubjectPhasePickerData;
@@ -61,12 +62,14 @@ const HomePage: NextPage<HomePageProps> = (props) => {
         curriculumPhaseOptions={curriculumPhaseOptions}
         aria-current="page"
       />
-      <HomePageLowerView
-        campaignPromoBanner={campaignPromoBanner}
-        posts={posts}
-        testimonials={testimonials}
-        introVideo={intro}
-      />
+      <TeacherBrowseAnalyticsStoreProvider>
+        <HomePageLowerView
+          campaignPromoBanner={campaignPromoBanner}
+          posts={posts}
+          testimonials={testimonials}
+          introVideo={intro}
+        />
+      </TeacherBrowseAnalyticsStoreProvider>
     </AppLayout>
   );
 };

--- a/src/storybook-decorators/TeacherBrowseAnalyticsDecorator.tsx
+++ b/src/storybook-decorators/TeacherBrowseAnalyticsDecorator.tsx
@@ -19,10 +19,28 @@ const state = {
     lessonResourceDownloadStarted: () =>
       console.log("lessonResourceDownloadStarted fired"),
     unitDownloadInitiated: () => console.log("unitDownloadInitiated fired"),
-    contentSaved: (props: ContentSavedProperties) =>
-      console.log("contentSaved fired", props),
-    contentUnsaved: (props: ContentUnsavedProperties) =>
-      console.log("contentUnsaved fired", props),
+    contentSaved: (
+      props: Pick<
+        ContentSavedProperties,
+        | "componentType"
+        | "keyStageSlug"
+        | "keyStageTitle"
+        | "subjectSlug"
+        | "subjectTitle"
+        | "contentItemSlug"
+      >,
+    ) => console.log("contentSaved fired", props),
+    contentUnsaved: (
+      props: Pick<
+        ContentUnsavedProperties,
+        | "componentType"
+        | "keyStageSlug"
+        | "keyStageTitle"
+        | "subjectSlug"
+        | "subjectTitle"
+        | "contentItemSlug"
+      >,
+    ) => console.log("contentUnsaved fired", props),
     newsletterSignUpCompleted: () =>
       console.log("newsletterSignUpCompleted fired"),
   },

--- a/src/storybook-decorators/TeacherBrowseAnalyticsDecorator.tsx
+++ b/src/storybook-decorators/TeacherBrowseAnalyticsDecorator.tsx
@@ -5,7 +5,11 @@ import { noopTrackingFns } from "./AnalyticsDecorator";
 import { TeacherBrowseAnalyticsStoreContext } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 import { getProgrammeStateForLesson } from "@/context/TeacherBrowseAnalytics/utils/getProgrammeState";
 import teachersLessonOverviewFixture from "@/node-lib/curriculum-api-2023/fixtures/teachersLessonOverview.fixture";
-import { NavigatedFrom } from "@/browser-lib/avo/Avo";
+import {
+  ContentSavedProperties,
+  ContentUnsavedProperties,
+  NavigatedFrom,
+} from "@/browser-lib/avo/Avo";
 
 const state = {
   programmeState: getProgrammeStateForLesson(teachersLessonOverviewFixture()),
@@ -15,6 +19,12 @@ const state = {
     lessonResourceDownloadStarted: () =>
       console.log("lessonResourceDownloadStarted fired"),
     unitDownloadInitiated: () => console.log("unitDownloadInitiated fired"),
+    contentSaved: (props: ContentSavedProperties) =>
+      console.log("contentSaved fired", props),
+    contentUnsaved: (props: ContentUnsavedProperties) =>
+      console.log("contentUnsaved fired", props),
+    newsletterSignUpCompleted: () =>
+      console.log("newsletterSignUpCompleted fired"),
   },
 };
 


### PR DESCRIPTION
## Description

Music year: 1951

**Closed PR due to discussion on Slack about whether this makes sense to do!**
Reasoning is:
- Non programme events don't really belong in a browse analytics store since there is no browse data to populate the store with
- For these my library events, we are passing all of the programme data to the events anyway and aren't getting the benefits of using the store
- We discussed potentially slicing the store as has been done between teacher/pupil areas, but this doesn't really make sense either due to confusion. The initial proposal was for a generic store but this is technically a group of teacher events as only teachers add to my library. Therefore this feels confusing.
- Another issue with this is needing to make the programme optional, which isn't ideal because some events require a programme and some don't. JourneyID has the same issue.
- Anyway, we are parking this for now to explore properly before making a snap decision.


- Moved content saved and newsletter sign up events to the analytics store

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]
2. Open the console
3. Save a unit
4. Go to my-library and unsave a unit
5. Sign up for the newsletter on the homepage
6. You should see the events fire correctly in the console

## Screenshots

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
