### PR TITLE
Changes to font sizes for `<OaksImpactStats/>`

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -667,7 +667,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
             </div>
           </div>
           <div
-            class="sc-aXZVg sc-gEvEer joTwcV iDBIXi"
+            class="sc-aXZVg sc-gEvEer girWOx iDBIXi"
           >
             <div
               class="sc-aXZVg bZTQLO"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -682,7 +682,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
                   >
                     <h2
-                      class="sc-eldPxv epUAyb"
+                      class="sc-eldPxv cIrFKd"
                     >
                       Oaks Impact stats heading
                     </h2>

--- a/src/components/GenericPagesComponents/OaksImpactStats/__snapshots__/OaksImpactStats.test.tsx.snap
+++ b/src/components/GenericPagesComponents/OaksImpactStats/__snapshots__/OaksImpactStats.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`OaksImpactStats renders correctly 1`] = `
               class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
             >
               <h2
-                class="sc-eldPxv epUAyb"
+                class="sc-eldPxv cIrFKd"
               >
                 Oak is now used in 72% of schools
               </h2>
@@ -103,7 +103,7 @@ exports[`OaksImpactStats renders correctly 1`] = `
                   class="sc-aXZVg sc-gEvEer kBnJtM cQXbIi"
                 >
                   <div
-                    class="sc-aXZVg gFNIew"
+                    class="sc-aXZVg gndKVA"
                   >
                     200,000
                   </div>
@@ -145,7 +145,7 @@ exports[`OaksImpactStats renders correctly 1`] = `
                   class="sc-aXZVg sc-gEvEer kBnJtM cQXbIi"
                 >
                   <div
-                    class="sc-aXZVg gFNIew"
+                    class="sc-aXZVg gndKVA"
                   >
                     85%
                   </div>
@@ -187,7 +187,7 @@ exports[`OaksImpactStats renders correctly 1`] = `
                   class="sc-aXZVg sc-gEvEer kBnJtM cQXbIi"
                 >
                   <div
-                    class="sc-aXZVg gFNIew"
+                    class="sc-aXZVg gndKVA"
                   >
                     92%
                   </div>

--- a/src/components/GenericPagesComponents/OaksImpactStats/__snapshots__/OaksImpactStats.test.tsx.snap
+++ b/src/components/GenericPagesComponents/OaksImpactStats/__snapshots__/OaksImpactStats.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OaksImpactStats renders correctly 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg sc-gEvEer joTwcV iDBIXi"
+      class="sc-aXZVg sc-gEvEer girWOx iDBIXi"
     >
       <div
         class="sc-aXZVg bZTQLO"

--- a/src/components/GenericPagesComponents/OaksImpactStats/index.tsx
+++ b/src/components/GenericPagesComponents/OaksImpactStats/index.tsx
@@ -35,7 +35,7 @@ export function OaksImpactStats(props: Readonly<OaksImpactStatsProps>) {
               <OakHeading
                 tag={"h2"}
                 $color={"text-primary"}
-                $font={"heading-3"}
+                $font={["heading-5", "heading-3", "heading-3"]}
               >
                 {props.textBlock.title}
               </OakHeading>
@@ -101,7 +101,11 @@ export function OaksImpactStats(props: Readonly<OaksImpactStatsProps>) {
                       >
                         <OakBox
                           $color={"text-primary"}
-                          $font={"heading-light-1"}
+                          $font={[
+                            "heading-light-3",
+                            "heading-light-3",
+                            "heading-light-1",
+                          ]}
                         >
                           {item.heading}
                         </OakBox>

--- a/src/components/GenericPagesComponents/OaksImpactStats/index.tsx
+++ b/src/components/GenericPagesComponents/OaksImpactStats/index.tsx
@@ -20,7 +20,10 @@ export type OaksImpactStatsProps = z.infer<
 >;
 export function OaksImpactStats(props: Readonly<OaksImpactStatsProps>) {
   return (
-    <OakFlex $background={"bg-decorative2-main"} $pv={"spacing-80"}>
+    <OakFlex
+      $background={"bg-decorative2-main"}
+      $pv={["spacing-56", "spacing-80", "spacing-80"]}
+    >
       <NewGutterMaxWidth>
         <OakFlex
           $flexDirection={["column", "row", "row"]}


### PR DESCRIPTION
## Description
Changes to font sizes for `<OaksImpactStats/>`

## Issue(s)
Fixes `ADOPT-2212`

## How to test

1. Go to https://oak-web-application-website-git-feat-adopt-2212-oak-impa-208ed2.vercel.thenational.academy/about-us/oaks-impact
2. Check impact sections no longer overflows on any viewport size

## Screenshots
No longer overflows

<img width="741" height="742" alt="Screenshot 2026-08-11 at 16 51 36" src="https://github.com/user-attachments/assets/bd828a72-e622-4520-b7bd-ee82073a9178" />

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
