### PR TITLE
Fix type issues with oak-components

### DIFF
--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -646,7 +646,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         class="sc-aXZVg dLPTTd"
                       >
                         <div
-                          class="sc-aXZVg sc-gEvEer laLcvy jMLdOa"
+                          class="sc-aXZVg sc-gEvEer kqqNVp jMLdOa"
                           data-percy-hide="contents"
                           style="box-sizing: content-box;"
                         />

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -808,7 +808,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                           class="sc-aXZVg dLPTTd"
                         >
                           <div
-                            class="sc-aXZVg sc-gEvEer laLcvy jMLdOa"
+                            class="sc-aXZVg sc-gEvEer kqqNVp jMLdOa"
                             data-percy-hide="contents"
                             style="box-sizing: content-box;"
                           />

--- a/src/components/GenericPagesComponents/OaksImpactCaseStudies/__snapshots__/OaksImpactCaseStudies.test.tsx.snap
+++ b/src/components/GenericPagesComponents/OaksImpactCaseStudies/__snapshots__/OaksImpactCaseStudies.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
             class="sc-aXZVg sc-tagGq bMQSvq jFIZYB"
           >
             <li
-              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi dJOgIA"
+              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi fjdsDR"
             >
               <div
                 class="sc-aXZVg sc-fTFjTM gQdNNR fPhXjy"
@@ -266,7 +266,7 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
               </div>
             </li>
             <li
-              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi dJOgIA"
+              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi fjdsDR"
             >
               <div
                 class="sc-aXZVg sc-fTFjTM gQdNNR fPhXjy"
@@ -333,7 +333,7 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
               </div>
             </li>
             <li
-              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi dJOgIA"
+              class="sc-aXZVg sc-gEvEer sc-esYiGF jPvJsJ iDBIXi fjdsDR"
             >
               <div
                 class="sc-aXZVg sc-fTFjTM gQdNNR fPhXjy"

--- a/src/components/GenericPagesComponents/OaksImpactCaseStudies/index.tsx
+++ b/src/components/GenericPagesComponents/OaksImpactCaseStudies/index.tsx
@@ -54,7 +54,7 @@ export const OaksImpactCaseStudies = ({
                 $colStart={
                   caseStudies.length === 2
                     ? [1, index === 0 ? 3 : 7]
-                    : [1, undefined]
+                    : [1, null]
                 }
               >
                 <OakCard

--- a/src/components/GenericPagesComponents/OaksImpactHeader/__snapshots__/OaksImpactHeader.test.tsx.snap
+++ b/src/components/GenericPagesComponents/OaksImpactHeader/__snapshots__/OaksImpactHeader.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`OaksImpactHeader renders correctly 1`] = `
                   class="sc-aXZVg dLPTTd"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer laLcvy jMLdOa"
+                    class="sc-aXZVg sc-gEvEer kqqNVp jMLdOa"
                     data-percy-hide="contents"
                     style="box-sizing: content-box;"
                   />

--- a/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/SharedComponents/VideoPlayer/VideoPlayer.tsx
@@ -120,7 +120,7 @@ function VideoContainer({
       data-percy-hide="contents"
       $alignItems={"center"}
       $justifyContent={"center"}
-      $ba={omitBorder ? "border-none" : "border-solid-l"}
+      $ba={omitBorder ? "border-solid-none" : "border-solid-l"}
       $minWidth={"100%"}
       $borderColor={"border-primary"}
       style={{

--- a/src/pages/about-us/case-studies/[slug].tsx
+++ b/src/pages/about-us/case-studies/[slug].tsx
@@ -57,11 +57,7 @@ const AboutUsOaksImpactCaseStudy: NextPage<
       topNavProps={topNav}
     >
       <OakBox $zIndex={"neutral"} $color={"text-primary"}>
-        <OakBox
-          $gap="spacing-32"
-          $bb="border-solid-xxxl"
-          $borderColor="border-decorative2"
-        >
+        <OakBox $bb="border-solid-xxxl" $borderColor="border-decorative2">
           <NewGutterMaxWidth>
             <OakBox $mt="spacing-40" $mb="spacing-56">
               <OakGrid $cg="spacing-16">


### PR DESCRIPTION
## Description
This will start throwing errors once https://github.com/oaknational/oak-components/pull/767 merges, so we want to fixes these prior

## Issue(s)
None

## How to test

1. Go to https://oak-web-application-website-git-fix-oak-components-type-issues.vercel.thenational.academy/about-us/oaks-impact
2. Regression test oaks impact pages for
   - Video border looks correct
   - Oaks case studies layout correctly on all viewport sizes
   - Borders are correct below header on `/about-us/case-studies/[slug]`


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
