### PR TITLE
Feat/adopt 2175/remove oaks impact flag

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.test.tsx.snap
@@ -2951,6 +2951,20 @@ exports[`Teachers Page Page component renders 1`] = `
                         >
                           <a
                             class="sc-fHjqPf cTauop sc-iHmpnF"
+                            href="/about-us/oaks-impact"
+                          >
+                            <span
+                              class="sc-eqUAAy iGfTGj"
+                            >
+                              Oak's impact
+                            </span>
+                          </a>
+                        </li>
+                        <li
+                          class="sc-fPXMVe jFJaNg"
+                        >
+                          <a
+                            class="sc-fHjqPf cTauop sc-iHmpnF"
                             href="/about-us/get-involved"
                           >
                             <span
@@ -3410,7 +3424,7 @@ exports[`Teachers Page Page component renders 1`] = `
                 </div>
               </div>
               <span
-                class="sc-aXZVg kvjdhA sc-98540f6b-0 qLtgo"
+                class="sc-aXZVg kvjdhA sc-301d1c44-0 bUETwi"
                 data-percy-hide="contents"
               >
                 <img

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -5453,6 +5453,59 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         class="c118 c119"
                       >
                         <a
+                          href="/about-us/oaks-impact"
+                          style="outline: none;"
+                        >
+                          <div
+                            class="c120 c121 c122"
+                            data-testid="who-we-are-explore-item"
+                          >
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c123"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763393164/icons/data-illustration_ukwdxg.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                            <div
+                              class="c124 c125"
+                            >
+                              Oak's impact
+                            </div>
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c77"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        class="c118 c119"
+                      >
+                        <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
@@ -6381,6 +6434,20 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             class="c25"
                           >
                             Oak's curricula
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c177"
+                      >
+                        <a
+                          class="c178 "
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="c25"
+                          >
+                            Oak's impact
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -5227,6 +5227,59 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         class="c115 c116"
                       >
                         <a
+                          href="/about-us/oaks-impact"
+                          style="outline: none;"
+                        >
+                          <div
+                            class="c117 c118 c119"
+                            data-testid="who-we-are-explore-item"
+                          >
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c120"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763393164/icons/data-illustration_ukwdxg.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                            <div
+                              class="c121 c122"
+                            >
+                              Oak's impact
+                            </div>
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c123"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        class="c115 c116"
+                      >
+                        <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
@@ -6155,6 +6208,20 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             class="c25"
                           >
                             Oak's curricula
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c175"
+                      >
+                        <a
+                          class="c176 "
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="c25"
+                          >
+                            Oak's impact
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -6113,6 +6113,59 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         class="c161 c162"
                       >
                         <a
+                          href="/about-us/oaks-impact"
+                          style="outline: none;"
+                        >
+                          <div
+                            class="c163 c164 c165"
+                            data-testid="who-we-are-explore-item"
+                          >
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c166"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763393164/icons/data-illustration_ukwdxg.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                            <div
+                              class="c167 c152"
+                            >
+                              Oak's impact
+                            </div>
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c168"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        class="c161 c162"
+                      >
+                        <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
@@ -7041,6 +7094,20 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             class="c25"
                           >
                             Oak's curricula
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c219"
+                      >
+                        <a
+                          class="c220 "
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="c25"
+                          >
+                            Oak's impact
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabled 1`] = `
+exports[`pages/about-us/oaks-impact.tsx renders title 1`] = `
 <div>
   <div
     data-overlay-container="true"
@@ -993,6 +993,59 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         class="sc-aXZVg sc-fTFjTM kBnJtM fvbgvK"
                       >
                         <a
+                          href="/about-us/oaks-impact"
+                          style="outline: none;"
+                        >
+                          <div
+                            class="sc-aXZVg sc-gEvEer sc-55af3af8-0 jtqxcT egjftS iWbjPe"
+                            data-testid="who-we-are-explore-item"
+                          >
+                            <div
+                              class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                            >
+                              <span
+                                class="sc-aXZVg fRjhP"
+                              >
+                                <img
+                                  alt=""
+                                  class="sc-iGgWBj cMzyFO"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763393164/icons/data-illustration_ukwdxg.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                            <div
+                              class="sc-aXZVg sc-gEvEer gFyjML fXHtRp"
+                            >
+                              Oak's impact
+                            </div>
+                            <div
+                              class="sc-aXZVg sc-gEvEer jPvJsJ iDBIXi"
+                            >
+                              <span
+                                class="sc-aXZVg fjkwRj"
+                              >
+                                <img
+                                  alt=""
+                                  class="sc-iGgWBj cMzyFO"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        class="sc-aXZVg sc-fTFjTM kBnJtM fvbgvK"
+                      >
+                        <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
@@ -1109,7 +1162,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
               class="sc-aXZVg bZTQLO"
             >
               <div
-                class="sc-aXZVg sc-gEvEer sc-ecfb8a2e-0 jPvJsJ iDBIXi eLBueB"
+                class="sc-aXZVg sc-gEvEer sc-8dbb083c-0 jPvJsJ iDBIXi jYaFZx"
               >
                 <div
                   class="sc-aXZVg sc-gEvEer sc-d650a570-0 ePSBwI fUxOFh"
@@ -1929,6 +1982,20 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                       >
                         <a
                           class="sc-fHjqPf cTauop sc-iHmpnF"
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="sc-eqUAAy iGfTGj"
+                          >
+                            Oak's impact
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="sc-fPXMVe jFJaNg"
+                      >
+                        <a
+                          class="sc-fHjqPf cTauop sc-iHmpnF"
                           href="/about-us/get-involved"
                         >
                           <span
@@ -2388,7 +2455,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
               </div>
             </div>
             <span
-              class="sc-aXZVg kvjdhA sc-98540f6b-0 qLtgo"
+              class="sc-aXZVg kvjdhA sc-301d1c44-0 bUETwi"
               data-percy-hide="contents"
             >
               <img

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -5259,6 +5259,59 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         class="c126 c127"
                       >
                         <a
+                          href="/about-us/oaks-impact"
+                          style="outline: none;"
+                        >
+                          <div
+                            class="c128 c129 c130"
+                            data-testid="who-we-are-explore-item"
+                          >
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c131"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1763393164/icons/data-illustration_ukwdxg.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                            <div
+                              class="c132 c81"
+                            >
+                              Oak's impact
+                            </div>
+                            <div
+                              class="c9 c46"
+                            >
+                              <span
+                                class="c133"
+                              >
+                                <img
+                                  alt=""
+                                  class="c21"
+                                  data-nimg="fill"
+                                  decoding="async"
+                                  loading="lazy"
+                                  src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1707149070/icons/fv0z57zerrioft52dd9n.svg"
+                                  style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                                />
+                              </span>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        class="c126 c127"
+                      >
+                        <a
                           href="/about-us/meet-the-team"
                           style="outline: none;"
                         >
@@ -6187,6 +6240,20 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             class="c25"
                           >
                             Oak's curricula
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c185"
+                      >
+                        <a
+                          class="c186 "
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="c25"
+                          >
+                            Oak's impact
                           </span>
                         </a>
                       </li>

--- a/src/__tests__/pages/about-us/get-involved.test.tsx
+++ b/src/__tests__/pages/about-us/get-involved.test.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/__tests__/__helpers__/cms";
 import CMSClient from "@/node-lib/cms";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 jest.mock("../../../node-lib/cms");
 jest.mock("@mux/mux-player-react/lazy", () => {
   return forwardRef((props, ref) => {
@@ -24,10 +23,6 @@ jest.mock("@mux/mux-player-react/lazy", () => {
     return <div data-testid="mux-player-mock" />;
   });
 });
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const testGetInvolvedPageData: GetInvolvedPageProps["pageData"] = {
   ...testAboutPageBaseData,
@@ -55,7 +50,6 @@ describe("pages/about/get-involved.tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     (CMSClient.getInvolvedPage as jest.Mock).mockResolvedValue(
       testGetInvolvedPageData,
     );

--- a/src/__tests__/pages/about-us/meet-the-team.test.tsx
+++ b/src/__tests__/pages/about-us/meet-the-team.test.tsx
@@ -13,13 +13,8 @@ import {
   portableTextFromString,
   mockImageAsset,
 } from "@/__tests__/__helpers__/cms";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 jest.mock("../../../node-lib/cms");
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const mockTeamMember = {
   id: "test-id",
@@ -62,7 +57,6 @@ const mockPageData: AboutUsMeetTheTeamPageProps["pageData"] = {
 describe("pages/about/meet-the-team.tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     (CMSClient.meetTheTeamPage as jest.Mock).mockResolvedValue(mockPageData);
   });
 

--- a/src/__tests__/pages/about-us/meet-the-team/[slug].test.tsx
+++ b/src/__tests__/pages/about-us/meet-the-team/[slug].test.tsx
@@ -11,13 +11,8 @@ import AboutUsMeetTheTeamPerson, {
 } from "@/pages/about-us/meet-the-team/[slug]";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import CMSClient from "@/node-lib/cms";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 jest.mock("../../../../node-lib/cms");
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const mockTeamMember: AboutUsMeetTheTeamPersonPageProps["pageData"] = {
   id: "test-id",
@@ -81,7 +76,6 @@ describe("pages/about/meet-the-team/[slug].tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     (CMSClient.teamMemberBySlug as jest.Mock).mockResolvedValue(mockTeamMember);
     (CMSClient.meetTheTeamPage as jest.Mock).mockResolvedValue(
       mockMeetTheTeamPage,

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -4019,6 +4019,20 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                       >
                         <a
                           class="c73 "
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="c25"
+                          >
+                            Oak's impact
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="c109"
+                      >
+                        <a
+                          class="c73 "
                           href="/about-us/get-involved"
                         >
                           <span

--- a/src/__tests__/pages/about-us/oaks-curricula.test.tsx
+++ b/src/__tests__/pages/about-us/oaks-curricula.test.tsx
@@ -13,13 +13,8 @@ import OaksCurricula, {
   getStaticProps,
 } from "@/pages/about-us/oaks-curricula";
 import CMSClient from "@/node-lib/cms";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 jest.mock("../../../node-lib/cms");
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const mockPageData: OaksCurriculaPageProps["pageData"] = {
   header: {
@@ -80,7 +75,6 @@ describe("pages/about/oaks-curricula.tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     (CMSClient.oaksCurriculaPage as jest.Mock).mockResolvedValue(mockPageData);
   });
 

--- a/src/__tests__/pages/about-us/oaks-impact.test.tsx
+++ b/src/__tests__/pages/about-us/oaks-impact.test.tsx
@@ -1,24 +1,10 @@
 import { screen } from "@testing-library/dom";
-import { GetServerSidePropsContext } from "next";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
-import OaksImpact, { getServerSideProps } from "@/pages/about-us/oaks-impact";
+import OaksImpact, { getStaticProps } from "@/pages/about-us/oaks-impact";
 import CMSClient from "@/node-lib/cms";
 import { OaksImpactPage } from "@/common-lib/cms-types/aboutPages";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
-
-const mockGetFeatureFlag = jest.fn();
-
-jest.mock("@/node-lib/posthog/getFeatureFlag", () => ({
-  __esModule: true,
-  getFeatureFlag: () => mockGetFeatureFlag(),
-}));
-
-jest.mock("@/node-lib/posthog/getPosthogId", () => ({
-  __esModule: true,
-  getPosthogIdFromCookie: jest.fn().mockReturnValue("test-id"),
-}));
 
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,
@@ -27,14 +13,9 @@ jest.mock("@/node-lib/curriculum-api-2023", () => ({
   },
 }));
 
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-
 jest.mock("../../../node-lib/cms");
 
 const mockCMSClient = CMSClient as jest.MockedObject<typeof CMSClient>;
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const mockPageData: OaksImpactPage = {
   header: {
@@ -71,14 +52,11 @@ const mockPageData: OaksImpactPage = {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.resetModules();
-  mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
   mockCMSClient.oaksImpactPage.mockResolvedValue(mockPageData);
 });
 
 describe("pages/about-us/oaks-impact.tsx", () => {
-  it("renders title when feature flag is enabled", async () => {
-    mockGetFeatureFlag.mockResolvedValue(true);
-
+  it("renders title", async () => {
     const { container } = renderWithProviders()(
       <OaksImpact pageData={mockPageData} topNav={topNavFixture} />,
     );
@@ -89,13 +67,9 @@ describe("pages/about-us/oaks-impact.tsx", () => {
     expect(container).toMatchSnapshot();
   });
 
-  describe("getServerSideProps", () => {
-    it("should return props data when feature flag is enabled", async () => {
-      mockGetFeatureFlag.mockResolvedValue(true);
-
-      const propsResult = await getServerSideProps({
-        req: { cookies: {} },
-      } as GetServerSidePropsContext);
+  describe("getStaticProps", () => {
+    it("should return props data", async () => {
+      const propsResult = await getStaticProps({});
 
       expect(propsResult).toMatchObject({
         props: {
@@ -104,24 +78,10 @@ describe("pages/about-us/oaks-impact.tsx", () => {
       });
     });
 
-    it("should return not found when feature flag is disabled", async () => {
-      mockGetFeatureFlag.mockResolvedValue(false);
-
-      const propsResult = await getServerSideProps({
-        req: { cookies: {} },
-      } as GetServerSidePropsContext);
-
-      expect(propsResult).toMatchObject({
-        notFound: true,
-      });
-    });
-
     it("should return notFound when CMS returns null", async () => {
       mockCMSClient.oaksImpactPage.mockResolvedValueOnce(null);
 
-      const propsResult = await getServerSideProps({
-        req: { cookies: {} },
-      } as GetServerSidePropsContext);
+      const propsResult = await getStaticProps({});
 
       expect(propsResult).toMatchObject({
         notFound: true,

--- a/src/__tests__/pages/about-us/oaks-impact/[slug].test.tsx
+++ b/src/__tests__/pages/about-us/oaks-impact/[slug].test.tsx
@@ -1,26 +1,18 @@
-import { GetServerSidePropsContext } from "next";
-
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import OaksImpact, {
-  getServerSideProps,
+  getStaticPaths,
+  getStaticProps,
 } from "@/pages/about-us/case-studies/[slug]";
 import CMSClient from "@/node-lib/cms";
-import { OaksImpactCaseStudyPage } from "@/common-lib/cms-types/aboutPages";
+import {
+  OaksImpactCaseStudyPage,
+  OaksImpactPage,
+} from "@/common-lib/cms-types/aboutPages";
 import { portableTextFromString } from "@/__tests__/__helpers__/cms";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
+import { getFallbackBlockingConfig } from "@/node-lib/isr";
 
-const mockGetFeatureFlag = jest.fn();
-
-jest.mock("@/node-lib/posthog/getFeatureFlag", () => ({
-  __esModule: true,
-  getFeatureFlag: () => mockGetFeatureFlag(),
-}));
-
-jest.mock("@/node-lib/posthog/getPosthogId", () => ({
-  __esModule: true,
-  getPosthogIdFromCookie: jest.fn().mockReturnValue("test-id"),
-}));
+let mockShouldSkipInitialBuild = false;
 
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
   __esModule: true,
@@ -29,14 +21,18 @@ jest.mock("@/node-lib/curriculum-api-2023", () => ({
   },
 }));
 
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
+jest.mock("@/node-lib/isr", () => ({
+  ...jest.requireActual("@/node-lib/isr"),
+  get shouldSkipInitialBuild() {
+    return mockShouldSkipInitialBuild;
+  },
+  getFallbackBlockingConfig: jest.fn(),
 }));
 
 jest.mock("@/node-lib/cms");
 
 const mockCMSClient = CMSClient as jest.MockedObject<typeof CMSClient>;
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
+const mockGetFallbackBlockingConfig = jest.mocked(getFallbackBlockingConfig);
 
 function caseStudyFixture(slug: string) {
   return {
@@ -76,17 +72,50 @@ const mockPageData: OaksImpactCaseStudyPage = {
   },
 };
 
+const mockImpactPageData: OaksImpactPage = {
+  header: {
+    introText: "Oaks Impact intro",
+    video: {
+      title: "Oaks Impact video",
+      video: {
+        asset: {
+          assetId: "123",
+          playbackId: "123",
+          thumbTime: null,
+        },
+      },
+      captions: ["Oaks Impact captions"],
+    },
+    videoDescription: "Oaks Impact video description",
+  },
+  statsSection: {
+    textBlock: {
+      title: "Oaks Impact stats heading",
+      bodyPortableText: [],
+    },
+    stats: [],
+  },
+  caseStudiesSection: mockPageData.caseStudiesSection,
+  schoolQuotes: {
+    heading: "Oaks Impact school quotes heading",
+    cards: [],
+  },
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.resetModules();
-  mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
+  mockShouldSkipInitialBuild = false;
+  mockGetFallbackBlockingConfig.mockReturnValue({
+    fallback: "blocking",
+    paths: [],
+  });
   mockCMSClient.oaksImpactCaseStudyPage.mockResolvedValue(mockPageData);
+  mockCMSClient.oaksImpactPage.mockResolvedValue(mockImpactPageData);
 });
 
 describe("pages/about-us/oaks-impact/case-studies/[slug].tsx", () => {
-  it("renders title when feature flag is enabled", async () => {
-    mockGetFeatureFlag.mockResolvedValue(true);
-
+  it("renders title", async () => {
     const { container } = renderWithProviders()(
       <OaksImpact
         pageData={{
@@ -101,14 +130,11 @@ describe("pages/about-us/oaks-impact/case-studies/[slug].tsx", () => {
     expect(container).toMatchSnapshot();
   });
 
-  describe("getServerSideProps", () => {
-    it("should return props data when feature flag is enabled", async () => {
-      mockGetFeatureFlag.mockResolvedValue(true);
-
-      const propsResult = await getServerSideProps({
+  describe("getStaticProps", () => {
+    it("returns props data", async () => {
+      const propsResult = await getStaticProps({
         params: { slug: "test-slug-1" },
-        req: { cookies: {} },
-      } as unknown as GetServerSidePropsContext<{ slug: string }>);
+      });
 
       expect(propsResult).toMatchObject({
         props: {
@@ -117,28 +143,50 @@ describe("pages/about-us/oaks-impact/case-studies/[slug].tsx", () => {
       });
     });
 
-    it("should return not found when feature flag is disabled", async () => {
-      mockGetFeatureFlag.mockResolvedValue(false);
-
-      const propsResult = await getServerSideProps({
-        params: { slug: "test-slug-1" },
-        req: { cookies: {} },
-      } as unknown as GetServerSidePropsContext<{ slug: string }>);
+    it("returns notFound when the slug is missing", async () => {
+      const propsResult = await getStaticProps({});
 
       expect(propsResult).toMatchObject({
         notFound: true,
       });
     });
 
-    it("should return notFound when CMS returns null", async () => {
-      mockCMSClient.oaksImpactPage.mockResolvedValueOnce(null);
+    it("returns notFound when CMS returns null", async () => {
+      mockCMSClient.oaksImpactCaseStudyPage.mockResolvedValueOnce(null);
 
-      const propsResult = await getServerSideProps({
-        req: { cookies: {} },
-      } as unknown as GetServerSidePropsContext<{ slug: string }>);
+      const propsResult = await getStaticProps({
+        params: { slug: "test-slug-1" },
+      });
 
       expect(propsResult).toMatchObject({
         notFound: true,
+      });
+    });
+  });
+
+  describe("getStaticPaths", () => {
+    it("returns the paths of all case studies", async () => {
+      const pathsResult = await getStaticPaths();
+
+      expect(pathsResult).toEqual({
+        fallback: "blocking",
+        paths: [
+          { params: { slug: "test-slug-1" } },
+          { params: { slug: "test-slug-2" } },
+          { params: { slug: "test-slug-3" } },
+        ],
+      });
+    });
+
+    it("returns the fallback blocking config when initial build is skipped", async () => {
+      mockShouldSkipInitialBuild = true;
+
+      const pathsResult = await getStaticPaths();
+
+      expect(mockGetFallbackBlockingConfig).toHaveBeenCalled();
+      expect(pathsResult).toEqual({
+        fallback: "blocking",
+        paths: [],
       });
     });
   });

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when feature flag is enabled 1`] = `
+exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title 1`] = `
 <div>
   <div
     data-overlay-container="true"
@@ -1223,6 +1223,20 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                       >
                         <a
                           class="sc-fHjqPf cTauop sc-iHmpnF"
+                          href="/about-us/oaks-impact"
+                        >
+                          <span
+                            class="sc-eqUAAy iGfTGj"
+                          >
+                            Oak's impact
+                          </span>
+                        </a>
+                      </li>
+                      <li
+                        class="sc-fPXMVe jFJaNg"
+                      >
+                        <a
+                          class="sc-fHjqPf cTauop sc-iHmpnF"
                           href="/about-us/get-involved"
                         >
                           <span
@@ -1682,7 +1696,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
               </div>
             </div>
             <span
-              class="sc-aXZVg kvjdhA sc-98540f6b-0 qLtgo"
+              class="sc-aXZVg kvjdhA sc-301d1c44-0 bUETwi"
               data-percy-hide="contents"
             >
               <img

--- a/src/__tests__/pages/about-us/who-we-are.test.tsx
+++ b/src/__tests__/pages/about-us/who-we-are.test.tsx
@@ -14,12 +14,8 @@ import {
   portableTextFromString,
   mockImageAsset,
 } from "@/__tests__/__helpers__/cms";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 jest.mock("../../../node-lib/cms");
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
 jest.mock("@mux/mux-player-react/lazy", () => {
   return forwardRef((props, ref) => {
     ref; // This prevents warning about ref not being used
@@ -28,7 +24,6 @@ jest.mock("@mux/mux-player-react/lazy", () => {
 });
 
 const mockCMSClient = CMSClient as jest.MockedObject<typeof CMSClient>;
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 const mockPageData: WhoWeArePage = {
   header2: {
@@ -70,7 +65,6 @@ describe("pages/about/who-we-are.tsx", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     mockCMSClient.whoWeArePage.mockResolvedValue(mockPageData);
   });
 

--- a/src/__tests__/pages/index.test.tsx
+++ b/src/__tests__/pages/index.test.tsx
@@ -4,14 +4,8 @@ import { SerializedPost } from "@/pages-helpers/home/getBlogPosts";
 import { BlogPostPreview, WebinarPreview } from "@/common-lib/cms-types";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import curriculumPhaseOptions from "@/browser-lib/fixtures/curriculumPhaseOptions";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
-
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
 
 const render = renderWithProviders();
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 
 export const mockPosts = [
   {
@@ -69,7 +63,6 @@ jest.mock("@/node-lib/cms", () => ({
 describe("Teachers Page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
   });
 
   describe("Page component", () => {
@@ -107,7 +100,6 @@ describe("Teachers Page", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       jest.resetModules();
-      mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
     });
 
     it("Should return no more than 4 posts", async () => {

--- a/src/app/(core)/__snapshots__/layout.test.tsx.snap
+++ b/src/app/(core)/__snapshots__/layout.test.tsx.snap
@@ -84,6 +84,11 @@ exports[`core layout renders correctly 1`] = `
               "title": "Oak's curricula",
             },
             {
+              "href": "/about-us/oaks-impact",
+              "slug": "about-oaks-impact",
+              "title": "Oak's impact",
+            },
+            {
               "href": "/about-us/get-involved",
               "slug": "about-get-involved",
               "title": "Get involved",

--- a/src/app/(core)/layout.test.tsx
+++ b/src/app/(core)/layout.test.tsx
@@ -8,7 +8,6 @@ import CoreLayout from "./layout";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import OakError from "@/errors/OakError";
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 const mockTopNav = jest.fn().mockResolvedValue(topNavFixture);
 jest.mock("@/node-lib/curriculum-api-2023", () => ({
@@ -16,10 +15,6 @@ jest.mock("@/node-lib/curriculum-api-2023", () => ({
   default: {
     topNav: () => mockTopNav(),
   },
-}));
-
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
 }));
 
 // Unmock the mock created in jest setup to get access to the notFound function
@@ -31,13 +26,11 @@ jest.mock("next/headers", () => ({
   }),
 }));
 
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
 const render = renderWithProviders();
 
 describe("core layout", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
   });
 
   it("renders correctly", async () => {

--- a/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
+++ b/src/components/AppComponents/LayoutSiteFooter/LayoutSiteFooter.tsx
@@ -27,7 +27,6 @@ import SocialButtons from "@/components/SharedComponents/SocialButtons";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 import { toSentenceCase } from "@/node-lib/curriculum-api-2023/helpers";
 import { buildAboutUsAnalytics } from "@/utils/analytics-builders";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 import { getCloudinaryImageUrl } from "@/utils/getCloudinaryImageUrl";
 import { resolveOakHref } from "@/common-lib/urls";
 
@@ -90,16 +89,12 @@ const footerSections: FooterSections = {
         href: resolveOakHref({ page: "about-oaks-curricula" }),
         track: trackAboutUsFooter,
       },
-      ...(isFeatureFlagEnabledStatic("oaks-impact")
-        ? [
-            {
-              text: "Oak's impact",
-              type: "link" as const,
-              href: resolveOakHref({ page: "about-oaks-impact" }),
-              track: trackAboutUsFooter,
-            },
-          ]
-        : []),
+      {
+        text: "Oak's impact",
+        type: "link" as const,
+        href: resolveOakHref({ page: "about-oaks-impact" }),
+        track: trackAboutUsFooter,
+      },
       {
         text: "Get involved",
         type: "link",

--- a/src/components/GenericPagesComponents/AboutUsLayout/AboutUsLayout.test.tsx
+++ b/src/components/GenericPagesComponents/AboutUsLayout/AboutUsLayout.test.tsx
@@ -33,7 +33,6 @@ describe("AboutUsLayout", () => {
       isReady: true,
       isPreview: false,
     } as never);
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "false";
   });
 
   it("renders children correctly", () => {
@@ -71,6 +70,7 @@ describe("AboutUsLayout", () => {
 
     expect(getByText("About Oak")).toBeInTheDocument();
     expect(getByText("Oak's curricula")).toBeInTheDocument();
+    expect(getByText("Oak's impact")).toBeInTheDocument();
     expect(getByText("Meet the team")).toBeInTheDocument();
     expect(getByText("Get involved")).toBeInTheDocument();
   });
@@ -93,6 +93,7 @@ describe("AboutUsLayout", () => {
 
     // Should still render other links
     expect(getByText("Oak's curricula")).toBeInTheDocument();
+    expect(getByText("Oak's impact")).toBeInTheDocument();
     expect(getByText("Meet the team")).toBeInTheDocument();
     expect(getByText("Get involved")).toBeInTheDocument();
   });
@@ -116,6 +117,7 @@ describe("AboutUsLayout", () => {
     // Should still render other links
     expect(getByText("About Oak")).toBeInTheDocument();
     expect(getByText("Oak's curricula")).toBeInTheDocument();
+    expect(getByText("Oak's impact")).toBeInTheDocument();
     expect(getByText("Meet the team")).toBeInTheDocument();
   });
 
@@ -131,7 +133,7 @@ describe("AboutUsLayout", () => {
     expect(form).toBeInTheDocument();
   });
 
-  it("only shows 3 links when current page matches one of the explore items", () => {
+  it("only shows 4 links when current page matches one of the explore items", () => {
     mockUseRouter.mockReturnValue({
       pathname: "/about-us/who-we-are",
       query: {},
@@ -148,10 +150,10 @@ describe("AboutUsLayout", () => {
     const exploreItems = container.querySelectorAll(
       '[data-testid="who-we-are-explore-item"]',
     );
-    expect(exploreItems).toHaveLength(3);
+    expect(exploreItems).toHaveLength(4);
   });
 
-  it("shows 4 links when current page does not match any explore item", () => {
+  it("shows 5 links when current page does not match any explore item", () => {
     mockUseRouter.mockReturnValue({
       pathname: "/different-page",
       query: {},
@@ -168,101 +170,6 @@ describe("AboutUsLayout", () => {
     const exploreItems = container.querySelectorAll(
       '[data-testid="who-we-are-explore-item"]',
     );
-    expect(exploreItems).toHaveLength(4);
-  });
-
-  it("does not render Oak's impact link when feature flag is false", () => {
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "false";
-
-    const { queryByText } = renderWithProviders()(
-      <AboutUsLayout>
-        <div>Test</div>
-      </AboutUsLayout>,
-    );
-
-    expect(queryByText("Oak's impact")).not.toBeInTheDocument();
-  });
-
-  describe("when Oak's impact feature flag is enabled", () => {
-    beforeEach(() => {
-      process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "true";
-    });
-
-    afterEach(() => {
-      process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "false";
-    });
-
-    it("renders Oak's impact link", () => {
-      const { getByText } = renderWithProviders()(
-        <AboutUsLayout>
-          <div>Test</div>
-        </AboutUsLayout>,
-      );
-
-      expect(getByText("Oak's impact")).toBeInTheDocument();
-    });
-
-    it("excludes 'Oak's Impact' link when on oaks-impact page", () => {
-      mockUseRouter.mockReturnValue({
-        pathname: "/about-us/oaks-impact",
-        query: {},
-        asPath: "/about-us/oaks-impact",
-      } as never);
-
-      const { queryByText, getByText } = renderWithProviders()(
-        <AboutUsLayout>
-          <div>Test</div>
-        </AboutUsLayout>,
-      );
-
-      // Should not render "Oak's impact" link
-      expect(queryByText("Oak's impact")).not.toBeInTheDocument();
-
-      // Should still render other links
-      expect(getByText("About Oak")).toBeInTheDocument();
-      expect(getByText("Oak's curricula")).toBeInTheDocument();
-      expect(getByText("Get involved")).toBeInTheDocument();
-      expect(getByText("Meet the team")).toBeInTheDocument();
-    });
-
-    it("only shows 4 links when current page matches one of the explore items", () => {
-      mockUseRouter.mockReturnValue({
-        pathname: "/about-us/who-we-are",
-        query: {},
-        asPath: "/about-us/who-we-are",
-      } as never);
-
-      const { container } = renderWithProviders()(
-        <AboutUsLayout>
-          <div>Test</div>
-        </AboutUsLayout>,
-      );
-
-      // Count the number of explore item links (they have data-testid="who-we-are-explore-item")
-      const exploreItems = container.querySelectorAll(
-        '[data-testid="who-we-are-explore-item"]',
-      );
-      expect(exploreItems).toHaveLength(4);
-    });
-
-    it("shows 5 links when current page does not match any explore item", () => {
-      mockUseRouter.mockReturnValue({
-        pathname: "/different-page",
-        query: {},
-        asPath: "/different-page",
-      } as never);
-
-      const { container } = renderWithProviders()(
-        <AboutUsLayout>
-          <div>Test</div>
-        </AboutUsLayout>,
-      );
-
-      // Count the number of explore item links
-      const exploreItems = container.querySelectorAll(
-        '[data-testid="who-we-are-explore-item"]',
-      );
-      expect(exploreItems).toHaveLength(5);
-    });
+    expect(exploreItems).toHaveLength(5);
   });
 });

--- a/src/components/GenericPagesComponents/AboutUsLayout/index.tsx
+++ b/src/components/GenericPagesComponents/AboutUsLayout/index.tsx
@@ -7,7 +7,6 @@ import { WhoAreWeExplore } from "@/components/GenericPagesComponents/WhoAreWeExp
 import NewsletterFormWrap from "@/components/GenericPagesComponents/NewsletterFormWrap";
 import { useNewsletterForm } from "@/components/GenericPagesComponents/NewsletterForm";
 import { NewGutterMaxWidth } from "@/components/GenericPagesComponents/NewGutterMaxWidth";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 import { resolveOakHref } from "@/common-lib/urls";
 
 const NewsletterWrapper = styled(OakFlex)`
@@ -45,18 +44,14 @@ export function AboutUsLayout({ children }: Readonly<AboutUsLayoutProps>) {
       }),
       componentType: "about_curriculum" as const,
     },
-    ...(isFeatureFlagEnabledStatic("oaks-impact")
-      ? [
-          {
-            iconName: "data" as const,
-            title: "Oak's impact",
-            href: resolveOakHref({
-              page: "about-oaks-impact",
-            }),
-            componentType: "about_curriculum" as const,
-          },
-        ]
-      : []),
+    {
+      iconName: "data" as const,
+      title: "Oak's impact",
+      href: resolveOakHref({
+        page: "about-oaks-impact",
+      }),
+      componentType: "about_curriculum" as const,
+    },
     {
       iconName: "snack-break" as const,
       title: "Meet the team",

--- a/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
@@ -1,5 +1,4 @@
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 export const topNavFixture: TopNavProps = {
   teachers: {
@@ -289,15 +288,11 @@ export const topNavFixture: TopNavProps = {
           title: "Oak's curricula",
           href: "/about-us/oaks-curricula",
         },
-        ...(isFeatureFlagEnabledStatic("oaks-impact")
-          ? [
-              {
-                slug: "about-oaks-impact",
-                title: "Oak's impact",
-                href: "/about-us/oaks-impact",
-              },
-            ]
-          : []),
+        {
+          slug: "about-oaks-impact",
+          title: "Oak's impact",
+          href: "/about-us/oaks-impact",
+        },
         {
           slug: "about-get-involved",
           title: "Get involved",

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
@@ -55,26 +55,7 @@ describe("TopNavQuery", () => {
     expect(
       res.teachers?.primary.keystages.children?.[0]?.children?.[0]?.href,
     ).toBeDefined();
-    expect(
-      res.teachers?.aboutUs.children.some(
-        ({ slug }) => slug === "about-oaks-impact",
-      ),
-    ).toBe(false);
-  });
-
-  it("includes Oak's impact when the build-time feature flag is enabled", async () => {
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(true);
-
-    const res = await topNavQuery({
-      ...sdk,
-      topNav: jest.fn(() => Promise.resolve(mockResponseData)),
-    })();
-
-    expect(
-      res.teachers?.aboutUs.children.some(
-        ({ slug }) => slug === "about-oaks-impact",
-      ),
-    ).toBe(true);
+    expect(res.teachers?.aboutUs.children).toHaveLength(6);
   });
 
   it("uses the cached topNav function when withCache is true", async () => {

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
@@ -5,7 +5,6 @@ import { topNavResponseSchema } from "./topNav.schema";
 import sdk from "@/node-lib/curriculum-api-2023/sdk";
 import { cacheData } from "@/node-lib/cache";
 import OakError from "@/errors/OakError";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 jest.mock("@/node-lib/curriculum-api-2023/sdk", () => {});
 
@@ -24,16 +23,9 @@ jest.mock("@/common-lib/error-reporter", () => ({
       mockErrorReporter(...args),
 }));
 
-jest.mock("@/utils/featureFlagChecks/static", () => ({
-  isFeatureFlagEnabledStatic: jest.fn(),
-}));
-
-const mockIsFeatureFlagEnabledStatic = jest.mocked(isFeatureFlagEnabledStatic);
-
 describe("TopNavQuery", () => {
   beforeEach(() => {
     mockCacheData.mockImplementation((fn) => fn);
-    mockIsFeatureFlagEnabledStatic.mockReturnValue(false);
   });
 
   it("parses mock response data including phase options", () => {

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
@@ -13,7 +13,6 @@ import errorReporter from "@/common-lib/error-reporter";
 import { resolveOakHref } from "@/common-lib/urls";
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
 import OakError from "@/errors/OakError";
-import { isFeatureFlagEnabledStatic } from "@/utils/featureFlagChecks/static";
 
 const topNavQuery = (sdk: Sdk) => {
   const cachedTopNav = cacheData(sdk.topNav, [
@@ -110,15 +109,11 @@ const topNavQuery = (sdk: Sdk) => {
             slug: "about-oaks-curricula",
             href: resolveOakHref({ page: "about-oaks-curricula" }),
           },
-          ...(isFeatureFlagEnabledStatic("oaks-impact")
-            ? [
-                {
-                  title: "Oak's impact",
-                  slug: "about-oaks-impact",
-                  href: resolveOakHref({ page: "about-oaks-impact" }),
-                },
-              ]
-            : []),
+          {
+            title: "Oak's impact",
+            slug: "about-oaks-impact",
+            href: resolveOakHref({ page: "about-oaks-impact" }),
+          },
           {
             title: "Get involved",
             slug: "about-get-involved",

--- a/src/pages/about-us/case-studies/[slug].tsx
+++ b/src/pages/about-us/case-studies/[slug].tsx
@@ -1,4 +1,9 @@
-import { NextPage, GetServerSideProps, GetStaticPropsResult } from "next";
+import {
+  NextPage,
+  GetStaticPathsResult,
+  GetStaticProps,
+  GetStaticPropsResult,
+} from "next";
 import {
   OakBreadcrumbs,
   OakBox,
@@ -13,6 +18,11 @@ import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { OaksImpactCaseStudyPage } from "@/common-lib/cms-types/aboutPages";
 import CMSClient from "@/node-lib/cms";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
+import getPageProps from "@/node-lib/getPageProps";
+import {
+  getFallbackBlockingConfig,
+  shouldSkipInitialBuild,
+} from "@/node-lib/isr";
 import Layout from "@/components/AppComponents/AppLayout";
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
 import { OaksImpactCaseStudies } from "@/components/GenericPagesComponents/OaksImpactCaseStudies";
@@ -20,7 +30,6 @@ import { resolveOakHref } from "@/common-lib/urls";
 import { NewGutterMaxWidth } from "@/components/GenericPagesComponents/NewGutterMaxWidth";
 import { useOakNotificationsContext } from "@/context/OakNotifications/useOakNotificationsContext";
 import { OaksImpactCaseStudyHeader } from "@/components/GenericPagesComponents/OaksImpactCaseStudyHeader";
-import { isFeatureFlagEnabledServer } from "@/utils/featureFlagChecks/server";
 import { OaksImpactCaseStudyContentLayout } from "@/components/GenericPagesComponents/OaksImpactCaseStudyContentLayout";
 import VideoPlayer from "@/components/SharedComponents/VideoPlayer";
 
@@ -131,89 +140,85 @@ const AboutUsOaksImpactCaseStudy: NextPage<
   );
 };
 
-// TODO: Add back in once moving back to `getStaticProps(...)`
-// export const getStaticPaths = async () => {
-//     console.log({shouldSkipInitialBuild})
-//   if (shouldSkipInitialBuild) {
-//     return getFallbackBlockingConfig();
-//   }
-
-//   const impactPageData = await CMSClient.oaksImpactPage();
-
-//   if (!impactPageData) {
-//     return {
-//       notFound: true,
-//     };
-//   }
-
-//   const paths = impactPageData.caseStudiesSection.caseStudies.map((caseStudy) => ({
-//     params: { slug: caseStudy.slug.current },
-//   }));
-
-//   console.log("getStaticPaths: paths", paths);
-
-//   const config: GetStaticPathsResult<URLParams> = {
-//     fallback: "blocking",
-//     paths,
-//   };
-//   return config;
-// };
-
 type URLParams = {
   slug: string;
 };
 
-export const getServerSideProps: GetServerSideProps<
+export const getStaticPaths = async () => {
+  if (shouldSkipInitialBuild) {
+    return getFallbackBlockingConfig();
+  }
+
+  const impactPageData = await CMSClient.oaksImpactPage();
+
+  if (!impactPageData) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const paths = impactPageData.caseStudiesSection.caseStudies.map(
+    (caseStudy) => ({
+      params: { slug: caseStudy.slug.current },
+    }),
+  );
+
+  const config: GetStaticPathsResult<URLParams> = {
+    fallback: "blocking",
+    paths,
+  };
+  return config;
+};
+
+export const getStaticProps: GetStaticProps<
   AboutUsOaksImpactCaseStudyPageProps,
   URLParams
 > = async (context) => {
-  const isImpactPageEnabled = await isFeatureFlagEnabledServer(
-    context.req.cookies,
-    "oaks-impact",
-  );
-  if (!isImpactPageEnabled) {
-    return {
-      notFound: true,
-    };
-  }
+  return getPageProps({
+    page: "about-oaks-impact-case-study::getStaticProps",
+    context,
+    getProps: async () => {
+      const slug = context.params?.slug;
+      if (!slug) {
+        return { notFound: true };
+      }
 
-  const slug = context.params?.slug;
-  if (!slug) {
-    return { notFound: true };
-  }
-  const isPreviewMode = context.preview === true;
-  const oaksImpactCaseStudyPage = await CMSClient.oaksImpactCaseStudyPage({
-    previewMode: isPreviewMode,
-  });
+      const isPreviewMode = context.preview === true;
+      const oaksImpactCaseStudyPage = await CMSClient.oaksImpactCaseStudyPage({
+        previewMode: isPreviewMode,
+      });
 
-  const caseStudy =
-    oaksImpactCaseStudyPage?.caseStudiesSection.caseStudies.find(
-      (caseStudy) => caseStudy.slug.current === slug,
-    );
+      const caseStudy =
+        oaksImpactCaseStudyPage?.caseStudiesSection.caseStudies.find(
+          (caseStudy) => caseStudy.slug.current === slug,
+        );
 
-  const topNav = await curriculumApi2023.topNav();
+      const topNav = await curriculumApi2023.topNav();
 
-  if (!oaksImpactCaseStudyPage || !caseStudy) {
-    return {
-      notFound: true,
-    };
-  }
+      if (!oaksImpactCaseStudyPage || !caseStudy) {
+        return {
+          notFound: true,
+        };
+      }
 
-  const otherCaseStudies =
-    oaksImpactCaseStudyPage?.caseStudiesSection.caseStudies.filter(
-      (caseStudy) => caseStudy.slug.current !== slug,
-    );
+      const otherCaseStudies =
+        oaksImpactCaseStudyPage.caseStudiesSection.caseStudies.filter(
+          (caseStudy) => caseStudy.slug.current !== slug,
+        );
 
-  const results: GetStaticPropsResult<AboutUsOaksImpactCaseStudyPageProps> = {
-    props: {
-      pageData: {
-        caseStudy,
-        otherCaseStudies,
-      },
-      topNav,
+      const results: GetStaticPropsResult<AboutUsOaksImpactCaseStudyPageProps> =
+        {
+          props: {
+            pageData: {
+              caseStudy,
+              otherCaseStudies,
+            },
+            topNav,
+          },
+        };
+      return results;
     },
-  };
-  return results;
+  });
 };
 
 export default AboutUsOaksImpactCaseStudy;

--- a/src/pages/about-us/oaks-impact.tsx
+++ b/src/pages/about-us/oaks-impact.tsx
@@ -1,6 +1,6 @@
 import {
-  GetServerSideProps,
-  GetServerSidePropsResult,
+  GetStaticProps,
+  GetStaticPropsResult,
   NextPage,
 } from "next/dist/types";
 
@@ -18,7 +18,6 @@ import { OaksImpactPage } from "@/common-lib/cms-types";
 import { OaksImpactSchoolQuotesSection } from "@/components/GenericPagesComponents/OaksImpactSchoolQuotesSection";
 import TrackScrolledTo from "@/components/SharedComponents/TrackScrolledTo";
 import { OaksImpactHeader } from "@/components/GenericPagesComponents/OaksImpactHeader";
-import { isFeatureFlagEnabledServer } from "@/utils/featureFlagChecks/server";
 import useTrackExitIntended from "@/hooks/useTrackExitIntended";
 
 export type OaksImpactPageProps = {
@@ -60,39 +59,31 @@ const OaksImpact: NextPage<OaksImpactPageProps> = ({ topNav, pageData }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const isImpactPageEnabled = await isFeatureFlagEnabledServer(
-    context.req.cookies,
-    "oaks-impact",
-  );
-  if (!isImpactPageEnabled) {
-    return {
-      notFound: true,
-    };
-  }
-
+export const getStaticProps: GetStaticProps<OaksImpactPageProps> = async (
+  context,
+) => {
   return getPageProps({
-    page: "about-oaks-impact::getServerSideProps",
+    page: "about-oaks-impact::getStaticProps",
     context,
-    withIsr: false,
     getProps: async () => {
-      const topNav = await curriculumApi2023.topNav();
       const isPreviewMode = context.preview === true;
 
-      const pageData = await CMSClient.oaksImpactPage({
+      const oaksImpactPage = await CMSClient.oaksImpactPage({
         previewMode: isPreviewMode,
       });
 
-      if (!pageData) {
+      const topNav = await curriculumApi2023.topNav();
+
+      if (!oaksImpactPage) {
         return {
           notFound: true,
         };
       }
 
-      const results: GetServerSidePropsResult<OaksImpactPageProps> = {
+      const results: GetStaticPropsResult<OaksImpactPageProps> = {
         props: {
+          pageData: oaksImpactPage,
           topNav,
-          pageData,
         },
       };
       return results;

--- a/src/utils/featureFlagChecks/__tests__/server.test.tsx
+++ b/src/utils/featureFlagChecks/__tests__/server.test.tsx
@@ -12,7 +12,7 @@ async function expectFeatureFlagResult({
   posthogEnabled: boolean;
   forceFlag: "true" | "false";
 }) {
-  process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = forceFlag;
+  process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_EXAMPLE_FEATURE = forceFlag;
   (getPosthogIdFromCookie as jest.Mock).mockReturnValue("1111");
   (getFeatureFlag as jest.Mock).mockResolvedValue(posthogEnabled);
 }
@@ -25,7 +25,7 @@ describe("isFeatureFlagEnabledServer", () => {
         forceFlag: "true",
       });
 
-      const result = await isFeatureFlagEnabledServer({}, "oaks-impact");
+      const result = await isFeatureFlagEnabledServer({}, "example-feature");
 
       expect(result).toBe(true);
     });
@@ -36,7 +36,7 @@ describe("isFeatureFlagEnabledServer", () => {
         forceFlag: "false",
       });
 
-      const result = await isFeatureFlagEnabledServer({}, "oaks-impact");
+      const result = await isFeatureFlagEnabledServer({}, "example-feature");
 
       expect(result).toBe(true);
     });
@@ -49,7 +49,7 @@ describe("isFeatureFlagEnabledServer", () => {
         forceFlag: "true",
       });
 
-      const result = await isFeatureFlagEnabledServer({}, "oaks-impact");
+      const result = await isFeatureFlagEnabledServer({}, "example-feature");
 
       expect(result).toBe(true);
     });
@@ -60,7 +60,7 @@ describe("isFeatureFlagEnabledServer", () => {
         forceFlag: "false",
       });
 
-      const result = await isFeatureFlagEnabledServer({}, "oaks-impact");
+      const result = await isFeatureFlagEnabledServer({}, "example-feature");
 
       expect(result).toBe(false);
     });

--- a/src/utils/featureFlagChecks/__tests__/static.test.tsx
+++ b/src/utils/featureFlagChecks/__tests__/static.test.tsx
@@ -2,16 +2,12 @@ import { isFeatureFlagEnabledStatic } from "../static";
 
 describe("isFeatureFlagEnabledStatic", () => {
   test("returns true when constant is 'true'", () => {
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "true";
-    expect(isFeatureFlagEnabledStatic("oaks-impact")).toBe(true);
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_IMPLEMENTATION_GUIDES = "true";
-    expect(isFeatureFlagEnabledStatic("implementation-guides")).toBe(true);
+    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_EXAMPLE_FEATURE = "true";
+    expect(isFeatureFlagEnabledStatic("example-feature")).toBe(true);
   });
 
   test("returns false when constant is not 'true'", () => {
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT = "false";
-    expect(isFeatureFlagEnabledStatic("oaks-impact")).toBe(false);
-    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_IMPLEMENTATION_GUIDES = "false";
-    expect(isFeatureFlagEnabledStatic("implementation-guides")).toBe(false);
+    process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_EXAMPLE_FEATURE = "false";
+    expect(isFeatureFlagEnabledStatic("example-feature")).toBe(false);
   });
 });

--- a/src/utils/featureFlagChecks/flags.tsx
+++ b/src/utils/featureFlagChecks/flags.tsx
@@ -1,7 +1,4 @@
 export const FLAGS = {
-  get "oaks-impact"() {
-    return process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_OAKS_IMPACT ?? "true";
-  },
   get "implementation-guides"() {
     return (
       process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_IMPLEMENTATION_GUIDES ??

--- a/src/utils/featureFlagChecks/flags.tsx
+++ b/src/utils/featureFlagChecks/flags.tsx
@@ -1,4 +1,9 @@
 export const FLAGS = {
+  get "example-feature"() {
+    return (
+      process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_EXAMPLE_FEATURE ?? "false"
+    );
+  },
   get "implementation-guides"() {
     return (
       process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAG_IMPLEMENTATION_GUIDES ??


### PR DESCRIPTION
## Description

Remove oak's impact feature flag dependancies in code and tests and switch to using static props

## Issue(s)

Fixes ADOPT-2175

## How to test

1. Go to https://oak-web-application-website-git-feat-adopt-2175remove-oa-c020ad.vercel.thenational.academy/about-us/oaks-impact
2. Click around and onto case studies page
3. Everything should work as normal

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
