### PR TITLE
Fixes "resources" value sent to hubspot when downloading files

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
@@ -385,7 +385,7 @@ describe("Programme Downloads", () => {
           schoolName: undefined,
           email: "test@example.com",
           terms: true,
-          resources: ["docx"],
+          resources: ["curriculumPlans"],
         }),
       );
 

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -233,7 +233,7 @@ export const ProgrammeDownloads = ({
         schoolName: data.schoolName,
         email: data.email,
         terms: data.terms,
-        resources: ["docx"],
+        resources: data.resources,
       });
       curriculumResourcesDownloaded(data);
 


### PR DESCRIPTION
## Description
Fixes "resources" value sent to hubspot when downloading files

Previously we always sent `["docx"]` which was `curriculumPlans` in the old format.

Now we send one of

 - `curriculumPlans`
 - `nationalCurriculum`

In addition once implementation-toolkit launches we'll also send 
 
 - `curriculumQuality`
 - `whatsIncluded`
 - `assessment`
 - `commonQuestions`
 - `equipmentList`


## Issue(s)
Fixes `ADOPT-2204`

## How to test

1. Go to https://oak-web-application-website-git-feat-adopt-2204-fix-hubs-d5b33d.vercel.thenational.academy/
2. Navigate to download a file from the programme downloads
3. Depending on which file you choose to download you should get all the correct resources types sent to the hubspot (see above)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
