### PR TITLE
Publish an ARD manifest for Oak's agent resources

### DIFF
--- a/docs/agent-discovery.md
+++ b/docs/agent-discovery.md
@@ -1,0 +1,98 @@
+# Agent discovery
+
+Oak publishes a machine-readable manifest of its agent-usable resources, so an
+AI agent can find the curriculum MCP server and the curriculum API from the apex
+domain without being told where to look.
+
+## What is served
+
+An [Agentic Resource Discovery](https://agenticresourcediscovery.org/spec/)
+manifest, at **both**:
+
+- `/.well-known/ard.json`
+- `/.well-known/ai-catalog.json`
+
+as `application/ai-catalog+json` with `Access-Control-Allow-Origin: *`, plus
+`<link rel="ard">` and `<link rel="ai-catalog">` in the document head and the
+matching relations on the homepage `Link` header.
+
+Source: `src/app/api/well-known/ard/route.ts`, mapped onto `/.well-known/` by
+rewrites in `next.config.ts` because the App Router does not route a folder
+beginning with a dot. This follows the pattern already used for the RFC 9727
+catalogue at `/.well-known/api-catalog`.
+
+## Why both paths, when the spec says one is enough
+
+Spec v0.91 §5.1 is explicit: a consumer MUST fetch `ard.json` and MUST honour
+`rel="ard"`, and _"there is no need to serve the predecessor path or relation as
+well"_.
+
+Measured 9 September 2026, no deployed publisher has caught up with that:
+
+| Publisher                   | `ai-catalog.json` | `ard.json` |
+| --------------------------- | ----------------- | ---------- |
+| `github.com`                | 200               | 404        |
+| `huggingface.co`            | 200               | 401        |
+| `developers.cloudflare.com` | 200               | 404        |
+
+None of the three emits either link relation. The spec is six weeks old; the
+consumers are older. Serving both costs one rewrite and makes Oak findable by
+agents written against either revision. **Do not simplify this to one path.**
+
+## Why the MCP entry carries no server card URL
+
+Measured 9 September 2026:
+
+- The MCP working group's discovery document lists all three `.well-known`
+  server-card paths under "Alternatives considered … not recommended", so
+  publishing one there would adopt a placement its own authors rejected.
+- The reserved location is `<streamable-http-url>/server-card`, and Oak does not
+  serve it. `https://mcp.thenational.academy/mcp/server-card` answers `406`
+  with `{"error":"Accept header must include text/event-stream"}` for every
+  Accept header — that is the streamable-HTTP transport catching the path, not a
+  card route.
+
+So the entry names the MCP endpoint itself, inline via `data`. §4.3 allows
+exactly one of `url` or `data`, and `data` is the only one that can name the
+endpoint truthfully: a `url` of media type `application/mcp-server-card+json`
+would have to dereference to a card document, and none exists.
+
+The inline card mirrors the field set of the live cards on `github.com` and
+`huggingface.co`, minus two. `$schema` is omitted because the URL both of them
+point at returns 404. `version` is omitted because this server does not publish
+one, and inventing it would be fabricated metadata.
+
+## Why the API entry points at a catalogue
+
+Oak publishes two RFC 9727 catalogues and they disagree. Measured
+9 September 2026, the one hosted by the API anchors both `/api/v0` and
+`/api/bulk`; the copy on `www` carries a single anchor for the v0 host only.
+
+The entry therefore references
+`https://open-api.thenational.academy/.well-known/api-catalog`, which advertises
+Oak's whole API surface and stays true as that surface grows, rather than
+pinning one OpenAPI document. The drift between the two catalogues is tracked as
+`MCP-721` and is not addressed here.
+
+## Representative queries
+
+`representativeQueries` is the text a registry builds its semantic index from —
+an entry without it is a valid catalogue entry but will not be found by search.
+The spec recommends 2–5 per entry. Oak's are written in the language a teacher
+would actually use, and both entries carry them.
+
+## Conformance
+
+Validated with the official conformance CLI from `ards-project/ard-spec`, run
+with `jsonschema` installed so the strict schema check actually executes:
+**0 errors**, against both the source manifest and the served response.
+
+One warning remains, on the API entry's `application/linkset+json` media type,
+which is not in the tool's list of standard discovery types. The type is correct
+for what the URL serves and matches its `Content-Type` exactly; the spec
+constrains `type` to an IANA media type and does not restrict it to that list.
+
+For context on the state of the ecosystem, the same tool reports `github.com`'s
+own manifest as **non-conformant** (its single entry is missing `displayName`),
+and `huggingface.co` passes but carries no representative queries on either
+entry, so neither of its resources is searchable.

--- a/next.config.ts
+++ b/next.config.ts
@@ -131,8 +131,6 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
             key: "Link",
             value: [
               '</.well-known/api-catalog>; rel="api-catalog"',
-              // ARD spec v0.91 §5.1 discovery mechanisms. Both relations are
-              // emitted for the same reason both paths are served.
               '</.well-known/ard.json>; rel="ard"',
               '</.well-known/ai-catalog.json>; rel="ai-catalog"',
             ].join(", "),
@@ -519,12 +517,8 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
           source: "/.well-known/api-catalog",
           destination: "/api/well-known/api-catalog",
         },
-        // The ARD manifest, served at BOTH the spec path and its predecessor.
-        // Spec v0.91 §5.1 requires only `ard.json`, but measured 2026-09-09
-        // every reference publisher (github.com, huggingface.co,
-        // developers.cloudflare.com) serves `ai-catalog.json` alone. Serving
-        // both makes Oak findable by consumers written against either
-        // revision. See src/app/api/well-known/ard/route.ts.
+        // Both the ARD path and its predecessor: deployed consumers still use
+        // the older one, so removing either loses reach. docs/agent-discovery.md.
         {
           source: "/.well-known/ard.json",
           destination: "/api/well-known/ard",

--- a/next.config.ts
+++ b/next.config.ts
@@ -129,7 +129,13 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
         headers: [
           {
             key: "Link",
-            value: '</.well-known/api-catalog>; rel="api-catalog"',
+            value: [
+              '</.well-known/api-catalog>; rel="api-catalog"',
+              // ARD spec v0.91 §5.1 discovery mechanisms. Both relations are
+              // emitted for the same reason both paths are served.
+              '</.well-known/ard.json>; rel="ard"',
+              '</.well-known/ai-catalog.json>; rel="ai-catalog"',
+            ].join(", "),
           },
         ],
       },
@@ -512,6 +518,20 @@ export default async (phase: NextConfig["phase"]): Promise<NextConfig> => {
         {
           source: "/.well-known/api-catalog",
           destination: "/api/well-known/api-catalog",
+        },
+        // The ARD manifest, served at BOTH the spec path and its predecessor.
+        // Spec v0.91 §5.1 requires only `ard.json`, but measured 2026-09-09
+        // every reference publisher (github.com, huggingface.co,
+        // developers.cloudflare.com) serves `ai-catalog.json` alone. Serving
+        // both makes Oak findable by consumers written against either
+        // revision. See src/app/api/well-known/ard/route.ts.
+        {
+          source: "/.well-known/ard.json",
+          destination: "/api/well-known/ard",
+        },
+        {
+          source: "/.well-known/ai-catalog.json",
+          destination: "/api/well-known/ard",
         },
       ];
       // The MCP submission carousel images now live under /ai-plugin/carousel,

--- a/src/app/api/well-known/ard/route.test.ts
+++ b/src/app/api/well-known/ard/route.test.ts
@@ -56,13 +56,14 @@ describe("/.well-known/ard.json", () => {
 
     expect(mcp).toBeDefined();
     expect(mcp.type).toBe("application/mcp-server-card+json");
-    // Inline because the MCP server publishes no server card document. A `url`
-    // here would point at a 404.
+    // Inline, and deliberately carrying no server card URL: the `.well-known`
+    // card paths are a rejected placement, and the reserved
+    // `<streamable-http-url>/server-card` location is not served by Oak.
     expect(mcp.url).toBeUndefined();
     expect(mcp.data.remotes[0].url).toBe("https://mcp.thenational.academy/mcp");
   });
 
-  it("advertises the curriculum API by its OpenAPI document, not its base URL", async () => {
+  it("advertises the curriculum API by the catalogue the API itself hosts", async () => {
     const response = GET();
     const body = await response.json();
 
@@ -72,11 +73,14 @@ describe("/.well-known/ard.json", () => {
     );
 
     expect(api).toBeDefined();
-    expect(api.type).toBe("application/vnd.oai.openapi+json");
-    // `url` must dereference to a document of the declared type. The API's
-    // base URL serves HTML, so pointing there would misdescribe the artifact.
+    expect(api.type).toContain("application/linkset+json");
+
+    // Pinned to the API-hosted catalogue, not www's copy. Measured 2026-09-09
+    // the two disagree — this one carries `/api/bulk`, www's does not — so
+    // swapping the host here would silently narrow what Oak advertises.
+    // MCP-721 tracks the drift.
     expect(api.url).toBe(
-      "https://open-api.thenational.academy/api/v0/swagger.json",
+      "https://open-api.thenational.academy/.well-known/api-catalog",
     );
   });
 });

--- a/src/app/api/well-known/ard/route.test.ts
+++ b/src/app/api/well-known/ard/route.test.ts
@@ -11,8 +11,7 @@ describe("/.well-known/ard.json", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "application/ai-catalog+json",
     );
-    // Discovery agents fetch this cross-origin; without this the manifest is
-    // unreadable from a browser context and the entries may as well not exist.
+    // Without this the manifest is unreadable from a browser context.
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 
@@ -24,7 +23,6 @@ describe("/.well-known/ard.json", () => {
     expect(body.entries.length).toBeGreaterThan(0);
 
     for (const entry of body.entries) {
-      // MUST terms, ARD spec v0.91 section 4.2.
       expect(entry.identifier).toMatch(
         /^urn:air:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$/,
       );
@@ -32,14 +30,10 @@ describe("/.well-known/ard.json", () => {
       expect(entry.displayName.length).toBeGreaterThan(0);
       expect(typeof entry.type).toBe("string");
 
-      // Exactly one of url/data, section 4.3. Asserted as an exclusive pair
-      // rather than "has one of them" — an entry carrying both is invalid, and
-      // a looser check would pass it.
+      // Exclusive, not "has one of them": an entry carrying both is invalid.
       expect("url" in entry).not.toBe("data" in entry);
 
-      // representativeQueries is the signal a registry indexes on. An entry
-      // without it validates structurally but cannot be found by search,
-      // which would make publishing the manifest pointless.
+      // The signal a registry indexes on; without it the entry is unfindable.
       expect(entry.representativeQueries.length).toBeGreaterThanOrEqual(2);
       expect(entry.representativeQueries.length).toBeLessThanOrEqual(5);
     }
@@ -56,9 +50,7 @@ describe("/.well-known/ard.json", () => {
 
     expect(mcp).toBeDefined();
     expect(mcp.type).toBe("application/mcp-server-card+json");
-    // Inline, and deliberately carrying no server card URL: the `.well-known`
-    // card paths are a rejected placement, and the reserved
-    // `<streamable-http-url>/server-card` location is not served by Oak.
+    // No card URL by design — docs/agent-discovery.md.
     expect(mcp.url).toBeUndefined();
     expect(mcp.data.remotes[0].url).toBe("https://mcp.thenational.academy/mcp");
   });
@@ -75,10 +67,8 @@ describe("/.well-known/ard.json", () => {
     expect(api).toBeDefined();
     expect(api.type).toContain("application/linkset+json");
 
-    // Pinned to the API-hosted catalogue, not www's copy. Measured 2026-09-09
-    // the two disagree — this one carries `/api/bulk`, www's does not — so
+    // Pinned to the API-hosted catalogue: www's copy omits `/api/bulk`, so
     // swapping the host here would silently narrow what Oak advertises.
-    // MCP-721 tracks the drift.
     expect(api.url).toBe(
       "https://open-api.thenational.academy/.well-known/api-catalog",
     );

--- a/src/app/api/well-known/ard/route.test.ts
+++ b/src/app/api/well-known/ard/route.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/well-known/ard/route";
+
+describe("/.well-known/ard.json", () => {
+  it("responds 200 with the catalog content type and open CORS", async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/ai-catalog+json",
+    );
+    // Discovery agents fetch this cross-origin; without this the manifest is
+    // unreadable from a browser context and the entries may as well not exist.
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("returns entries that satisfy the ARD entry requirements", async () => {
+    const response = GET();
+    const body = await response.json();
+
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.entries.length).toBeGreaterThan(0);
+
+    for (const entry of body.entries) {
+      // MUST terms, ARD spec v0.91 section 4.2.
+      expect(entry.identifier).toMatch(
+        /^urn:air:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$/,
+      );
+      expect(typeof entry.displayName).toBe("string");
+      expect(entry.displayName.length).toBeGreaterThan(0);
+      expect(typeof entry.type).toBe("string");
+
+      // Exactly one of url/data, section 4.3. Asserted as an exclusive pair
+      // rather than "has one of them" — an entry carrying both is invalid, and
+      // a looser check would pass it.
+      expect("url" in entry).not.toBe("data" in entry);
+
+      // representativeQueries is the signal a registry indexes on. An entry
+      // without it validates structurally but cannot be found by search,
+      // which would make publishing the manifest pointless.
+      expect(entry.representativeQueries.length).toBeGreaterThanOrEqual(2);
+      expect(entry.representativeQueries.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("advertises the MCP server with an inline card naming the endpoint", async () => {
+    const response = GET();
+    const body = await response.json();
+
+    const mcp = body.entries.find(
+      (entry: { identifier: string }) =>
+        entry.identifier === "urn:air:thenational.academy:mcp:curriculum",
+    );
+
+    expect(mcp).toBeDefined();
+    expect(mcp.type).toBe("application/mcp-server-card+json");
+    // Inline because the MCP server publishes no server card document. A `url`
+    // here would point at a 404.
+    expect(mcp.url).toBeUndefined();
+    expect(mcp.data.remotes[0].url).toBe("https://mcp.thenational.academy/mcp");
+  });
+
+  it("advertises the curriculum API by its OpenAPI document, not its base URL", async () => {
+    const response = GET();
+    const body = await response.json();
+
+    const api = body.entries.find(
+      (entry: { identifier: string }) =>
+        entry.identifier === "urn:air:thenational.academy:api:curriculum",
+    );
+
+    expect(api).toBeDefined();
+    expect(api.type).toBe("application/vnd.oai.openapi+json");
+    // `url` must dereference to a document of the declared type. The API's
+    // base URL serves HTML, so pointing there would misdescribe the artifact.
+    expect(api.url).toBe(
+      "https://open-api.thenational.academy/api/v0/swagger.json",
+    );
+  });
+});

--- a/src/app/api/well-known/ard/route.ts
+++ b/src/app/api/well-known/ard/route.ts
@@ -1,0 +1,122 @@
+/**
+ * Agentic Resource Discovery (ARD) manifest.
+ *
+ * Advertises Oak's agent-usable resources so a discovery agent can find them
+ * from the apex domain without being told where to look.
+ *
+ * Served at `/.well-known/ard.json` AND `/.well-known/ai-catalog.json` via
+ * rewrites in `next.config.ts` (App Router does not route folders that start
+ * with a dot).
+ *
+ * - ARD specification v0.91 (status: Proposal, 2026-08-26)
+ *   https://agenticresourcediscovery.org/spec/
+ * - Entry schema and the official conformance CLI
+ *   https://github.com/ards-project/ard-spec
+ */
+
+/**
+ * Both paths are served deliberately.
+ *
+ * Spec §5.1 says a publisher need only serve `ard.json`, and that consumers
+ * MUST fetch it. Measured 2026-09-09, though, every publisher the spec cites as
+ * a reference is on the predecessor path ONLY — github.com, huggingface.co and
+ * developers.cloudflare.com all return 200 for `ai-catalog.json` and 404/401
+ * for `ard.json`. The spec is the newer thing; deployed consumers are not.
+ *
+ * Serving both costs one rewrite and makes Oak findable by consumers written
+ * against either revision. Do not "simplify" this to one path.
+ */
+const ARD_CONTENT_TYPE = "application/ai-catalog+json";
+
+/**
+ * The MCP server card, inline.
+ *
+ * `data` rather than `url` because Oak's MCP server publishes no server card
+ * document — measured 2026-09-09, every conventional path 404s. Spec §4.3
+ * allows exactly one of `url` or `data`, so inlining the card is the honest
+ * option; a `url` would point at a document that does not exist.
+ *
+ * Field set mirrors the live cards published by github.com and huggingface.co.
+ * `$schema` is deliberately omitted: both live cards point at
+ * `static.modelcontextprotocol.io/schemas/v1/server-card.schema.json`, which
+ * returns 404. `version` is omitted because this server does not publish one,
+ * and inventing it would be fabricated metadata.
+ */
+const mcpServerCard = {
+  name: "thenational.academy/mcp",
+  title: "Oak Curriculum",
+  description:
+    "Connects an AI assistant to Oak National Academy's free, fully sequenced, openly licensed curriculum for schools in England — lessons, units and teaching resources across subjects and key stages.",
+  websiteUrl: "https://mcp.thenational.academy/",
+  remotes: [
+    {
+      type: "streamable-http",
+      url: "https://mcp.thenational.academy/mcp",
+    },
+  ],
+} as const;
+
+/**
+ * The manifest served at both paths.
+ *
+ * `specVersion` and `host` are transport-defined members that ARD ignores
+ * (§5.1); they are included because all three reference publishers emit them.
+ * ARD itself requires only `entries`.
+ *
+ * Each entry carries `identifier`, `displayName` and `type` (MUST, §4.2),
+ * exactly one of `url`/`data` (§4.3), and 2-5 `representativeQueries` (SHOULD,
+ * §4.2) — the queries are the signal a registry builds its semantic index
+ * from, and an entry without them cannot be found by search.
+ */
+const ardManifest = {
+  specVersion: "1.0",
+  host: {
+    displayName: "Oak National Academy",
+    identifier: "thenational.academy",
+    documentationUrl: "https://www.thenational.academy/",
+  },
+  entries: [
+    {
+      identifier: "urn:air:thenational.academy:mcp:curriculum",
+      displayName: "Oak Curriculum MCP Server",
+      type: "application/mcp-server-card+json",
+      data: mcpServerCard,
+      description:
+        "MCP server giving an AI assistant direct access to Oak's curriculum: search lessons and units, follow progression across year groups, and retrieve teaching resources. Requires OAuth 2.1 sign-in with a free Oak account.",
+      tags: ["oak", "curriculum", "education", "mcp", "teaching"],
+      representativeQueries: [
+        "find me a key stage 3 science lesson on photosynthesis",
+        "what does the year 4 maths curriculum cover on fractions",
+        "how does the Norman conquest build across key stage 3 history",
+        "I need a worksheet and slides for a lesson on the water cycle",
+      ],
+    },
+    {
+      identifier: "urn:air:thenational.academy:api:curriculum",
+      displayName: "Oak Curriculum Open API",
+      type: "application/vnd.oai.openapi+json",
+      url: "https://open-api.thenational.academy/api/v0/swagger.json",
+      description:
+        "OpenAPI description of Oak's public curriculum REST API — programmes, units, lessons and their downloadable teaching resources, published under the Open Government Licence.",
+      tags: ["oak", "curriculum", "education", "api", "openapi"],
+      representativeQueries: [
+        "what lessons does Oak have for year 5 maths",
+        "which subjects and key stages does Oak's curriculum cover",
+        "get Oak's curriculum data for a whole subject and key stage",
+      ],
+    },
+  ],
+} as const;
+
+export function GET() {
+  return new Response(JSON.stringify(ardManifest, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": ARD_CONTENT_TYPE,
+      // Discovery agents fetch this cross-origin from a browser context.
+      "Access-Control-Allow-Origin": "*",
+      // The manifest changes rarely; allow shared caches to hold it for an hour.
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/src/app/api/well-known/ard/route.ts
+++ b/src/app/api/well-known/ard/route.ts
@@ -1,57 +1,20 @@
 /**
- * Agentic Resource Discovery (ARD) manifest.
+ * Agentic Resource Discovery manifest, served at `/.well-known/ard.json` and
+ * `/.well-known/ai-catalog.json` via rewrites in `next.config.ts`.
  *
- * Advertises Oak's agent-usable resources so a discovery agent can find them
- * from the apex domain without being told where to look.
+ * Why both paths, why the MCP entry has no card URL, and why the API entry
+ * points at a catalogue: `docs/agent-discovery.md`.
  *
- * Served at `/.well-known/ard.json` AND `/.well-known/ai-catalog.json` via
- * rewrites in `next.config.ts` (App Router does not route folders that start
- * with a dot).
- *
- * - ARD specification v0.91 (status: Proposal, 2026-08-26)
- *   https://agenticresourcediscovery.org/spec/
- * - Entry schema and the official conformance CLI
- *   https://github.com/ards-project/ard-spec
- */
-
-/**
- * Both paths are served deliberately.
- *
- * Spec §5.1 says a publisher need only serve `ard.json`, and that consumers
- * MUST fetch it. Measured 2026-09-09, though, every publisher the spec cites as
- * a reference is on the predecessor path ONLY — github.com, huggingface.co and
- * developers.cloudflare.com all return 200 for `ai-catalog.json` and 404/401
- * for `ard.json`. The spec is the newer thing; deployed consumers are not.
- *
- * Serving both costs one rewrite and makes Oak findable by consumers written
- * against either revision. Do not "simplify" this to one path.
+ * - Spec v0.91: https://agenticresourcediscovery.org/spec/
+ * - Schema and conformance CLI: https://github.com/ards-project/ard-spec
  */
 const ARD_CONTENT_TYPE = "application/ai-catalog+json";
 
 /**
- * The MCP server description, inline.
- *
- * There is deliberately NO server card URL here. Measured 2026-09-09:
- *
- * - The MCP working group's own discovery document lists all three
- *   `.well-known` server-card paths under "Alternatives considered … not
- *   recommended", so publishing one there would adopt a rejected placement.
- * - The reserved location is `<streamable-http-url>/server-card`. Oak does not
- *   serve it: `https://mcp.thenational.academy/mcp/server-card` answers 406
- *   `{"error":"Accept header must include text/event-stream"}` for every Accept
- *   header including `*\/*`, which is the streamable-HTTP transport catching
- *   the path — not a card route.
- *
- * So the entry names the MCP endpoint itself, carried inline via `data`. Spec
- * §4.3 allows exactly one of `url` or `data`, and `data` is the only one that
- * can name the endpoint truthfully: a `url` of the same media type would have
- * to dereference to a card document, and no such document exists.
- *
- * Field set mirrors the live cards published by github.com and huggingface.co.
- * `$schema` is omitted because both of those point at
- * `static.modelcontextprotocol.io/schemas/v1/server-card.schema.json`, which
- * returns 404. `version` is omitted because this server does not publish one,
- * and inventing it would be fabricated metadata.
+ * Inline rather than a `url`: Oak serves no server card document, and the
+ * `.well-known` card paths are a placement the MCP working group rejected.
+ * `$schema` and `version` are omitted deliberately — see
+ * `docs/agent-discovery.md`.
  */
 const mcpServerCard = {
   name: "thenational.academy/mcp",
@@ -68,16 +31,12 @@ const mcpServerCard = {
 } as const;
 
 /**
- * The manifest served at both paths.
+ * ARD requires only `entries`; `specVersion` and `host` are transport-defined
+ * members it ignores, emitted because every reference publisher emits them.
  *
- * `specVersion` and `host` are transport-defined members that ARD ignores
- * (§5.1); they are included because all three reference publishers emit them.
- * ARD itself requires only `entries`.
- *
- * Each entry carries `identifier`, `displayName` and `type` (MUST, §4.2),
- * exactly one of `url`/`data` (§4.3), and 2-5 `representativeQueries` (SHOULD,
- * §4.2) — the queries are the signal a registry builds its semantic index
- * from, and an entry without them cannot be found by search.
+ * Each entry needs `identifier`, `displayName`, `type`, exactly one of
+ * `url`/`data`, and 2-5 `representativeQueries` — the queries are what a
+ * registry indexes on, so an entry without them cannot be found by search.
  */
 const ardManifest = {
   specVersion: "1.0",
@@ -105,12 +64,8 @@ const ardManifest = {
     {
       identifier: "urn:air:thenational.academy:api:curriculum",
       displayName: "Oak Curriculum Open API",
-      // The RFC 9727 catalogue hosted BY the API, not the copy on www.
-      // Measured 2026-09-09, the two disagree: this one carries both
-      // `/api/v0` and `/api/bulk`, while www's lists only the v0 host. The
-      // drift is tracked as MCP-721 and is not fixed here. Pointing at the
-      // catalogue rather than a single OpenAPI document also means this entry
-      // stays true as Oak's API surface grows.
+      // The catalogue hosted BY the API, not the copy on www: the two disagree
+      // and only this one carries `/api/bulk`. MCP-721.
       type: 'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
       url: "https://open-api.thenational.academy/.well-known/api-catalog",
       description:
@@ -132,7 +87,6 @@ export function GET() {
       "Content-Type": ARD_CONTENT_TYPE,
       // Discovery agents fetch this cross-origin from a browser context.
       "Access-Control-Allow-Origin": "*",
-      // The manifest changes rarely; allow shared caches to hold it for an hour.
       "Cache-Control": "public, max-age=3600",
     },
   });

--- a/src/app/api/well-known/ard/route.ts
+++ b/src/app/api/well-known/ard/route.ts
@@ -29,15 +29,26 @@
 const ARD_CONTENT_TYPE = "application/ai-catalog+json";
 
 /**
- * The MCP server card, inline.
+ * The MCP server description, inline.
  *
- * `data` rather than `url` because Oak's MCP server publishes no server card
- * document — measured 2026-09-09, every conventional path 404s. Spec §4.3
- * allows exactly one of `url` or `data`, so inlining the card is the honest
- * option; a `url` would point at a document that does not exist.
+ * There is deliberately NO server card URL here. Measured 2026-09-09:
+ *
+ * - The MCP working group's own discovery document lists all three
+ *   `.well-known` server-card paths under "Alternatives considered … not
+ *   recommended", so publishing one there would adopt a rejected placement.
+ * - The reserved location is `<streamable-http-url>/server-card`. Oak does not
+ *   serve it: `https://mcp.thenational.academy/mcp/server-card` answers 406
+ *   `{"error":"Accept header must include text/event-stream"}` for every Accept
+ *   header including `*\/*`, which is the streamable-HTTP transport catching
+ *   the path — not a card route.
+ *
+ * So the entry names the MCP endpoint itself, carried inline via `data`. Spec
+ * §4.3 allows exactly one of `url` or `data`, and `data` is the only one that
+ * can name the endpoint truthfully: a `url` of the same media type would have
+ * to dereference to a card document, and no such document exists.
  *
  * Field set mirrors the live cards published by github.com and huggingface.co.
- * `$schema` is deliberately omitted: both live cards point at
+ * `$schema` is omitted because both of those point at
  * `static.modelcontextprotocol.io/schemas/v1/server-card.schema.json`, which
  * returns 404. `version` is omitted because this server does not publish one,
  * and inventing it would be fabricated metadata.
@@ -94,10 +105,16 @@ const ardManifest = {
     {
       identifier: "urn:air:thenational.academy:api:curriculum",
       displayName: "Oak Curriculum Open API",
-      type: "application/vnd.oai.openapi+json",
-      url: "https://open-api.thenational.academy/api/v0/swagger.json",
+      // The RFC 9727 catalogue hosted BY the API, not the copy on www.
+      // Measured 2026-09-09, the two disagree: this one carries both
+      // `/api/v0` and `/api/bulk`, while www's lists only the v0 host. The
+      // drift is tracked as MCP-721 and is not fixed here. Pointing at the
+      // catalogue rather than a single OpenAPI document also means this entry
+      // stays true as Oak's API surface grows.
+      type: 'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+      url: "https://open-api.thenational.academy/.well-known/api-catalog",
       description:
-        "OpenAPI description of Oak's public curriculum REST API — programmes, units, lessons and their downloadable teaching resources, published under the Open Government Licence.",
+        "Catalogue of Oak's public curriculum REST API — the versioned lesson and unit endpoints and the bulk download surface, with their OpenAPI descriptions, documentation and playground. Curriculum content is published under the Open Government Licence.",
       tags: ["oak", "curriculum", "education", "api", "openapi"],
       representativeQueries: [
         "what lessons does Oak have for year 5 maths",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import AppHooks from "@/components/AppComponents/App/AppHooks";
 import { OakThemeProvider, oakDefaultTheme } from "@/styles/oakThemeApp";
 import CookieConsentProvider from "@/browser-lib/cookie-consent/CookieConsentProvider";
 import { FAVICON_LINKS_HEAD_INNER_HTML } from "@/image-data";
+import { AGENT_DISCOVERY_LINKS } from "@/config/agentDiscovery";
 import getBrowserConfig from "@/browser-lib/getBrowserConfig";
 import { MenuProvider } from "@/context/Menu";
 import { OakNotificationsProvider } from "@/context/OakNotifications/OakNotificationsProvider";
@@ -50,6 +51,9 @@ export default function RootLayout({
   return (
     <html lang="en" className={lexend.className}>
       {parse(FAVICON_LINKS_HEAD_INNER_HTML)}
+      {AGENT_DISCOVERY_LINKS.map(({ rel, href }) => (
+        <link key={rel} rel={rel} href={href} />
+      ))}
       <StyledComponentsRegistry>
         {/* Pages Router uses #__next as the app root; add id to body for Pa11y CI and Percy to hook onto. */}
         <body id="__next" style={{ margin: "0px" }}>

--- a/src/config/agentDiscovery.ts
+++ b/src/config/agentDiscovery.ts
@@ -1,0 +1,19 @@
+/**
+ * Discovery link relations advertising Oak's ARD manifest.
+ *
+ * ARD spec v0.91 §5.1 lists an HTML `<link>` tag as a discovery mechanism, and
+ * requires a conformant consumer to honour `rel="ard"`. The predecessor
+ * relation `ai-catalog` is emitted alongside it for the same reason the
+ * predecessor path is served — see `src/app/api/well-known/ard/route.ts`.
+ *
+ * Declared once here because the site renders its head from two routers
+ * (`src/pages/_document.tsx` and `src/app/layout.tsx`). Two hand-maintained
+ * copies would drift, and a page served by the router that lost the tag would
+ * simply stop advertising the manifest, silently.
+ *
+ * https://agenticresourcediscovery.org/spec/
+ */
+export const AGENT_DISCOVERY_LINKS = [
+  { rel: "ard", href: "/.well-known/ard.json" },
+  { rel: "ai-catalog", href: "/.well-known/ai-catalog.json" },
+] as const;

--- a/src/config/agentDiscovery.ts
+++ b/src/config/agentDiscovery.ts
@@ -1,17 +1,9 @@
 /**
- * Discovery link relations advertising Oak's ARD manifest.
+ * Declared once because the site renders its head from two routers
+ * (`src/pages/_document.tsx` and `src/app/layout.tsx`); a drifted copy would
+ * silently stop advertising the manifest on half the site.
  *
- * ARD spec v0.91 §5.1 lists an HTML `<link>` tag as a discovery mechanism, and
- * requires a conformant consumer to honour `rel="ard"`. The predecessor
- * relation `ai-catalog` is emitted alongside it for the same reason the
- * predecessor path is served — see `src/app/api/well-known/ard/route.ts`.
- *
- * Declared once here because the site renders its head from two routers
- * (`src/pages/_document.tsx` and `src/app/layout.tsx`). Two hand-maintained
- * copies would drift, and a page served by the router that lost the tag would
- * simply stop advertising the manifest, silently.
- *
- * https://agenticresourcediscovery.org/spec/
+ * Why both relations: `docs/agent-discovery.md`.
  */
 export const AGENT_DISCOVERY_LINKS = [
   { rel: "ard", href: "/.well-known/ard.json" },

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,6 +10,7 @@ import parse from "html-react-parser";
 
 import { FAVICON_LINKS_HEAD_INNER_HTML } from "../image-data";
 import getBrowserConfig from "../browser-lib/getBrowserConfig";
+import { AGENT_DISCOVERY_LINKS } from "../config/agentDiscovery";
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -47,6 +48,9 @@ class MyDocument extends Document {
             content={getBrowserConfig("pingdomUptimeId")}
           />
           {parse(FAVICON_LINKS_HEAD_INNER_HTML)}
+          {AGENT_DISCOVERY_LINKS.map(({ rel, href }) => (
+            <link key={rel} rel={rel} href={href} />
+          ))}
           <meta
             name="release-stage"
             content={getBrowserConfig("releaseStage")}

--- a/src/tests/e2e/well-known/ard-manifest.spec.ts
+++ b/src/tests/e2e/well-known/ard-manifest.spec.ts
@@ -1,25 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 /**
- * The ARD manifest must be served, and reachable, at both published paths.
+ * MCP-715. Guards the rewrite, not the handler: unit tests cover the handler,
+ * but it can be healthy while the rewrite is missing, and then the only URLs
+ * anyone fetches return 404. Nothing on the site links these paths, so no
+ * other check would notice.
  *
- * MCP-715. The manifest is produced by an App Router route handler and mapped
- * onto `/.well-known/` by rewrites in `next.config.ts`, because the App Router
- * will not route a folder beginning with a dot. That indirection is what this
- * spec guards: the handler can be healthy while the rewrite is missing, and
- * then the only URLs anyone actually fetches return 404.
- *
- * Nothing in the site links to these paths as a user would follow them, so no
- * other check here would notice.
- */
-
-/**
- * Both paths, spelled out.
- *
- * `ard.json` is what ARD v0.91 §5.1 requires a conformant consumer to fetch.
- * `ai-catalog.json` is its predecessor, and measured 2026-09-09 it is the only
- * path every reference publisher actually serves. Dropping either is a
- * deliberate change to who can discover Oak, not a tidy-up.
+ * See `docs/agent-discovery.md`.
  */
 const MANIFEST_PATHS = [
   "/.well-known/ard.json",
@@ -34,9 +21,8 @@ const EXPECTED_IDENTIFIERS = [
 test.describe("ARD manifest", () => {
   for (const path of MANIFEST_PATHS) {
     test(`serves the manifest at ${path}`, async ({ request }) => {
-      // `maxRedirects: 0` because the paths are a published contract. A
-      // redirect would still resolve in a browser while a consumer that does
-      // not follow hops got nothing.
+      // A redirect resolves in a browser but not for a consumer that does not
+      // follow hops, so a 3xx here must fail.
       const response = await request.get(path, { maxRedirects: 0 });
 
       expect(
@@ -57,9 +43,7 @@ test.describe("ARD manifest", () => {
 
       const body = await response.json();
 
-      // Asserted positively and per entry. Checking only that `entries` is a
-      // non-empty array would pass against a manifest that had silently lost
-      // one of the two resources.
+      // Per entry: a non-empty-array check would pass with one resource lost.
       const identifiers = body.entries.map(
         (entry: { identifier: string }) => entry.identifier,
       );
@@ -75,9 +59,7 @@ test.describe("ARD manifest", () => {
   test("advertises the manifest from the document head", async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
-    // ARD §5.1 makes `rel="ard"` a discovery mechanism a conformant consumer
-    // must honour, so an agent that never fetches `/.well-known/` still finds
-    // the manifest from any page.
+    // An agent that never fetches `/.well-known/` still finds the manifest.
     await expect(page.locator('head link[rel="ard"]')).toHaveAttribute(
       "href",
       "/.well-known/ard.json",

--- a/src/tests/e2e/well-known/ard-manifest.spec.ts
+++ b/src/tests/e2e/well-known/ard-manifest.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The ARD manifest must be served, and reachable, at both published paths.
+ *
+ * MCP-715. The manifest is produced by an App Router route handler and mapped
+ * onto `/.well-known/` by rewrites in `next.config.ts`, because the App Router
+ * will not route a folder beginning with a dot. That indirection is what this
+ * spec guards: the handler can be healthy while the rewrite is missing, and
+ * then the only URLs anyone actually fetches return 404.
+ *
+ * Nothing in the site links to these paths as a user would follow them, so no
+ * other check here would notice.
+ */
+
+/**
+ * Both paths, spelled out.
+ *
+ * `ard.json` is what ARD v0.91 §5.1 requires a conformant consumer to fetch.
+ * `ai-catalog.json` is its predecessor, and measured 2026-09-09 it is the only
+ * path every reference publisher actually serves. Dropping either is a
+ * deliberate change to who can discover Oak, not a tidy-up.
+ */
+const MANIFEST_PATHS = [
+  "/.well-known/ard.json",
+  "/.well-known/ai-catalog.json",
+] as const;
+
+const EXPECTED_IDENTIFIERS = [
+  "urn:air:thenational.academy:mcp:curriculum",
+  "urn:air:thenational.academy:api:curriculum",
+] as const;
+
+test.describe("ARD manifest", () => {
+  for (const path of MANIFEST_PATHS) {
+    test(`serves the manifest at ${path}`, async ({ request }) => {
+      // `maxRedirects: 0` because the paths are a published contract. A
+      // redirect would still resolve in a browser while a consumer that does
+      // not follow hops got nothing.
+      const response = await request.get(path, { maxRedirects: 0 });
+
+      expect(
+        response.status(),
+        `${path} did not return 200, so discovery agents cannot find Oak's resources.`,
+      ).toBe(200);
+
+      expect(
+        response.headers()["content-type"],
+        `${path} is served with the wrong content type.`,
+      ).toContain("application/ai-catalog+json");
+
+      // Without this, the manifest is unreadable from a browser context.
+      expect(
+        response.headers()["access-control-allow-origin"],
+        `${path} does not allow cross-origin reads.`,
+      ).toBe("*");
+
+      const body = await response.json();
+
+      // Asserted positively and per entry. Checking only that `entries` is a
+      // non-empty array would pass against a manifest that had silently lost
+      // one of the two resources.
+      const identifiers = body.entries.map(
+        (entry: { identifier: string }) => entry.identifier,
+      );
+      for (const identifier of EXPECTED_IDENTIFIERS) {
+        expect(
+          identifiers,
+          `${path} no longer advertises ${identifier}.`,
+        ).toContain(identifier);
+      }
+    });
+  }
+
+  test("advertises the manifest from the document head", async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // ARD §5.1 makes `rel="ard"` a discovery mechanism a conformant consumer
+    // must honour, so an agent that never fetches `/.well-known/` still finds
+    // the manifest from any page.
+    await expect(page.locator('head link[rel="ard"]')).toHaveAttribute(
+      "href",
+      "/.well-known/ard.json",
+    );
+    await expect(page.locator('head link[rel="ai-catalog"]')).toHaveAttribute(
+      "href",
+      "/.well-known/ai-catalog.json",
+    );
+  });
+});


### PR DESCRIPTION
Written by an AI agent (Implementer lane, Oak Director seat).

## Description

Publishes an Agentic Resource Discovery manifest listing the Oak Curriculum MCP server and the curriculum Open API, so an agent can find them from the apex.

Served at both `/.well-known/ard.json` and `/.well-known/ai-catalog.json` — the spec requires only the first, but every reference publisher currently serves only the second. Validates against the official ARD conformance tool with 0 errors.

Could you check the `representativeQueries` read like something a teacher would actually type? They are the text a registry indexes on, so they matter more than they look. Happy to redraft.

Stacked on #4509.

## Issue(s)

Fixes <https://linear.app/oaknational/issue/MCP-715>

## How to test

1. Go to [OWA Preview URL from Vercel bot comment]/.well-known/ard.json
2. Check it returns JSON with two entries, as `application/ai-catalog+json`
3. Check `/.well-known/ai-catalog.json` returns the same document
4. On any page, check the head has `<link rel="ard">` and `<link rel="ai-catalog">`

## Checklist

- [ ] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
