### PR TITLE
fix: handle missing pupil lesson overview data

### DIFF
--- a/src/__tests__/pages/pupils/lessons/[lessonSlug]/overview.test.tsx
+++ b/src/__tests__/pages/pupils/lessons/[lessonSlug]/overview.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { fireEvent } from "@testing-library/react";
+import { StrictMode } from "react";
 
 import PupilLessonOverviewPage, {
   getStaticProps,
@@ -32,13 +33,25 @@ jest.mock("@/components/PupilComponents/pupilUtils/getWorksheetInfo", () => ({
 const routerPush = jest.fn();
 const routerReplace = jest.fn();
 const routerBack = jest.fn();
+const routerReload = jest.fn();
 jest.mock("next/router", () => ({
   useRouter: () => ({
     asPath: "/pupils/lessons/lesson-1/overview?utm=x",
     push: routerPush,
     replace: routerReplace,
     back: routerBack,
+    reload: routerReload,
   }),
+}));
+
+const mockReportError = jest.fn();
+jest.mock("@/common-lib/error-reporter", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/common-lib/error-reporter"),
+  default:
+    () =>
+    (...args: unknown[]) =>
+      mockReportError(...args),
 }));
 
 const assignmentSearchParams = {
@@ -107,7 +120,7 @@ jest.mock(
 
 const render = renderWithProvidersByName(["oakTheme"]);
 
-const renderPage = (overrides: { backUrl?: string | null } = {}) =>
+const renderPage = (overrides: Partial<PupilLessonPageProps> = {}) =>
   render(
     <PupilLessonOverviewPage
       browseData={lessonBrowseDataFixture({})}
@@ -120,6 +133,7 @@ const renderPage = (overrides: { backUrl?: string | null } = {}) =>
       variant={null}
       initialSection="overview"
       pageType="canonical"
+      {...overrides}
     />,
   );
 
@@ -129,6 +143,8 @@ describe("pages/pupils/lessons/[lessonSlug]/overview", () => {
       routerPush.mockReset();
       routerReplace.mockReset();
       routerBack.mockReset();
+      routerReload.mockReset();
+      mockReportError.mockReset();
       Object.values(analyticsFns).forEach((fn) => fn.mockReset());
       assignmentSearchParams.isClassroomAssignment = false;
       assignmentSearchParams.classroomAssignmentChecked = true;
@@ -143,6 +159,90 @@ describe("pages/pupils/lessons/[lessonSlug]/overview", () => {
       const { getByTestId } = renderPage();
       expect(getByTestId("pupil-layout")).toBeInTheDocument();
       expect(getByTestId("proceed-to-next-section")).toBeInTheDocument();
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it.each(["browseData", "lessonContent"] as const)(
+      "offers a reload instead of crashing when %s is missing",
+      (property) => {
+        const { getByRole, queryByTestId } = renderPage({
+          [property]: undefined,
+        });
+
+        expect(
+          getByRole("heading", { name: "We couldn't load this lesson" }),
+        ).toBeInTheDocument();
+        expect(
+          queryByTestId("proceed-to-next-section"),
+        ).not.toBeInTheDocument();
+        expect(mockReportError).toHaveBeenCalledTimes(1);
+        expect(mockReportError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Pupil lesson overview data is missing",
+          }),
+          expect.objectContaining({
+            missingBrowseData: property === "browseData",
+            missingLessonContent: property === "lessonContent",
+          }),
+        );
+        expect(routerReload).not.toHaveBeenCalled();
+
+        fireEvent.click(getByRole("button", { name: "Reload lesson" }));
+
+        expect(routerReload).toHaveBeenCalledTimes(1);
+        expect(routerPush).not.toHaveBeenCalled();
+        expect(analyticsFns.trackLessonStarted).not.toHaveBeenCalled();
+      },
+    );
+
+    it("handles an empty page props response without mounting the lesson", () => {
+      const { getByRole, queryByTestId } = render(
+        <PupilLessonOverviewPage {...({} as PupilLessonPageProps)} />,
+      );
+
+      expect(
+        getByRole("button", { name: "Reload lesson" }),
+      ).toBeInTheDocument();
+      expect(queryByTestId("proceed-to-next-section")).not.toBeInTheDocument();
+    });
+
+    it("reports missing data only once in Strict Mode", () => {
+      const page = (
+        <StrictMode>
+          <PupilLessonOverviewPage {...({} as PupilLessonPageProps)} />
+        </StrictMode>
+      );
+      const { rerender } = render(page);
+      rerender(page);
+
+      expect(mockReportError).toHaveBeenCalledTimes(1);
+      expect(routerReload).not.toHaveBeenCalled();
+    });
+
+    it("renders the lesson when missing page data becomes available", () => {
+      const { rerender, getByTestId, queryByRole } = render(
+        <PupilLessonOverviewPage {...({} as PupilLessonPageProps)} />,
+      );
+
+      rerender(
+        <PupilLessonOverviewPage
+          browseData={lessonBrowseDataFixture({})}
+          lessonContent={lessonContentFixture({})}
+          hasWorksheet={false}
+          worksheetInfo={null}
+          hasAdditionalFiles={false}
+          additionalFiles={null}
+          variant={null}
+          initialSection="overview"
+          pageType="canonical"
+        />,
+      );
+
+      expect(
+        queryByRole("button", { name: "Reload lesson" }),
+      ).not.toBeInTheDocument();
+      expect(getByTestId("proceed-to-next-section")).toBeInTheDocument();
+      expect(mockReportError).toHaveBeenCalledTimes(1);
     });
 
     it("hides the back button when the lesson is opened from Google Classroom", () => {

--- a/src/components/PupilComponents/Views/PageContent/OverviewPageContent.tsx
+++ b/src/components/PupilComponents/Views/PageContent/OverviewPageContent.tsx
@@ -1,3 +1,5 @@
+import { PupilLessonDataError } from "./PupilLessonDataError";
+
 import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
 import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
 import { ViewAllLessonsButton } from "@/components/PupilComponents/ViewAllLessonsButton/ViewAllLessonsButton";
@@ -133,6 +135,15 @@ const OverviewContent = ({
  */
 const OverviewPageContent = (props: PupilLessonPageProps) => {
   const { browseData, lessonContent, backUrl, variant } = props;
+
+  if (!browseData || !lessonContent) {
+    return (
+      <PupilLessonDataError
+        missingBrowseData={!browseData}
+        missingLessonContent={!lessonContent}
+      />
+    );
+  }
 
   return (
     <PupilLayout

--- a/src/components/PupilComponents/Views/PageContent/PupilLessonDataError.tsx
+++ b/src/components/PupilComponents/Views/PageContent/PupilLessonDataError.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/router";
+import {
+  OakFlex,
+  OakHeading,
+  OakMaxWidth,
+  OakP,
+  OakPrimaryButton,
+} from "@oaknational/oak-components";
+
+import { PupilLayout } from "@/components/PupilComponents/PupilLayout/PupilLayout";
+import { getSeoProps } from "@/browser-lib/seo/getSeoProps";
+import errorReporter from "@/common-lib/error-reporter";
+
+const reportError = errorReporter("pupil-lesson-overview");
+
+type PupilLessonDataErrorProps = {
+  missingBrowseData: boolean;
+  missingLessonContent: boolean;
+};
+
+export const PupilLessonDataError = ({
+  missingBrowseData,
+  missingLessonContent,
+}: PupilLessonDataErrorProps) => {
+  const router = useRouter();
+  const reported = useRef(false);
+
+  useEffect(() => {
+    if (reported.current) {
+      return;
+    }
+    reported.current = true;
+    reportError(new Error("Pupil lesson overview data is missing"), {
+      pathname: router.pathname,
+      isFallback: router.isFallback,
+      missingBrowseData,
+      missingLessonContent,
+    });
+  }, [
+    router.pathname,
+    router.isFallback,
+    missingBrowseData,
+    missingLessonContent,
+  ]);
+
+  return (
+    <PupilLayout
+      seoProps={{
+        ...getSeoProps({ title: "We couldn't load this lesson" }),
+        noIndex: true,
+      }}
+    >
+      <main>
+        <OakMaxWidth>
+          <OakFlex
+            $flexDirection="column"
+            $alignItems="flex-start"
+            $gap="spacing-24"
+            $ph="spacing-24"
+            $pv="spacing-48"
+          >
+            <OakHeading tag="h1" $font={["heading-5", "heading-4"]}>
+              We couldn't load this lesson
+            </OakHeading>
+            <OakP>Reload the lesson to try again.</OakP>
+            <OakPrimaryButton onClick={() => router.reload()}>
+              Reload lesson
+            </OakPrimaryButton>
+          </OakFlex>
+        </OakMaxWidth>
+      </main>
+    </PupilLayout>
+  );
+};


### PR DESCRIPTION
## Description

Music year: 1969

Handle missing page data on pupil lesson overviews without crashing the page. Pupils can reload the current lesson instead of being sent to the generic error screen.

- Keep the normal overview layout and lesson behaviour unchanged
- Report which data is missing through the existing error reporter
- Add regression tests for empty props, partial props, reload and recovery

## Issue(s)

[Pupil lesson overview error in Bugsnag](https://app.bugsnag.com/oak-national-academy/oak-web-application/errors/6a58b327fdca5cb0d6dabc42)

This is a recovery fix. The crash is reproduced in tests, but the cause of the missing props in the affected browser sessions still needs investigation. Current HTML and page-data requests return complete lesson data.

## How to test

1. Open a pupil lesson overview in the branch preview and check that the lesson starts normally.
2. Use a local response override to return `{"pageProps":{},"__N_SSG":true}` for its Next.js overview data request, then navigate to the overview from the lesson list.
3. Check that the page offers a Reload lesson button instead of crashing.
4. Remove the override and reload the lesson. The current URL, including query parameters, should be retained.

## Validation

- All 56 tests across the three overview suites pass, including the new missing-data cases
- Type check, scoped lint and formatting checks pass
- The recovery component passes local Chromium checks at 390px and 1440px, including keyboard reload and preserving the current URL
- Production has not been changed

## Checklist

- [x] Added or updated tests where appropriate
- [ ] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Design sign-off
- [ ] Approved by product owner
- [ ] Does this PR update a package with a breaking change
