### PR TITLE
Added case study list page behind flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@mux/mux-player": "^3.10.2",
     "@mux/mux-player-react": "3.10.2",
     "@oaknational/google-classroom-addon": "^1.33.0",
-    "@oaknational/oak-components": "^3.12.3",
+    "@oaknational/oak-components": "^3.16.0",
     "@oaknational/oak-consent-client": "2.4.0",
     "@oaknational/oak-curriculum-schema": "2.14.1",
     "@ooxml-tools/units": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,10 +65,10 @@ importers:
         version: 3.10.2(@types/react-dom@18.3.0)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@oaknational/google-classroom-addon':
         specifier: ^1.33.0
-        version: 1.33.0(1b484a671be87d63ab30c45b59af466a)
+        version: 1.33.0(5a8d126863ce94a44fbe26827855c8d8)
       '@oaknational/oak-components':
-        specifier: ^3.12.3
-        version: 3.12.3(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))
+        specifier: ^3.16.0
+        version: 3.16.0(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))
       '@oaknational/oak-consent-client':
         specifier: 2.4.0
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.3.6)
@@ -3803,8 +3803,8 @@ packages:
       zod: '>=3.25.76'
       zustand: '>=5.0.9'
 
-  '@oaknational/oak-components@3.12.3':
-    resolution: {integrity: sha512-v0+fFQtD0GzIfZcgKo4rc6PT0BrQ9TJI2oODxwvLYuk4qviR9nGaEYJc9DrfpcmYp9LyeqSmoAtyAPiYWHLSxw==}
+  '@oaknational/oak-components@3.16.0':
+    resolution: {integrity: sha512-gWHxUwrpbwZLsvMZpNWQDmw6tFM/qEfLyYGv8RungtADpb7YSnMk+WFvDl/tdu1q8HzyJPZ7HSi5JraqTdAuWw==}
     engines: {node: '24', pnpm: '>=11'}
     peerDependencies:
       '@portabletext/react': '>=4.0.1'
@@ -18989,7 +18989,7 @@ snapshots:
   '@graphql-tools/optimize@2.0.0(graphql@16.10.0)':
     dependencies:
       graphql: 16.10.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/prisma-loader@8.0.3(@types/node@22.19.17)(graphql@16.10.0)':
     dependencies:
@@ -19024,7 +19024,7 @@ snapshots:
       '@ardatan/relay-compiler': 13.0.1(graphql@16.10.0)
       '@graphql-tools/utils': 11.0.1(graphql@16.10.0)
       graphql: 16.10.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/schema@10.0.23(graphql@16.10.0)':
     dependencies:
@@ -20106,11 +20106,11 @@ snapshots:
   '@npmcli/redact@4.0.0':
     optional: true
 
-  '@oaknational/google-classroom-addon@1.33.0(1b484a671be87d63ab30c45b59af466a)':
+  '@oaknational/google-classroom-addon@1.33.0(5a8d126863ce94a44fbe26827855c8d8)':
     dependencies:
       '@google-cloud/firestore': 7.11.6
       '@googleapis/classroom': 4.9.0
-      '@oaknational/oak-components': 3.12.3(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))
+      '@oaknational/oak-components': 3.16.0(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))
       google-auth-library: 9.15.1
       iron-session: 8.0.4
       lodash: 4.18.1
@@ -20120,7 +20120,7 @@ snapshots:
       zod: 4.3.6
       zustand: 5.0.12(@types/react@18.2.79)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
 
-  '@oaknational/oak-components@3.12.3(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))':
+  '@oaknational/oak-components@3.16.0(@portabletext/react@4.0.3(react@18.3.1))(@tiptap/core@2.14.0(@tiptap/pm@2.14.0))(@tiptap/pm@2.14.0)(@types/react@18.2.79)(next-cloudinary@6.16.0(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react@18.3.1))(next@15.5.19(@babel/core@7.28.3)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.75.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1))':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -20134,6 +20134,7 @@ snapshots:
       react-focus-on: 3.10.2(@types/react@18.2.79)(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-components: 5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.8)(react@18.3.1)
+      tslib: 2.8.1
       url: 0.11.4
     transitivePeerDependencies:
       - '@tiptap/core'

--- a/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/get-involved.test.tsx.snap
@@ -4891,46 +4891,50 @@ exports[`pages/about/get-involved.tsx renders 1`] = `
           class="c68"
         >
           <div
-            class="c69"
+            class="c9"
           >
             <div
-              class="c70 c71"
+              class="c69"
             >
               <div
-                class="c9 c72"
+                class="c70 c71"
               >
-                <h1
-                  class="c73"
+                <div
+                  class="c9 c72"
+                >
+                  <h1
+                    class="c73"
+                  >
+                    <span
+                      class="c74"
+                    >
+                      Get involved
+                    </span>
+                  </h1>
+                  <p
+                    class="c75"
+                  >
+                    We need your help to understand what's needed in the classroom. Want to get involved? We can't wait to hear from you.
+                  </p>
+                </div>
+                <div
+                  class="c9 c76"
                 >
                   <span
-                    class="c74"
+                    class="c77 c78"
+                    data-testid="about-shared-loop"
                   >
-                    Get involved
+                    <img
+                      alt=""
+                      class="c21"
+                      data-nimg="fill"
+                      decoding="async"
+                      loading="lazy"
+                      src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg"
+                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                    />
                   </span>
-                </h1>
-                <p
-                  class="c75"
-                >
-                  We need your help to understand what's needed in the classroom. Want to get involved? We can't wait to hear from you.
-                </p>
-              </div>
-              <div
-                class="c9 c76"
-              >
-                <span
-                  class="c77 c78"
-                  data-testid="about-shared-loop"
-                >
-                  <img
-                    alt=""
-                    class="c21"
-                    data-nimg="fill"
-                    decoding="async"
-                    loading="lazy"
-                    src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg"
-                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                  />
-                </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/meet-the-team.test.tsx.snap
@@ -4739,47 +4739,51 @@ exports[`pages/about/meet-the-team.tsx renders 1`] = `
           class="c68"
         >
           <div
-            class="c69"
+            class="c9"
           >
             <div
-              class="c70 c71"
+              class="c69"
             >
               <div
-                class="c9 c72"
+                class="c70 c71"
               >
-                <h1
-                  class="c73"
+                <div
+                  class="c9 c72"
+                >
+                  <h1
+                    class="c73"
+                  >
+                    <span
+                      class="c74"
+                    >
+                      Meet the team
+                    </span>
+                  </h1>
+                  <p
+                    class="c75"
+                  >
+                    Learn more about the experts from across education, technology, school support and education who make up our leadership team and board.
+                  </p>
+                </div>
+                <div
+                  class="c9 c76"
                 >
                   <span
-                    class="c74"
+                    class="c77"
                   >
-                    Meet the team
+                    <img
+                      alt=""
+                      class="c27"
+                      data-nimg="fill"
+                      decoding="async"
+                      loading="lazy"
+                      sizes="100vw"
+                      src="http://localhost/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
+                      srcset="/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
+                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                    />
                   </span>
-                </h1>
-                <p
-                  class="c75"
-                >
-                  Learn more about the experts from across education, technology, school support and education who make up our leadership team and board.
-                </p>
-              </div>
-              <div
-                class="c9 c76"
-              >
-                <span
-                  class="c77"
-                >
-                  <img
-                    alt=""
-                    class="c27"
-                    data-nimg="fill"
-                    decoding="async"
-                    loading="lazy"
-                    sizes="100vw"
-                    src="http://localhost/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
-                    srcset="/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
-                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                  />
-                </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/oaks-curricula.test.tsx.snap
@@ -5306,47 +5306,51 @@ exports[`pages/about/oaks-curricula.tsx renders 1`] = `
           class="c68"
         >
           <div
-            class="c69"
+            class="c9"
           >
             <div
-              class="c70 c71"
+              class="c69"
             >
               <div
-                class="c9 c72"
+                class="c70 c71"
               >
-                <h1
-                  class="c73"
+                <div
+                  class="c9 c72"
+                >
+                  <h1
+                    class="c73"
+                  >
+                    <span
+                      class="c74"
+                    >
+                      Oak's curricula
+                    </span>
+                  </h1>
+                  <p
+                    class="c75"
+                  >
+                    Oak offers complete curriculum support for clarity and coherence in every national curriculum subject.
+                  </p>
+                </div>
+                <div
+                  class="c9 c76"
                 >
                   <span
-                    class="c74"
+                    class="c77"
                   >
-                    Oak's curricula
+                    <img
+                      alt=""
+                      class="c27"
+                      data-nimg="fill"
+                      decoding="async"
+                      loading="lazy"
+                      sizes="100vw"
+                      src="http://localhost/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
+                      srcset="/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
+                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                    />
                   </span>
-                </h1>
-                <p
-                  class="c75"
-                >
-                  Oak offers complete curriculum support for clarity and coherence in every national curriculum subject.
-                </p>
-              </div>
-              <div
-                class="c9 c76"
-              >
-                <span
-                  class="c77"
-                >
-                  <img
-                    alt=""
-                    class="c27"
-                    data-nimg="fill"
-                    decoding="async"
-                    loading="lazy"
-                    sizes="100vw"
-                    src="http://localhost/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
-                    srcset="/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_SANITY_ASSET_CDN_HOST%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
-                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                  />
-                </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
+++ b/src/__tests__/pages/about-us/__snapshots__/who-we-are.test.tsx.snap
@@ -4883,47 +4883,51 @@ exports[`pages/about/who-we-are.tsx renders 1`] = `
           class="c68"
         >
           <div
-            class="c69"
+            class="c9"
           >
             <div
-              class="c70 c71"
+              class="c69"
             >
               <div
-                class="c9 c72"
+                class="c70 c71"
               >
-                <h1
-                  class="c73"
+                <div
+                  class="c9 c72"
+                >
+                  <h1
+                    class="c73"
+                  >
+                    <span
+                      class="c74"
+                    >
+                      About Oak
+                    </span>
+                  </h1>
+                  <p
+                    class="c75"
+                  >
+                    We create free resources for teachers.
+                  </p>
+                </div>
+                <div
+                  class="c9 c76"
                 >
                   <span
-                    class="c74"
+                    class="c77"
                   >
-                    About Oak
+                    <img
+                      alt=""
+                      class="c27"
+                      data-nimg="fill"
+                      decoding="async"
+                      loading="lazy"
+                      sizes="100vw"
+                      src="http://localhost/_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
+                      srcset="/_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
+                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                    />
                   </span>
-                </h1>
-                <p
-                  class="c75"
-                >
-                  We create free resources for teachers.
-                </p>
-              </div>
-              <div
-                class="c9 c76"
-              >
-                <span
-                  class="c77"
-                >
-                  <img
-                    alt=""
-                    class="c27"
-                    data-nimg="fill"
-                    decoding="async"
-                    loading="lazy"
-                    sizes="100vw"
-                    src="http://localhost/_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75"
-                    srcset="/_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fcdn.sanity.io%2Fimages%2Fp%2Fd%2Fabcdef-300x300.png&w=3840&q=75 3840w"
-                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                  />
-                </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages/about-us/case-studies/index.tsx renders title 1`] = `
+exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
 <div>
   <div
     data-overlay-container="true"
@@ -603,7 +603,142 @@ exports[`pages/about-us/case-studies/index.tsx renders title 1`] = `
         class="sc-aXZVg sc-gEvEer bwVgbu fUxOFh"
         id="main"
       >
-        TODO: Case Study list page
+        <div
+          class="sc-aXZVg iebDQK"
+        >
+          <div
+            class="sc-aXZVg bZTQLO"
+          >
+            <div
+              class="sc-aXZVg sc-gEvEer guaSoh jIBBQP"
+            >
+              <div
+                class="sc-aXZVg sc-gEvEer epcFtP fVNIMq"
+              >
+                <div
+                  class="sc-aXZVg sc-fTFjTM iETyDq fPhXjy"
+                >
+                  <a
+                    class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
+                    href="/about-us/case-studies/Test-1"
+                  >
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75"
+                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                    <div
+                      class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
+                    >
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ fVNIMq"
+                      >
+                        <h3
+                          class="sc-eldPxv ibGcSM"
+                        >
+                          Test 1
+                        </h3>
+                      </div>
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ bRjxks"
+                      />
+                    </div>
+                  </a>
+                </div>
+                <div
+                  class="sc-aXZVg sc-fTFjTM iETyDq fPhXjy"
+                >
+                  <a
+                    class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
+                    href="/about-us/case-studies/Test-2"
+                  >
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75"
+                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                    <div
+                      class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
+                    >
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ fVNIMq"
+                      >
+                        <h3
+                          class="sc-eldPxv ibGcSM"
+                        >
+                          Test 2
+                        </h3>
+                      </div>
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ bRjxks"
+                      />
+                    </div>
+                  </a>
+                </div>
+                <div
+                  class="sc-aXZVg sc-fTFjTM iETyDq fPhXjy"
+                >
+                  <a
+                    class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
+                    href="/about-us/case-studies/Test-3"
+                  >
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75"
+                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                    <div
+                      class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
+                    >
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ fVNIMq"
+                      >
+                        <h3
+                          class="sc-eldPxv ibGcSM"
+                        >
+                          Test 3
+                        </h3>
+                      </div>
+                      <div
+                        class="sc-aXZVg sc-gEvEer jPvJsJ bRjxks"
+                      />
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </main>
       <footer
         class="sc-aXZVg gSjcjC"

--- a/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
@@ -671,21 +671,25 @@ exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
                     class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
                     href="/about-us/case-studies/Test-1"
                   >
-                    <span
-                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    <div
+                      class="sc-aXZVg gZoCWt"
                     >
-                      <img
-                        alt=""
-                        class="sc-iGgWBj dZvqhO"
-                        data-nimg="fill"
-                        decoding="async"
-                        loading="lazy"
-                        sizes="100vw"
-                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75"
-                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75 3840w"
-                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                      />
-                    </span>
+                      <span
+                        class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj dZvqhO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          sizes="100vw"
+                          src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75"
+                          srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-1&w=3840&q=75 3840w"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
                     <div
                       class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                     >
@@ -711,21 +715,25 @@ exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
                     class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
                     href="/about-us/case-studies/Test-2"
                   >
-                    <span
-                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    <div
+                      class="sc-aXZVg gZoCWt"
                     >
-                      <img
-                        alt=""
-                        class="sc-iGgWBj dZvqhO"
-                        data-nimg="fill"
-                        decoding="async"
-                        loading="lazy"
-                        sizes="100vw"
-                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75"
-                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75 3840w"
-                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                      />
-                    </span>
+                      <span
+                        class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj dZvqhO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          sizes="100vw"
+                          src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75"
+                          srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-2&w=3840&q=75 3840w"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
                     <div
                       class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                     >
@@ -751,21 +759,25 @@ exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
                     class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi fzgqkD"
                     href="/about-us/case-studies/Test-3"
                   >
-                    <span
-                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    <div
+                      class="sc-aXZVg gZoCWt"
                     >
-                      <img
-                        alt=""
-                        class="sc-iGgWBj dZvqhO"
-                        data-nimg="fill"
-                        decoding="async"
-                        loading="lazy"
-                        sizes="100vw"
-                        src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75"
-                        srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75 3840w"
-                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                      />
-                    </span>
+                      <span
+                        class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                      >
+                        <img
+                          alt=""
+                          class="sc-iGgWBj dZvqhO"
+                          data-nimg="fill"
+                          decoding="async"
+                          loading="lazy"
+                          sizes="100vw"
+                          src="http://localhost/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75"
+                          srcset="/_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=640&q=75 640w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=750&q=75 750w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=828&q=75 828w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1080&q=75 1080w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1200&q=75 1200w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=1920&q=75 1920w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=2048&q=75 2048w, /_next/image?url=http%3A%2F%2Flocalhost%2FTest-3&w=3840&q=75 3840w"
+                          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                        />
+                      </span>
+                    </div>
                     <div
                       class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                     >

--- a/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
@@ -634,7 +634,7 @@ exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
                   </p>
                 </div>
                 <div
-                  class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
+                  class="sc-aXZVg sc-92f05ab6-0 jPvJsJ dsUbtv"
                 >
                   <span
                     class="sc-aXZVg kSyyew"

--- a/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/pages/about-us/case-studies/__snapshots__/index.test.tsx.snap
@@ -607,6 +607,55 @@ exports[`pages/about-us/case-studies/index.tsx renders content 1`] = `
           class="sc-aXZVg iebDQK"
         >
           <div
+            class="sc-aXZVg diJnZN"
+          >
+            <div
+              class="sc-aXZVg bZTQLO"
+            >
+              <div
+                class="sc-aXZVg sc-gEvEer fjNszh hPyKbx"
+              >
+                <div
+                  class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
+                >
+                  <h1
+                    class="sc-eldPxv kSQYKV"
+                  >
+                    <span
+                      class="sc-eqUAAy AfXps"
+                    >
+                      Case studies
+                    </span>
+                  </h1>
+                  <p
+                    class="sc-ikkxIA fPezaI"
+                  >
+                    Explore how schools and trusts are using Oak to tackle their biggest challenges
+                  </p>
+                </div>
+                <div
+                  class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
+                >
+                  <span
+                    class="sc-aXZVg kSyyew"
+                  >
+                    <img
+                      alt=""
+                      class="sc-iGgWBj dZvqhO"
+                      data-nimg="fill"
+                      decoding="async"
+                      loading="lazy"
+                      sizes="100vw"
+                      src="http://localhost/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=3840&q=75"
+                      srcset="/_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=640&q=75 640w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=750&q=75 750w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=828&q=75 828w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2FNEXT_PUBLIC_OAK_ASSETS_HOST%2FNEXT_PUBLIC_OAK_ASSETS_PATH%2Fv1788884308%2F647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png&w=3840&q=75 3840w"
+                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
             class="sc-aXZVg bZTQLO"
           >
             <div

--- a/src/__tests__/pages/about-us/case-studies/index.test.tsx
+++ b/src/__tests__/pages/about-us/case-studies/index.test.tsx
@@ -1,40 +1,73 @@
 import { GetServerSidePropsContext } from "next/types";
+import slugify from "slugify";
 
 import renderWithProviders from "@/__tests__/__helpers__/renderWithProviders";
 import { topNavFixture } from "@/node-lib/curriculum-api-2023/fixtures/topNav.fixture";
 import OaksCaseStudyList, {
+  AboutUsOaksImpactCaseStudyListPageProps,
   getServerSideProps,
 } from "@/pages/about-us/case-studies/index";
 import { isFeatureFlagEnabledServer } from "@/utils/featureFlagChecks/server";
-
-const mockShouldSkipInitialBuild = false;
-
-jest.mock("@/node-lib/curriculum-api-2023", () => ({
-  __esModule: true,
-  default: {
-    topNav: () => jest.fn().mockResolvedValue(topNavFixture)(),
-  },
-}));
-
-jest.mock("@/node-lib/isr", () => ({
-  ...jest.requireActual("@/node-lib/isr"),
-  get shouldSkipInitialBuild() {
-    return mockShouldSkipInitialBuild;
-  },
-  getFallbackBlockingConfig: jest.fn(),
-}));
+import CMSClient from "@/node-lib/cms";
 
 jest.mock("@/node-lib/cms");
+const mockCMSClient = CMSClient as jest.MockedObject<typeof CMSClient>;
 
 jest.mock("@/utils/featureFlagChecks/server", () => ({
   isFeatureFlagEnabledServer: jest.fn(() => false),
 }));
 
+function fixtureCaseStudy(title: string) {
+  const slug = slugify(title);
+  return {
+    video: {
+      title: title,
+      video: {
+        asset: {
+          assetId: `asset-${slug}`,
+          playbackId: `playback-${slug}`,
+          thumbTime: null,
+        },
+      },
+    },
+    slug: {
+      current: slug,
+    },
+    image: {
+      asset: {
+        _id: slug,
+        url: `http://localhost/${slug}`,
+      },
+    },
+    publishedAt: new Date(0).toISOString(),
+  };
+}
+
+const mockPageData: AboutUsOaksImpactCaseStudyListPageProps["pageData"] = {
+  caseStudies: [
+    fixtureCaseStudy(`Test 1`),
+    fixtureCaseStudy(`Test 2`),
+    fixtureCaseStudy(`Test 3`),
+  ],
+};
+
 describe("pages/about-us/case-studies/index.tsx", () => {
-  it("renders title", async () => {
-    const { container } = renderWithProviders()(
-      <OaksCaseStudyList topNav={topNavFixture} />,
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockCMSClient.oaksImpactCaseStudyListPage.mockResolvedValue(
+      mockPageData.caseStudies,
     );
+  });
+
+  it("renders content", async () => {
+    const { container } = renderWithProviders()(
+      <OaksCaseStudyList topNav={topNavFixture} pageData={mockPageData} />,
+    );
+
+    expect(container).toHaveTextContent("Test 1");
+    expect(container).toHaveTextContent("Test 2");
+    expect(container).toHaveTextContent("Test 3");
 
     expect(container).toMatchSnapshot();
   });
@@ -56,6 +89,7 @@ describe("pages/about-us/case-studies/index.tsx", () => {
       expect(propsResult).toMatchObject({
         props: {
           topNav: topNavFixture,
+          pageData: mockPageData,
         },
       });
     });

--- a/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
+++ b/src/__tests__/pages/about-us/oaks-impact/__snapshots__/[slug].test.tsx.snap
@@ -864,21 +864,25 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title 1`] = 
                         class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                         href="/about-us/case-studies/test-slug-2"
                       >
-                        <span
-                          class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                        <div
+                          class="sc-aXZVg jPvJsJ"
                         >
-                          <img
-                            alt=""
-                            class="sc-iGgWBj dZvqhO"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            sizes="100vw"
-                            src="http://localhost/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75"
-                            srcset="/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75 3840w"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
-                        </span>
+                          <span
+                            class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                          >
+                            <img
+                              alt=""
+                              class="sc-iGgWBj dZvqhO"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              sizes="100vw"
+                              src="http://localhost/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75"
+                              srcset="/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75 3840w"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </div>
                         <div
                           class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                         >
@@ -931,21 +935,25 @@ exports[`pages/about-us/oaks-impact/case-studies/[slug].tsx renders title 1`] = 
                         class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                         href="/about-us/case-studies/test-slug-3"
                       >
-                        <span
-                          class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                        <div
+                          class="sc-aXZVg jPvJsJ"
                         >
-                          <img
-                            alt=""
-                            class="sc-iGgWBj dZvqhO"
-                            data-nimg="fill"
-                            decoding="async"
-                            loading="lazy"
-                            sizes="100vw"
-                            src="http://localhost/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75"
-                            srcset="/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75 3840w"
-                            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                          />
-                        </span>
+                          <span
+                            class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                          >
+                            <img
+                              alt=""
+                              class="sc-iGgWBj dZvqhO"
+                              data-nimg="fill"
+                              decoding="async"
+                              loading="lazy"
+                              sizes="100vw"
+                              src="http://localhost/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75"
+                              srcset="/_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fexample.com%2Ftest-image.jpg&w=3840&q=75 3840w"
+                              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                            />
+                          </span>
+                        </div>
                         <div
                           class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                         >

--- a/src/common-lib/cms-types/aboutPages.ts
+++ b/src/common-lib/cms-types/aboutPages.ts
@@ -210,8 +210,14 @@ export const oaksImpactCaseStudyPageSchema = z.object({
   }),
 });
 
+export const oaksImpactCaseStudyListPageSchema = z.array(caseStudySchema);
+
 export type OaksImpactCaseStudyPage = z.infer<
   typeof oaksImpactCaseStudyPageSchema
+>;
+
+export type OaksImpactCaseStudyListPage = z.infer<
+  typeof oaksImpactCaseStudyListPageSchema
 >;
 
 // Aliases for about pages (old naming convention - mapping new queries to existing schemas)

--- a/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
+++ b/src/components/CurriculumComponents/CurricTimetablingUnits/__snapshots__/CurricTimetablingUnits.test.tsx.snap
@@ -970,7 +970,7 @@ exports[`CurricTimetablingUnits snapshot (mode=normal) 1`] = `
                       </span>
                     </div>
                     <div
-                      class="sc-aXZVg sc-gEvEer bwVgbu FqbMN"
+                      class="sc-aXZVg sc-gEvEer bwVgbu eISTqr"
                     >
                       <div
                         class="sc-aXZVg sc-gEvEer bwVgbu eFZOSO"

--- a/src/components/GenericPagesComponents/AboutSharedHeader/__snapshots__/AboutSharedHeader.test.tsx.snap
+++ b/src/components/GenericPagesComponents/AboutSharedHeader/__snapshots__/AboutSharedHeader.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`AboutSharedHeader renders correctly 1`] = `
             </p>
           </div>
           <div
-            class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
+            class="sc-aXZVg sc-92f05ab6-0 jPvJsJ dsUbtv"
           >
             <span
               class="sc-aXZVg kvjdhA"
@@ -85,10 +85,10 @@ exports[`AboutSharedHeader renders correctly with loop illustration 1`] = `
             </p>
           </div>
           <div
-            class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
+            class="sc-aXZVg sc-92f05ab6-0 jPvJsJ dsUbtv"
           >
             <span
-              class="sc-aXZVg fjkwRj sc-c5bbc7dd-1 hLyHyG"
+              class="sc-aXZVg fjkwRj sc-92f05ab6-1 kbrnCV"
               data-testid="about-shared-loop"
             >
               <img

--- a/src/components/GenericPagesComponents/AboutSharedHeader/__snapshots__/AboutSharedHeader.test.tsx.snap
+++ b/src/components/GenericPagesComponents/AboutSharedHeader/__snapshots__/AboutSharedHeader.test.tsx.snap
@@ -4,45 +4,49 @@ exports[`AboutSharedHeader renders correctly 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg bZTQLO"
+      class="sc-aXZVg jPvJsJ"
     >
       <div
-        class="sc-aXZVg sc-gEvEer fjNszh hPyKbx"
+        class="sc-aXZVg bZTQLO"
       >
         <div
-          class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
+          class="sc-aXZVg sc-gEvEer fjNszh hPyKbx"
         >
-          <h1
-            class="sc-eldPxv kSQYKV"
+          <div
+            class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
+          >
+            <h1
+              class="sc-eldPxv kSQYKV"
+            >
+              <span
+                class="sc-eqUAAy buaVGR"
+              >
+                TESTING_TITLE
+              </span>
+            </h1>
+            <p
+              class="sc-ikkxIA fPezaI"
+            >
+              TESTING_CONTENT
+            </p>
+          </div>
+          <div
+            class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
           >
             <span
-              class="sc-eqUAAy buaVGR"
+              class="sc-aXZVg kvjdhA"
             >
-              TESTING_TITLE
+              <img
+                alt="Oak logo"
+                class="sc-iGgWBj dZvqhO"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                src="http://example.com/image.svg"
+                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+              />
             </span>
-          </h1>
-          <p
-            class="sc-ikkxIA fPezaI"
-          >
-            TESTING_CONTENT
-          </p>
-        </div>
-        <div
-          class="sc-aXZVg sc-2c4f354b-0 jPvJsJ bnaXAx"
-        >
-          <span
-            class="sc-aXZVg kvjdhA"
-          >
-            <img
-              alt="Oak logo"
-              class="sc-iGgWBj dZvqhO"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              src="http://example.com/image.svg"
-              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-            />
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -54,46 +58,50 @@ exports[`AboutSharedHeader renders correctly with loop illustration 1`] = `
 <body>
   <div>
     <div
-      class="sc-aXZVg bZTQLO"
+      class="sc-aXZVg jPvJsJ"
     >
       <div
-        class="sc-aXZVg sc-gEvEer fjNszh hPyKbx"
+        class="sc-aXZVg bZTQLO"
       >
         <div
-          class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
+          class="sc-aXZVg sc-gEvEer fjNszh hPyKbx"
         >
-          <h1
-            class="sc-eldPxv kSQYKV"
+          <div
+            class="sc-aXZVg sc-gEvEer jPvJsJ daEtut"
+          >
+            <h1
+              class="sc-eldPxv kSQYKV"
+            >
+              <span
+                class="sc-eqUAAy buaVGR"
+              >
+                TESTING_TITLE
+              </span>
+            </h1>
+            <p
+              class="sc-ikkxIA fPezaI"
+            >
+              TESTING_CONTENT
+            </p>
+          </div>
+          <div
+            class="sc-aXZVg sc-c5bbc7dd-0 jPvJsJ fXYulI"
           >
             <span
-              class="sc-eqUAAy buaVGR"
+              class="sc-aXZVg fjkwRj sc-c5bbc7dd-1 hLyHyG"
+              data-testid="about-shared-loop"
             >
-              TESTING_TITLE
+              <img
+                alt=""
+                class="sc-iGgWBj cMzyFO"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg"
+                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+              />
             </span>
-          </h1>
-          <p
-            class="sc-ikkxIA fPezaI"
-          >
-            TESTING_CONTENT
-          </p>
-        </div>
-        <div
-          class="sc-aXZVg sc-2c4f354b-0 jPvJsJ bnaXAx"
-        >
-          <span
-            class="sc-aXZVg fjkwRj sc-2c4f354b-1 kfUPWX"
-            data-testid="about-shared-loop"
-          >
-            <img
-              alt=""
-              class="sc-iGgWBj cMzyFO"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              src="https://next_public_oak_assets_host/NEXT_PUBLIC_OAK_ASSETS_PATH/v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg"
-              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-            />
-          </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/GenericPagesComponents/AboutSharedHeader/index.tsx
+++ b/src/components/GenericPagesComponents/AboutSharedHeader/index.tsx
@@ -100,48 +100,59 @@ export type AboutSharedHeaderProps = {
   content: PortableTextJSON | string;
   children?: ReactNode;
   titleHighlight?: OakUiRoleToken;
+  $background?: OakUiRoleToken;
 };
 export function AboutSharedHeader({
   title,
   content,
   children,
   titleHighlight,
+  $background,
 }: Readonly<AboutSharedHeaderProps>) {
   return (
-    <NewGutterMaxWidth>
-      <OakFlex
-        $alignItems="center"
-        $justifyContent="space-between"
-        $pt={["spacing-56", "spacing-72"]}
-        $pb={["spacing-56", "spacing-72"]}
-        $gap={["spacing-0", "spacing-48", "spacing-240"]}
-        $overflow={"hidden"}
-      >
-        <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
-          <OakHeading tag="h1" $font={["heading-4", "heading-2", "heading-2"]}>
-            <OakSpan
-              $background={titleHighlight ?? "bg-decorative1-main"}
-              $ph={"spacing-4"}
+    <OakBox $background={$background}>
+      <NewGutterMaxWidth>
+        <OakFlex
+          $alignItems="center"
+          $justifyContent="space-between"
+          $pt={["spacing-56", "spacing-72"]}
+          $pb={["spacing-56", "spacing-72"]}
+          $gap={["spacing-0", "spacing-48", "spacing-240"]}
+          $overflow={"hidden"}
+        >
+          <OakFlex $flexDirection={"column"} $gap={"spacing-24"}>
+            <OakHeading
+              tag="h1"
+              $font={["heading-4", "heading-2", "heading-2"]}
             >
-              {title}
-            </OakSpan>
-          </OakHeading>
-          {typeof content === "string" ? (
-            <OakP
-              $font={["heading-light-5", "heading-light-3", "heading-light-3"]}
-            >
-              {content}
-            </OakP>
-          ) : (
-            <PortableTextWithDefaults
-              value={content}
-              withoutDefaultComponents={true}
-              components={portableTextComponents}
-            />
-          )}
+              <OakSpan
+                $background={titleHighlight ?? "bg-decorative1-main"}
+                $ph={"spacing-4"}
+              >
+                {title}
+              </OakSpan>
+            </OakHeading>
+            {typeof content === "string" ? (
+              <OakP
+                $font={[
+                  "heading-light-5",
+                  "heading-light-3",
+                  "heading-light-3",
+                ]}
+              >
+                {content}
+              </OakP>
+            ) : (
+              <PortableTextWithDefaults
+                value={content}
+                withoutDefaultComponents={true}
+                components={portableTextComponents}
+              />
+            )}
+          </OakFlex>
+          <IllustrationPanel>{children}</IllustrationPanel>
         </OakFlex>
-        <IllustrationPanel>{children}</IllustrationPanel>
-      </OakFlex>
-    </NewGutterMaxWidth>
+      </NewGutterMaxWidth>
+    </OakBox>
   );
 }

--- a/src/components/GenericPagesComponents/OaksImpactCaseStudies/__snapshots__/OaksImpactCaseStudies.test.tsx.snap
+++ b/src/components/GenericPagesComponents/OaksImpactCaseStudies/__snapshots__/OaksImpactCaseStudies.test.tsx.snap
@@ -38,21 +38,25 @@ exports[`OaksImpactCaseStudies renders correctly when 2 case studies are provide
                   class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                   href="/about-us/case-studies/case-study-1"
                 >
-                  <span
-                    class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                  <div
+                    class="sc-aXZVg jPvJsJ"
                   >
-                    <img
-                      alt=""
-                      class="sc-iGgWBj dZvqhO"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      sizes="100vw"
-                      src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75"
-                      srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75 3840w"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75"
+                        srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                   <div
                     class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                   >
@@ -105,21 +109,25 @@ exports[`OaksImpactCaseStudies renders correctly when 2 case studies are provide
                   class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                   href="/about-us/case-studies/case-study-2"
                 >
-                  <span
-                    class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                  <div
+                    class="sc-aXZVg jPvJsJ"
                   >
-                    <img
-                      alt=""
-                      class="sc-iGgWBj dZvqhO"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      sizes="100vw"
-                      src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75"
-                      srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75 3840w"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75"
+                        srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                   <div
                     class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                   >
@@ -208,21 +216,25 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
                   class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                   href="/about-us/case-studies/case-study-1"
                 >
-                  <span
-                    class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                  <div
+                    class="sc-aXZVg jPvJsJ"
                   >
-                    <img
-                      alt=""
-                      class="sc-iGgWBj dZvqhO"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      sizes="100vw"
-                      src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75"
-                      srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75 3840w"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75"
+                        srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336490%2Fsample.jpg&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                   <div
                     class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                   >
@@ -275,21 +287,25 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
                   class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                   href="/about-us/case-studies/case-study-2"
                 >
-                  <span
-                    class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                  <div
+                    class="sc-aXZVg jPvJsJ"
                   >
-                    <img
-                      alt=""
-                      class="sc-iGgWBj dZvqhO"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      sizes="100vw"
-                      src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75"
-                      srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75 3840w"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75"
+                        srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Flandscapes%2Fnature-mountains.jpg&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                   <div
                     class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                   >
@@ -342,21 +358,25 @@ exports[`OaksImpactCaseStudies renders correctly when 3 case studies are provide
                   class="sc-aXZVg sc-gEvEer sc-kbousE eyLmQc dXoawi iNGAcO"
                   href="/about-us/case-studies/case-study-3"
                 >
-                  <span
-                    class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                  <div
+                    class="sc-aXZVg jPvJsJ"
                   >
-                    <img
-                      alt=""
-                      class="sc-iGgWBj dZvqhO"
-                      data-nimg="fill"
-                      decoding="async"
-                      loading="lazy"
-                      sizes="100vw"
-                      src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=3840&q=75"
-                      srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=3840&q=75 3840w"
-                      style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-                    />
-                  </span>
+                    <span
+                      class="sc-aXZVg kvjdhA sc-gfoqjT giDcXR"
+                    >
+                      <img
+                        alt=""
+                        class="sc-iGgWBj dZvqhO"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        sizes="100vw"
+                        src="http://localhost/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=3840&q=75"
+                        srcset="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Foak-web-application%2Fimage%2Fupload%2Fv1698336494%2Fsamples%2Fanimals%2Fcat.jpg&w=3840&q=75 3840w"
+                        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+                      />
+                    </span>
+                  </div>
                   <div
                     class="sc-aXZVg sc-gEvEer sc-eyvILC jPvJsJ jFNgPm"
                   >

--- a/src/components/TeacherComponents/RiskAssessmentBanner/__snapshots__/RiskAssessmentBanner.test.tsx.snap
+++ b/src/components/TeacherComponents/RiskAssessmentBanner/__snapshots__/RiskAssessmentBanner.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`RiskAssessmentBanner renders the RiskAssessmentBanner component 1`] = `
           </span>
         </div>
         <div
-          class="sc-aXZVg sc-gEvEer bwVgbu FqbMN"
+          class="sc-aXZVg sc-gEvEer bwVgbu eISTqr"
         >
           <div
             class="sc-aXZVg sc-gEvEer bwVgbu eFZOSO"

--- a/src/node-lib/cms/sanity-client/index.ts
+++ b/src/node-lib/cms/sanity-client/index.ts
@@ -27,6 +27,7 @@ import {
   teamMemberSchema,
   oaksImpactPageSchema,
   oaksImpactCaseStudyPageSchema,
+  oaksImpactCaseStudyListPageSchema,
   implementationGuidesSchema,
 } from "../../../common-lib/cms-types";
 import { webinarsListingPageSchema } from "../../../common-lib/cms-types/webinarsListingPage";
@@ -252,6 +253,11 @@ const getSanityClient = () => ({
     sanityGraphqlApi.oaksImpactCaseStudyPage,
     oaksImpactCaseStudyPageSchema,
     (result) => result?.allNewAboutCorePageOaksImpact?.[0],
+  ),
+  oaksImpactCaseStudyListPage: getList(
+    sanityGraphqlApi.oaksImpactCaseStudyListPage,
+    oaksImpactCaseStudyListPageSchema,
+    (result) => result.allCaseStudy,
   ),
   meetTheTeamPage: getSingleton(
     sanityGraphqlApi.meetTheTeamPage,

--- a/src/node-lib/sanity-graphql/generated/sdk.ts
+++ b/src/node-lib/sanity-graphql/generated/sdk.ts
@@ -6460,6 +6460,13 @@ export type OaksCurriculaPageQueryVariables = Exact<{
 
 export type OaksCurriculaPageQuery = { __typename?: 'RootQuery', allNewAboutCorePageOaksCurricula: Array<{ __typename?: 'NewAboutCorePageOaksCurricula', id?: string | null, header?: { __typename?: 'OaksCurriculaPageHeader', introText?: string | null, image?: { __typename?: 'ImageWithAltText', altText?: string | null, isPresentational?: boolean | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null, hotspot?: { __typename?: 'SanityImageHotspot', x?: number | null, y?: number | null, width?: number | null, height?: number | null } | null } | null } | null, guidingPrinciples?: { __typename?: 'OaksCurriculaPageGuidingPrinciples', textRaw?: any | null, image?: { __typename?: 'ImageWithAltText', altText?: string | null, isPresentational?: boolean | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null, hotspot?: { __typename?: 'SanityImageHotspot', x?: number | null, y?: number | null, width?: number | null, height?: number | null } | null } | null, principles?: Array<{ __typename?: 'OaksCurriculaPageGuidingPrinciple', heading?: string | null, text2Raw?: any | null } | null> | null } | null, curriculumPartners?: { __typename?: 'OaksCurriculaPageCurriculumPartnersSection', textRaw?: any | null, current?: { __typename?: 'OaksCurriculaPagePartnerSection', textRaw?: any | null, partners?: Array<{ __typename?: 'OaksCurriculaPagePartner', logo?: { __typename?: 'ImageWithAltText', altText?: string | null, isPresentational?: boolean | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null, hotspot?: { __typename?: 'SanityImageHotspot', x?: number | null, y?: number | null, width?: number | null, height?: number | null } | null } | null } | null> | null } | null, legacy?: { __typename?: 'OaksCurriculaPagePartnerSection', textRaw?: any | null, partners?: Array<{ __typename?: 'OaksCurriculaPagePartner', logo?: { __typename?: 'ImageWithAltText', altText?: string | null, isPresentational?: boolean | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null, hotspot?: { __typename?: 'SanityImageHotspot', x?: number | null, y?: number | null, width?: number | null, height?: number | null } | null } | null } | null> | null } | null } | null, seo?: { __typename?: 'Seo', title?: string | null, description?: string | null, canonicalURL?: string | null } | null }> };
 
+export type OaksImpactCaseStudyListPageQueryVariables = Exact<{
+  isDraftFilter?: InputMaybe<Sanity_DocumentFilter>;
+}>;
+
+
+export type OaksImpactCaseStudyListPageQuery = { __typename?: 'RootQuery', allCaseStudy: Array<{ __typename?: 'CaseStudy', publishedAt?: any | null, textRaw?: any | null, slug?: { __typename?: 'Slug', current?: string | null } | null, video?: { __typename?: 'Video', title?: string | null, captions?: Array<string | null> | null, transcript?: any | null, video?: { __typename?: 'MuxVideo', asset?: { __typename?: 'MuxVideoAsset', assetId?: string | null, thumbTime?: number | null, playbackId?: string | null } | null } | null } | null, image?: { __typename?: 'ImageWithAltText', altText?: string | null, isPresentational?: boolean | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null, hotspot?: { __typename?: 'SanityImageHotspot', x?: number | null, y?: number | null, width?: number | null, height?: number | null } | null } | null }> };
+
 export type OaksImpactCaseStudyPageQueryVariables = Exact<{
   isDraftFilter?: InputMaybe<Sanity_DocumentFilter>;
 }>;
@@ -7626,6 +7633,24 @@ export const OaksCurriculaPageDocument = gql`
 }
     ${ImageWithAltTextFragmentDoc}
 ${SeoFragmentDoc}`;
+export const OaksImpactCaseStudyListPageDocument = gql`
+    query oaksImpactCaseStudyListPage($isDraftFilter: Sanity_DocumentFilter) {
+  allCaseStudy(where: {_: $isDraftFilter}) {
+    slug {
+      current
+    }
+    video {
+      ...Video
+    }
+    image {
+      ...ImageWithAltText
+    }
+    publishedAt
+    textRaw
+  }
+}
+    ${VideoFragmentDoc}
+${ImageWithAltTextFragmentDoc}`;
 export const OaksImpactCaseStudyPageDocument = gql`
     query oaksImpactCaseStudyPage($isDraftFilter: Sanity_DocumentFilter) {
   allNewAboutCorePageOaksImpact(
@@ -8071,6 +8096,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     oaksCurriculaPage(variables?: OaksCurriculaPageQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<OaksCurriculaPageQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<OaksCurriculaPageQuery>({ document: OaksCurriculaPageDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'oaksCurriculaPage', 'query', variables);
+    },
+    oaksImpactCaseStudyListPage(variables?: OaksImpactCaseStudyListPageQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<OaksImpactCaseStudyListPageQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<OaksImpactCaseStudyListPageQuery>({ document: OaksImpactCaseStudyListPageDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'oaksImpactCaseStudyListPage', 'query', variables);
     },
     oaksImpactCaseStudyPage(variables?: OaksImpactCaseStudyPageQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<OaksImpactCaseStudyPageQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<OaksImpactCaseStudyPageQuery>({ document: OaksImpactCaseStudyPageDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'oaksImpactCaseStudyPage', 'query', variables);

--- a/src/node-lib/sanity-graphql/queries/oaksImpactCaseStudyListPage.gql
+++ b/src/node-lib/sanity-graphql/queries/oaksImpactCaseStudyListPage.gql
@@ -1,0 +1,19 @@
+query oaksImpactCaseStudyListPage($isDraftFilter: Sanity_DocumentFilter) {
+  allCaseStudy (
+    where: {
+      _: $isDraftFilter
+    }
+  ) {
+    slug {
+      current
+    },
+    video {
+      ...Video
+    },
+    image {
+      ...ImageWithAltText
+    }
+    publishedAt,
+    textRaw,
+  }
+}

--- a/src/pages/about-us/case-studies/index.tsx
+++ b/src/pages/about-us/case-studies/index.tsx
@@ -6,18 +6,32 @@ import Layout from "@/components/AppComponents/AppLayout";
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
 import { TeacherBrowseAnalyticsStoreProvider } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 import { isFeatureFlagEnabledServer } from "@/utils/featureFlagChecks/server";
+import { OakBox, OakCard, OakFlex } from "@/styles/oakThemeApp";
+import { NewGutterMaxWidth } from "@/components/GenericPagesComponents/NewGutterMaxWidth";
+import CMSClient from "@/node-lib/cms";
+import { OaksImpactCaseStudyListPage } from "@/common-lib/cms-types/aboutPages";
+import getProxiedSanityAssetUrl from "@/common-lib/urls/getProxiedSanityAssetUrl";
+import { resolveOakHref } from "@/common-lib/urls";
 
 export type AboutUsOaksImpactCaseStudyListPageProps = {
-  // pageData: {};
+  pageData: {
+    caseStudies: OaksImpactCaseStudyListPage;
+  };
   topNav: TopNavProps;
 };
 
 export const AboutUsOaksImpactCaseStudyList: NextPage<
   AboutUsOaksImpactCaseStudyListPageProps
-> = ({
-  // pageData: {},
-  topNav,
-}) => {
+> = ({ pageData: { caseStudies }, topNav }) => {
+  const items = caseStudies.map((caseStudy) => ({
+    heading: caseStudy.video.title,
+    href: resolveOakHref({
+      page: "about-case-study",
+      slug: caseStudy.slug.current,
+    }),
+    imageSrc: getProxiedSanityAssetUrl(caseStudy.image?.asset?.url) ?? "",
+  }));
+
   return (
     <TeacherBrowseAnalyticsStoreProvider
       programmeState={null}
@@ -28,7 +42,34 @@ export const AboutUsOaksImpactCaseStudyList: NextPage<
         $background={"bg-primary"}
         topNavProps={topNav}
       >
-        TODO: Case Study list page
+        <OakBox $zIndex={"neutral"} $color={"text-primary"}>
+          <NewGutterMaxWidth>
+            <OakFlex
+              $pv={["spacing-56", "spacing-80", "spacing-80"]}
+              $alignItems="flex-start"
+            >
+              <OakFlex
+                $maxWidth="spacing-960"
+                $gap="spacing-16"
+                $flexDirection="column"
+                $pa={["spacing-16", "spacing-20", "spacing-20"]}
+                $borderRadius="border-radius-l"
+                $background="bg-decorative2-very-subdued"
+              >
+                {items.map((item) => {
+                  return (
+                    <OakCard
+                      key={item.href}
+                      aspectRatio="4/3"
+                      cardOrientation={["column", "row", "row"]}
+                      {...item}
+                    />
+                  );
+                })}
+              </OakFlex>
+            </OakFlex>
+          </NewGutterMaxWidth>
+        </OakBox>
       </Layout>
     </TeacherBrowseAnalyticsStoreProvider>
   );
@@ -45,22 +86,24 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  //   const isPreviewMode = context.preview === true;
-  //   const oaksImpactCaseStudyPage = await CMSClient.oaksImpactCaseStudyPage({
-  //     previewMode: isPreviewMode,
-  //   });
+  const isPreviewMode = context.preview === true;
+  const oaksImpactCaseStudyPage = await CMSClient.oaksImpactCaseStudyListPage({
+    previewMode: isPreviewMode,
+  });
 
   const topNav = await curriculumApi2023.topNav();
 
-  //   if (!oaksImpactCaseStudyPage) {
-  //     return {
-  //       notFound: true,
-  //     };
-  //   }
+  if (!oaksImpactCaseStudyPage) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {
-      // pageData: {},
+      pageData: {
+        caseStudies: oaksImpactCaseStudyPage,
+      },
       topNav,
     },
   };

--- a/src/pages/about-us/case-studies/index.tsx
+++ b/src/pages/about-us/case-studies/index.tsx
@@ -1,4 +1,10 @@
 import { NextPage, GetServerSideProps } from "next";
+import {
+  OakImage,
+  OakBox,
+  OakCard,
+  OakFlex,
+} from "@oaknational/oak-components";
 
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import curriculumApi2023 from "@/node-lib/curriculum-api-2023";
@@ -6,12 +12,13 @@ import Layout from "@/components/AppComponents/AppLayout";
 import { TopNavProps } from "@/components/AppComponents/TopNav/TopNav";
 import { TeacherBrowseAnalyticsStoreProvider } from "@/context/TeacherBrowseAnalytics/TeacherBrowseAnalyticsProvider";
 import { isFeatureFlagEnabledServer } from "@/utils/featureFlagChecks/server";
-import { OakBox, OakCard, OakFlex } from "@/styles/oakThemeApp";
 import { NewGutterMaxWidth } from "@/components/GenericPagesComponents/NewGutterMaxWidth";
 import CMSClient from "@/node-lib/cms";
 import { OaksImpactCaseStudyListPage } from "@/common-lib/cms-types/aboutPages";
 import getProxiedSanityAssetUrl from "@/common-lib/urls/getProxiedSanityAssetUrl";
 import { resolveOakHref } from "@/common-lib/urls";
+import { AboutSharedHeader } from "@/components/GenericPagesComponents/AboutSharedHeader";
+import { getCloudinaryImageUrl } from "@/utils/getCloudinaryImageUrl";
 
 export type AboutUsOaksImpactCaseStudyListPageProps = {
   pageData: {
@@ -43,6 +50,23 @@ export const AboutUsOaksImpactCaseStudyList: NextPage<
         topNavProps={topNav}
       >
         <OakBox $zIndex={"neutral"} $color={"text-primary"}>
+          <AboutSharedHeader
+            $background="bg-decorative2-main"
+            titleHighlight={"bg-primary"}
+            title="Case studies"
+            content="Explore how schools and trusts are using Oak to tackle their biggest challenges"
+          >
+            <OakImage
+              src={getCloudinaryImageUrl(
+                "v1788884308/647625e5e86caf2c5f0c1e48b25ea1ab6c77c4c8_vzw6ax.png",
+              )}
+              alt=""
+              $height={"spacing-360"}
+              $width={"spacing-360"}
+              $pa={"spacing-0"}
+            />
+          </AboutSharedHeader>
+
           <NewGutterMaxWidth>
             <OakFlex
               $pv={["spacing-56", "spacing-80", "spacing-80"]}

--- a/src/pages/about-us/case-studies/index.tsx
+++ b/src/pages/about-us/case-studies/index.tsx
@@ -86,6 +86,7 @@ export const AboutUsOaksImpactCaseStudyList: NextPage<
                       key={item.href}
                       aspectRatio="4/3"
                       cardOrientation={["column", "row", "row"]}
+                      showImage={[false, true, true]}
                       {...item}
                     />
                   );


### PR DESCRIPTION
## Description
Added case study list page behind flag

## Issue(s)
Fixes `ADOPT-2249`

## How to test
Enable `case-studies-v2`

1. Go to https://oak-web-application-website-git-feat-adopt-2249-case-stu-b73c35.vercel.thenational.academy/about-us/case-studies
2. Check designs against figma in ticket

Verify that without feature flag enabled it 404's

Note that is currently always displays and image even on a mobile viewport, this will be fixed in https://app.notion.com/p/oaknationalacademy/HOLD-Add-showImage-to-OakCard-so-we-can-show-hide-image-on-media-query-3cf26cc4e1b1805b807df0e3e0659ce0?v=d9869bab5f8a4e28a7a960d37f6ab31e&source=copy_link

## Screenshots
<img width="2360" height="4998" alt="case-studies(iPad Air)" src="https://github.com/user-attachments/assets/41c4c1c0-126b-4a22-a08a-aee9efd153eb" />


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
