### PR TITLE
feat: change border colour to border-neutral-stronger

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.test.tsx.snap
@@ -406,7 +406,7 @@ exports[`Teachers Page Page component renders 1`] = `
                     class="sc-aXZVg ksEYoI"
                   >
                     <div
-                      class="sc-aXZVg sc-gEvEer sc-kdBSHD jsSxFg uEMma hwfiFr"
+                      class="sc-aXZVg sc-gEvEer sc-kdBSHD kTJpCI uEMma hwfiFr"
                     >
                       <input
                         aria-invalid="false"

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
   color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
-  border-color: #cacaca;
+  border-color: #575757;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
   color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
-  border-color: #cacaca;
+  border-color: #575757;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
   color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
-  border-color: #cacaca;
+  border-color: #575757;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-impact.test.tsx.snap
@@ -405,7 +405,7 @@ exports[`pages/about-us/oaks-impact.tsx renders title 1`] = `
                   class="sc-aXZVg ksEYoI"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-kdBSHD jsSxFg uEMma hwfiFr"
+                    class="sc-aXZVg sc-gEvEer sc-kdBSHD kTJpCI uEMma hwfiFr"
                   >
                     <input
                       aria-invalid="false"

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
   color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
-  border-color: #cacaca;
+  border-color: #575757;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;

--- a/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/meet-the-team/__snapshots__/[slug].test.tsx.snap
@@ -118,7 +118,7 @@ exports[`pages/about/meet-the-team/[slug].tsx renders 1`] = `
   color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
-  border-color: #cacaca;
+  border-color: #575757;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -405,7 +405,7 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title 1`] = 
                   class="sc-aXZVg ksEYoI"
                 >
                   <div
-                    class="sc-aXZVg sc-gEvEer sc-kdBSHD jsSxFg uEMma hwfiFr"
+                    class="sc-aXZVg sc-gEvEer sc-kdBSHD kTJpCI uEMma hwfiFr"
                   >
                     <input
                       aria-invalid="false"

--- a/src/components/AppComponents/SearchBar/SearchBar.tsx
+++ b/src/components/AppComponents/SearchBar/SearchBar.tsx
@@ -23,6 +23,7 @@ const SearchBar = () => {
             name="term"
             aria-label="Lesson and unit search"
             $pr="spacing-32"
+            borderColor="border-neutral-stronger"
           />
         </OakBox>
         <OakBox


### PR DESCRIPTION
## Description

Music year: 1953

- Change border color to `border-neutral-stronger` to pass minimum ratio.

## Issue(s)

Fixes #

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/
2. You should see that the search bar has the colour #575757

## Screenshots

How it should now look:
<img width="517" height="285" alt="image" src="https://github.com/user-attachments/assets/cade01cf-302e-495e-9b7e-b4666d4e9bfa" />

## Checklist

- [ ] Added or updated tests where appropriate
- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
