### PR TITLE
Make programme downloads accordion open by default

### DIFF
--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.test.tsx
@@ -207,7 +207,7 @@ describe("Programme Downloads", () => {
 
   describe("implementation guides", () => {
     test("should show implementation guides when they are available (and enabled)", async () => {
-      const { findByRole, findAllByRole } = renderComponent({
+      const { findAllByRole } = renderComponent({
         curriculumDownloadsTabData: {
           ...defaultProps.curriculumDownloadsTabData,
         },
@@ -225,13 +225,6 @@ describe("Programme Downloads", () => {
         },
       });
 
-      const buttonEl = await findByRole("button", {
-        name: /All resources selected/,
-      });
-      const user = userEvent.setup();
-
-      await user.click(buttonEl);
-
       const region = (await findAllByRole("region"))[1]!;
 
       expect(
@@ -241,7 +234,7 @@ describe("Programme Downloads", () => {
   });
 
   test("should show file sizes", async () => {
-    const { findByRole, findAllByRole } = renderComponent({
+    const { findAllByRole } = renderComponent({
       curriculumDownloadsTabData: {
         ...defaultProps.curriculumDownloadsTabData,
       },
@@ -266,13 +259,6 @@ describe("Programme Downloads", () => {
         "implementation-guides": true,
       },
     });
-
-    const buttonEl = await findByRole("button", {
-      name: /All resources selected/,
-    });
-    const user = userEvent.setup();
-
-    await user.click(buttonEl);
 
     const region = (await findAllByRole("region"))[1]!;
 

--- a/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
+++ b/src/app/(core)/teachers/programmes/[slug]/[tab]/Components/ProgrammeDownloads/ProgrammeDownloads.tsx
@@ -351,6 +351,7 @@ export const ProgrammeDownloads = ({
                 triggerForm={form.trigger}
                 validationSummaryKey={form.submitCount}
                 apiError={submitError}
+                initialOpen={true}
                 cardGroup={
                   <OakFlex $gap={"spacing-32"} $flexDirection={"column"}>
                     {curriculumDownloadsWithLabels.length > 0 && (

--- a/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
+++ b/src/components/TeacherComponents/DownloadPageWithAccordion/DownloadPageWithAccordion.tsx
@@ -64,6 +64,7 @@ type DownloadPageWithAccordionProps = ResourcePageDetailsCompletedProps &
     curriculumDownloads?: DownloadTypeLabel[];
     additionalFiles?: LessonDownloadsPageData["additionalFiles"];
     validationSummaryKey?: number;
+    initialOpen?: boolean;
   };
 
 export type DownloadWrapperProps = {
@@ -153,6 +154,7 @@ export const DownloadPageWithAccordionContent = (
     | "cta"
     | "apiError"
     | "validationSummaryKey"
+    | "initialOpen"
   >,
 ) => {
   const {
@@ -184,6 +186,7 @@ export const DownloadPageWithAccordionContent = (
     cta,
     apiError,
     validationSummaryKey,
+    initialOpen,
   } = props;
 
   const hasFormErrors = Object.keys(errors).length > 0;
@@ -211,7 +214,7 @@ export const DownloadPageWithAccordionContent = (
         handleToggleSelectAll={handleToggleSelectAll}
         selectAllChecked={selectAllChecked}
         id="downloads-accordion"
-        initialOpen={!selectAllChecked}
+        initialOpen={initialOpen ?? !selectAllChecked}
       >
         <OakBox $pa={"spacing-0"} $ba={"border-solid-none"} as={"fieldset"}>
           <OakBox


### PR DESCRIPTION
## Description
Make programme downloads accordion open by default

## Issue(s)
Fixes `ADOPT-2273`

## How to test

1. Go to https://oak-web-application-website-git-feat-adopt-2273-accordio-deb2a6.vercel.thenational.academy/teachers/programmes/english-primary/download
2. Check download accordion is open by default and functional (opens and closes)


## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
