### PR TITLE
feat(nav): expand the AI experiments link into a dropdown

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.test.tsx.snap
@@ -359,12 +359,12 @@ exports[`Teachers Page Page component renders 1`] = `
                       <div
                         class="sc-aXZVg kpXzs yellow-shadow"
                       />
-                      <a
-                        aria-label="Ai experiments (this will open in a new tab)"
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="true"
                         class="sc-dcJsrY sc-jXbUNg hodcpD kwUki internal-button"
-                        href="https://labs.thenational.academy"
-                        id="teachers-labs"
-                        target="_blank"
+                        data-testid="teachers-aiExperiments"
+                        id="teachers-aiExperiments"
                       >
                         <div
                           class="sc-aXZVg sc-gEvEer jPvJsJ kejpBe"
@@ -372,23 +372,10 @@ exports[`Teachers Page Page component renders 1`] = `
                           <span
                             class="sc-eqUAAy kJIzWq"
                           >
-                            Ai experiments
-                          </span>
-                          <span
-                            class="sc-aXZVg jJQFnr"
-                          >
-                            <img
-                              alt=""
-                              class="sc-iGgWBj lcrpYX"
-                              data-nimg="fill"
-                              decoding="async"
-                              loading="lazy"
-                              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                            />
+                            AI experiments
                           </span>
                         </div>
-                      </a>
+                      </button>
                     </div>
                   </li>
                 </ul>

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -97,19 +97,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c37 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c38 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c39 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -130,17 +130,17 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c40:hover {
+.c39:hover {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c44 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -148,7 +148,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c50 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -159,7 +159,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c53 {
+.c52 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -168,12 +168,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c55 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c58 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -193,7 +193,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c60 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -203,12 +203,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c64 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -732,7 +732,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -744,7 +744,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -755,14 +755,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -781,7 +781,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -796,7 +796,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1189,7 +1189,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   text-align: left;
 }
 
-.c55 {
+.c54 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1367,7 +1367,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   cursor: default;
 }
 
-.c48 {
+.c47 {
   background: none;
   color: inherit;
   border: none;
@@ -1381,12 +1381,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
 }
 
-.c48:disabled {
+.c47:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c57 {
+.c56 {
   background: none;
   color: inherit;
   border: none;
@@ -1399,12 +1399,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57:disabled {
+.c56:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c63 {
+.c62 {
   background: none;
   color: inherit;
   border: none;
@@ -1434,12 +1434,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c63:disabled {
+.c62:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c65 {
   background: none;
   color: inherit;
   border: none;
@@ -1463,7 +1463,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-style: none;
 }
 
-.c66:disabled {
+.c65:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1529,15 +1529,15 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c36 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+.c53 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c54 {
-  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+.c66 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
@@ -1685,13 +1685,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   display: none;
 }
 
-.c64 {
+.c63 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c64:hover {
+.c63:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1699,27 +1699,27 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c64:hover [data-state="selected"] {
+.c63:hover [data-state="selected"] {
   display: none;
 }
 
-.c64:active {
+.c63:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c64:active [data-state="selected"] {
+.c63:active [data-state="selected"] {
   display: none;
 }
 
-.c64:disabled {
+.c63:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c64:disabled [data-state="selected"] {
+.c63:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1773,46 +1773,46 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c49 {
+.c48 {
   display: inline-block;
   position: relative;
 }
 
-.c49:hover {
+.c48:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c49:active {
+.c48:active {
   color: #222222;
 }
 
-.c49:disabled {
+.c48:disabled {
   color: #808080;
 }
 
-.c47 > :first-child:focus-visible .shadow {
+.c46 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:hover .shadow {
+.c46 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c47 > :first-child:active .shadow {
+.c46 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:disabled .icon-container {
+.c46 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c47 > :first-child:hover .icon-container {
+.c46 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c47 > :first-child:active .icon-container {
+.c46 > :first-child:active .icon-container {
   background: #222222;
 }
 
@@ -2241,7 +2241,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c43 {
+.c42 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2257,44 +2257,44 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   width: 100%;
 }
 
-.c43::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c43::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #575757;
 }
 
-.c43:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #575757;
 }
 
-.c43::placeholder {
+.c42::placeholder {
   color: #575757;
 }
 
-.c43::-webkit-search-decoration,
-.c43::-webkit-search-cancel-button,
-.c43::-webkit-search-results-button,
-.c43::-webkit-search-results-decoration {
+.c42::-webkit-search-decoration,
+.c42::-webkit-search-cancel-button,
+.c42::-webkit-search-results-button,
+.c42::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c43:disabled {
+.c42:disabled {
   cursor: not-allowed;
 }
 
-.c42 {
+.c41 {
   background: #ffffff;
 }
 
-.c42:hover {
+.c41:hover {
   cursor: text;
 }
 
-.c42:focus-within {
+.c41:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
@@ -2420,11 +2420,11 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c58:hover .oak-save-count {
+.c57:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c58:focus-visible .oak-save-count {
+.c57:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -2857,7 +2857,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c37 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2866,19 +2866,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c39 {
+  .c38 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2886,37 +2886,37 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c56 {
+  .c55 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c61 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c64 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c64 {
     display: none;
   }
 }
@@ -3237,19 +3237,19 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c59 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -3948,13 +3948,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
 }
 
 @media (max-width:750px) {
-  .c43 {
+  .c42 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c42:hover:not(:focus-within) {
+  .c41:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
@@ -4642,12 +4642,12 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     <div
                       class="c6 yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c32 c33 internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="c9 c34"
@@ -4655,46 +4655,33 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         <span
                           class="c35"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="c20"
-                        >
-                          <img
-                            alt=""
-                            class="c36"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>
             </div>
             <div
-              class="c9 c37"
+              class="c9 c36"
             >
               <form
                 action="/teachers/search"
-                class="c38"
+                class="c37"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <div
-                    class="c40 c41 c42"
+                    class="c39 c40 c41"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c43"
+                      class="c42"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4702,24 +4689,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   <div
-                    class="c45 c46 c47"
+                    class="c44 c45 c46"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c48 c49"
+                      class="c47 c48"
                       type="submit"
                     >
                       <div
-                        class="c9 c50"
+                        class="c9 c49"
                       >
                         <div
-                          class="c51 c52 icon-container"
+                          class="c50 c51 icon-container"
                         >
                           <div
-                            class="c53 shadow"
+                            class="c52 shadow"
                           />
                           <span
                             class="c20"
@@ -4727,7 +4714,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c54"
+                              class="c53"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4737,7 +4724,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c55"
+                          class="c54"
                         />
                       </div>
                     </button>
@@ -4745,24 +4732,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c56"
+                class="c55"
               >
                 <div
-                  class="c45 c46 c47"
+                  class="c44 c45 c46"
                 >
                   <a
                     aria-label="Search"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c51 c52 icon-container"
+                        class="c50 c51 icon-container"
                       >
                         <div
-                          class="c53 shadow"
+                          class="c52 shadow"
                         />
                         <span
                           class="c20"
@@ -4770,7 +4757,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c54"
+                            class="c53"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4780,7 +4767,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
@@ -4788,14 +4775,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c57 c58"
+                class="c56 c57"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c59 c60 oak-save-count"
+                  class="c58 c59 oak-save-count"
                 >
                   <span
-                    class="c61"
+                    class="c60"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4809,7 +4796,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c62"
+                    class="c61"
                   >
                     My library
                   </div>
@@ -4825,7 +4812,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c63 c64 internal-button"
+                  class="c62 c63 internal-button"
                 >
                   <div
                     class="c9 c34"
@@ -4841,7 +4828,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c65"
+            class="c64"
           >
             <div
               class="c4 c5"
@@ -4855,18 +4842,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c66 c8 internal-button"
+                class="c65 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c50"
+                  class="c9 c49"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c36"
+                      class="c66"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4947,7 +4934,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c9 c82"
                 >
                   <div
-                    class="c9 c46 c83"
+                    class="c9 c45 c83"
                   >
                     <h2
                       class="c84"
@@ -4956,7 +4943,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </h2>
                   </div>
                   <div
-                    class="c9 c46 c85"
+                    class="c9 c45 c85"
                   >
                     <div
                       class="c86 c87"
@@ -4977,7 +4964,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9 c46 c90"
+                    class="c9 c45 c90"
                   >
                     <div
                       class="c9 c72"
@@ -5263,7 +5250,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                   class="c9 c106"
                 >
                   <div
-                    class="c107 c46"
+                    class="c107 c45"
                   >
                     <span
                       class="c88"
@@ -5355,7 +5342,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5377,7 +5364,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               About Oak
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c77"
@@ -5408,7 +5395,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5430,7 +5417,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c77"
@@ -5461,7 +5448,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5483,7 +5470,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               Meet the team
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c77"
@@ -5514,7 +5501,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5536,7 +5523,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                               Get involved
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c77"
@@ -5569,7 +5556,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               class="c69"
             >
               <div
-                class="c9 c46 c127"
+                class="c9 c45 c127"
               >
                 <div
                   class="c128 c1"
@@ -5578,7 +5565,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     class="c9 c129"
                   >
                     <div
-                      class="c9 c46 c130"
+                      class="c9 c45 c130"
                     >
                       <div
                         class="c131 c132"
@@ -5623,7 +5610,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c136 c46 c130"
+                      class="c136 c45 c130"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
@@ -6072,7 +6059,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c156 c46"
+                            class="c156 c45"
                           >
                             <label
                               class="c144 c145 c146"
@@ -6093,7 +6080,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             type="button"
                           >
                             <div
-                              class="c159 c41 c160"
+                              class="c159 c40 c160"
                             >
                               <span
                                 class="c161 c162"
@@ -6164,7 +6151,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
         class="c167"
       >
         <div
-          class="c168 c46"
+          class="c168 c45"
         >
           <svg
             aria-hidden="true"
@@ -6197,7 +6184,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
               class="c9 c129"
             >
               <div
-                class="c9 c46 c172"
+                class="c9 c45 c172"
               >
                 <div
                   class="c173 c81"
@@ -6326,7 +6313,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c172"
+                class="c9 c45 c172"
               >
                 <div
                   class="c173 c81"
@@ -6544,7 +6531,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c172"
+                class="c9 c45 c172"
               >
                 <div
                   class="c173 c81"
@@ -6704,13 +6691,13 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c172"
+                class="c9 c45 c172"
               >
                 <div
                   class="c173 c183"
                 >
                   <div
-                    class="c39"
+                    class="c38"
                   >
                     <span
                       class="c184"
@@ -6730,18 +6717,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                     class="c185 c186"
                   >
                     <div
-                      class="c45 c46 c187 c188"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c189 c52 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
                               class="c190 shadow"
@@ -6752,7 +6739,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6762,24 +6749,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c187 c188"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c189 c52 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
                               class="c190 shadow"
@@ -6790,7 +6777,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6800,24 +6787,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c187 c188"
+                      class="c44 c45 c187 c188"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c189 c52 icon-container"
+                            class="c189 c51 icon-container"
                           >
                             <div
                               class="c190 shadow"
@@ -6828,7 +6815,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6838,7 +6825,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
@@ -6870,18 +6857,18 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                 class="c194 c195"
               >
                 <div
-                  class="c45 c46 c187 c188"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c189 c52 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
                           class="c190 shadow"
@@ -6892,7 +6879,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6902,24 +6889,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c187 c188"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c189 c52 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
                           class="c190 shadow"
@@ -6930,7 +6917,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6940,24 +6927,24 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c187 c188"
+                  class="c44 c45 c187 c188"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c189 c52 icon-container"
+                        class="c189 c51 icon-container"
                       >
                         <div
                           class="c190 shadow"
@@ -6968,7 +6955,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6978,14 +6965,14 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c56"
+                class="c55"
               >
                 <span
                   class="c184"
@@ -7079,7 +7066,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
             class="c9 c212"
           >
             <div
-              class="c213 c41"
+              class="c213 c40"
             >
               <button
                 class="c214"

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -97,19 +97,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c37 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c38 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c39 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -130,17 +130,17 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c40:hover {
+.c39:hover {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c44 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -148,7 +148,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c50 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -159,7 +159,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c53 {
+.c52 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -168,12 +168,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c55 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c58 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -193,7 +193,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c60 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -203,12 +203,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c64 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -760,7 +760,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -772,7 +772,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -783,14 +783,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -809,7 +809,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -824,7 +824,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1194,7 +1194,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-align: left;
 }
 
-.c55 {
+.c54 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1384,7 +1384,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   cursor: default;
 }
 
-.c48 {
+.c47 {
   background: none;
   color: inherit;
   border: none;
@@ -1398,12 +1398,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
 }
 
-.c48:disabled {
+.c47:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c57 {
+.c56 {
   background: none;
   color: inherit;
   border: none;
@@ -1416,12 +1416,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57:disabled {
+.c56:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c63 {
+.c62 {
   background: none;
   color: inherit;
   border: none;
@@ -1451,12 +1451,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c63:disabled {
+.c62:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c65 {
   background: none;
   color: inherit;
   border: none;
@@ -1480,7 +1480,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-style: none;
 }
 
-.c66:disabled {
+.c65:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1546,15 +1546,15 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c36 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+.c53 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c54 {
-  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+.c66 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
@@ -1693,13 +1693,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   display: none;
 }
 
-.c64 {
+.c63 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c64:hover {
+.c63:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1707,27 +1707,27 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c64:hover [data-state="selected"] {
+.c63:hover [data-state="selected"] {
   display: none;
 }
 
-.c64:active {
+.c63:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c64:active [data-state="selected"] {
+.c63:active [data-state="selected"] {
   display: none;
 }
 
-.c64:disabled {
+.c63:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c64:disabled [data-state="selected"] {
+.c63:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1781,46 +1781,46 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c49 {
+.c48 {
   display: inline-block;
   position: relative;
 }
 
-.c49:hover {
+.c48:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c49:active {
+.c48:active {
   color: #222222;
 }
 
-.c49:disabled {
+.c48:disabled {
   color: #808080;
 }
 
-.c47 > :first-child:focus-visible .shadow {
+.c46 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:hover .shadow {
+.c46 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c47 > :first-child:active .shadow {
+.c46 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:disabled .icon-container {
+.c46 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c47 > :first-child:hover .icon-container {
+.c46 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c47 > :first-child:active .icon-container {
+.c46 > :first-child:active .icon-container {
   background: #222222;
 }
 
@@ -2285,7 +2285,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c43 {
+.c42 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2301,44 +2301,44 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   width: 100%;
 }
 
-.c43::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c43::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #575757;
 }
 
-.c43:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #575757;
 }
 
-.c43::placeholder {
+.c42::placeholder {
   color: #575757;
 }
 
-.c43::-webkit-search-decoration,
-.c43::-webkit-search-cancel-button,
-.c43::-webkit-search-results-button,
-.c43::-webkit-search-results-decoration {
+.c42::-webkit-search-decoration,
+.c42::-webkit-search-cancel-button,
+.c42::-webkit-search-results-button,
+.c42::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c43:disabled {
+.c42:disabled {
   cursor: not-allowed;
 }
 
-.c42 {
+.c41 {
   background: #ffffff;
 }
 
-.c42:hover {
+.c41:hover {
   cursor: text;
 }
 
-.c42:focus-within {
+.c41:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
@@ -2455,11 +2455,11 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   text-decoration-thickness: 18%;
 }
 
-.c58:hover .oak-save-count {
+.c57:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c58:focus-visible .oak-save-count {
+.c57:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -2946,7 +2946,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c37 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2955,19 +2955,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c39 {
+  .c38 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2975,37 +2975,37 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c56 {
+  .c55 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c61 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c64 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c64 {
     display: none;
   }
 }
@@ -3344,19 +3344,19 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c59 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -4003,13 +4003,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
 }
 
 @media (max-width:750px) {
-  .c43 {
+  .c42 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c42:hover:not(:focus-within) {
+  .c41:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
@@ -4490,12 +4490,12 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     <div
                       class="c6 yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c32 c33 internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="c9 c34"
@@ -4503,46 +4503,33 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         <span
                           class="c35"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="c20"
-                        >
-                          <img
-                            alt=""
-                            class="c36"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>
             </div>
             <div
-              class="c9 c37"
+              class="c9 c36"
             >
               <form
                 action="/teachers/search"
-                class="c38"
+                class="c37"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <div
-                    class="c40 c41 c42"
+                    class="c39 c40 c41"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c43"
+                      class="c42"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4550,24 +4537,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   <div
-                    class="c45 c46 c47"
+                    class="c44 c45 c46"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c48 c49"
+                      class="c47 c48"
                       type="submit"
                     >
                       <div
-                        class="c9 c50"
+                        class="c9 c49"
                       >
                         <div
-                          class="c51 c52 icon-container"
+                          class="c50 c51 icon-container"
                         >
                           <div
-                            class="c53 shadow"
+                            class="c52 shadow"
                           />
                           <span
                             class="c20"
@@ -4575,7 +4562,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c54"
+                              class="c53"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4585,7 +4572,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c55"
+                          class="c54"
                         />
                       </div>
                     </button>
@@ -4593,24 +4580,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c56"
+                class="c55"
               >
                 <div
-                  class="c45 c46 c47"
+                  class="c44 c45 c46"
                 >
                   <a
                     aria-label="Search"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c51 c52 icon-container"
+                        class="c50 c51 icon-container"
                       >
                         <div
-                          class="c53 shadow"
+                          class="c52 shadow"
                         />
                         <span
                           class="c20"
@@ -4618,7 +4605,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c54"
+                            class="c53"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4628,7 +4615,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
@@ -4636,14 +4623,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c57 c58"
+                class="c56 c57"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c59 c60 oak-save-count"
+                  class="c58 c59 oak-save-count"
                 >
                   <span
-                    class="c61"
+                    class="c60"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4657,7 +4644,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c62"
+                    class="c61"
                   >
                     My library
                   </div>
@@ -4673,7 +4660,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c63 c64 internal-button"
+                  class="c62 c63 internal-button"
                 >
                   <div
                     class="c9 c34"
@@ -4689,7 +4676,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c65"
+            class="c64"
           >
             <div
               class="c4 c5"
@@ -4703,18 +4690,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c66 c8 internal-button"
+                class="c65 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c50"
+                  class="c9 c49"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c36"
+                      class="c66"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4951,7 +4938,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               class="c9 c104"
                             >
                               <div
-                                class="c9 c41"
+                                class="c9 c40"
                               >
                                 <span
                                   class="c105"
@@ -5031,7 +5018,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               class="c9 c104"
                             >
                               <div
-                                class="c9 c41"
+                                class="c9 c40"
                               >
                                 <span
                                   class="c105"
@@ -5129,7 +5116,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c120"
@@ -5151,7 +5138,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               About Oak
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5182,7 +5169,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c120"
@@ -5204,7 +5191,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5235,7 +5222,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c120"
@@ -5257,7 +5244,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               Meet the team
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5288,7 +5275,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c120"
@@ -5310,7 +5297,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                               Get involved
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c123"
@@ -5343,7 +5330,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               class="c69"
             >
               <div
-                class="c9 c46 c125"
+                class="c9 c45 c125"
               >
                 <div
                   class="c126 c1"
@@ -5352,7 +5339,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     class="c9 c127"
                   >
                     <div
-                      class="c9 c46 c128"
+                      class="c9 c45 c128"
                     >
                       <div
                         class="c129 c130"
@@ -5397,7 +5384,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c134 c46 c128"
+                      class="c134 c45 c128"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
@@ -5846,7 +5833,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c154 c46"
+                            class="c154 c45"
                           >
                             <label
                               class="c142 c143 c144"
@@ -5867,7 +5854,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             type="button"
                           >
                             <div
-                              class="c157 c41 c158"
+                              class="c157 c40 c158"
                             >
                               <span
                                 class="c159 c160"
@@ -5938,7 +5925,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
         class="c165"
       >
         <div
-          class="c166 c46"
+          class="c166 c45"
         >
           <svg
             aria-hidden="true"
@@ -5971,7 +5958,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
               class="c9 c127"
             >
               <div
-                class="c9 c46 c170"
+                class="c9 c45 c170"
               >
                 <div
                   class="c171 c151"
@@ -6100,7 +6087,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c170"
+                class="c9 c45 c170"
               >
                 <div
                   class="c171 c151"
@@ -6318,7 +6305,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c170"
+                class="c9 c45 c170"
               >
                 <div
                   class="c171 c151"
@@ -6478,13 +6465,13 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c170"
+                class="c9 c45 c170"
               >
                 <div
                   class="c171 c181"
                 >
                   <div
-                    class="c39"
+                    class="c38"
                   >
                     <span
                       class="c182"
@@ -6504,18 +6491,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                     class="c183 c184"
                   >
                     <div
-                      class="c45 c46 c185 c186"
+                      class="c44 c45 c185 c186"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c187 c52 icon-container"
+                            class="c187 c51 icon-container"
                           >
                             <div
                               class="c188 shadow"
@@ -6526,7 +6513,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6536,24 +6523,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c185 c186"
+                      class="c44 c45 c185 c186"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c187 c52 icon-container"
+                            class="c187 c51 icon-container"
                           >
                             <div
                               class="c188 shadow"
@@ -6564,7 +6551,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6574,24 +6561,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c185 c186"
+                      class="c44 c45 c185 c186"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c187 c52 icon-container"
+                            class="c187 c51 icon-container"
                           >
                             <div
                               class="c188 shadow"
@@ -6602,7 +6589,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6612,7 +6599,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
@@ -6644,18 +6631,18 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                 class="c193 c194"
               >
                 <div
-                  class="c45 c46 c185 c186"
+                  class="c44 c45 c185 c186"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c187 c52 icon-container"
+                        class="c187 c51 icon-container"
                       >
                         <div
                           class="c188 shadow"
@@ -6666,7 +6653,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6676,24 +6663,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c185 c186"
+                  class="c44 c45 c185 c186"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c187 c52 icon-container"
+                        class="c187 c51 icon-container"
                       >
                         <div
                           class="c188 shadow"
@@ -6704,7 +6691,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6714,24 +6701,24 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c185 c186"
+                  class="c44 c45 c185 c186"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c187 c52 icon-container"
+                        class="c187 c51 icon-container"
                       >
                         <div
                           class="c188 shadow"
@@ -6742,7 +6729,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6752,14 +6739,14 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c56"
+                class="c55"
               >
                 <span
                   class="c182"
@@ -6853,7 +6840,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
             class="c9 c211"
           >
             <div
-              class="c212 c41"
+              class="c212 c40"
             >
               <button
                 class="c213"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -97,19 +97,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c37 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c38 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c39 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -130,17 +130,17 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c40:hover {
+.c39:hover {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c44 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -148,7 +148,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c50 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -159,7 +159,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c53 {
+.c52 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -168,12 +168,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c55 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c58 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -193,7 +193,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c60 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -203,12 +203,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c64 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -947,7 +947,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -959,7 +959,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -970,14 +970,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -996,7 +996,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1011,7 +1011,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1518,7 +1518,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   text-align: left;
 }
 
-.c55 {
+.c54 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1709,7 +1709,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   cursor: default;
 }
 
-.c48 {
+.c47 {
   background: none;
   color: inherit;
   border: none;
@@ -1723,12 +1723,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
 }
 
-.c48:disabled {
+.c47:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c57 {
+.c56 {
   background: none;
   color: inherit;
   border: none;
@@ -1741,12 +1741,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57:disabled {
+.c56:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c63 {
+.c62 {
   background: none;
   color: inherit;
   border: none;
@@ -1776,12 +1776,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c63:disabled {
+.c62:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c65 {
   background: none;
   color: inherit;
   border: none;
@@ -1805,7 +1805,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-style: none;
 }
 
-.c66:disabled {
+.c65:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1871,15 +1871,15 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c36 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+.c53 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c54 {
-  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+.c66 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
@@ -2018,13 +2018,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   display: none;
 }
 
-.c64 {
+.c63 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c64:hover {
+.c63:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -2032,27 +2032,27 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c64:hover [data-state="selected"] {
+.c63:hover [data-state="selected"] {
   display: none;
 }
 
-.c64:active {
+.c63:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c64:active [data-state="selected"] {
+.c63:active [data-state="selected"] {
   display: none;
 }
 
-.c64:disabled {
+.c63:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c64:disabled [data-state="selected"] {
+.c63:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -2106,46 +2106,46 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c49 {
+.c48 {
   display: inline-block;
   position: relative;
 }
 
-.c49:hover {
+.c48:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c49:active {
+.c48:active {
   color: #222222;
 }
 
-.c49:disabled {
+.c48:disabled {
   color: #808080;
 }
 
-.c47 > :first-child:focus-visible .shadow {
+.c46 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:hover .shadow {
+.c46 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c47 > :first-child:active .shadow {
+.c46 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:disabled .icon-container {
+.c46 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c47 > :first-child:hover .icon-container {
+.c46 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c47 > :first-child:active .icon-container {
+.c46 > :first-child:active .icon-container {
   background: #222222;
 }
 
@@ -2674,7 +2674,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c43 {
+.c42 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2690,44 +2690,44 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   width: 100%;
 }
 
-.c43::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c43::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #575757;
 }
 
-.c43:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #575757;
 }
 
-.c43::placeholder {
+.c42::placeholder {
   color: #575757;
 }
 
-.c43::-webkit-search-decoration,
-.c43::-webkit-search-cancel-button,
-.c43::-webkit-search-results-button,
-.c43::-webkit-search-results-decoration {
+.c42::-webkit-search-decoration,
+.c42::-webkit-search-cancel-button,
+.c42::-webkit-search-results-button,
+.c42::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c43:disabled {
+.c42:disabled {
   cursor: not-allowed;
 }
 
-.c42 {
+.c41 {
   background: #ffffff;
 }
 
-.c42:hover {
+.c41:hover {
   cursor: text;
 }
 
-.c42:focus-within {
+.c41:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
@@ -2850,11 +2850,11 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c58:hover .oak-save-count {
+.c57:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c58:focus-visible .oak-save-count {
+.c57:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -3323,7 +3323,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c37 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3332,19 +3332,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c39 {
+  .c38 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -3352,37 +3352,37 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c56 {
+  .c55 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c61 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c64 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c64 {
     display: none;
   }
 }
@@ -3775,19 +3775,19 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c59 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -4584,13 +4584,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
 }
 
 @media (max-width:750px) {
-  .c43 {
+  .c42 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c42:hover:not(:focus-within) {
+  .c41:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
@@ -5057,12 +5057,12 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     <div
                       class="c6 yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c32 c33 internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="c9 c34"
@@ -5070,46 +5070,33 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         <span
                           class="c35"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="c20"
-                        >
-                          <img
-                            alt=""
-                            class="c36"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>
             </div>
             <div
-              class="c9 c37"
+              class="c9 c36"
             >
               <form
                 action="/teachers/search"
-                class="c38"
+                class="c37"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <div
-                    class="c40 c41 c42"
+                    class="c39 c40 c41"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c43"
+                      class="c42"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -5117,24 +5104,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   <div
-                    class="c45 c46 c47"
+                    class="c44 c45 c46"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c48 c49"
+                      class="c47 c48"
                       type="submit"
                     >
                       <div
-                        class="c9 c50"
+                        class="c9 c49"
                       >
                         <div
-                          class="c51 c52 icon-container"
+                          class="c50 c51 icon-container"
                         >
                           <div
-                            class="c53 shadow"
+                            class="c52 shadow"
                           />
                           <span
                             class="c20"
@@ -5142,7 +5129,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c54"
+                              class="c53"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -5152,7 +5139,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c55"
+                          class="c54"
                         />
                       </div>
                     </button>
@@ -5160,24 +5147,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c56"
+                class="c55"
               >
                 <div
-                  class="c45 c46 c47"
+                  class="c44 c45 c46"
                 >
                   <a
                     aria-label="Search"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c51 c52 icon-container"
+                        class="c50 c51 icon-container"
                       >
                         <div
-                          class="c53 shadow"
+                          class="c52 shadow"
                         />
                         <span
                           class="c20"
@@ -5185,7 +5172,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c54"
+                            class="c53"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -5195,7 +5182,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
@@ -5203,14 +5190,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c57 c58"
+                class="c56 c57"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c59 c60 oak-save-count"
+                  class="c58 c59 oak-save-count"
                 >
                   <span
-                    class="c61"
+                    class="c60"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -5224,7 +5211,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c62"
+                    class="c61"
                   >
                     My library
                   </div>
@@ -5240,7 +5227,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c63 c64 internal-button"
+                  class="c62 c63 internal-button"
                 >
                   <div
                     class="c9 c34"
@@ -5256,7 +5243,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c65"
+            class="c64"
           >
             <div
               class="c4 c5"
@@ -5270,18 +5257,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c66 c8 internal-button"
+                class="c65 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c50"
+                  class="c9 c49"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c36"
+                      class="c66"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -5492,7 +5479,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c98 c46"
+                      class="c98 c45"
                     >
                       <span
                         class="c99"
@@ -5728,7 +5715,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                                           >
                                             <img
                                               alt=""
-                                              class="c54"
+                                              class="c53"
                                               data-nimg="fill"
                                               decoding="async"
                                               loading="lazy"
@@ -5874,7 +5861,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c9 c146"
               >
                 <div
-                  class="c9 c46 c147"
+                  class="c9 c45 c147"
                 >
                   <div
                     class="c9 c148"
@@ -5924,7 +5911,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c54"
+                                class="c53"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -5939,7 +5926,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9 c46 c150"
+                  class="c9 c45 c150"
                 >
                   <div
                     class="c151 c152"
@@ -6015,7 +6002,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c166"
@@ -6037,7 +6024,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               About Oak
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c168"
@@ -6068,7 +6055,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c166"
@@ -6090,7 +6077,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c168"
@@ -6121,7 +6108,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c166"
@@ -6143,7 +6130,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               Meet the team
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c168"
@@ -6174,7 +6161,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c166"
@@ -6196,7 +6183,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                               Get involved
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c168"
@@ -6229,7 +6216,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               class="c69"
             >
               <div
-                class="c9 c46 c170"
+                class="c9 c45 c170"
               >
                 <div
                   class="c171 c1"
@@ -6238,7 +6225,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     class="c9 c172"
                   >
                     <div
-                      class="c9 c46 c173"
+                      class="c9 c45 c173"
                     >
                       <div
                         class="c174 c175"
@@ -6283,7 +6270,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c179 c46 c173"
+                      class="c179 c45 c173"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
@@ -6732,7 +6719,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c199 c46"
+                            class="c199 c45"
                           >
                             <label
                               class="c187 c188 c189"
@@ -6753,7 +6740,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             type="button"
                           >
                             <div
-                              class="c202 c41 c203"
+                              class="c202 c40 c203"
                             >
                               <span
                                 class="c204 c205"
@@ -6824,7 +6811,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
         class="c210"
       >
         <div
-          class="c211 c46"
+          class="c211 c45"
         >
           <svg
             aria-hidden="true"
@@ -6857,7 +6844,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
               class="c9 c172"
             >
               <div
-                class="c9 c46 c215"
+                class="c9 c45 c215"
               >
                 <div
                   class="c216 c95"
@@ -6986,7 +6973,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c215"
+                class="c9 c45 c215"
               >
                 <div
                   class="c216 c95"
@@ -7204,7 +7191,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c215"
+                class="c9 c45 c215"
               >
                 <div
                   class="c216 c95"
@@ -7364,13 +7351,13 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c215"
+                class="c9 c45 c215"
               >
                 <div
                   class="c216 c225"
                 >
                   <div
-                    class="c39"
+                    class="c38"
                   >
                     <span
                       class="c226"
@@ -7390,18 +7377,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                     class="c227 c228"
                   >
                     <div
-                      class="c45 c46 c229 c230"
+                      class="c44 c45 c229 c230"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c231 c52 icon-container"
+                            class="c231 c51 icon-container"
                           >
                             <div
                               class="c232 shadow"
@@ -7412,7 +7399,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7422,24 +7409,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c229 c230"
+                      class="c44 c45 c229 c230"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c231 c52 icon-container"
+                            class="c231 c51 icon-container"
                           >
                             <div
                               class="c232 shadow"
@@ -7450,7 +7437,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7460,24 +7447,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c229 c230"
+                      class="c44 c45 c229 c230"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c231 c52 icon-container"
+                            class="c231 c51 icon-container"
                           >
                             <div
                               class="c232 shadow"
@@ -7488,7 +7475,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -7498,7 +7485,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
@@ -7530,18 +7517,18 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                 class="c236 c237"
               >
                 <div
-                  class="c45 c46 c229 c230"
+                  class="c44 c45 c229 c230"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c231 c52 icon-container"
+                        class="c231 c51 icon-container"
                       >
                         <div
                           class="c232 shadow"
@@ -7552,7 +7539,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7562,24 +7549,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c229 c230"
+                  class="c44 c45 c229 c230"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c231 c52 icon-container"
+                        class="c231 c51 icon-container"
                       >
                         <div
                           class="c232 shadow"
@@ -7590,7 +7577,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7600,24 +7587,24 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c229 c230"
+                  class="c44 c45 c229 c230"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c231 c52 icon-container"
+                        class="c231 c51 icon-container"
                       >
                         <div
                           class="c232 shadow"
@@ -7628,7 +7615,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -7638,14 +7625,14 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c56"
+                class="c55"
               >
                 <span
                   class="c226"
@@ -7739,7 +7726,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
             class="c9 c254"
           >
             <div
-              class="c255 c41"
+              class="c255 c40"
             >
               <button
                 class="c256"

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -358,12 +358,12 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                     <div
                       class="sc-aXZVg kpXzs yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="sc-dcJsrY sc-jXbUNg hodcpD kwUki internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="sc-aXZVg sc-gEvEer jPvJsJ kejpBe"
@@ -371,23 +371,10 @@ exports[`pages/about-us/oaks-impact.tsx renders title when feature flag is enabl
                         <span
                           class="sc-eqUAAy kJIzWq"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="sc-aXZVg jJQFnr"
-                        >
-                          <img
-                            alt=""
-                            class="sc-iGgWBj lcrpYX"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -97,19 +97,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c37 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c38 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c39 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -130,17 +130,17 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c40:hover {
+.c39:hover {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c44 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -148,7 +148,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c50 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -159,7 +159,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c53 {
+.c52 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -168,12 +168,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c55 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c58 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -193,7 +193,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c60 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -203,12 +203,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c64 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -813,7 +813,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -825,7 +825,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -836,14 +836,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -862,7 +862,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -877,7 +877,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   justify-content: center;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1232,7 +1232,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   text-align: left;
 }
 
-.c55 {
+.c54 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1410,7 +1410,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   cursor: default;
 }
 
-.c48 {
+.c47 {
   background: none;
   color: inherit;
   border: none;
@@ -1424,12 +1424,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
 }
 
-.c48:disabled {
+.c47:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c57 {
+.c56 {
   background: none;
   color: inherit;
   border: none;
@@ -1442,12 +1442,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57:disabled {
+.c56:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c63 {
+.c62 {
   background: none;
   color: inherit;
   border: none;
@@ -1477,12 +1477,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c63:disabled {
+.c62:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c65 {
   background: none;
   color: inherit;
   border: none;
@@ -1506,7 +1506,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-style: none;
 }
 
-.c66:disabled {
+.c65:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1572,15 +1572,15 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c36 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+.c53 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c54 {
-  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+.c66 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
@@ -1728,13 +1728,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   display: none;
 }
 
-.c64 {
+.c63 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c64:hover {
+.c63:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1742,27 +1742,27 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c64:hover [data-state="selected"] {
+.c63:hover [data-state="selected"] {
   display: none;
 }
 
-.c64:active {
+.c63:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c64:active [data-state="selected"] {
+.c63:active [data-state="selected"] {
   display: none;
 }
 
-.c64:disabled {
+.c63:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c64:disabled [data-state="selected"] {
+.c63:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1816,46 +1816,46 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c49 {
+.c48 {
   display: inline-block;
   position: relative;
 }
 
-.c49:hover {
+.c48:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c49:active {
+.c48:active {
   color: #222222;
 }
 
-.c49:disabled {
+.c48:disabled {
   color: #808080;
 }
 
-.c47 > :first-child:focus-visible .shadow {
+.c46 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:hover .shadow {
+.c46 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c47 > :first-child:active .shadow {
+.c46 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:disabled .icon-container {
+.c46 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c47 > :first-child:hover .icon-container {
+.c46 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c47 > :first-child:active .icon-container {
+.c46 > :first-child:active .icon-container {
   background: #222222;
 }
 
@@ -2330,7 +2330,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c43 {
+.c42 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -2346,44 +2346,44 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   width: 100%;
 }
 
-.c43::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c43::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #575757;
 }
 
-.c43:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #575757;
 }
 
-.c43::placeholder {
+.c42::placeholder {
   color: #575757;
 }
 
-.c43::-webkit-search-decoration,
-.c43::-webkit-search-cancel-button,
-.c43::-webkit-search-results-button,
-.c43::-webkit-search-results-decoration {
+.c42::-webkit-search-decoration,
+.c42::-webkit-search-cancel-button,
+.c42::-webkit-search-results-button,
+.c42::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c43:disabled {
+.c42:disabled {
   cursor: not-allowed;
 }
 
-.c42 {
+.c41 {
   background: #ffffff;
 }
 
-.c42:hover {
+.c41:hover {
   cursor: text;
 }
 
-.c42:focus-within {
+.c41:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
@@ -2484,11 +2484,11 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c58:hover .oak-save-count {
+.c57:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c58:focus-visible .oak-save-count {
+.c57:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -2918,7 +2918,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c37 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2927,19 +2927,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c39 {
+  .c38 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2947,37 +2947,37 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c56 {
+  .c55 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c61 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c64 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c64 {
     display: none;
   }
 }
@@ -3382,19 +3382,19 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c59 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -4161,13 +4161,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
 }
 
 @media (max-width:750px) {
-  .c43 {
+  .c42 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c42:hover:not(:focus-within) {
+  .c41:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
@@ -4634,12 +4634,12 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     <div
                       class="c6 yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c32 c33 internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="c9 c34"
@@ -4647,46 +4647,33 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         <span
                           class="c35"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="c20"
-                        >
-                          <img
-                            alt=""
-                            class="c36"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>
             </div>
             <div
-              class="c9 c37"
+              class="c9 c36"
             >
               <form
                 action="/teachers/search"
-                class="c38"
+                class="c37"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <div
-                    class="c40 c41 c42"
+                    class="c39 c40 c41"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c43"
+                      class="c42"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -4694,24 +4681,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   <div
-                    class="c45 c46 c47"
+                    class="c44 c45 c46"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c48 c49"
+                      class="c47 c48"
                       type="submit"
                     >
                       <div
-                        class="c9 c50"
+                        class="c9 c49"
                       >
                         <div
-                          class="c51 c52 icon-container"
+                          class="c50 c51 icon-container"
                         >
                           <div
-                            class="c53 shadow"
+                            class="c52 shadow"
                           />
                           <span
                             class="c20"
@@ -4719,7 +4706,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c54"
+                              class="c53"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -4729,7 +4716,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c55"
+                          class="c54"
                         />
                       </div>
                     </button>
@@ -4737,24 +4724,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c56"
+                class="c55"
               >
                 <div
-                  class="c45 c46 c47"
+                  class="c44 c45 c46"
                 >
                   <a
                     aria-label="Search"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c51 c52 icon-container"
+                        class="c50 c51 icon-container"
                       >
                         <div
-                          class="c53 shadow"
+                          class="c52 shadow"
                         />
                         <span
                           class="c20"
@@ -4762,7 +4749,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c54"
+                            class="c53"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4772,7 +4759,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
@@ -4780,14 +4767,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c57 c58"
+                class="c56 c57"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c59 c60 oak-save-count"
+                  class="c58 c59 oak-save-count"
                 >
                   <span
-                    class="c61"
+                    class="c60"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -4801,7 +4788,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c62"
+                    class="c61"
                   >
                     My library
                   </div>
@@ -4817,7 +4804,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c63 c64 internal-button"
+                  class="c62 c63 internal-button"
                 >
                   <div
                     class="c9 c34"
@@ -4833,7 +4820,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c65"
+            class="c64"
           >
             <div
               class="c4 c5"
@@ -4847,18 +4834,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c66 c8 internal-button"
+                class="c65 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c50"
+                  class="c9 c49"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c36"
+                      class="c66"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -4928,7 +4915,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c78 c46 c79"
+            class="c78 c45 c79"
           >
             <div
               class="c80 c81"
@@ -4972,7 +4959,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c9 c90"
                 >
                   <div
-                    class="c9 c46 c91"
+                    class="c9 c45 c91"
                   >
                     <div
                       class="c9 c92"
@@ -4998,7 +4985,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                   class="c9 c90"
                 >
                   <div
-                    class="c9 c46 c95"
+                    class="c9 c45 c95"
                   >
                     <div
                       class="c9 c96"
@@ -5066,7 +5053,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c9 c112"
               >
                 <div
-                  class="c9 c46 c113 c114"
+                  class="c9 c45 c113 c114"
                   data-testid="who-we-are-desc-item"
                 >
                   <div
@@ -5161,7 +5148,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c131"
@@ -5183,7 +5170,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               About Oak
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c133"
@@ -5214,7 +5201,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c131"
@@ -5236,7 +5223,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               Oak's curricula
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c133"
@@ -5267,7 +5254,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c131"
@@ -5289,7 +5276,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               Meet the team
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c133"
@@ -5320,7 +5307,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             data-testid="who-we-are-explore-item"
                           >
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c131"
@@ -5342,7 +5329,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                               Get involved
                             </div>
                             <div
-                              class="c9 c46"
+                              class="c9 c45"
                             >
                               <span
                                 class="c133"
@@ -5375,7 +5362,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               class="c69"
             >
               <div
-                class="c9 c46 c135"
+                class="c9 c45 c135"
               >
                 <div
                   class="c136 c1"
@@ -5384,7 +5371,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     class="c9 c137"
                   >
                     <div
-                      class="c9 c46 c138"
+                      class="c9 c45 c138"
                     >
                       <div
                         class="c139 c140"
@@ -5429,7 +5416,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                       </p>
                     </div>
                     <div
-                      class="c144 c46 c138"
+                      class="c144 c45 c138"
                     >
                       <form
                         aria-describedby="react-use-id-test-result-newsletter-form-description"
@@ -5878,7 +5865,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             />
                           </svg>
                           <div
-                            class="c164 c46"
+                            class="c164 c45"
                           >
                             <label
                               class="c152 c153 c154"
@@ -5899,7 +5886,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             type="button"
                           >
                             <div
-                              class="c167 c41 c168"
+                              class="c167 c40 c168"
                             >
                               <span
                                 class="c169 c170"
@@ -5970,7 +5957,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
         class="c175"
       >
         <div
-          class="c176 c46"
+          class="c176 c45"
         >
           <svg
             aria-hidden="true"
@@ -6003,7 +5990,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
               class="c9 c137"
             >
               <div
-                class="c9 c46 c180"
+                class="c9 c45 c180"
               >
                 <div
                   class="c181 c96"
@@ -6132,7 +6119,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c180"
+                class="c9 c45 c180"
               >
                 <div
                   class="c181 c96"
@@ -6350,7 +6337,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c180"
+                class="c9 c45 c180"
               >
                 <div
                   class="c181 c96"
@@ -6510,13 +6497,13 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c180"
+                class="c9 c45 c180"
               >
                 <div
                   class="c181 c191"
                 >
                   <div
-                    class="c39"
+                    class="c38"
                   >
                     <span
                       class="c192"
@@ -6536,18 +6523,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                     class="c193 c194"
                   >
                     <div
-                      class="c45 c46 c195 c196"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c197 c52 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
                               class="c198 shadow"
@@ -6558,7 +6545,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6568,24 +6555,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c195 c196"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c197 c52 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
                               class="c198 shadow"
@@ -6596,7 +6583,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6606,24 +6593,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c195 c196"
+                      class="c44 c45 c195 c196"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c197 c52 icon-container"
+                            class="c197 c51 icon-container"
                           >
                             <div
                               class="c198 shadow"
@@ -6634,7 +6621,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -6644,7 +6631,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
@@ -6676,18 +6663,18 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                 class="c202 c203"
               >
                 <div
-                  class="c45 c46 c195 c196"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c197 c52 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
                           class="c198 shadow"
@@ -6698,7 +6685,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6708,24 +6695,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c195 c196"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c197 c52 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
                           class="c198 shadow"
@@ -6736,7 +6723,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6746,24 +6733,24 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c195 c196"
+                  class="c44 c45 c195 c196"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c197 c52 icon-container"
+                        class="c197 c51 icon-container"
                       >
                         <div
                           class="c198 shadow"
@@ -6774,7 +6761,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -6784,14 +6771,14 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c56"
+                class="c55"
               >
                 <span
                   class="c192"
@@ -6885,7 +6872,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
             class="c9 c220"
           >
             <div
-              class="c221 c41"
+              class="c221 c40"
             >
               <button
                 class="c222"

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -97,19 +97,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c38 {
+.c37 {
   position: relative;
   max-width: 11.25rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c39 {
+.c38 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c40 {
+.c39 {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -130,17 +130,17 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c40:hover {
+.c39:hover {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   top: 50%;
   right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c45 {
+.c44 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -148,7 +148,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c51 {
+.c50 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -159,7 +159,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c53 {
+.c52 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -168,12 +168,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c55 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c58 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -193,7 +193,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c61 {
+.c60 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -203,12 +203,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c62 {
+.c61 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c65 {
+.c64 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -623,7 +623,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0.25rem;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -635,7 +635,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 1.5rem;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -646,14 +646,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -672,7 +672,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   gap: 0rem;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -687,7 +687,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   justify-content: center;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -928,7 +928,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   text-align: left;
 }
 
-.c55 {
+.c54 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1077,7 +1077,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   cursor: default;
 }
 
-.c48 {
+.c47 {
   background: none;
   color: inherit;
   border: none;
@@ -1091,12 +1091,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
 }
 
-.c48:disabled {
+.c47:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c57 {
+.c56 {
   background: none;
   color: inherit;
   border: none;
@@ -1109,12 +1109,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c57:disabled {
+.c56:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c63 {
+.c62 {
   background: none;
   color: inherit;
   border: none;
@@ -1144,12 +1144,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-radius: 0.25rem;
 }
 
-.c63:disabled {
+.c62:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c66 {
+.c65 {
   background: none;
   color: inherit;
   border: none;
@@ -1173,7 +1173,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-style: none;
 }
 
-.c66:disabled {
+.c65:disabled {
   pointer-events: none;
   cursor: default;
 }
@@ -1238,15 +1238,15 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   object-fit: contain;
 }
 
-.c36 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+.c53 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c54 {
-  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+.c66 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
@@ -1385,13 +1385,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   display: none;
 }
 
-.c64 {
+.c63 {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.c64:hover {
+.c63:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #ffffff;
@@ -1399,27 +1399,27 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   border-color: #575757;
 }
 
-.c64:hover [data-state="selected"] {
+.c63:hover [data-state="selected"] {
   display: none;
 }
 
-.c64:active {
+.c63:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c64:active [data-state="selected"] {
+.c63:active [data-state="selected"] {
   display: none;
 }
 
-.c64:disabled {
+.c63:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c64:disabled [data-state="selected"] {
+.c63:disabled [data-state="selected"] {
   display: none;
 }
 
@@ -1511,46 +1511,46 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c49 {
+.c48 {
   display: inline-block;
   position: relative;
 }
 
-.c49:hover {
+.c48:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #575757;
 }
 
-.c49:active {
+.c48:active {
   color: #222222;
 }
 
-.c49:disabled {
+.c48:disabled {
   color: #808080;
 }
 
-.c47 > :first-child:focus-visible .shadow {
+.c46 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:hover .shadow {
+.c46 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c47 > :first-child:active .shadow {
+.c46 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c47 > :first-child:disabled .icon-container {
+.c46 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c47 > :first-child:hover .icon-container {
+.c46 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c47 > :first-child:active .icon-container {
+.c46 > :first-child:active .icon-container {
   background: #222222;
 }
 
@@ -1915,7 +1915,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
 
-.c43 {
+.c42 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -1931,44 +1931,44 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   width: 100%;
 }
 
-.c43::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c43::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #575757;
 }
 
-.c43:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #575757;
 }
 
-.c43::placeholder {
+.c42::placeholder {
   color: #575757;
 }
 
-.c43::-webkit-search-decoration,
-.c43::-webkit-search-cancel-button,
-.c43::-webkit-search-results-button,
-.c43::-webkit-search-results-decoration {
+.c42::-webkit-search-decoration,
+.c42::-webkit-search-cancel-button,
+.c42::-webkit-search-results-button,
+.c42::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c43:disabled {
+.c42:disabled {
   cursor: not-allowed;
 }
 
-.c42 {
+.c41 {
   background: #ffffff;
 }
 
-.c42:hover {
+.c41:hover {
   cursor: text;
 }
 
-.c42:focus-within {
+.c41:focus-within {
   border-color: #222222;
   background: #ffffff;
 }
@@ -2057,11 +2057,11 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   max-width: 100%;
 }
 
-.c58:hover .oak-save-count {
+.c57:hover .oak-save-count {
   background-color: #bef2bd;
 }
 
-.c58:focus-visible .oak-save-count {
+.c57:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -2140,7 +2140,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c38 {
+  .c37 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2149,19 +2149,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c39 {
+  .c38 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     position: absolute;
   }
 }
 
 @media (min-width:750px) {
-  .c44 {
+  .c43 {
     -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
@@ -2169,37 +2169,37 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c56 {
+  .c55 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c59 {
+  .c58 {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c62 {
+  .c61 {
     display: contents;
   }
 }
 
 @media (min-width:750px) {
-  .c65 {
+  .c64 {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c65 {
+  .c64 {
     display: none;
   }
 }
@@ -2489,19 +2489,19 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (min-width:750px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c37 {
+  .c36 {
     gap: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c60 {
+  .c59 {
     -webkit-box-pack: initial;
     -webkit-justify-content: initial;
     -ms-flex-pack: initial;
@@ -2929,13 +2929,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
 }
 
 @media (max-width:750px) {
-  .c43 {
+  .c42 {
     font-size: 16px;
   }
 }
 
 @media (hover:hover) {
-  .c42:hover:not(:focus-within) {
+  .c41:hover:not(:focus-within) {
     background: #f2f2f2;
     border-color: #808080;
   }
@@ -3323,12 +3323,12 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     <div
                       class="c6 yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="c32 c33 internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="c9 c34"
@@ -3336,46 +3336,33 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         <span
                           class="c35"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="c20"
-                        >
-                          <img
-                            alt=""
-                            class="c36"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>
             </div>
             <div
-              class="c9 c37"
+              class="c9 c36"
             >
               <form
                 action="/teachers/search"
-                class="c38"
+                class="c37"
                 method="get"
                 role="search"
               >
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <div
-                    class="c40 c41 c42"
+                    class="c39 c40 c41"
                   >
                     <input
                       aria-invalid="false"
                       aria-label="Lesson and unit search"
-                      class="c43"
+                      class="c42"
                       name="term"
                       placeholder="Search"
                       type="search"
@@ -3383,24 +3370,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   <div
-                    class="c45 c46 c47"
+                    class="c44 c45 c46"
                   >
                     <button
                       aria-label="Submit search"
-                      class="c48 c49"
+                      class="c47 c48"
                       type="submit"
                     >
                       <div
-                        class="c9 c50"
+                        class="c9 c49"
                       >
                         <div
-                          class="c51 c52 icon-container"
+                          class="c50 c51 icon-container"
                         >
                           <div
-                            class="c53 shadow"
+                            class="c52 shadow"
                           />
                           <span
                             class="c20"
@@ -3408,7 +3395,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           >
                             <img
                               alt=""
-                              class="c54"
+                              class="c53"
                               data-nimg="fill"
                               decoding="async"
                               loading="lazy"
@@ -3418,7 +3405,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                           </span>
                         </div>
                         <span
-                          class="c55"
+                          class="c54"
                         />
                       </div>
                     </button>
@@ -3426,24 +3413,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </form>
               <div
-                class="c56"
+                class="c55"
               >
                 <div
-                  class="c45 c46 c47"
+                  class="c44 c45 c46"
                 >
                   <a
                     aria-label="Search"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="/teachers/search"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c51 c52 icon-container"
+                        class="c50 c51 icon-container"
                       >
                         <div
-                          class="c53 shadow"
+                          class="c52 shadow"
                         />
                         <span
                           class="c20"
@@ -3451,7 +3438,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c54"
+                            class="c53"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3461,7 +3448,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
@@ -3469,14 +3456,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               </div>
               <a
                 aria-label="My library"
-                class="c57 c58"
+                class="c56 c57"
                 href="/teachers/my-library"
               >
                 <div
-                  class="c59 c60 oak-save-count"
+                  class="c58 c59 oak-save-count"
                 >
                   <span
-                    class="c61"
+                    class="c60"
                     data-testid="bookmark-outlined"
                   >
                     <img
@@ -3490,7 +3477,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     />
                   </span>
                   <div
-                    class="c62"
+                    class="c61"
                   >
                     My library
                   </div>
@@ -3506,7 +3493,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                   class="c6 yellow-shadow"
                 />
                 <button
-                  class="c63 c64 internal-button"
+                  class="c62 c63 internal-button"
                 >
                   <div
                     class="c9 c34"
@@ -3522,7 +3509,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             </div>
           </div>
           <div
-            class="c65"
+            class="c64"
           >
             <div
               class="c4 c5"
@@ -3536,18 +3523,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               <button
                 aria-expanded="false"
                 aria-label="Open navigation menu"
-                class="c66 c8 internal-button"
+                class="c65 c8 internal-button"
                 data-testid="top-nav-hamburger-button"
               >
                 <div
-                  class="c9 c50"
+                  class="c9 c49"
                 >
                   <span
                     class="c20"
                   >
                     <img
                       alt=""
-                      class="c36"
+                      class="c66"
                       data-nimg="fill"
                       decoding="async"
                       loading="lazy"
@@ -3572,7 +3559,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
           class="c68"
         >
           <div
-            class="c69 c46"
+            class="c69 c45"
           >
             <nav
               aria-label="Breadcrumb"
@@ -3662,7 +3649,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             class="c76 c77"
           >
             <div
-              class="c39 c78 c79"
+              class="c38 c78 c79"
             />
             <div
               class="c9 c80 c81"
@@ -3731,7 +3718,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3773,7 +3760,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -3794,7 +3781,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
         class="c97"
       >
         <div
-          class="c98 c46"
+          class="c98 c45"
         >
           <svg
             aria-hidden="true"
@@ -3827,7 +3814,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
               class="c9 c102"
             >
               <div
-                class="c9 c46 c103"
+                class="c9 c45 c103"
               >
                 <div
                   class="c104 c105"
@@ -3956,7 +3943,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c103"
+                class="c9 c45 c103"
               >
                 <div
                   class="c104 c105"
@@ -4174,7 +4161,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c103"
+                class="c9 c45 c103"
               >
                 <div
                   class="c104 c105"
@@ -4334,13 +4321,13 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 </div>
               </div>
               <div
-                class="c9 c46 c103"
+                class="c9 c45 c103"
               >
                 <div
                   class="c104 c115"
                 >
                   <div
-                    class="c39"
+                    class="c38"
                   >
                     <span
                       class="c116"
@@ -4360,18 +4347,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                     class="c117 c118"
                   >
                     <div
-                      class="c45 c46 c119 c120"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="instagram for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://instagram.com/oaknational"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c121 c52 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
                               class="c122 shadow"
@@ -4382,7 +4369,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4392,24 +4379,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c119 c120"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="facebook for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://facebook.com/oaknationalacademy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c121 c52 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
                               class="c122 shadow"
@@ -4420,7 +4407,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4430,24 +4417,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
                     </div>
                     <div
-                      class="c45 c46 c119 c120"
+                      class="c44 c45 c119 c120"
                     >
                       <a
                         aria-label="linkedIn for Oak National Academy"
-                        class="c48 c49"
+                        class="c47 c48"
                         href="https://www.linkedin.com/company/oak-national-academy"
                       >
                         <div
-                          class="c9 c50"
+                          class="c9 c49"
                         >
                           <div
-                            class="c121 c52 icon-container"
+                            class="c121 c51 icon-container"
                           >
                             <div
                               class="c122 shadow"
@@ -4458,7 +4445,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             >
                               <img
                                 alt=""
-                                class="c36"
+                                class="c66"
                                 data-nimg="fill"
                                 decoding="async"
                                 loading="lazy"
@@ -4468,7 +4455,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                             </span>
                           </div>
                           <span
-                            class="c55"
+                            class="c54"
                           />
                         </div>
                       </a>
@@ -4500,18 +4487,18 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                 class="c127 c128"
               >
                 <div
-                  class="c45 c46 c119 c120"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="instagram for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://instagram.com/oaknational"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c121 c52 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
                           class="c122 shadow"
@@ -4522,7 +4509,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4532,24 +4519,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c119 c120"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="facebook for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://facebook.com/oaknationalacademy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c121 c52 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
                           class="c122 shadow"
@@ -4560,7 +4547,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4570,24 +4557,24 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
                 <div
-                  class="c45 c46 c119 c120"
+                  class="c44 c45 c119 c120"
                 >
                   <a
                     aria-label="linkedIn for Oak National Academy"
-                    class="c48 c49"
+                    class="c47 c48"
                     href="https://www.linkedin.com/company/oak-national-academy"
                   >
                     <div
-                      class="c9 c50"
+                      class="c9 c49"
                     >
                       <div
-                        class="c121 c52 icon-container"
+                        class="c121 c51 icon-container"
                       >
                         <div
                           class="c122 shadow"
@@ -4598,7 +4585,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         >
                           <img
                             alt=""
-                            class="c36"
+                            class="c66"
                             data-nimg="fill"
                             decoding="async"
                             loading="lazy"
@@ -4608,14 +4595,14 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
                         </span>
                       </div>
                       <span
-                        class="c55"
+                        class="c54"
                       />
                     </div>
                   </a>
                 </div>
               </div>
               <div
-                class="c56"
+                class="c55"
               >
                 <span
                   class="c116"
@@ -4709,7 +4696,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
             class="c9 c145"
           >
             <div
-              class="c146 c41"
+              class="c146 c40"
             >
               <button
                 class="c147"

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -358,12 +358,12 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                     <div
                       class="sc-aXZVg kpXzs yellow-shadow"
                     />
-                    <a
-                      aria-label="Ai experiments (this will open in a new tab)"
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="sc-dcJsrY sc-jXbUNg hodcpD kwUki internal-button"
-                      href="https://labs.thenational.academy"
-                      id="teachers-labs"
-                      target="_blank"
+                      data-testid="teachers-aiExperiments"
+                      id="teachers-aiExperiments"
                     >
                       <div
                         class="sc-aXZVg sc-gEvEer jPvJsJ kejpBe"
@@ -371,23 +371,10 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title when f
                         <span
                           class="sc-eqUAAy kJIzWq"
                         >
-                          Ai experiments
-                        </span>
-                        <span
-                          class="sc-aXZVg jJQFnr"
-                        >
-                          <img
-                            alt=""
-                            class="sc-iGgWBj lcrpYX"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1699953892/icons/hlxmejse3mcr4tqo6t8u.svg"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
+                          AI experiments
                         </span>
                       </div>
-                    </a>
+                    </button>
                   </div>
                 </li>
               </ul>

--- a/src/app/(core)/__snapshots__/layout.test.tsx.snap
+++ b/src/app/(core)/__snapshots__/layout.test.tsx.snap
@@ -103,10 +103,27 @@ exports[`core layout renders correctly 1`] = `
           "title": "About us",
         },
         "aiExperiments": {
-          "external": true,
-          "href": "https://labs.thenational.academy",
-          "slug": "labs",
-          "title": "Ai experiments",
+          "children": [
+            {
+              "external": true,
+              "href": "https://labs.thenational.academy",
+              "slug": "labs",
+              "title": "Labs home",
+            },
+            {
+              "external": true,
+              "href": "https://labs.thenational.academy/aila",
+              "slug": "aila",
+              "title": "Aila",
+            },
+            {
+              "href": "/mcp",
+              "slug": "mcp",
+              "title": "Oak Curriculum MCP",
+            },
+          ],
+          "slug": "aiExperiments",
+          "title": "AI experiments",
         },
         "guidance": {
           "children": [

--- a/src/common-lib/urls/urls.test.ts
+++ b/src/common-lib/urls/urls.test.ts
@@ -243,6 +243,14 @@ describe("urls.ts", () => {
         "https://labs.thenational.academy",
       );
     });
+    it("Aila", () => {
+      expect(resolveOakHref({ page: "aila" })).toBe(
+        "https://labs.thenational.academy/aila",
+      );
+    });
+    it("Oak Curriculum MCP", () => {
+      expect(resolveOakHref({ page: "mcp" })).toBe("/mcp");
+    });
     it("Teacher hub", () => {
       expect(resolveOakHref({ page: "teacher-hub" })).toBe(
         "https://teachers.thenational.academy",

--- a/src/common-lib/urls/urls.ts
+++ b/src/common-lib/urls/urls.ts
@@ -256,6 +256,8 @@ type LabsTeachingMaterialsLinkProps = {
   page: "labs-teaching-materials";
   query?: UrlQueryObject;
 };
+type AilaLinkProps = { page: "aila" };
+type McpLinkProps = { page: "mcp" };
 type TeacherHubLinkProps = { page: "teacher-hub" };
 
 type OnboardingLinkProps = {
@@ -344,6 +346,8 @@ export type OakLinkPropsRequiringPageOnly = Extract<
 export type OakLinkProps =
   | LabsLinkProps
   | LabsTeachingMaterialsLinkProps
+  | AilaLinkProps
+  | McpLinkProps
   | TeachersHomePageProps
   | LandingPageLinkProps
   | LessonDownloadsLinkProps
@@ -666,6 +670,18 @@ export const OAK_PAGES: {
     analyticsPageName: "[external] Labs",
     configType: "external",
     pageType: "labs-teaching-materials",
+  }),
+  aila: createOakPageConfig({
+    url: "https://labs.thenational.academy/aila",
+    analyticsPageName: "[external] Labs",
+    configType: "external",
+    pageType: "aila",
+  }),
+  mcp: createOakPageConfig({
+    pathPattern: "/mcp",
+    analyticsPageName: "Landing Page",
+    configType: "internal",
+    pageType: "mcp",
   }),
   "our-teachers": createOakPageConfig({
     url: "https://classroom.thenational.academy/teachers",

--- a/src/components/AppComponents/TopNav/SubNav/SubNav.test.tsx
+++ b/src/components/AppComponents/TopNav/SubNav/SubNav.test.tsx
@@ -34,19 +34,16 @@ describe("SubNav (Teachers)", () => {
     jest.clearAllMocks();
   });
 
-  it("renders Ai experiments link as a link element with external icon", () => {
+  it("renders AI experiments as a button", () => {
     render(<SubNav {...defaultProps} />);
 
-    const aiExperimentsLink = screen.getByRole("link", {
-      name: "Ai experiments (this will open in a new tab)",
+    const aiExperimentsButton = screen.getByRole("button", {
+      name: "AI experiments",
     });
 
-    expect(aiExperimentsLink).toBeInTheDocument();
-    expect(aiExperimentsLink).toHaveAttribute(
-      "href",
-      "https://labs.thenational.academy",
-    );
-    expect(aiExperimentsLink).toHaveAttribute("target", "_blank");
+    expect(aiExperimentsButton).toBeInTheDocument();
+    expect(aiExperimentsButton).not.toHaveAttribute("href");
+    expect(aiExperimentsButton).toHaveAttribute("aria-haspopup", "true");
   });
 
   it("renders Primary as a button", () => {

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerMainMenu.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import {
   OakBox,
   OakLI,
-  OakIconName,
   OakFlex,
   OakHeading,
   OakSvg,
@@ -10,7 +9,6 @@ import {
   OakLeftAlignedButton,
   OakLIProps,
 } from "@oaknational/oak-components";
-import Link from "next/link";
 
 import { HamburgerMenuHook } from "./TeachersTopNavHamburger";
 
@@ -18,7 +16,6 @@ import {
   TeachersBrowse,
   TeachersSubNavData,
 } from "@/node-lib/curriculum-api-2023/queries/topNav/topNav.schema";
-import { resolveOakHref } from "@/common-lib/urls";
 import useAnalytics from "@/context/Analytics/useAnalytics";
 
 export function MainMenuContent(
@@ -63,15 +60,12 @@ export function MainMenuContent(
         }
         $pb="spacing-16"
       />
-      <MainMenuLink
-        onClick={hamburgerMenu.handleCloseHamburger}
-        href={resolveOakHref({
-          page: "labs",
-        })}
-        external={true}
-        title="AI Experiments"
-        iconName="external"
-        aria-label="AI Experiments (this will open in a new tab)"
+      <MainMenuButton
+        title={"AI experiments"}
+        onClick={() =>
+          hamburgerMenu.handleNav({ menu: "OakMenu", value: "AI experiments" })
+        }
+        $pb="spacing-16"
       />
     </OakUL>
   );
@@ -214,36 +208,5 @@ export function MainMenuButton({
         {title}
       </OakLeftAlignedButton>
     </OakLI>
-  );
-}
-
-function MainMenuLink({
-  href,
-  title,
-  iconName,
-  external,
-  onClick,
-}: {
-  readonly href: string;
-  readonly title: string;
-  readonly external?: boolean;
-  readonly iconName?: OakIconName;
-  readonly onClick: () => void;
-}) {
-  return (
-    <OakLeftAlignedButton
-      width={"100%"}
-      element={Link}
-      isTrailingIcon
-      iconName={iconName}
-      href={href}
-      target={external ? "_blank" : "_self"}
-      aria-label={
-        external ? `${title} (this will open in a new tab)` : undefined
-      }
-      onClick={onClick}
-    >
-      {title}
-    </OakLeftAlignedButton>
   );
 }

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/HamburgerSubMenu.tsx
@@ -106,7 +106,11 @@ export function HamburgerMenuContent(
   switch (submenuOpen.menu) {
     case "OakMenu": {
       const links =
-        submenuOpen.value === "About us" ? navData.aboutUs : navData.guidance;
+        submenuOpen.value === "About us"
+          ? navData.aboutUs
+          : submenuOpen.value === "AI experiments"
+            ? navData.aiExperiments
+            : navData.guidance;
       return (
         <SubmenuContainer
           title={submenuOpen.value}

--- a/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
+++ b/src/components/AppComponents/TopNav/TeachersTopNavHamburger/TeachersTopNavHamburger.test.tsx
@@ -321,7 +321,7 @@ describe("TeachersTopNavHamburger", () => {
     expect(getByText("Computer science")).toBeInTheDocument();
   });
 
-  it("should render an aria label for external links in the main nav", async () => {
+  it("should render the AI experiments submenu with its links", async () => {
     const { getByTestId, getByRole } = render(
       <TeachersTopNavHamburger {...mockTopNavProps} />,
     );
@@ -329,10 +329,32 @@ describe("TeachersTopNavHamburger", () => {
     const button = getByTestId("top-nav-hamburger-button");
     await user.click(button);
 
-    const aiExperimentsLink = getByRole("link", {
-      name: "AI Experiments (this will open in a new tab)",
+    const aiExperimentsButton = getByRole("button", {
+      name: "AI experiments",
     });
-    expect(aiExperimentsLink).toHaveTextContent("AI Experiments");
+    await user.click(aiExperimentsButton);
+
+    const labsLink = getByRole("link", {
+      name: "Labs home (this will open in a new tab)",
+    });
+    expect(labsLink).toHaveAttribute(
+      "href",
+      "https://labs.thenational.academy",
+    );
+    expect(labsLink).toHaveAttribute("target", "_blank");
+
+    const ailaLink = getByRole("link", {
+      name: "Aila (this will open in a new tab)",
+    });
+    expect(ailaLink).toHaveAttribute(
+      "href",
+      "https://labs.thenational.academy/aila",
+    );
+    expect(ailaLink).toHaveAttribute("target", "_blank");
+
+    const mcpLink = getByRole("link", { name: "Oak Curriculum MCP" });
+    expect(mcpLink).toHaveAttribute("href", "/mcp");
+    expect(mcpLink).toHaveAttribute("target", "_self");
   });
 
   it("renders the submenu correctly", async () => {

--- a/src/components/AppComponents/TopNav/TopNav.test.tsx
+++ b/src/components/AppComponents/TopNav/TopNav.test.tsx
@@ -210,7 +210,7 @@ const subnavLabels = [
   { label: "Secondary", element: "button" },
   { label: "Guidance", element: "button" },
   { label: "About us", element: "button" },
-  { label: "Ai experiments (this will open in a new tab)", element: "link" },
+  { label: "AI experiments", element: "button" },
 ];
 
 describe("TopNav accessibility", () => {

--- a/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.test.tsx
+++ b/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.test.tsx
@@ -492,6 +492,48 @@ describe("TopNavDropdown", () => {
 
         expect(externalLink).toHaveAttribute("target", "_blank");
       });
+
+      it("renders the AI experiments section with its links", async () => {
+        render(
+          <TopNavDropdown
+            teachers={topNavFixture.teachers!}
+            pupils={topNavFixture.pupils!}
+            activeArea="TEACHERS"
+            selectedMenu="aiExperiments"
+            focusManager={teachersFocusManager}
+            onClose={onCloseMock}
+          />,
+        );
+
+        const heading = await screen.findByRole("heading", {
+          name: "AI experiments",
+        });
+        expect(heading).toBeInTheDocument();
+
+        const labsLink = await screen.findByRole("link", {
+          name: "Labs home (opens in a new tab)",
+        });
+        expect(labsLink).toHaveAttribute(
+          "href",
+          "https://labs.thenational.academy",
+        );
+        expect(labsLink).toHaveAttribute("target", "_blank");
+
+        const ailaLink = await screen.findByRole("link", {
+          name: "Aila (opens in a new tab)",
+        });
+        expect(ailaLink).toHaveAttribute(
+          "href",
+          "https://labs.thenational.academy/aila",
+        );
+        expect(ailaLink).toHaveAttribute("target", "_blank");
+
+        const mcpLink = await screen.findByRole("link", {
+          name: "Oak Curriculum MCP",
+        });
+        expect(mcpLink).toHaveAttribute("href", "/mcp");
+        expect(mcpLink).not.toHaveAttribute("target", "_blank");
+      });
     });
   });
 

--- a/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.tsx
+++ b/src/components/AppComponents/TopNav/TopNavDropdown/TopNavDropdown.tsx
@@ -369,7 +369,7 @@ const TeachersLinksSection = ({
                     ? `${link.title} (opens in a new tab)`
                     : undefined
                 }
-                width={"spacing-160"}
+                width={"max-content"}
                 id={buttonId}
                 onClick={onClose}
                 onKeyDown={(e) => focusManager.handleTabKeyDown(e, buttonId)}

--- a/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
+++ b/src/node-lib/curriculum-api-2023/fixtures/topNav.fixture.ts
@@ -316,10 +316,27 @@ export const topNavFixture: TopNavProps = {
       ],
     },
     aiExperiments: {
-      slug: "labs",
-      title: "Ai experiments",
-      href: "https://labs.thenational.academy",
-      external: true,
+      slug: "aiExperiments",
+      title: "AI experiments",
+      children: [
+        {
+          slug: "labs",
+          title: "Labs home",
+          href: "https://labs.thenational.academy",
+          external: true,
+        },
+        {
+          slug: "aila",
+          title: "Aila",
+          href: "https://labs.thenational.academy/aila",
+          external: true,
+        },
+        {
+          slug: "mcp",
+          title: "Oak Curriculum MCP",
+          href: "/mcp",
+        },
+      ],
     },
   },
   pupils: {

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.test.ts
@@ -77,6 +77,35 @@ describe("TopNavQuery", () => {
     ).toBe(true);
   });
 
+  it("returns AI experiments as a dropdown with the AI links", async () => {
+    const res = await topNavQuery({
+      ...sdk,
+      topNav: jest.fn(() => Promise.resolve(mockResponseData)),
+    })();
+
+    const aiExperiments = res.teachers?.aiExperiments;
+    expect(aiExperiments?.slug).toBe("aiExperiments");
+    expect(aiExperiments?.children).toEqual([
+      {
+        title: "Labs home",
+        slug: "labs",
+        href: "https://labs.thenational.academy",
+        external: true,
+      },
+      {
+        title: "Aila",
+        slug: "aila",
+        href: "https://labs.thenational.academy/aila",
+        external: true,
+      },
+      {
+        title: "Oak Curriculum MCP",
+        slug: "mcp",
+        href: "/mcp",
+      },
+    ]);
+  });
+
   it("uses the cached topNav function when withCache is true", async () => {
     const mockTopNav = jest.fn(() => Promise.resolve(mockResponseData));
     const mockCachedTopNav = jest.fn(() => Promise.resolve(mockResponseData));

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.query.ts
@@ -138,9 +138,26 @@ const topNavQuery = (sdk: Sdk) => {
       },
       aiExperiments: {
         title: "AI experiments",
-        slug: "labs",
-        href: resolveOakHref({ page: "labs" }),
-        external: true,
+        slug: "aiExperiments",
+        children: [
+          {
+            title: "Labs home",
+            slug: "labs",
+            href: resolveOakHref({ page: "labs" }),
+            external: true,
+          },
+          {
+            title: "Aila",
+            slug: "aila",
+            href: resolveOakHref({ page: "aila" }),
+            external: true,
+          },
+          {
+            title: "Oak Curriculum MCP",
+            slug: "mcp",
+            href: resolveOakHref({ page: "mcp" }),
+          },
+        ],
       },
     };
 

--- a/src/node-lib/curriculum-api-2023/queries/topNav/topNav.schema.ts
+++ b/src/node-lib/curriculum-api-2023/queries/topNav/topNav.schema.ts
@@ -32,7 +32,7 @@ export type TeachersSubNavData = {
   secondary: TeachersBrowse;
   guidance: NavDropDownButton;
   aboutUs: NavDropDownButton;
-  aiExperiments: NavLink;
+  aiExperiments: NavDropDownButton;
 };
 
 export type PupilsSubNavData = {
@@ -78,7 +78,10 @@ type PhaseState = {
   value: PhaseTitle;
 };
 type KeystageOptionsState = { menu: "KeystageOptions"; value: PhaseTitle };
-type OakState = { menu: "OakMenu"; value: "About us" | "Guidance" };
+type OakState = {
+  menu: "OakMenu";
+  value: "About us" | "Guidance" | "AI experiments";
+};
 type KS4OptionsState = { menu: "Ks4Options"; value: string };
 type MainMenuState = { menu: "MainMenu"; value: null };
 
@@ -229,7 +232,9 @@ export function isNavDropDownButtonItem(
 ): section is NavDropDownButton {
   return (
     "slug" in section &&
-    (section.slug === "guidance" || section.slug === "aboutUs")
+    (section.slug === "guidance" ||
+      section.slug === "aboutUs" ||
+      section.slug === "aiExperiments")
   );
 }
 


### PR DESCRIPTION
## Description

Music year: 1994

Expands the `AI experiments` link in the global nav into a dropdown, per the new Figma design: `Labs home` and `Aila` (both external, to Labs) plus an internal `Oak Curriculum MCP` link to `/mcp`. The MCP link is not gated, so this should merge after the `/mcp` landing page (`feat/mcp-landing-page`) is live.

## Issue(s)

Fixes #

[Figma](https://www.figma.com/design/t3tkWC64R8j21SnjSgJUSH/%F0%9F%8C%B3-Oak-MCP-v1?node-id=24394-39037&p=f&t=OI1X2xn0TaRRXZnn-0)

## How to test

1. Go to [OWA Preview URL from Vercel bot comment] as a teacher
2. On desktop widths, click `AI experiments` in the top nav
3. You should see a dropdown with `Labs home` and `Aila` (each with an external-link icon, opening Labs in a new tab) and `Oak Curriculum MCP` linking to `/mcp`
4. Keyboard: Tab to the `AI experiments` button, press Enter, Tab through the links, then Escape; focus should return to the button
5. On mobile widths, open the hamburger; `AI experiments` is now a submenu button; tap it to see the same three links, and the back button should return focus to it

>[!NOTE]
>
> This is to be merged in after the Oak MCP landing page work goes in

## Screenshots

How it used to look:

How it should now look:

## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] ~~Does this PR update a package with a breaking change~~ (no package changes)