### PR TITLE
Correct case for subject/phase in inline banner for implementation guides

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/ImplementationGuideCallout.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/ImplementationGuideCallout.test.tsx
@@ -5,38 +5,56 @@ import { ImplementationGuideCallout } from "./index";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 
 describe("ImplementationGuideCallout", () => {
-  test("renders the component with the correct message and link", () => {
+  test("renders maths with the correct message and link", () => {
     // Render the component with test props
     const { getByText } = renderWithProviders()(
       <ImplementationGuideCallout
         subject="maths"
-        phase="ks3"
+        phase="ks1"
         subjectTitle="Maths"
-        phaseTitle="Key Stage 3"
+        phaseTitle="Primary"
       />,
     );
 
     // Check if the message is rendered correctly
     const message = getByText(
-      /Leading your school's use of Oak's maths key stage 3 curriculum\? Download our implementation toolkit\./i,
+      "Leading your school's use of Oak's maths primary curriculum? Download our implementation toolkit.",
     );
     expect(message).toBeInTheDocument();
   });
 
-  test("renders the component with uppercase for language subjects", () => {
+  test("renders English with the correct message and link", () => {
     // Render the component with test props
     const { getByText } = renderWithProviders()(
       <ImplementationGuideCallout
         subject="english"
         phase="ks3"
         subjectTitle="English"
-        phaseTitle="Key Stage 3"
+        phaseTitle="Secondary"
       />,
     );
 
     // Check if the message is rendered correctly
     const message = getByText(
-      /Leading your school's use of Oak's English key stage 3 curriculum\? Download our implementation toolkit\./i,
+      "Leading your school's use of Oak's English secondary curriculum? Download our implementation toolkit.",
+    );
+    expect(message).toBeInTheDocument();
+  });
+
+  test("renders rshe-pshe with the correct message and link", () => {
+    // Render the component with test props
+    const { getByText } = renderWithProviders()(
+      <ImplementationGuideCallout
+        subject="rshe-pshe"
+        phase="ks2"
+        subjectTitle="RSHE (PSHE)"
+        phaseTitle="Primary"
+      />,
+    );
+
+    // Check if the message is rendered correctly
+    const message = getByText(
+      "Leading your school's use of Oak's RSHE (PSHE) primary curriculum? Download our implementation toolkit.",
     );
     expect(message).toBeInTheDocument();
   });

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/ImplementationGuideCallout.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/ImplementationGuideCallout.test.tsx
@@ -1,0 +1,43 @@
+import "@testing-library/jest-dom";
+
+import { ImplementationGuideCallout } from "./index";
+
+import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
+
+describe("ImplementationGuideCallout", () => {
+  test("renders the component with the correct message and link", () => {
+    // Render the component with test props
+    const { getByText } = renderWithProviders()(
+      <ImplementationGuideCallout
+        subject="maths"
+        phase="ks3"
+        subjectTitle="Maths"
+        phaseTitle="Key Stage 3"
+      />,
+    );
+
+    // Check if the message is rendered correctly
+    const message = getByText(
+      /Leading your school's use of Oak's maths key stage 3 curriculum\? Download our implementation toolkit\./i,
+    );
+    expect(message).toBeInTheDocument();
+  });
+
+  test("renders the component with uppercase for language subjects", () => {
+    // Render the component with test props
+    const { getByText } = renderWithProviders()(
+      <ImplementationGuideCallout
+        subject="english"
+        phase="ks3"
+        subjectTitle="English"
+        phaseTitle="Key Stage 3"
+      />,
+    );
+
+    // Check if the message is rendered correctly
+    const message = getByText(
+      /Leading your school's use of Oak's English key stage 3 curriculum\? Download our implementation toolkit\./i,
+    );
+    expect(message).toBeInTheDocument();
+  });
+});

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/index.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ImplementationGuideCallout/index.tsx
@@ -6,6 +6,7 @@ import {
   OakBox,
 } from "@oaknational/oak-components";
 
+import { subjectTitleWithCase } from "@/utils/curriculum/formatting";
 import { resolveOakHref } from "@/common-lib/urls";
 
 type ImplementationGuideCalloutProps = {
@@ -33,7 +34,7 @@ export function ImplementationGuideCallout({
           isOpen
           type="info"
           variant="regular"
-          message={`Leading your school's use of Oak's ${subjectTitle} ${phaseTitle} curriculum? Download our implementation toolkit.`}
+          message={`Leading your school's use of Oak's ${subjectTitleWithCase(subjectTitle)} ${phaseTitle.toLowerCase()} curriculum? Download our implementation toolkit.`}
           cta={
             <OakBox $whiteSpace="nowrap">
               <OakLink


### PR DESCRIPTION
## Description
Correct case for subject/phase in inline banner for implementation guides

## Issue(s)
Fixes `ADOPT-2221`

## How to test
With the `implementation-guide` feature flag enabled

1. Go to https://oak-web-application-website-git-feat-adopt-2221subject-p-477169.vercel.thenational.academy/
2. Go to a subject/phase
3. Check that it's titlecase only for languages not other subjects (see ticket)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
