### PR TITLE
Sonarcloud prefers `.toBeUndefined()`

### DIFF
--- a/src/common-lib/forms/formToZod.test.ts
+++ b/src/common-lib/forms/formToZod.test.ts
@@ -29,7 +29,7 @@ describe("formToZod.ts", () => {
       const schema = fieldToZod(field);
 
       expect(schema.parse("ross")).toEqual("ross");
-      expect(schema.parse(undefined)).toEqual(undefined);
+      expect(schema.parse(undefined)).toBeUndefined();
     });
 
     it("marks required `string` type fields as non-empty", () => {
@@ -61,7 +61,7 @@ describe("formToZod.ts", () => {
 
       const schema = fieldToZod(field);
 
-      expect(schema.parse("")).toEqual(undefined);
+      expect(schema.parse("")).toBeUndefined();
     });
 
     it("handles `select` type fields", () => {
@@ -101,7 +101,7 @@ describe("formToZod.ts", () => {
 
       const schema = fieldToZod(field);
 
-      expect(schema.parse("")).toEqual(undefined);
+      expect(schema.parse("")).toBeUndefined();
 
       expect(() => {
         schema.parse("not-in-allowed");

--- a/src/common-lib/urls/getProxiedSanityAssetUrl.test.ts
+++ b/src/common-lib/urls/getProxiedSanityAssetUrl.test.ts
@@ -21,6 +21,6 @@ describe("getProxiedSanityAssetUrl", () => {
     expect(getProxiedSanityAssetUrl(null)).toEqual(null);
   });
   test("should return undefined if undefined passed", () => {
-    expect(getProxiedSanityAssetUrl(undefined)).toEqual(undefined);
+    expect(getProxiedSanityAssetUrl(undefined)).toBeUndefined();
   });
 });

--- a/src/pages-helpers/curriculum/docx/builder/8_units/unit_details.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/8_units/unit_details.test.ts
@@ -73,7 +73,7 @@ describe("buildUnitPriorKnowledgeReqs", () => {
       }),
     );
     expect(insertNumberingMock).not.toHaveBeenCalled();
-    expect(out).toEqual(undefined);
+    expect(out).toBeUndefined();
   });
 
   test("no data", async () => {
@@ -84,6 +84,6 @@ describe("buildUnitPriorKnowledgeReqs", () => {
       }),
     );
     expect(insertNumberingMock).not.toHaveBeenCalled();
-    expect(out).toEqual(undefined);
+    expect(out).toBeUndefined();
   });
 });

--- a/src/pages-helpers/curriculum/docx/builder/helper.test.ts
+++ b/src/pages-helpers/curriculum/docx/builder/helper.test.ts
@@ -156,11 +156,11 @@ describe("helper", () => {
     });
 
     it("undefined if no slug", () => {
-      expect(subjectFromUnits(data, undefined)).toEqual(undefined);
+      expect(subjectFromUnits(data, undefined)).toBeUndefined();
     });
 
     it("undefined if no unit with subject", () => {
-      expect(subjectFromUnits(data, "foobar")).toEqual(undefined);
+      expect(subjectFromUnits(data, "foobar")).toBeUndefined();
     });
   });
 
@@ -449,7 +449,7 @@ describe("getSuffixFromPathway", () => {
   });
 
   it("none", () => {
-    expect(getSuffixFromPathway("foobar")).toEqual(undefined);
+    expect(getSuffixFromPathway("foobar")).toBeUndefined();
   });
 });
 

--- a/src/pages-helpers/curriculum/docx/xml.test.ts
+++ b/src/pages-helpers/curriculum/docx/xml.test.ts
@@ -26,7 +26,7 @@ describe("xml", () => {
 
     it("should return empty if empty", () => {
       const json = xmlElementToJson(undefined);
-      expect(json).toEqual(undefined);
+      expect(json).toBeUndefined();
     });
 
     it("should throw with valid XML with multiple root nodes", () => {

--- a/src/pages-helpers/curriculum/xlsx/helper.test.ts
+++ b/src/pages-helpers/curriculum/xlsx/helper.test.ts
@@ -472,7 +472,7 @@ describe("isExamboardSlug", () => {
 
 describe("getSubjectOveride", () => {
   test("override", () => {
-    expect(getSubjectOveride("english", "10", "aqa")).toEqual(undefined);
+    expect(getSubjectOveride("english", "10", "aqa")).toBeUndefined();
   });
 
   test("non-override", () => {

--- a/src/utils/curriculum/formatting.test.ts
+++ b/src/utils/curriculum/formatting.test.ts
@@ -558,8 +558,8 @@ describe("getPhaseFromCategory", () => {
 describe("getPathwaySuffix", () => {
   it("should display nothing for non-ks4 years", () => {
     for (let year = 1; year < 10; year++) {
-      expect(getPathwaySuffix(`${year}`, "core")).toEqual(undefined);
-      expect(getPathwaySuffix(`${year}`, "non_core")).toEqual(undefined);
+      expect(getPathwaySuffix(`${year}`, "core")).toBeUndefined();
+      expect(getPathwaySuffix(`${year}`, "non_core")).toBeUndefined();
     }
   });
   it("should display nothing for non-ks4 years", () => {

--- a/src/utils/curriculum/slugs.test.ts
+++ b/src/utils/curriculum/slugs.test.ts
@@ -136,7 +136,7 @@ describe("parseSubjectPhaseSlug", () => {
   it("should reject an invalid slug", () => {
     const slug = "not_a_valid_slug";
     const parsed = parseSubjectPhaseSlug(slug);
-    expect(parsed).toEqual(undefined);
+    expect(parsed).toBeUndefined();
   });
 });
 
@@ -302,7 +302,7 @@ describe("getKs4RedirectSlug", () => {
         phaseSlug: "secondary",
         ks4OptionSlug: "aqa",
       }),
-    ).toEqual(undefined);
+    ).toBeUndefined();
   });
 
   it("return undefined if no match", () => {
@@ -312,7 +312,7 @@ describe("getKs4RedirectSlug", () => {
         phaseSlug: "secondary",
         ks4OptionSlug: null,
       }),
-    ).toEqual(undefined);
+    ).toBeUndefined();
   });
 
   it("return correct default when specified", () => {

--- a/src/utils/featureFlags.test.ts
+++ b/src/utils/featureFlags.test.ts
@@ -41,7 +41,7 @@ describe("getFeatureFlagValue", () => {
     ]);
     (getFeatureFlag as jest.Mock).mockResolvedValue(true);
     const result = await getFeatureFlagValue("foo", "string");
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test("boolean assertion with valid type", async () => {
@@ -73,6 +73,6 @@ describe("getFeatureFlagValue", () => {
     ]);
     (getFeatureFlag as jest.Mock).mockResolvedValue("test");
     const result = await getFeatureFlagValue("foo", "boolean");
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 });

--- a/src/utils/slugModifiers/addLegacySlugSuffix.test.ts
+++ b/src/utils/slugModifiers/addLegacySlugSuffix.test.ts
@@ -7,10 +7,10 @@ describe("addLegacySlugSuffix", () => {
     );
   });
   it("returns undefined if no slug is passed in", () => {
-    expect(addLegacySlugSuffix()).toEqual(undefined);
+    expect(addLegacySlugSuffix()).toBeUndefined();
   });
   it("returns undefined if null is passed in", () => {
-    expect(addLegacySlugSuffix(null)).toEqual(undefined);
+    expect(addLegacySlugSuffix(null)).toBeUndefined();
   });
   it("returns slug unmodified if it is already legacy slug", () => {
     expect(addLegacySlugSuffix("chemistry-secondary-ks4-l")).toEqual(


### PR DESCRIPTION
## Description
Sonarcloud prefers `.toBeUndefined()`

## Issue(s)
https://sonarcloud.io/project/issues?id=oaknational_owa&open=AZ7wDdpzuSUPZtIUHZYC&s=IMPACT_RANK and alike

Fixes #
All the issues that match the title of https://sonarcloud.io/project/issues?id=oaknational_owa&open=AZ7wDdpzuSUPZtIUHZYC&s=IMPACT_RANK

## How to test
Code review only

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
