### PR TITLE
Changed `<WhoAreWeExplore/>` to support 4 items

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -5342,7 +5342,6 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   >
                     <ul
                       class="c117"
-                      size="4"
                     >
                       <li
                         class="c118 c119"

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -2455,7 +2455,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
   grid-auto-rows: 1fr;
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(2,1fr);
 }
 
 .c150 {
@@ -5342,6 +5342,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   >
                     <ul
                       class="c117"
+                      size="4"
                     >
                       <li
                         class="c118 c119"

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -5116,7 +5116,6 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   >
                     <ul
                       class="c114"
-                      size="4"
                     >
                       <li
                         class="c115 c116"

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -2577,7 +2577,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
   grid-auto-rows: 1fr;
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(2,1fr);
 }
 
 .c147 {
@@ -5116,6 +5116,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   >
                     <ul
                       class="c114"
+                      size="4"
                     >
                       <li
                         class="c115 c116"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -6021,7 +6021,6 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   >
                     <ul
                       class="c160"
-                      size="4"
                     >
                       <li
                         class="c161 c162"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -6020,12 +6020,8 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-<<<<<<< HEAD
-                      class="c158"
-                      size="4"
-=======
                       class="c160"
->>>>>>> origin/main
+                      size="4"
                     >
                       <li
                         class="c161 c162"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -2870,7 +2870,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
   grid-auto-rows: 1fr;
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(2,1fr);
 }
 
 .c191 {
@@ -5985,6 +5985,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   >
                     <ul
                       class="c158"
+                      size="4"
                     >
                       <li
                         class="c159 c160"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -852,7 +852,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-982d7e83-1 jvmsVB"
+                      class="sc-55af3af8-1 jFmwgk"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -862,7 +862,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -915,7 +915,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -968,7 +968,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -1021,7 +1021,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -852,8 +852,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-eb50514b-1 hZZYCP"
-                      size="4"
+                      class="sc-982d7e83-1 jvmsVB"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -863,7 +862,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -916,7 +915,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -969,7 +968,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -1022,7 +1021,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -852,7 +852,8 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-d3fa22d1-1 fewXIw"
+                      class="sc-1278282e-1 dvtndS"
+                      size="4"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -862,7 +863,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -915,7 +916,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -968,7 +969,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -1021,7 +1022,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -2642,7 +2642,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
   grid-auto-rows: 1fr;
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(2,1fr);
 }
 
 .c157 {
@@ -5169,6 +5169,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   >
                     <ul
                       class="c124"
+                      size="4"
                     >
                       <li
                         class="c125 c126"

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -5169,7 +5169,6 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   >
                     <ul
                       class="c124"
-                      size="4"
                     >
                       <li
                         class="c125 c126"

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -688,7 +688,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-982d7e83-1 jvmsVB"
+                      class="sc-55af3af8-1 jFmwgk"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -698,7 +698,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -751,7 +751,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -804,7 +804,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -857,7 +857,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -688,8 +688,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-eb50514b-1 hZZYCP"
-                      size="4"
+                      class="sc-982d7e83-1 jvmsVB"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -699,7 +698,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -752,7 +751,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -805,7 +804,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -858,7 +857,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                            class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -688,7 +688,8 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                     aria-labelledby="react-use-id-test-result"
                   >
                     <ul
-                      class="sc-d3fa22d1-1 fewXIw"
+                      class="sc-1278282e-1 dvtndS"
+                      size="4"
                     >
                       <li
                         class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -698,7 +699,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -751,7 +752,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -804,7 +805,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div
@@ -857,7 +858,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           style="outline: none;"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                            class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                             data-testid="who-we-are-explore-item"
                           >
                             <div

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.stories.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.stories.tsx
@@ -12,47 +12,45 @@ const meta: Meta<typeof Component> = {
 export default meta;
 type Story = StoryObj<typeof Component>;
 
-export const Default: Story = {
+const items = [
+  {
+    iconName: "logo",
+    title: "About Oak",
+    href: "#",
+    componentType: "about_oak",
+  },
+  {
+    iconName: "homepage-teacher-map",
+    title: "Oak's curricula",
+    href: "#",
+    componentType: "about_curriculum",
+  },
+  {
+    iconName: "snack-break",
+    title: "Meet the team",
+    href: "#",
+    componentType: "meet_the_team",
+  },
+  {
+    iconName: "chatting",
+    title: "Get involved",
+    href: "#",
+    componentType: "get_involved",
+  },
+] as const;
+
+export const FourItems: Story = {
   args: {
     title: "Explore more about Oak",
-    items: [
-      {
-        iconName: "curriculum-plan",
-        title: "About Oak’s curriculum",
-        href: "#",
-        componentType: "about_curriculum",
-      },
-      {
-        iconName: "ai-worksheet",
-        title: "Oak’s impact",
-        href: "#",
-        componentType: "oaks_impact",
-      },
-      {
-        iconName: "ai-worksheet",
-        title: "Meet the team",
-        href: "#",
-        componentType: "meet_the_team",
-      },
-      {
-        iconName: "ai-worksheet",
-        title: "Get involved",
-        href: "#",
-        componentType: "get_involved",
-      },
-      {
-        iconName: "ai-worksheet",
-        title: "Something else",
-        href: "#",
-        componentType: "about_oak",
-      },
-      {
-        iconName: "ai-worksheet",
-        title: "Yet another thing",
-        href: "#",
-        componentType: "about_oak",
-      },
-    ],
+    items: items.slice(0, 4),
+  },
+  render: (args) => <Component {...args} />,
+};
+
+export const ThreeItems: Story = {
+  args: {
+    title: "Explore more about Oak",
+    items: items.slice(0, 3),
   },
   render: (args) => <Component {...args} />,
 };

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.test.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.test.tsx
@@ -49,7 +49,7 @@ describe("WhoAreWeExplore", () => {
     expect(getByRole("heading")).toHaveTextContent("TEST_TITLE");
 
     const elements = getAllByRole("link");
-    expect(elements.length).toEqual(4);
+    expect(elements).toHaveLength(4);
 
     expect(elements[0]).toHaveTextContent("ITEM_ONE");
     expect(elements[0]).toHaveAttribute("href", "#item_one");
@@ -92,7 +92,7 @@ describe("WhoAreWeExplore", () => {
     expect(getByRole("heading")).toHaveTextContent("TEST_TITLE");
 
     const elements = getAllByRole("link");
-    expect(elements.length).toEqual(3);
+    expect(elements).toHaveLength(3);
 
     expect(elements[0]).toHaveTextContent("ITEM_ONE");
     expect(elements[0]).toHaveAttribute("href", "#item_one");

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.test.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/WhoAreWeExplore.test.tsx
@@ -13,7 +13,56 @@ jest.mock("@/browser-lib/avo/Avo", () => ({
 }));
 
 describe("WhoAreWeExplore", () => {
-  it("renders correctly", () => {
+  it("renders correctly with 4 items", () => {
+    const { baseElement, getByRole, getAllByRole } = render(
+      <WhoAreWeExplore
+        title={"TEST_TITLE"}
+        items={[
+          {
+            iconName: "search",
+            title: "ITEM_ONE",
+            href: "#item_one",
+            componentType: "about_oak",
+          },
+          {
+            iconName: "search",
+            title: "ITEM_TWO",
+            href: "#item_two",
+            componentType: "get_involved",
+          },
+          {
+            iconName: "search",
+            title: "ITEM_THREE",
+            href: "#item_three",
+            componentType: "meet_the_team",
+          },
+          {
+            iconName: "search",
+            title: "ITEM_FOUR",
+            href: "#item_four",
+            componentType: "oaks_impact",
+          },
+        ]}
+      />,
+    );
+
+    expect(getByRole("heading")).toHaveTextContent("TEST_TITLE");
+
+    const elements = getAllByRole("link");
+    expect(elements.length).toEqual(4);
+
+    expect(elements[0]).toHaveTextContent("ITEM_ONE");
+    expect(elements[0]).toHaveAttribute("href", "#item_one");
+    expect(elements[1]).toHaveTextContent("ITEM_TWO");
+    expect(elements[1]).toHaveAttribute("href", "#item_two");
+    expect(elements[2]).toHaveTextContent("ITEM_THREE");
+    expect(elements[2]).toHaveAttribute("href", "#item_three");
+    expect(elements[3]).toHaveTextContent("ITEM_FOUR");
+    expect(elements[3]).toHaveAttribute("href", "#item_four");
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders correctly with 3 items", () => {
     const { baseElement, getByRole, getAllByRole } = render(
       <WhoAreWeExplore
         title={"TEST_TITLE"}

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -36,8 +36,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-eb50514b-1 kobMMa"
-              size="3"
+              class="sc-982d7e83-1 eSBxYo"
             >
               <li
                 class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -47,7 +46,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -100,7 +99,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -153,7 +152,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -243,8 +242,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-eb50514b-1 hZZYCP"
-              size="4"
+              class="sc-982d7e83-1 jvmsVB"
             >
               <li
                 class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -254,7 +252,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -307,7 +305,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -360,7 +358,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -413,7 +411,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
+                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
                     data-testid="who-we-are-explore-item"
                   >
                     <div

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-1278282e-1 bhryUH"
+              class="sc-eb50514b-1 kobMMa"
               size="3"
             >
               <li
@@ -47,7 +47,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -100,7 +100,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -153,7 +153,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -243,7 +243,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-1278282e-1 dvtndS"
+              class="sc-eb50514b-1 hZZYCP"
               size="4"
             >
               <li
@@ -254,7 +254,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -307,7 +307,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -360,7 +360,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -413,7 +413,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    class="sc-aXZVg sc-gEvEer sc-eb50514b-0 jtqxcT egjftS fUdzbp"
                     data-testid="who-we-are-explore-item"
                   >
                     <div

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WhoAreWeExplore renders correctly 1`] = `
+exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
 <body>
   <div>
     <div
@@ -36,7 +36,8 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-d3fa22d1-1 fewXIw"
+              class="sc-1278282e-1 bhryUH"
+              size="3"
             >
               <li
                 class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -46,7 +47,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -99,7 +100,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -152,7 +153,7 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-d3fa22d1-0 jtqxcT egjftS dykJko"
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -176,6 +177,266 @@ exports[`WhoAreWeExplore renders correctly 1`] = `
                       class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
                     >
                       ITEM_THREE
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fjkwRj"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-aXZVg fMrRXk"
+    >
+      <span
+        class="sc-aXZVg cegGxk"
+        style="pointer-events: none;"
+      >
+        <img
+          alt=""
+          class="sc-iGgWBj cMzyFO"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763546694/ui-graphics/confetti-background_xbvfrc.svg"
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+        />
+      </span>
+      <div
+        class="sc-aXZVg bZTQLO"
+      >
+        <div
+          class="sc-aXZVg sc-gEvEer hjAuSJ cLpNFw"
+        >
+          <h2
+            class="sc-eldPxv bZYxxV"
+            id="react-use-id-test-result"
+          >
+            TEST_TITLE
+          </h2>
+          <nav
+            aria-labelledby="react-use-id-test-result"
+          >
+            <ul
+              class="sc-1278282e-1 dvtndS"
+              size="4"
+            >
+              <li
+                class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
+              >
+                <a
+                  href="#item_one"
+                  style="outline: none;"
+                >
+                  <div
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    data-testid="who-we-are-explore-item"
+                  >
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fRjhP"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1704901279/icons/canbi3fuz5fanzom2hvi.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
+                    >
+                      ITEM_ONE
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fjkwRj"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
+              >
+                <a
+                  href="#item_two"
+                  style="outline: none;"
+                >
+                  <div
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    data-testid="who-we-are-explore-item"
+                  >
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fRjhP"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1704901279/icons/canbi3fuz5fanzom2hvi.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
+                    >
+                      ITEM_TWO
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fjkwRj"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
+              >
+                <a
+                  href="#item_three"
+                  style="outline: none;"
+                >
+                  <div
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    data-testid="who-we-are-explore-item"
+                  >
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fRjhP"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1704901279/icons/canbi3fuz5fanzom2hvi.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
+                    >
+                      ITEM_THREE
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fjkwRj"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+              <li
+                class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
+              >
+                <a
+                  href="#item_four"
+                  style="outline: none;"
+                >
+                  <div
+                    class="sc-aXZVg sc-gEvEer sc-1278282e-0 jtqxcT egjftS cJCVPo"
+                    data-testid="who-we-are-explore-item"
+                  >
+                    <div
+                      class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                    >
+                      <span
+                        class="sc-aXZVg fRjhP"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj cMzyFO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1704901279/icons/canbi3fuz5fanzom2hvi.svg"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
+                    >
+                      ITEM_FOUR
                     </div>
                     <div
                       class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/__snapshots__/WhoAreWeExplore.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-982d7e83-1 eSBxYo"
+              class="sc-55af3af8-1 hJcdvp"
             >
               <li
                 class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -46,7 +46,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -99,7 +99,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -152,7 +152,7 @@ exports[`WhoAreWeExplore renders correctly with 3 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -242,7 +242,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
             aria-labelledby="react-use-id-test-result"
           >
             <ul
-              class="sc-982d7e83-1 jvmsVB"
+              class="sc-55af3af8-1 jFmwgk"
             >
               <li
                 class="sc-aXZVg sc-hZDyAQ kBnJtM iMmmjC"
@@ -252,7 +252,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -305,7 +305,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -358,7 +358,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div
@@ -411,7 +411,7 @@ exports[`WhoAreWeExplore renders correctly with 4 items 1`] = `
                   style="outline: none;"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-982d7e83-0 jtqxcT egjftS kLpzZb"
+                    class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
                     data-testid="who-we-are-explore-item"
                   >
                     <div

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
@@ -27,7 +27,7 @@ const HoverableCard = styled(OakFlex)`
   }
 `;
 
-const CustomUlAsGrid = styled.ul`
+const CustomUlAsGrid = styled.ul<{ size: number }>`
   margin: 0;
   padding: 0;
   list-style: none;
@@ -35,7 +35,7 @@ const CustomUlAsGrid = styled.ul`
   row-gap: ${() => parseSpacing("spacing-16")};
   column-gap: ${() => parseSpacing("spacing-16")};
   grid-auto-rows: 1fr;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: ${({ size }) => `repeat(${size === 3 ? 3 : 2}, 1fr)`};
 
   @media (max-width: 800px) {
     grid-template-columns: repeat(1, 1fr);
@@ -90,7 +90,7 @@ export function WhoAreWeExplore({
             {title}
           </OakHeading>
           <nav aria-labelledby={headingId}>
-            <CustomUlAsGrid>
+            <CustomUlAsGrid size={items.length}>
               {items.map(({ title, iconName, href, componentType }) => {
                 return (
                   <OakFocusIndicator

--- a/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
+++ b/src/components/GenericPagesComponents/WhoAreWeExplore/index.tsx
@@ -27,7 +27,7 @@ const HoverableCard = styled(OakFlex)`
   }
 `;
 
-const CustomUlAsGrid = styled.ul<{ size: number }>`
+const CustomUlAsGrid = styled.ul<{ $size: number }>`
   margin: 0;
   padding: 0;
   list-style: none;
@@ -35,7 +35,8 @@ const CustomUlAsGrid = styled.ul<{ size: number }>`
   row-gap: ${() => parseSpacing("spacing-16")};
   column-gap: ${() => parseSpacing("spacing-16")};
   grid-auto-rows: 1fr;
-  grid-template-columns: ${({ size }) => `repeat(${size === 3 ? 3 : 2}, 1fr)`};
+  grid-template-columns: ${({ $size }) =>
+    `repeat(${$size === 3 ? 3 : 2}, 1fr)`};
 
   @media (max-width: 800px) {
     grid-template-columns: repeat(1, 1fr);
@@ -90,7 +91,7 @@ export function WhoAreWeExplore({
             {title}
           </OakHeading>
           <nav aria-labelledby={headingId}>
-            <CustomUlAsGrid size={items.length}>
+            <CustomUlAsGrid $size={items.length}>
               {items.map(({ title, iconName, href, componentType }) => {
                 return (
                   <OakFocusIndicator


### PR DESCRIPTION
## Description
Changed `<WhoAreWeExplore/>` to support 3 & 4 items

## Issue(s)
Fixes `ADOPT-2177`

## How to test
Test component in storybook

 - [4 items](https://oak-web-application-storybook-git-feat-adopt-2177-four-i-d33061.vercel.thenational.academy/?path=/story/components-genericpagescomponents-whoareweexplore--four-items)
 - [3 items](https://oak-web-application-storybook-git-feat-adopt-2177-four-i-d33061.vercel.thenational.academy/?path=/story/components-genericpagescomponents-whoareweexplore--three-items)

## Screenshots
<img width="857" height="449" alt="Screenshot 2026-07-28 at 13 38 23" src="https://github.com/user-attachments/assets/5e630d32-6c64-443b-99ec-77c75b13e014" />
<img width="857" height="344" alt="Screenshot 2026-07-28 at 13 38 16" src="https://github.com/user-attachments/assets/410108c6-adaa-46bb-ba0b-ec09be2b5d11" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
