### PR TITLE
Alt text for quiz answers

### DIFF
--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.test.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.test.tsx
@@ -14,7 +14,7 @@ describe("QuizQuestionsMCAnswers", () => {
     );
     const answers = getAllByRole("listitem");
 
-    expect(answers.length).toBe(4);
+    expect(answers).toHaveLength(4);
   });
 
   it("renders the answer text", () => {
@@ -63,6 +63,32 @@ describe("QuizQuestionsMCAnswers", () => {
       <QuizQuestionsMCAnswers answers={mcqImageAnswers} questionNumber={0} />,
     );
 
-    expect(getAllByRole("presentation").length).toBe(3);
+    expect(getAllByRole("presentation")).toHaveLength(3);
+  });
+
+  it("uses image alt text when present on image object", () => {
+    const answersWithAlt: MCAnswer[] = [
+      {
+        answer: [
+          {
+            type: "image",
+            imageObject: {
+              format: "jpg",
+              secureUrl:
+                "https://oaknationalacademy-res.cloudinary.com/image/upload/v1687374653/Trees.jpg",
+              metadata: [],
+              alt: "A tree in a field",
+            },
+          },
+        ],
+        answerIsCorrect: true,
+      },
+    ];
+
+    const { getByAltText } = renderWithTheme(
+      <QuizQuestionsMCAnswers answers={answersWithAlt} questionNumber={0} />,
+    );
+
+    expect(getByAltText("A tree in a field")).toBeInTheDocument();
   });
 });

--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.test.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.test.tsx
@@ -91,4 +91,30 @@ describe("QuizQuestionsMCAnswers", () => {
 
     expect(getByAltText("A tree in a field")).toBeInTheDocument();
   });
+
+  it("uses a fallback alt text for image-only answers when alt is missing", () => {
+    const answersWithoutAlt: MCAnswer[] = [
+      {
+        answer: [
+          {
+            type: "image",
+            imageObject: {
+              format: "jpg",
+              secureUrl:
+                "https://oaknationalacademy-res.cloudinary.com/image/upload/v1687374653/Trees.jpg",
+              metadata: [],
+              alt: undefined,
+            },
+          },
+        ],
+        answerIsCorrect: false,
+      },
+    ];
+
+    const { getByAltText } = renderWithTheme(
+      <QuizQuestionsMCAnswers answers={answersWithoutAlt} questionNumber={0} />,
+    );
+
+    expect(getByAltText("Answer image")).toBeInTheDocument();
+  });
 });

--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
@@ -105,7 +105,7 @@ export const QuizQuestionsMCAnswers = (props: {
                     key={`q-${questionNumber}-answer-element-${j}`}
                     src={answerItem.imageObject}
                     answerIsCorrect={choice.answerIsCorrect && imageAnswer}
-                    alt={answerItem.imageObject.alt}
+                    alt={answerItem.imageObject.alt ?? "Answer image"}
                   />
                 ) : (
                   <QuizImage

--- a/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsMCAnswers/QuizQuestionsMCAnswers.tsx
@@ -18,12 +18,9 @@ export const QuizQuestionsMCAnswers = (props: {
 }) => {
   const { answers, questionNumber } = props;
 
-  const containsImages =
-    answers.filter(
-      (choice) =>
-        choice.answer.filter((answerItem) => answerItem.type === "image")
-          .length > 0,
-    ).length > 0;
+  const containsImages = answers.some((choice) =>
+    choice.answer.some((answerItem) => answerItem.type === "image"),
+  );
 
   return (
     <OakFlex
@@ -108,12 +105,13 @@ export const QuizQuestionsMCAnswers = (props: {
                     key={`q-${questionNumber}-answer-element-${j}`}
                     src={answerItem.imageObject}
                     answerIsCorrect={choice.answerIsCorrect && imageAnswer}
-                    alt="An image in a quiz"
+                    alt={answerItem.imageObject.alt}
                   />
                 ) : (
                   <QuizImage
                     key={`q-${questionNumber}-answer-element-${j}`}
                     src={answerItem.imageObject}
+                    alt={answerItem.imageObject.alt}
                   />
                 );
               }

--- a/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
+++ b/src/components/TeacherComponents/QuizQuestionsQuestionStem/QuizQuestionsQuestionStem.tsx
@@ -67,7 +67,10 @@ export const QuizQuestionsQuestionStem = ({
               $pv="spacing-24"
               key={`q-${displayNumber}-stem-element-${i}`}
             >
-              <QuizImage src={stemItem.imageObject} alt="An image in a quiz" />
+              <QuizImage
+                src={stemItem.imageObject}
+                alt={stemItem.imageObject.alt}
+              />
             </OakFlex>
           );
         }

--- a/src/node-lib/curriculum-api-2023/fixtures/quizElements.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/quizElements.fixture.ts
@@ -16,6 +16,7 @@ export const imageObject: StemImageObject["imageObject"] = {
   width: 1280,
   height: 852,
   metadata: { attribution: "test attribution picture" },
+  alt: undefined,
   publicId: "Trees",
   version: 1687374653,
 };

--- a/src/node-lib/curriculum-api-2023/shared.schema.test.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+import { lessonOverviewQuizQuestionSchema } from "./shared.schema";
+
+const secureUrl =
+  "https://oaknationalacademy-res.cloudinary.com/image/upload/v1687374653/Trees.jpg";
+
+const parseImageStem = (imageObject: Record<string, unknown>) => {
+  const question = lessonOverviewQuizQuestionSchema.parse({
+    questionId: 1,
+    questionUid: "QUES-TEST-00001",
+    questionType: "multiple-choice",
+    questionStem: [{ type: "image", imageObject }],
+    feedback: "",
+    hint: "",
+    active: false,
+  });
+
+  const stem = question.questionStem[0];
+
+  if (!stem || stem.type !== "image") {
+    throw new Error("Expected an image stem");
+  }
+
+  return stem.imageObject.alt;
+};
+
+describe("stem image alt", () => {
+  it("Defaults to the Cloudinary context alt", () => {
+    expect(
+      parseImageStem({
+        secureUrl,
+        context: { custom: { alt: "Context alt" } },
+        metadata: { assetDescription: "Metadata alt" },
+        displayName: "Display name",
+      }),
+    ).toBe("Context alt");
+  });
+
+  it("falls back to the metadata asset description", () => {
+    expect(
+      parseImageStem({
+        secureUrl,
+        metadata: { assetDescription: "Metadata alt" },
+        displayName: "Display name",
+      }),
+    ).toBe("Metadata alt");
+  });
+
+  it("falls back to the display name", () => {
+    expect(
+      parseImageStem({
+        secureUrl,
+        metadata: [],
+        displayName: "Display name",
+      }),
+    ).toBe("Display name");
+  });
+
+  it("is undefined when no source is available", () => {
+    expect(parseImageStem({ secureUrl, metadata: [] })).toBeUndefined();
+  });
+});

--- a/src/node-lib/curriculum-api-2023/shared.schema.ts
+++ b/src/node-lib/curriculum-api-2023/shared.schema.ts
@@ -68,25 +68,51 @@ export const isStemTextObject = (
   return obj.type === "text";
 };
 
-const stemImageObjectSchema = z.object({
-  imageObject: z.object({
-    format: z.enum(["png", "jpg", "jpeg", "webp", "gif", "svg"]).optional(),
-    secureUrl: z.url(),
-    url: z.url().optional(),
-    height: z.number().optional(),
-    width: z.number().optional(),
-    metadata: z.union([
-      z.array(z.any()),
-      z.object({
-        attribution: z.string().optional(),
-        usageRestriction: z.string().optional(),
-      }),
-    ]),
-    publicId: z.string().optional(),
-    version: z.number().optional(),
-  }),
-  type: z.literal("image"),
-});
+const stemImageObjectSchema = z
+  .object({
+    imageObject: z.object({
+      format: z.enum(["png", "jpg", "jpeg", "webp", "gif", "svg"]).optional(),
+      secureUrl: z.url(),
+      url: z.url().optional(),
+      height: z.number().optional(),
+      width: z.number().optional(),
+      metadata: z.union([
+        z.array(z.any()),
+        z.object({
+          attribution: z.string().optional(),
+          usageRestriction: z.string().optional(),
+          assetDescription: z.string().optional(),
+        }),
+      ]),
+      context: z
+        .object({
+          custom: z
+            .object({
+              alt: z.string().optional(),
+            })
+            .optional(),
+        })
+        .optional(),
+
+      displayName: z.string().optional(),
+      publicId: z.string().optional(),
+      version: z.number().optional(),
+    }),
+    type: z.literal("image"),
+  })
+  // Cloudinary does not return a top-level `alt`, so derive one for consumers.
+  .transform(({ imageObject, ...rest }) => ({
+    ...rest,
+    imageObject: {
+      ...imageObject,
+      alt:
+        imageObject.context?.custom?.alt ??
+        (Array.isArray(imageObject.metadata)
+          ? undefined
+          : imageObject.metadata.assetDescription) ??
+        imageObject.displayName,
+    },
+  }));
 
 export type StemImageObject = z.infer<typeof stemImageObjectSchema>;
 


### PR DESCRIPTION
## Description

Music year: 1951

⚠️ Because of the output of the query being cached we need to wait up to 2 hours for this deploy to actually render the alt text. 😞 

- Evaluates the image alt text in the `teachersLessonOverview` query, using the cloudinary context alt as a default, and falling back to `asset_description` and `display_name` when not present
- Renders the alt text on the image element
- Does not affect the equivalent pupil page

## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/path/to/page
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
