### PR TITLE
Fix/lesq 2163/school picker error [LESQ-2163]

### DIFF
--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
@@ -1,9 +1,5 @@
 import { OakSpan } from "@oaknational/oak-components";
 
-// Escape regex metacharacters to avoid errors when using the value to create a regex
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 export const formatSchoolName = (
   schoolName: string,
   inputValue: string | undefined,
@@ -12,7 +8,7 @@ export const formatSchoolName = (
     return <OakSpan $font={"heading-light-7"}>{schoolName}</OakSpan>;
   }
 
-  const escapedInput = escapeRegExp(inputValue);
+  const escapedInput = RegExp.escape(inputValue);
   const splitRegex = new RegExp(`(${escapedInput})`, "gi");
   const exactMatchRegex = new RegExp(`^${escapedInput}$`, "i");
   const splitSchoolName = schoolName.split(splitRegex);

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
@@ -1,5 +1,9 @@
 import { OakSpan } from "@oaknational/oak-components";
 
+// Escape regex metacharacters to avoid errors when using the value to create a regex
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
 export const formatSchoolName = (
   schoolName: string,
   inputValue: string | undefined,
@@ -8,7 +12,7 @@ export const formatSchoolName = (
     return <OakSpan $font={"heading-light-7"}>{schoolName}</OakSpan>;
   }
 
-  const escapedInput = RegExp.escape(inputValue);
+  const escapedInput = escapeRegExp(inputValue);
   const splitRegex = new RegExp(`(${escapedInput})`, "gi");
   const exactMatchRegex = new RegExp(`^${escapedInput}$`, "i");
   const splitSchoolName = schoolName.split(splitRegex);

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
@@ -1,19 +1,20 @@
 import { OakSpan } from "@oaknational/oak-components";
 
-const toAlphanumericOnly = (value: string) => value.replace(/[^a-z0-9]/gi, "");
+// Escape regex metacharacters to avoid errors when using the value to create a regex
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export const formatSchoolName = (
   schoolName: string,
-  inputValue: string | undefined = "",
+  inputValue: string | undefined,
 ) => {
-  const normalizedInput = toAlphanumericOnly(inputValue);
-
-  if (!normalizedInput) {
+  if (!inputValue) {
     return <OakSpan $font={"heading-light-7"}>{schoolName}</OakSpan>;
   }
 
-  const splitRegex = new RegExp(`(${normalizedInput})`, "gi");
-  const exactMatchRegex = new RegExp(`^${normalizedInput}$`, "i");
+  const escapedInput = escapeRegExp(inputValue);
+  const splitRegex = new RegExp(`(${escapedInput})`, "gi");
+  const exactMatchRegex = new RegExp(`^${escapedInput}$`, "i");
   const splitSchoolName = schoolName.split(splitRegex);
 
   return (

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/formatSchoolName.tsx
@@ -1,39 +1,39 @@
-import { ReactNode } from "react";
 import { OakSpan } from "@oaknational/oak-components";
 
+const toAlphanumericOnly = (value: string) => value.replace(/[^a-z0-9]/gi, "");
+
 export const formatSchoolName = (
-  schoolName: ReactNode,
-  inputValue: string | undefined,
+  schoolName: string,
+  inputValue: string | undefined = "",
 ) => {
-  const schoolNameString = `${schoolName}`;
-  const inputValueString = inputValue || "";
-  const regexPattern = new RegExp(inputValueString, "i");
-  const firstIndexOfPattern = schoolNameString.search(regexPattern);
-  const splitSchoolName = schoolNameString.split(regexPattern);
-  const sliceToMakeBold = schoolNameString.slice(
-    firstIndexOfPattern,
-    firstIndexOfPattern + (inputValueString.length || 0),
-  );
+  const normalizedInput = toAlphanumericOnly(inputValue);
+
+  if (!normalizedInput) {
+    return <OakSpan $font={"heading-light-7"}>{schoolName}</OakSpan>;
+  }
+
+  const splitRegex = new RegExp(`(${normalizedInput})`, "gi");
+  const exactMatchRegex = new RegExp(`^${normalizedInput}$`, "i");
+  const splitSchoolName = schoolName.split(splitRegex);
 
   return (
     <OakSpan $font={"heading-light-7"}>
-      {splitSchoolName.map((splitSchoolNameItem: string, index: number) => {
-        return (
-          <OakSpan key={index}>
-            {`${splitSchoolNameItem}`}
-            {index < splitSchoolName.length - 1 && (
-              <OakSpan
-                $font={"body-2-bold"}
-                $textDecoration={"underline"}
-                $color={"text-link-active"}
-                data-testid="strong-element"
-              >
-                {sliceToMakeBold}
-              </OakSpan>
-            )}
-          </OakSpan>
-        );
-      })}
+      {splitSchoolName.map((part: string, index: number) => (
+        <OakSpan key={index}>
+          {exactMatchRegex.test(part) ? (
+            <OakSpan
+              $font={"body-2-bold"}
+              $textDecoration={"underline"}
+              $color={"text-link-active"}
+              data-testid="strong-element"
+            >
+              {part}
+            </OakSpan>
+          ) : (
+            part
+          )}
+        </OakSpan>
+      ))}
     </OakSpan>
   );
 };

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.test.tsx
@@ -96,11 +96,11 @@ describe("useSchoolPicker", () => {
     });
     await expect(
       async () => await fetcher("https://school-picker/value"),
-    ).rejects.toThrowError(
+    ).rejects.toThrow(
       new OakError({ code: "school-picker/fetch-suggestions" }),
     );
-    expect(mockJson).toBeCalled();
-    expect(reportError).toBeCalled();
+    expect(mockJson).toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalled();
   });
   test("should return and empty array with no data ", async () => {
     fetch.mockResolvedValue({
@@ -115,5 +115,27 @@ describe("useSchoolPicker", () => {
     );
 
     expect(result.current.schools).toEqual([]);
+  });
+  test("should retun an empty array on 400 error", async () => {
+    fetch.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ res: undefined }),
+      ok: true,
+      status: 400,
+      statusText: "",
+    });
+    const { result } = renderHook(() =>
+      useSchoolPicker({ withHomeschool: true }),
+    );
+    expect(result.current.schools).toEqual([]);
+  });
+  test("should not report 400 errors", async () => {
+    fetch.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ res: undefined }),
+      ok: true,
+      status: 400,
+      statusText: "",
+    });
+    renderHook(() => useSchoolPicker({ withHomeschool: true }));
+    expect(reportError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.test.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.test.tsx
@@ -116,7 +116,7 @@ describe("useSchoolPicker", () => {
 
     expect(result.current.schools).toEqual([]);
   });
-  test("should retun an empty array on 400 error", async () => {
+  test("should return an empty array on 400 error", async () => {
     fetch.mockResolvedValue({
       json: jest.fn().mockResolvedValue({ res: undefined }),
       ok: true,

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
@@ -12,10 +12,8 @@ export const fetcher = async (queryUrl: string) => {
   try {
     const res = await fetch(queryUrl);
     if (!res.ok) {
-      if (res.status === 400) {
-        // Don't report bad request errors due to invalid input characters
-        return undefined;
-      } else {
+      if (res.status !== 400) {
+        // Don't report bad request errors due to invalid input characters ie. 400 response
         throw new Error(
           new OakError({
             code: "school-picker/fetch-suggestions",
@@ -43,6 +41,7 @@ export const fetcher = async (queryUrl: string) => {
     }
 
     reportError(oakError);
+    throw oakError;
   }
 };
 

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
@@ -12,7 +12,9 @@ export const fetcher = async (queryUrl: string) => {
   try {
     const res = await fetch(queryUrl);
     if (!res.ok) {
-      if (res.status !== 400) {
+      if (res.status === 400) {
+        return [];
+      } else {
         // Don't report bad request errors due to invalid input characters ie. 400 response
         throw new Error(
           new OakError({

--- a/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
+++ b/src/components/TeacherComponents/ResourcePageSchoolPicker/useSchoolPicker.tsx
@@ -8,25 +8,43 @@ import OakError from "@/errors/OakError";
 
 const reportError = errorReporter("SchoolPicker");
 
-export const fetcher = (queryUrl: string) =>
-  fetch(queryUrl).then((res) => {
-    if (res.ok) {
-      return res.json();
-    } else {
-      const error = new OakError({
+export const fetcher = async (queryUrl: string) => {
+  try {
+    const res = await fetch(queryUrl);
+    if (!res.ok) {
+      if (res.status === 400) {
+        // Don't report bad request errors due to invalid input characters
+        return undefined;
+      } else {
+        throw new Error(
+          new OakError({
+            code: "school-picker/fetch-suggestions",
+            meta: {
+              queryUrl,
+              status: res.status,
+              statusText: res.statusText,
+              json: await res.json(),
+            },
+          }),
+        );
+      }
+    }
+    return res.json();
+  } catch (err) {
+    let oakError = err;
+    if (!(err instanceof OakError)) {
+      oakError = new OakError({
         code: "school-picker/fetch-suggestions",
+        originalError: err,
         meta: {
-          status: res.status,
-          statusText: res.statusText,
           queryUrl,
-          json: res.json(),
         },
       });
-
-      reportError(error);
-      throw error;
     }
-  });
+
+    reportError(oakError);
+  }
+};
 
 export const HOMESCHOOL_URN = "homeschool";
 


### PR DESCRIPTION
## Description

Music year: 2012

- Update the function to highlight input text within the matching schools list to prevent invalid Regex errors due to `\`  characters
- Update the school picker fetch fn to stop reporting errors due to invalid request (ie. when characters such as `[` are in the query string)

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]teachers/programmes/computing-primary-ks1/units/digital-writing/lessons/adding-and-removing-text/downloads?preselected=all
2. Click on edit details and start typing into the school input field (you need to be signed out)
3. Enter a backslash eg: `Hul\`
4. You should not see any error page
5. Enter other characters into the string eg: `Hul[`
6. You should not see any errors being reported (you can still see the erroring requests in the network tab)

## Screenshots

How it used to look (delete if n/a):
<img width="800" alt="Screenshot 2026-07-28 at 08 53 15" src="https://github.com/user-attachments/assets/4ca448a9-08e1-44ae-b7e4-fb0940b74eea" />

Console error reporter:
<img width="400" alt="Screenshot 2026-07-28 at 08 52 26" src="https://github.com/user-attachments/assets/30f2a90a-19d1-47c1-8fde-f6af5392ec12" />

How it should now look:
<img width="800"  alt="Screenshot 2026-07-28 at 08 50 51" src="https://github.com/user-attachments/assets/a66ae2c5-6abb-4b3b-ae19-bcdb9a61c2a6" />

Console error, no reporter:
<img width="400" alt="Screenshot 2026-07-28 at 08 52 52" src="https://github.com/user-attachments/assets/25d89487-3bee-4309-871a-aa96b465d829" />
